### PR TITLE
Add Godot MCP runtime bridge for live game testing

### DIFF
--- a/40k/addons/godot_mcp/README.md
+++ b/40k/addons/godot_mcp/README.md
@@ -1,0 +1,162 @@
+# Godot MCP
+
+In-game MCP (Model Context Protocol) server for the Warhammer 40K project.
+Gives an AI assistant (Claude Code, Claude Desktop, Cline, etc.) "eyes and
+hands" inside the running game so it can verify code changes by capturing
+screenshots, simulating input, inspecting scene state, and running domain
+commands like `get_board_state` or `select_unit`.
+
+## Architecture
+
+```
+┌────────────┐   stdio MCP    ┌──────────────────────┐   NDJSON / TCP   ┌─────────────────────┐
+│ Claude /   │ ─────────────▶ │ godot-mcp-bridge     │ ───────────────▶ │ MCPServer autoload  │  port 9080
+│ MCP host   │ ◀───────────── │ (Node.js, see        │ ◀─────────────── │ (running game)      │
+└────────────┘                │  ../../godot-mcp/)   │                  └─────────────────────┘
+                              │                      │   NDJSON / TCP   ┌─────────────────────┐
+                              │                      │ ───────────────▶ │ Editor bridge       │  port 9081
+                              │                      │ ◀─────────────── │ (Godot editor)      │
+                              └──────────────────────┘                  └─────────────────────┘
+```
+
+- The Godot addon registers an autoload `MCPServer` that listens on
+  `127.0.0.1:9080` whenever the game runs (editor playtest or exported build).
+- The same plugin starts a small editor bridge on `127.0.0.1:9081` so commands
+  like `play_scene` / `stop_scene` / `list_scenes` work even when the game is
+  not running.
+- The Node.js bridge in `godot-mcp/src/runtime_bridge.ts` translates between
+  MCP stdio and the TCP NDJSON protocol, routing each command to the right
+  port.
+
+The wire protocol is one JSON object per line:
+
+```
+→ { "id": 1, "command": "ping", "params": {} }
+← { "id": 1, "command": "ping", "result": { "status": "ok", "pong": 1234567 } }
+```
+
+## Setup
+
+1. Enable the plugin
+
+   The plugin is enabled by default in `40k/project.godot`. If you fork the
+   addon into another project, enable it via
+   `Project → Project Settings → Plugins → Godot MCP`.
+
+2. Build the bridge
+
+   ```bash
+   cd godot-mcp
+   npm install
+   npm run build
+   ```
+
+3. Configure your MCP host
+
+   For Claude Desktop / Claude Code, add an entry under `mcpServers`:
+
+   ```json
+   {
+     "mcpServers": {
+       "godot-mcp-bridge": {
+         "command": "node",
+         "args": ["/absolute/path/to/godot-mcp/build/runtime_bridge.js"]
+       }
+     }
+   }
+   ```
+
+   For Claude Code CLI specifically:
+
+   ```bash
+   claude mcp add godot-mcp-bridge node /absolute/path/to/godot-mcp/build/runtime_bridge.js
+   ```
+
+4. Run the game (editor playtest or exported binary). You should see
+   `[GodotMCP] Listening on 127.0.0.1:9080` in the log.
+
+5. From Claude, call any tool, e.g. `ping` or `get_board_state`.
+
+## Environment variables
+
+| Var                          | Default        | Purpose                                  |
+|-----------------------------:|:---------------|:-----------------------------------------|
+| `GODOT_MCP_HOST`             | `127.0.0.1`    | Bridge → Godot host.                     |
+| `GODOT_MCP_PORT`             | `9080`         | Runtime autoload port.                   |
+| `GODOT_MCP_EDITOR_PORT`      | `9081`         | Editor bridge port.                      |
+| `GODOT_MCP_TIMEOUT_MS`       | `30000`        | Request timeout in the Node bridge.      |
+| `GODOT_MCP_DISABLED=1`       | unset          | Skip starting the runtime server. Useful in CI when only specific scenes need it. |
+
+## Tool catalogue
+
+### Generic / project / scene
+- `ping`, `list_tools`
+- `get_project_info`, `get_project_setting`, `list_files`
+- `get_current_scene`, `get_node_info`, `get_node_property`, `set_node_property`,
+  `call_node_method`
+- `read_script`, `write_script` (refuses paths outside `res://`)
+
+### Core testing
+- `capture_screenshot` — PNG to `user://test_screenshots/<label>.png`, base64
+  blob in the response
+- `simulate_click`, `simulate_mouse_move`, `simulate_drag`,
+  `simulate_key_press`, `simulate_action`
+- `get_scene_state` — recursive tree dump with positions, visibility, and
+  script-defined properties
+- `execute_script` — evaluate a one-line GDScript expression against an
+  optional target node
+- `wait_frames`, `wait_seconds`
+- `get_log_path` — returns absolute paths of `user://logs` and
+  `user://test_screenshots`
+
+### Editor-only (port 9081)
+- `play_scene`, `play_main_scene`, `stop_scene`, `get_edited_scene`,
+  `list_scenes`, `reload_scripts`
+
+### WH40K
+- `get_board_state` — phase, active player, players (CP/VP), unit roster
+- `list_units`, `get_unit_details`
+- `get_current_phase`, `advance_phase`, `transition_to_phase`
+- `select_unit` — locates the token in the running scene and synthesizes a
+  click on its screen position (UI selection path)
+- `dispatch_action` — runs a phase action through `validate_action` /
+  `process_action` on the active phase instance
+- `move_unit_to` — convenience wrapper that builds a `MOVE_UNIT` action
+
+## Implementation notes
+
+- **NDJSON over TCP, not WebSocket.** The implementation guide in `CLAUDE.md`
+  describes a WebSocket server; on localhost between two trusted processes
+  WebSocket framing adds complexity for no benefit, so the addon uses
+  newline-delimited JSON over plain TCP. The Node.js bridge handles that
+  difference.
+- **Two ports.** Editor commands (`play_scene` etc.) need access to
+  `EditorInterface`, which only exists in the editor. They go to port 9081.
+  Runtime tools (`capture_screenshot` etc.) go to port 9080 because they need
+  the running game's viewport / input system.
+- **Action dispatch.** `dispatch_action` and `move_unit_to` route through the
+  current phase instance's `validate_action` / `process_action`, so any
+  in-game validation and side effects fire normally — exactly as if the human
+  UI had triggered the action.
+- **Token discovery.** `select_unit` searches the running scene for a
+  `Node2D` whose name matches `unit_id` or that exposes a `unit_id` script
+  property / metadata. Adapt your token nodes accordingly if necessary.
+- **Logs.** All addon `print` lines also land in
+  `user://logs/debug_*.log` via Godot's standard logging — same path as the
+  rest of the project (see `CLAUDE.md`).
+
+## Test workflow example
+
+```
+# Claude:
+1. play_scene { path: "res://scenes/Main.tscn" }
+2. wait_seconds { seconds: 1.0 }
+3. get_board_state
+4. select_unit { unit_id: "U_INTERCESSORS_A" }
+5. capture_screenshot { label: "selected" }
+6. transition_to_phase { phase: "MOVEMENT" }
+7. move_unit_to { unit_id: "U_INTERCESSORS_A", dest_x: 600, dest_y: 800 }
+8. wait_seconds { seconds: 1.5 }
+9. capture_screenshot { label: "moved" }
+10. get_unit_details { unit_id: "U_INTERCESSORS_A" }
+```

--- a/40k/addons/godot_mcp/README.md
+++ b/40k/addons/godot_mcp/README.md
@@ -97,8 +97,11 @@ The wire protocol is one JSON object per line:
 - `read_script`, `write_script` (refuses paths outside `res://`)
 
 ### Core testing
-- `capture_screenshot` — PNG to `user://test_screenshots/<label>.png`, base64
-  blob in the response
+- `capture_screenshot` — PNG to `user://test_screenshots/<label>.png` plus an
+  inline image content block. Vision-capable MCP hosts (Claude Code/Desktop)
+  see it as a real image they can reason over, not as base64 text. Inline
+  copy is downscaled to `max_dim` on the long side (default 1280); the
+  on-disk file is full resolution.
 - `simulate_click`, `simulate_mouse_move`, `simulate_drag`,
   `simulate_key_press`, `simulate_action`
 - `get_scene_state` — recursive tree dump with positions, visibility, and

--- a/40k/addons/godot_mcp/command_router.gd
+++ b/40k/addons/godot_mcp/command_router.gd
@@ -1,0 +1,100 @@
+extends RefCounted
+
+# Routes a command name + params dictionary to the appropriate handler.
+# We use explicit per-handler method lists rather than introspection because
+# `Object.get_method_list()` returns inherited internals (`_init`, `_get`,
+# `_set`, etc.) that we don't want exposed.
+
+const TestingHandlers := preload("res://addons/godot_mcp/handlers/testing_handlers.gd")
+const CoreHandlers := preload("res://addons/godot_mcp/handlers/core_handlers.gd")
+const Wh40kHandlers := preload("res://addons/godot_mcp/handlers/wh40k_handlers.gd")
+
+var host: Node = null
+
+var _testing: RefCounted = null
+var _core: RefCounted = null
+var _wh40k: RefCounted = null
+
+# command -> [handler_object, method_name]
+var _routes: Dictionary = {}
+
+
+func _init() -> void:
+	_testing = TestingHandlers.new()
+	_core = CoreHandlers.new()
+	_wh40k = Wh40kHandlers.new()
+	_register_routes()
+
+
+func _register_routes() -> void:
+	# Built-in / informational
+	_routes["ping"] = [self, "_ping"]
+	_routes["list_tools"] = [self, "_list_tools"]
+
+	var core_methods := [
+		"get_project_info", "get_project_setting", "list_files",
+		"get_current_scene", "get_node_info", "get_node_property",
+		"set_node_property", "call_node_method",
+		"read_script", "write_script",
+	]
+	for m in core_methods:
+		_routes[m] = [_core, m]
+
+	var testing_methods := [
+		"capture_screenshot",
+		"simulate_click", "simulate_mouse_move", "simulate_drag",
+		"simulate_key_press", "simulate_action",
+		"get_scene_state", "execute_script",
+		"wait_frames", "wait_seconds",
+		"get_log_path",
+	]
+	for m in testing_methods:
+		_routes[m] = [_testing, m]
+
+	var wh40k_methods := [
+		"get_board_state", "get_unit_details", "list_units",
+		"get_current_phase", "advance_phase", "transition_to_phase",
+		"select_unit", "dispatch_action", "move_unit_to",
+	]
+	for m in wh40k_methods:
+		_routes[m] = [_wh40k, m]
+
+
+func _propagate_host() -> void:
+	# `host` may be assigned after _init(); always forward the current value
+	# to handlers so their tree access is up-to-date.
+	if _testing:
+		_testing.host = host
+	if _core:
+		_core.host = host
+	if _wh40k:
+		_wh40k.host = host
+
+
+func dispatch(command: String, params: Dictionary):
+	_propagate_host()
+	if not _routes.has(command):
+		return {"status": "error", "message": "Unknown command: %s" % command}
+	var route = _routes[command]
+	var handler = route[0]
+	var method: String = route[1]
+	# `await` on a synchronous return value is a no-op in Godot 4, so this
+	# safely supports both sync and `await`-using handlers.
+	var result = await handler.callv(method, [params])
+	return result
+
+
+# --- Built-in commands --------------------------------------------------------
+
+func _ping(_params: Dictionary) -> Dictionary:
+	return {
+		"status": "ok",
+		"pong": Time.get_ticks_msec(),
+		"engine_version": Engine.get_version_info(),
+	}
+
+
+func _list_tools(_params: Dictionary) -> Dictionary:
+	var names := _routes.keys()
+	names.sort()
+	return {"status": "ok", "tools": names}

--- a/40k/addons/godot_mcp/editor_bridge.gd
+++ b/40k/addons/godot_mcp/editor_bridge.gd
@@ -1,0 +1,202 @@
+@tool
+extends Node
+
+# Editor-side bridge. Runs only inside the Godot editor (not the running game).
+# Hosts a tiny TCP server on a different port and provides commands that need
+# EditorInterface — e.g. play / stop scene, list project scenes, get the
+# currently edited scene path.
+#
+# The runtime autoload (mcp_server.gd) listens on port 9080 inside the running
+# game; this editor bridge listens on 9081 in the editor. The Node.js MCP
+# bridge picks the correct port per command.
+
+const DEFAULT_PORT := 9081
+
+var editor_plugin: EditorPlugin = null
+
+var _server: TCPServer = null
+var _port: int = DEFAULT_PORT
+var _connections: Array = []
+var _running := false
+
+
+func start() -> void:
+	if _running:
+		return
+	var env_port := OS.get_environment("GODOT_MCP_EDITOR_PORT")
+	if env_port != "":
+		var parsed := int(env_port)
+		if parsed > 0:
+			_port = parsed
+	_server = TCPServer.new()
+	var err := _server.listen(_port, "127.0.0.1")
+	if err != OK:
+		push_warning("[GodotMCP] Editor bridge failed to listen on %d: %s" % [_port, error_string(err)])
+		_server = null
+		return
+	_running = true
+	set_process(true)
+	print("[GodotMCP] Editor bridge listening on 127.0.0.1:%d" % _port)
+
+
+func stop() -> void:
+	_running = false
+	set_process(false)
+	if _server:
+		_server.stop()
+		_server = null
+	for conn in _connections:
+		var peer: StreamPeerTCP = conn.peer
+		if peer:
+			peer.disconnect_from_host()
+	_connections.clear()
+
+
+func _process(_delta: float) -> void:
+	if _server == null:
+		return
+	while _server.is_connection_available():
+		var peer := _server.take_connection()
+		if peer:
+			peer.set_no_delay(true)
+			_connections.append({"peer": peer, "buffer": PackedByteArray()})
+	for i in range(_connections.size() - 1, -1, -1):
+		var conn = _connections[i]
+		var peer: StreamPeerTCP = conn.peer
+		peer.poll()
+		if peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+			_connections.remove_at(i)
+			continue
+		var available := peer.get_available_bytes()
+		if available > 0:
+			var got := peer.get_data(available)
+			if got[0] == OK:
+				var buf: PackedByteArray = conn.buffer
+				buf.append_array(got[1])
+				conn.buffer = buf
+		_drain(conn)
+
+
+func _drain(conn: Dictionary) -> void:
+	var buf: PackedByteArray = conn.buffer
+	while true:
+		var nl := buf.find(0x0A)
+		if nl == -1:
+			conn.buffer = buf
+			return
+		var line := buf.slice(0, nl)
+		buf = buf.slice(nl + 1)
+		conn.buffer = buf
+		var text := line.get_string_from_utf8().strip_edges()
+		if text == "":
+			continue
+		_handle(conn.peer, text)
+
+
+func _handle(peer: StreamPeerTCP, text: String) -> void:
+	var parsed = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_reply(peer, null, {"status": "error", "message": "Invalid JSON"})
+		return
+	var msg: Dictionary = parsed
+	var msg_id = msg.get("id", null)
+	var command := str(msg.get("command", ""))
+	var params: Dictionary = msg.get("params", {}) if typeof(msg.get("params", {})) == TYPE_DICTIONARY else {}
+	var result: Dictionary
+	match command:
+		"ping":
+			result = {"status": "ok", "where": "editor", "engine_version": Engine.get_version_info()}
+		"play_scene":
+			result = _cmd_play_scene(params)
+		"play_main_scene":
+			result = _cmd_play_main_scene()
+		"stop_scene":
+			result = _cmd_stop_scene()
+		"get_edited_scene":
+			result = _cmd_get_edited_scene()
+		"list_scenes":
+			result = _cmd_list_scenes(params)
+		"reload_scripts":
+			result = _cmd_reload_scripts()
+		_:
+			result = {"status": "error", "message": "Unknown editor command: %s" % command}
+	_reply(peer, msg_id, result)
+
+
+func _reply(peer: StreamPeerTCP, msg_id, result: Dictionary) -> void:
+	var envelope := {"id": msg_id, "result": result}
+	var bytes := (JSON.stringify(envelope) + "\n").to_utf8_buffer()
+	peer.put_data(bytes)
+
+
+# --- Editor commands -----------------------------------------------------
+
+func _cmd_play_scene(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	if path == "":
+		EditorInterface.play_main_scene()
+		return {"status": "ok", "played": "main_scene"}
+	if not FileAccess.file_exists(path):
+		return {"status": "error", "message": "Scene not found: %s" % path}
+	EditorInterface.play_custom_scene(path)
+	return {"status": "ok", "played": path}
+
+
+func _cmd_play_main_scene() -> Dictionary:
+	EditorInterface.play_main_scene()
+	return {"status": "ok"}
+
+
+func _cmd_stop_scene() -> Dictionary:
+	EditorInterface.stop_playing_scene()
+	return {"status": "ok"}
+
+
+func _cmd_get_edited_scene() -> Dictionary:
+	var root := EditorInterface.get_edited_scene_root()
+	if root == null:
+		return {"status": "ok", "scene": null}
+	return {
+		"status": "ok",
+		"scene": {
+			"name": root.name,
+			"type": root.get_class(),
+			"path": root.scene_file_path,
+		},
+	}
+
+
+func _cmd_list_scenes(params: Dictionary) -> Dictionary:
+	var dir_path: String = params.get("path", "res://scenes")
+	var results := []
+	_walk_scenes(dir_path, results)
+	return {"status": "ok", "scenes": results}
+
+
+func _walk_scenes(path: String, out: Array) -> void:
+	var dir := DirAccess.open(path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		if entry.begins_with("."):
+			entry = dir.get_next()
+			continue
+		var full := path
+		if not full.ends_with("/"):
+			full += "/"
+		full += entry
+		if dir.current_is_dir():
+			_walk_scenes(full, out)
+		elif entry.ends_with(".tscn") or entry.ends_with(".scn"):
+			out.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+func _cmd_reload_scripts() -> Dictionary:
+	var rfs := EditorInterface.get_resource_filesystem()
+	if rfs:
+		rfs.scan()
+	return {"status": "ok"}

--- a/40k/addons/godot_mcp/handlers/core_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/core_handlers.gd
@@ -1,0 +1,243 @@
+extends RefCounted
+
+# Generic Godot tools — project info, scene tree, node properties, scripts.
+# Every public method (no leading underscore) is auto-registered as a command.
+
+var host: Node = null
+
+
+# --- Project --------------------------------------------------------------
+
+func get_project_info(_params: Dictionary) -> Dictionary:
+	return {
+		"status": "ok",
+		"project_name": ProjectSettings.get_setting("application/config/name", ""),
+		"main_scene": ProjectSettings.get_setting("application/run/main_scene", ""),
+		"engine_version": Engine.get_version_info(),
+		"viewport_size": [
+			ProjectSettings.get_setting("display/window/size/viewport_width", 0),
+			ProjectSettings.get_setting("display/window/size/viewport_height", 0),
+		],
+		"feature_flags": OS.get_cmdline_args(),
+	}
+
+
+func get_project_setting(params: Dictionary) -> Dictionary:
+	var key: String = params.get("key", "")
+	if key == "":
+		return {"status": "error", "message": "Missing 'key'"}
+	return {
+		"status": "ok",
+		"key": key,
+		"value": ProjectSettings.get_setting(key, null),
+	}
+
+
+func list_files(params: Dictionary) -> Dictionary:
+	# List files under a `res://` directory. Useful for discovering scenes/scripts.
+	var path: String = params.get("path", "res://")
+	var pattern: String = params.get("pattern", "")
+	var recursive: bool = params.get("recursive", false)
+	var results: Array = []
+	_walk(path, pattern, recursive, results)
+	return {"status": "ok", "path": path, "files": results}
+
+
+func _walk(dir_path: String, pattern: String, recursive: bool, out: Array) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		if entry.begins_with("."):
+			entry = dir.get_next()
+			continue
+		var full := dir_path
+		if not full.ends_with("/"):
+			full += "/"
+		full += entry
+		if dir.current_is_dir():
+			if recursive:
+				_walk(full, pattern, recursive, out)
+		else:
+			if pattern == "" or entry.matchn(pattern):
+				out.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+
+# --- Scene tree -----------------------------------------------------------
+
+func get_current_scene(_params: Dictionary) -> Dictionary:
+	if host == null or host.get_tree() == null:
+		return {"status": "error", "message": "No scene tree available"}
+	var scene := host.get_tree().current_scene
+	if scene == null:
+		return {"status": "ok", "scene": null}
+	return {
+		"status": "ok",
+		"scene": {
+			"name": scene.name,
+			"type": scene.get_class(),
+			"path": scene.scene_file_path,
+		},
+	}
+
+
+func get_node_info(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	if path == "":
+		return {"status": "error", "message": "Missing 'path'"}
+	var node := _resolve_node(path)
+	if node == null:
+		return {"status": "error", "message": "Node not found: %s" % path}
+	return {"status": "ok", "node": _node_summary(node)}
+
+
+func get_node_property(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var prop: String = params.get("property", "")
+	if path == "" or prop == "":
+		return {"status": "error", "message": "Missing 'path' or 'property'"}
+	var node := _resolve_node(path)
+	if node == null:
+		return {"status": "error", "message": "Node not found: %s" % path}
+	return {"status": "ok", "value": _to_serializable(node.get(prop))}
+
+
+func set_node_property(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var prop: String = params.get("property", "")
+	if path == "" or prop == "":
+		return {"status": "error", "message": "Missing 'path' or 'property'"}
+	if not params.has("value"):
+		return {"status": "error", "message": "Missing 'value'"}
+	var node := _resolve_node(path)
+	if node == null:
+		return {"status": "error", "message": "Node not found: %s" % path}
+	node.set(prop, params["value"])
+	return {"status": "ok", "value": _to_serializable(node.get(prop))}
+
+
+func call_node_method(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	var method: String = params.get("method", "")
+	var args: Array = params.get("args", [])
+	if path == "" or method == "":
+		return {"status": "error", "message": "Missing 'path' or 'method'"}
+	var node := _resolve_node(path)
+	if node == null:
+		return {"status": "error", "message": "Node not found: %s" % path}
+	if not node.has_method(method):
+		return {"status": "error", "message": "Node has no method '%s'" % method}
+	var result = node.callv(method, args)
+	return {"status": "ok", "result": _to_serializable(result)}
+
+
+# --- Scripts --------------------------------------------------------------
+
+func read_script(params: Dictionary) -> Dictionary:
+	var path: String = params.get("path", "")
+	if path == "":
+		return {"status": "error", "message": "Missing 'path'"}
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return {"status": "error", "message": "Cannot open file: %s" % path}
+	var content := f.get_as_text()
+	f.close()
+	return {"status": "ok", "path": path, "content": content}
+
+
+func write_script(params: Dictionary) -> Dictionary:
+	# Note: only allowed within `res://` so we don't write outside the project.
+	var path: String = params.get("path", "")
+	var content: String = params.get("content", "")
+	if path == "" or not path.begins_with("res://"):
+		return {"status": "error", "message": "Path must be under res://"}
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	if f == null:
+		return {"status": "error", "message": "Cannot open file for writing: %s" % path}
+	f.store_string(content)
+	f.close()
+	return {"status": "ok", "path": path, "bytes_written": content.length()}
+
+
+# --- Helpers --------------------------------------------------------------
+
+func _resolve_node(path: String) -> Node:
+	if host == null:
+		return null
+	var tree := host.get_tree()
+	if tree == null:
+		return null
+	var root := tree.root
+	if root == null:
+		return null
+	# `get_node_or_null` accepts both absolute paths ("/root/...") and
+	# relative paths. For absolute paths we resolve from any node in the
+	# tree; for unrooted paths we treat them as relative to the current scene.
+	if path.begins_with("/"):
+		return host.get_node_or_null(NodePath(path))
+	var current := tree.current_scene
+	if current == null:
+		return null
+	return current.get_node_or_null(NodePath(path))
+
+
+func _node_summary(node: Node) -> Dictionary:
+	var info := {
+		"name": node.name,
+		"type": node.get_class(),
+		"path": String(node.get_path()),
+		"child_count": node.get_child_count(),
+		"children": [],
+	}
+	for child in node.get_children():
+		info["children"].append({
+			"name": child.name,
+			"type": child.get_class(),
+		})
+	if node is Node2D:
+		info["position"] = [node.global_position.x, node.global_position.y]
+		info["visible"] = node.visible
+		info["rotation"] = node.rotation
+	if node is Control:
+		info["position"] = [node.global_position.x, node.global_position.y]
+		info["size"] = [node.size.x, node.size.y]
+		info["visible"] = node.visible
+	return info
+
+
+func _to_serializable(value):
+	# JSON.stringify can serialize most primitives; convert exotic types here.
+	match typeof(value):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return [value.x, value.y]
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return [value.x, value.y, value.z]
+		TYPE_RECT2, TYPE_RECT2I:
+			return {
+				"position": [value.position.x, value.position.y],
+				"size": [value.size.x, value.size.y],
+			}
+		TYPE_COLOR:
+			return [value.r, value.g, value.b, value.a]
+		TYPE_NODE_PATH:
+			return String(value)
+		TYPE_OBJECT:
+			if value == null:
+				return null
+			return "<%s>" % value.get_class()
+		TYPE_DICTIONARY:
+			var out := {}
+			for k in value.keys():
+				out[str(k)] = _to_serializable(value[k])
+			return out
+		TYPE_ARRAY:
+			var out_arr := []
+			for v in value:
+				out_arr.append(_to_serializable(v))
+			return out_arr
+		_:
+			return value

--- a/40k/addons/godot_mcp/handlers/testing_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/testing_handlers.gd
@@ -16,6 +16,10 @@ func capture_screenshot(params: Dictionary) -> Dictionary:
 	var label: String = params.get("label", "capture_%d" % Time.get_ticks_msec())
 	var include_base64: bool = params.get("include_base64", true)
 	var include_path: bool = params.get("include_path", true)
+	# Default to 1280px on the long side. Claude's vision pipeline downscales
+	# anything larger, so transmitting full 1920+ wastes tokens. Pass 0 to
+	# disable scaling.
+	var max_dim: int = int(params.get("max_dim", 1280))
 	if host == null:
 		return {"status": "error", "message": "MCP host not ready"}
 
@@ -32,11 +36,14 @@ func capture_screenshot(params: Dictionary) -> Dictionary:
 	if image == null:
 		return {"status": "error", "message": "Failed to read viewport image"}
 
+	var orig_size := [image.get_width(), image.get_height()]
+
+	# Save the full-resolution PNG to disk before any resizing, so callers
+	# can still inspect the original if needed.
 	var result := {
 		"status": "ok",
-		"size": [image.get_width(), image.get_height()],
+		"size": orig_size,
 	}
-
 	if include_path:
 		DirAccess.make_dir_recursive_absolute("user://test_screenshots")
 		var path := "user://test_screenshots/%s.png" % label
@@ -46,8 +53,23 @@ func capture_screenshot(params: Dictionary) -> Dictionary:
 			result["absolute_path"] = ProjectSettings.globalize_path(path)
 
 	if include_base64:
-		var buffer := image.save_png_to_buffer()
+		# Downscale only the inline copy. Image.resize is in-place so we
+		# duplicate first to keep the on-disk file at full res.
+		var inline_image := image
+		if max_dim > 0:
+			var w := image.get_width()
+			var h := image.get_height()
+			var long := max(w, h)
+			if long > max_dim:
+				inline_image = image.duplicate()
+				var scale := float(max_dim) / float(long)
+				var new_w := int(round(w * scale))
+				var new_h := int(round(h * scale))
+				inline_image.resize(new_w, new_h, Image.INTERPOLATE_BILINEAR)
+				result["inline_size"] = [new_w, new_h]
+		var buffer := inline_image.save_png_to_buffer()
 		result["image_base64"] = Marshalls.raw_to_base64(buffer)
+		result["image_mime_type"] = "image/png"
 
 	return result
 

--- a/40k/addons/godot_mcp/handlers/testing_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/testing_handlers.gd
@@ -1,0 +1,381 @@
+extends RefCounted
+
+# Generic in-game testing tools.
+#
+# These methods all run inside the running game's main scene tree, so
+# `host.get_tree()` and `host.get_viewport()` are valid. The MCP server
+# autoload calls these via `await router.dispatch(...)` so they can yield
+# on `process_frame`, timers, and `RenderingServer.frame_post_draw`.
+
+var host: Node = null
+
+
+# --- Screenshot -----------------------------------------------------------
+
+func capture_screenshot(params: Dictionary) -> Dictionary:
+	var label: String = params.get("label", "capture_%d" % Time.get_ticks_msec())
+	var include_base64: bool = params.get("include_base64", true)
+	var include_path: bool = params.get("include_path", true)
+	if host == null:
+		return {"status": "error", "message": "MCP host not ready"}
+
+	# Wait until the next post-draw so we capture the most recent frame.
+	await RenderingServer.frame_post_draw
+
+	var viewport := host.get_viewport()
+	if viewport == null:
+		return {"status": "error", "message": "No viewport available"}
+	var texture := viewport.get_texture()
+	if texture == null:
+		return {"status": "error", "message": "No texture on viewport"}
+	var image := texture.get_image()
+	if image == null:
+		return {"status": "error", "message": "Failed to read viewport image"}
+
+	var result := {
+		"status": "ok",
+		"size": [image.get_width(), image.get_height()],
+	}
+
+	if include_path:
+		DirAccess.make_dir_recursive_absolute("user://test_screenshots")
+		var path := "user://test_screenshots/%s.png" % label
+		var save_err := image.save_png(path)
+		if save_err == OK:
+			result["path"] = path
+			result["absolute_path"] = ProjectSettings.globalize_path(path)
+
+	if include_base64:
+		var buffer := image.save_png_to_buffer()
+		result["image_base64"] = Marshalls.raw_to_base64(buffer)
+
+	return result
+
+
+# --- Input simulation ----------------------------------------------------
+
+func simulate_click(params: Dictionary) -> Dictionary:
+	if not params.has("x") or not params.has("y"):
+		return {"status": "error", "message": "Missing 'x' or 'y'"}
+	var pos := Vector2(float(params["x"]), float(params["y"]))
+	var button: int = int(params.get("button", MOUSE_BUTTON_LEFT))
+	var double_click: bool = params.get("double_click", false)
+
+	var press := InputEventMouseButton.new()
+	press.button_index = button
+	press.position = pos
+	press.global_position = pos
+	press.pressed = true
+	press.double_click = double_click
+	press.button_mask = _button_mask_for(button)
+	Input.parse_input_event(press)
+
+	# Yield a frame so the press is processed before release.
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+
+	var release := InputEventMouseButton.new()
+	release.button_index = button
+	release.position = pos
+	release.global_position = pos
+	release.pressed = false
+	release.button_mask = 0
+	Input.parse_input_event(release)
+
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+
+	return {
+		"status": "ok",
+		"position": [pos.x, pos.y],
+		"button": button,
+	}
+
+
+func simulate_mouse_move(params: Dictionary) -> Dictionary:
+	if not params.has("x") or not params.has("y"):
+		return {"status": "error", "message": "Missing 'x' or 'y'"}
+	var pos := Vector2(float(params["x"]), float(params["y"]))
+	var motion := InputEventMouseMotion.new()
+	motion.position = pos
+	motion.global_position = pos
+	motion.relative = Vector2.ZERO
+	Input.parse_input_event(motion)
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+	return {"status": "ok", "position": [pos.x, pos.y]}
+
+
+func simulate_drag(params: Dictionary) -> Dictionary:
+	# Press at start, move through optional waypoints to end, release.
+	if not params.has("from_x") or not params.has("from_y") \
+			or not params.has("to_x") or not params.has("to_y"):
+		return {"status": "error", "message": "Missing from_x/from_y/to_x/to_y"}
+	var start := Vector2(float(params["from_x"]), float(params["from_y"]))
+	var end := Vector2(float(params["to_x"]), float(params["to_y"]))
+	var steps: int = int(params.get("steps", 10))
+	var button: int = int(params.get("button", MOUSE_BUTTON_LEFT))
+
+	var press := InputEventMouseButton.new()
+	press.button_index = button
+	press.position = start
+	press.global_position = start
+	press.pressed = true
+	press.button_mask = _button_mask_for(button)
+	Input.parse_input_event(press)
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+
+	var prev := start
+	for i in range(1, steps + 1):
+		var t := float(i) / float(steps)
+		var here := start.lerp(end, t)
+		var motion := InputEventMouseMotion.new()
+		motion.position = here
+		motion.global_position = here
+		motion.relative = here - prev
+		motion.button_mask = _button_mask_for(button)
+		Input.parse_input_event(motion)
+		prev = here
+		if host and host.get_tree():
+			await host.get_tree().process_frame
+
+	var release := InputEventMouseButton.new()
+	release.button_index = button
+	release.position = end
+	release.global_position = end
+	release.pressed = false
+	release.button_mask = 0
+	Input.parse_input_event(release)
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+
+	return {
+		"status": "ok",
+		"from": [start.x, start.y],
+		"to": [end.x, end.y],
+		"steps": steps,
+	}
+
+
+func simulate_key_press(params: Dictionary) -> Dictionary:
+	if not params.has("keycode"):
+		return {"status": "error", "message": "Missing 'keycode'"}
+	var keycode: int = int(params["keycode"])
+	var duration: float = float(params.get("duration", 0.05))
+
+	var press := InputEventKey.new()
+	press.keycode = keycode
+	press.physical_keycode = keycode
+	press.pressed = true
+	Input.parse_input_event(press)
+
+	if host and host.get_tree():
+		await host.get_tree().create_timer(duration).timeout
+
+	var release := InputEventKey.new()
+	release.keycode = keycode
+	release.physical_keycode = keycode
+	release.pressed = false
+	Input.parse_input_event(release)
+
+	return {"status": "ok", "keycode": keycode, "duration": duration}
+
+
+func simulate_action(params: Dictionary) -> Dictionary:
+	var action: String = params.get("action", "")
+	if action == "":
+		return {"status": "error", "message": "Missing 'action'"}
+	if not InputMap.has_action(action):
+		return {"status": "error", "message": "Action not in InputMap: %s" % action}
+	var duration: float = float(params.get("duration", 0.1))
+	Input.action_press(action)
+	if host and host.get_tree():
+		await host.get_tree().create_timer(duration).timeout
+	Input.action_release(action)
+	return {"status": "ok", "action": action, "duration": duration}
+
+
+# --- Scene state inspection ----------------------------------------------
+
+func get_scene_state(params: Dictionary) -> Dictionary:
+	if host == null or host.get_tree() == null:
+		return {"status": "error", "message": "No scene tree"}
+	var max_depth: int = int(params.get("max_depth", 10))
+	var include_props: bool = params.get("include_script_properties", true)
+	var include_invisible: bool = params.get("include_invisible", true)
+	var root_path: String = params.get("root", "")
+
+	var root_node: Node
+	if root_path == "":
+		root_node = host.get_tree().current_scene
+		if root_node == null:
+			root_node = host.get_tree().root
+	else:
+		# get_node_or_null accepts both absolute ("/root/...") and relative paths.
+		root_node = host.get_node_or_null(NodePath(root_path))
+		if root_node == null:
+			return {"status": "error", "message": "Root not found: %s" % root_path}
+
+	return {
+		"status": "ok",
+		"scene_tree": _collect_state(root_node, 0, max_depth, include_props, include_invisible),
+	}
+
+
+func _collect_state(node: Node, depth: int, max_depth: int,
+		include_props: bool, include_invisible: bool) -> Dictionary:
+	var info := {
+		"name": node.name,
+		"type": node.get_class(),
+		"path": String(node.get_path()),
+	}
+	if node is Node2D:
+		info["position"] = [node.global_position.x, node.global_position.y]
+		info["visible"] = node.visible
+		info["rotation"] = node.rotation
+		info["scale"] = [node.scale.x, node.scale.y]
+	elif node is Control:
+		info["position"] = [node.global_position.x, node.global_position.y]
+		info["size"] = [node.size.x, node.size.y]
+		info["visible"] = node.visible
+	elif node is Node3D:
+		info["position"] = [node.global_position.x, node.global_position.y, node.global_position.z]
+		info["visible"] = node.visible
+
+	if node is Sprite2D or node is AnimatedSprite2D:
+		if node.has_method("get_frame"):
+			info["frame"] = node.frame
+
+	if include_props:
+		var props := []
+		for prop in node.get_property_list():
+			var usage: int = int(prop.get("usage", 0))
+			if not (usage & PROPERTY_USAGE_SCRIPT_VARIABLE):
+				continue
+			var pname: String = prop.get("name", "")
+			if pname == "" or pname.begins_with("_"):
+				continue
+			var value = node.get(pname)
+			props.append({"name": pname, "value": _serialize(value)})
+		if props.size() > 0:
+			info["script_properties"] = props
+
+	if depth < max_depth:
+		var children := []
+		for child in node.get_children():
+			if not include_invisible and child is CanvasItem and not child.visible:
+				continue
+			children.append(_collect_state(child, depth + 1, max_depth,
+				include_props, include_invisible))
+		info["children"] = children
+	else:
+		info["children_truncated"] = node.get_child_count()
+
+	return info
+
+
+func _serialize(value):
+	match typeof(value):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return [value.x, value.y]
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return [value.x, value.y, value.z]
+		TYPE_RECT2, TYPE_RECT2I:
+			return {
+				"position": [value.position.x, value.position.y],
+				"size": [value.size.x, value.size.y],
+			}
+		TYPE_COLOR:
+			return [value.r, value.g, value.b, value.a]
+		TYPE_NODE_PATH:
+			return String(value)
+		TYPE_OBJECT:
+			if value == null:
+				return null
+			return "<%s>" % value.get_class()
+		TYPE_DICTIONARY:
+			var out := {}
+			for k in value.keys():
+				out[str(k)] = _serialize(value[k])
+			return out
+		TYPE_ARRAY:
+			var out_arr := []
+			for v in value:
+				out_arr.append(_serialize(v))
+			return out_arr
+		_:
+			return value
+
+
+# --- Script execution ---------------------------------------------------
+
+func execute_script(params: Dictionary) -> Dictionary:
+	# Parse a one-line GDScript expression and evaluate it against an optional
+	# target node. Useful for poking at game state from the bridge without
+	# adding a dedicated tool.
+	var code: String = params.get("code", "")
+	if code == "":
+		return {"status": "error", "message": "Missing 'code'"}
+	var node_path: String = params.get("node_path", "/root")
+
+	var target: Object = null
+	if host and host.get_tree():
+		# Absolute and relative paths both resolve via get_node_or_null.
+		target = host.get_node_or_null(NodePath(node_path))
+	if target == null:
+		return {"status": "error", "message": "Node not found: %s" % node_path}
+
+	var input_names: Array = params.get("input_names", [])
+	var input_values: Array = params.get("input_values", [])
+	var expression := Expression.new()
+	var parse_err := expression.parse(code, PackedStringArray(input_names))
+	if parse_err != OK:
+		return {"status": "error", "message": expression.get_error_text()}
+	var result = expression.execute(input_values, target, true)
+	if expression.has_execute_failed():
+		return {"status": "error", "message": "Execution failed: %s" % expression.get_error_text()}
+	return {"status": "ok", "result": _serialize(result)}
+
+
+# --- Frame / time waits --------------------------------------------------
+
+func wait_frames(params: Dictionary) -> Dictionary:
+	var frames: int = int(params.get("frames", 1))
+	if host == null or host.get_tree() == null:
+		return {"status": "error", "message": "No scene tree"}
+	for i in range(frames):
+		await host.get_tree().process_frame
+	return {"status": "ok", "frames_waited": frames}
+
+
+func wait_seconds(params: Dictionary) -> Dictionary:
+	var seconds: float = float(params.get("seconds", 1.0))
+	if host == null or host.get_tree() == null:
+		return {"status": "error", "message": "No scene tree"}
+	await host.get_tree().create_timer(seconds).timeout
+	return {"status": "ok", "seconds_waited": seconds}
+
+
+func get_log_path(_params: Dictionary) -> Dictionary:
+	# Convenience: returns the absolute logs dir so callers can tail the
+	# debug log alongside command results.
+	return {
+		"status": "ok",
+		"logs_dir": ProjectSettings.globalize_path("user://logs/"),
+		"screenshots_dir": ProjectSettings.globalize_path("user://test_screenshots/"),
+	}
+
+
+# --- Helpers --------------------------------------------------------------
+
+func _button_mask_for(button_index: int) -> int:
+	match button_index:
+		MOUSE_BUTTON_LEFT:
+			return MOUSE_BUTTON_MASK_LEFT
+		MOUSE_BUTTON_RIGHT:
+			return MOUSE_BUTTON_MASK_RIGHT
+		MOUSE_BUTTON_MIDDLE:
+			return MOUSE_BUTTON_MASK_MIDDLE
+		_:
+			return 0

--- a/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
@@ -1,0 +1,398 @@
+extends RefCounted
+
+# WH40K-specific MCP tools.
+#
+# These commands assume the game's autoloads are present:
+#   GameState, PhaseManager, TurnManager, RulesEngine, BoardState
+#
+# When an autoload is missing (e.g. the addon is enabled in another project)
+# the handlers respond with a structured error rather than crashing.
+
+var host: Node = null
+
+
+# --- Board / overall state --------------------------------------------
+
+func get_board_state(_params: Dictionary) -> Dictionary:
+	var gs := _autoload("GameState")
+	var pm := _autoload("PhaseManager")
+	var tm := _autoload("TurnManager")
+	if gs == null:
+		return {"status": "error", "message": "GameState autoload not found"}
+
+	var state: Dictionary = gs.state
+	var meta: Dictionary = state.get("meta", {})
+	var phase_name := _phase_name(meta.get("phase", -1))
+
+	var summary := {
+		"status": "ok",
+		"phase": phase_name,
+		"phase_id": meta.get("phase", -1),
+		"battle_round": meta.get("battle_round", 0),
+		"turn_number": meta.get("turn_number", 0),
+		"active_player": meta.get("active_player", 0),
+		"deployment_type": meta.get("deployment_type", ""),
+		"players": {},
+		"units": [],
+		"board_size": state.get("board", {}).get("size", {}),
+		"objectives": state.get("board", {}).get("objectives", []),
+	}
+
+	for pid in state.get("players", {}).keys():
+		var p: Dictionary = state["players"][pid]
+		summary["players"][str(pid)] = {
+			"cp": p.get("cp", 0),
+			"vp": p.get("vp", 0),
+			"primary_vp": p.get("primary_vp", 0),
+			"secondary_vp": p.get("secondary_vp", 0),
+		}
+
+	for uid in state.get("units", {}).keys():
+		var unit: Dictionary = state["units"][uid]
+		summary["units"].append(_unit_summary(uid, unit))
+
+	if pm and pm.has_method("get_available_actions"):
+		summary["available_actions"] = pm.get_available_actions()
+	if tm and tm.has_method("get_game_status"):
+		summary["game_status"] = tm.get_game_status()
+
+	return summary
+
+
+func get_unit_details(params: Dictionary) -> Dictionary:
+	var gs := _autoload("GameState")
+	if gs == null:
+		return {"status": "error", "message": "GameState autoload not found"}
+	var unit_id: String = params.get("unit_id", "")
+	if unit_id == "" and params.has("unit_name"):
+		unit_id = _resolve_unit_id(gs, params["unit_name"])
+	if unit_id == "":
+		return {"status": "error", "message": "Missing 'unit_id' or 'unit_name'"}
+	var unit: Dictionary = gs.get_unit(unit_id) if gs.has_method("get_unit") else gs.state["units"].get(unit_id, {})
+	if unit.is_empty():
+		return {"status": "error", "message": "Unit not found: %s" % unit_id}
+
+	var details := _unit_summary(unit_id, unit)
+	details["meta"] = unit.get("meta", {})
+	details["models"] = unit.get("models", [])
+	details["weapons"] = unit.get("weapons", [])
+	details["abilities"] = unit.get("abilities", [])
+	details["status_effects"] = unit.get("status_effects", [])
+	details["embarked_in"] = unit.get("embarked_in", null)
+	details["attached_to"] = unit.get("attached_to", null)
+	details["raw"] = unit
+	return {"status": "ok", "unit": details}
+
+
+func list_units(params: Dictionary) -> Dictionary:
+	var gs := _autoload("GameState")
+	if gs == null:
+		return {"status": "error", "message": "GameState autoload not found"}
+	var owner_filter = params.get("owner", null)
+	var include_destroyed: bool = params.get("include_destroyed", false)
+	var out := []
+	for uid in gs.state.get("units", {}).keys():
+		var unit: Dictionary = gs.state["units"][uid]
+		if owner_filter != null and int(unit.get("owner", 0)) != int(owner_filter):
+			continue
+		if not include_destroyed and gs.has_method("is_unit_destroyed") and gs.is_unit_destroyed(uid):
+			continue
+		out.append(_unit_summary(uid, unit))
+	return {"status": "ok", "units": out, "count": out.size()}
+
+
+# --- Phase control ----------------------------------------------------
+
+func get_current_phase(_params: Dictionary) -> Dictionary:
+	var gs := _autoload("GameState")
+	var pm := _autoload("PhaseManager")
+	if gs == null:
+		return {"status": "error", "message": "GameState autoload not found"}
+	var phase_id: int = gs.state.get("meta", {}).get("phase", -1)
+	var info := {
+		"status": "ok",
+		"phase_id": phase_id,
+		"phase": _phase_name(phase_id),
+		"active_player": gs.state.get("meta", {}).get("active_player", 0),
+		"turn_number": gs.state.get("meta", {}).get("turn_number", 0),
+		"battle_round": gs.state.get("meta", {}).get("battle_round", 0),
+	}
+	if pm and pm.has_method("get_available_actions"):
+		info["available_actions"] = pm.get_available_actions()
+	return info
+
+
+func advance_phase(_params: Dictionary) -> Dictionary:
+	var pm := _autoload("PhaseManager")
+	if pm == null:
+		return {"status": "error", "message": "PhaseManager autoload not found"}
+	if pm.has_method("advance_to_next_phase"):
+		pm.advance_to_next_phase()
+	else:
+		return {"status": "error", "message": "PhaseManager has no advance_to_next_phase()"}
+	return get_current_phase({})
+
+
+func transition_to_phase(params: Dictionary) -> Dictionary:
+	var pm := _autoload("PhaseManager")
+	var gs := _autoload("GameState")
+	if pm == null or gs == null:
+		return {"status": "error", "message": "PhaseManager or GameState not found"}
+	var phase_arg = params.get("phase", null)
+	if phase_arg == null:
+		return {"status": "error", "message": "Missing 'phase'"}
+	var phase_id := -1
+	if typeof(phase_arg) == TYPE_INT or typeof(phase_arg) == TYPE_FLOAT:
+		phase_id = int(phase_arg)
+	else:
+		phase_id = _phase_from_name(str(phase_arg))
+	if phase_id < 0:
+		return {"status": "error", "message": "Unknown phase: %s" % str(phase_arg)}
+	pm.transition_to_phase(phase_id)
+	return get_current_phase({})
+
+
+# --- Unit interaction --------------------------------------------------
+
+func select_unit(params: Dictionary) -> Dictionary:
+	# Find the unit's token in the running scene and click it. This routes
+	# through the actual UI rather than poking GameState directly, so any
+	# selection logic / signals fire normally.
+	var gs := _autoload("GameState")
+	if gs == null:
+		return {"status": "error", "message": "GameState autoload not found"}
+	var unit_id: String = params.get("unit_id", "")
+	if unit_id == "" and params.has("unit_name"):
+		unit_id = _resolve_unit_id(gs, params["unit_name"])
+	if unit_id == "":
+		return {"status": "error", "message": "Missing 'unit_id' or 'unit_name'"}
+
+	var token := _find_unit_token(unit_id)
+	if token == null:
+		return {
+			"status": "error",
+			"message": "No token found for unit %s. Token discovery looks for nodes named '%s' or with `unit_id` matching." % [unit_id, unit_id],
+		}
+
+	var screen_pos := _node2d_to_screen(token)
+	if screen_pos == Vector2.INF:
+		return {"status": "error", "message": "Could not project unit token to screen"}
+
+	# Synthesize a click via Input — same path a human takes.
+	var press := InputEventMouseButton.new()
+	press.button_index = MOUSE_BUTTON_LEFT
+	press.position = screen_pos
+	press.global_position = screen_pos
+	press.pressed = true
+	press.button_mask = MOUSE_BUTTON_MASK_LEFT
+	Input.parse_input_event(press)
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+	var release := InputEventMouseButton.new()
+	release.button_index = MOUSE_BUTTON_LEFT
+	release.position = screen_pos
+	release.global_position = screen_pos
+	release.pressed = false
+	Input.parse_input_event(release)
+	if host and host.get_tree():
+		await host.get_tree().process_frame
+
+	var unit: Dictionary = gs.get_unit(unit_id) if gs.has_method("get_unit") else gs.state["units"].get(unit_id, {})
+	return {
+		"status": "ok",
+		"unit_id": unit_id,
+		"screen_position": [screen_pos.x, screen_pos.y],
+		"unit": _unit_summary(unit_id, unit),
+	}
+
+
+# --- Action dispatch (movement / shooting / etc) ----------------------
+
+func dispatch_action(params: Dictionary) -> Dictionary:
+	# Sends a phase action through PhaseManager's current phase instance.
+	# This is the same path that the in-game UI uses for player actions, so
+	# any validation, state mutation, and UI refresh happens normally.
+	var pm := _autoload("PhaseManager")
+	if pm == null:
+		return {"status": "error", "message": "PhaseManager autoload not found"}
+	var current = pm.get_current_phase_instance() if pm.has_method("get_current_phase_instance") else null
+	if current == null:
+		return {"status": "error", "message": "No active phase instance"}
+	var action: Dictionary = params.get("action", {})
+	if typeof(action) != TYPE_DICTIONARY or action.is_empty():
+		return {"status": "error", "message": "Missing 'action' dict"}
+
+	# Many phases expose `validate_action` and `process_action` (see BasePhase).
+	# Fall back gracefully if the phase doesn't.
+	if current.has_method("validate_action"):
+		var validation = current.validate_action(action)
+		if typeof(validation) == TYPE_DICTIONARY and validation.get("valid", true) == false:
+			return {
+				"status": "error",
+				"message": "Phase rejected action: %s" % str(validation.get("errors", [])),
+				"validation": validation,
+			}
+	if current.has_method("process_action"):
+		var result = current.process_action(action)
+		return {"status": "ok", "result": _to_serializable(result)}
+	return {"status": "error", "message": "Active phase has no process_action()"}
+
+
+func move_unit_to(params: Dictionary) -> Dictionary:
+	# Convenience wrapper: build a STAGE_MODEL_MOVE / move action against
+	# MovementPhase. Phase action shape is project-specific; this dispatches
+	# whichever the project's MovementPhase expects via dispatch_action with
+	# fallback heuristics.
+	var unit_id: String = params.get("unit_id", "")
+	if unit_id == "":
+		return {"status": "error", "message": "Missing 'unit_id'"}
+	var dest_x = params.get("dest_x", null)
+	var dest_y = params.get("dest_y", null)
+	var model_id = params.get("model_id", null)
+	if dest_x == null or dest_y == null:
+		return {"status": "error", "message": "Missing 'dest_x' or 'dest_y'"}
+
+	# Hand off to dispatch_action with a movement-shaped payload. Projects
+	# using a different action shape can call dispatch_action directly.
+	var action := {
+		"type": "MOVE_UNIT",
+		"unit_id": unit_id,
+		"dest": [float(dest_x), float(dest_y)],
+	}
+	if model_id != null:
+		action["model_id"] = model_id
+	return dispatch_action({"action": action})
+
+
+# --- Helpers ----------------------------------------------------------
+
+func _autoload(name: String) -> Node:
+	if host == null or host.get_tree() == null:
+		return null
+	return host.get_tree().root.get_node_or_null(name)
+
+
+func _phase_name(phase_id) -> String:
+	# Mirrors GameStateData.Phase enum order.
+	var names := [
+		"FORMATIONS", "DEPLOYMENT", "REDEPLOYMENT", "ROLL_OFF",
+		"SCOUT", "SCOUT_MOVES", "COMMAND", "MOVEMENT", "SHOOTING",
+		"CHARGE", "FIGHT", "SCORING", "MORALE",
+	]
+	var i := int(phase_id)
+	if i < 0 or i >= names.size():
+		return "UNKNOWN(%d)" % i
+	return names[i]
+
+
+func _phase_from_name(name: String) -> int:
+	var upper := name.to_upper()
+	var names := [
+		"FORMATIONS", "DEPLOYMENT", "REDEPLOYMENT", "ROLL_OFF",
+		"SCOUT", "SCOUT_MOVES", "COMMAND", "MOVEMENT", "SHOOTING",
+		"CHARGE", "FIGHT", "SCORING", "MORALE",
+	]
+	return names.find(upper)
+
+
+func _unit_summary(uid: String, unit: Dictionary) -> Dictionary:
+	var meta: Dictionary = unit.get("meta", {})
+	var models: Array = unit.get("models", [])
+	var alive_models := 0
+	var total_wounds := 0
+	var current_wounds := 0
+	for m in models:
+		if m.get("alive", true):
+			alive_models += 1
+		total_wounds += int(m.get("wounds", 0))
+		current_wounds += int(m.get("current_wounds", m.get("wounds", 0)))
+	return {
+		"id": uid,
+		"name": meta.get("display_name", meta.get("name", uid)),
+		"owner": unit.get("owner", 0),
+		"status": unit.get("status", -1),
+		"flags": unit.get("flags", {}),
+		"models_total": models.size(),
+		"models_alive": alive_models,
+		"wounds_total": total_wounds,
+		"wounds_current": current_wounds,
+	}
+
+
+func _resolve_unit_id(gs: Node, target) -> String:
+	# Accept either an exact id match or a case-insensitive display name match.
+	var query := str(target)
+	if gs.state["units"].has(query):
+		return query
+	var lower := query.to_lower()
+	for uid in gs.state["units"].keys():
+		var unit: Dictionary = gs.state["units"][uid]
+		var name: String = unit.get("meta", {}).get("display_name", unit.get("meta", {}).get("name", uid))
+		if str(name).to_lower() == lower:
+			return uid
+	return ""
+
+
+func _find_unit_token(unit_id: String) -> Node2D:
+	if host == null or host.get_tree() == null:
+		return null
+	var tree := host.get_tree()
+	var roots := [tree.current_scene, tree.root]
+	for r in roots:
+		if r == null:
+			continue
+		var found := _search_node_by_unit_id(r, unit_id)
+		if found:
+			return found
+	return null
+
+
+func _search_node_by_unit_id(node: Node, unit_id: String) -> Node2D:
+	if node is Node2D:
+		# Match by exact name first (TokenLayer children are commonly named after unit_id).
+		if node.name == unit_id:
+			return node
+		# Match by `unit_id` script property if present.
+		if "unit_id" in node and str(node.get("unit_id")) == unit_id:
+			return node
+		if node.has_meta("unit_id") and str(node.get_meta("unit_id")) == unit_id:
+			return node
+	for child in node.get_children():
+		var found := _search_node_by_unit_id(child, unit_id)
+		if found:
+			return found
+	return null
+
+
+func _node2d_to_screen(node: Node2D) -> Vector2:
+	# Convert a Node2D's global position into the viewport's screen-space
+	# coordinates (post-camera-transform).
+	var viewport := node.get_viewport()
+	if viewport == null:
+		return Vector2.INF
+	var canvas_xform := viewport.get_canvas_transform()
+	return canvas_xform * node.global_position
+
+
+func _to_serializable(value):
+	match typeof(value):
+		TYPE_VECTOR2, TYPE_VECTOR2I:
+			return [value.x, value.y]
+		TYPE_VECTOR3, TYPE_VECTOR3I:
+			return [value.x, value.y, value.z]
+		TYPE_DICTIONARY:
+			var out := {}
+			for k in value.keys():
+				out[str(k)] = _to_serializable(value[k])
+			return out
+		TYPE_ARRAY:
+			var out_arr := []
+			for v in value:
+				out_arr.append(_to_serializable(v))
+			return out_arr
+		TYPE_OBJECT:
+			if value == null:
+				return null
+			return "<%s>" % value.get_class()
+		_:
+			return value

--- a/40k/addons/godot_mcp/mcp_server.gd
+++ b/40k/addons/godot_mcp/mcp_server.gd
@@ -1,0 +1,176 @@
+extends Node
+
+# Runtime autoload. Starts a TCP server on a configurable port and dispatches
+# incoming JSON-RPC-style commands to the command router. Each line on the
+# socket is a single JSON message terminated by '\n'. Responses are also one
+# JSON object per line.
+#
+# This autoload is registered by the editor plugin in addons/godot_mcp/plugin.gd.
+# It does nothing if disabled via the GODOT_MCP_DISABLED env var.
+#
+# The server is intentionally line-delimited JSON (NDJSON) over TCP rather than
+# WebSocket. WebSocket framing adds complexity for no benefit on localhost where
+# the only client is a trusted MCP bridge process. The bridge translates between
+# stdio MCP protocol and this NDJSON socket.
+
+const CommandRouter := preload("res://addons/godot_mcp/command_router.gd")
+
+const DEFAULT_PORT := 9080
+const RECV_BUF_LIMIT := 8 * 1024 * 1024  # 8 MB safety cap on per-connection buffer
+
+var _server: TCPServer = null
+var _port: int = DEFAULT_PORT
+var _connections: Array = []  # Array of { peer: StreamPeerTCP, buffer: PackedByteArray }
+var _router: RefCounted = null
+var _enabled := true
+
+
+func _ready() -> void:
+	if OS.has_feature("editor") == false and OS.get_environment("GODOT_MCP_DISABLED") == "1":
+		_enabled = false
+		print("[GodotMCP] Disabled via GODOT_MCP_DISABLED=1")
+		return
+
+	# Allow the port to be overridden via env or project setting for CI.
+	var env_port := OS.get_environment("GODOT_MCP_PORT")
+	if env_port != "":
+		var parsed := int(env_port)
+		if parsed > 0:
+			_port = parsed
+
+	_router = CommandRouter.new()
+	_router.host = self
+	_start_server()
+	set_process(true)
+
+
+func _exit_tree() -> void:
+	_stop_server()
+
+
+func _start_server() -> void:
+	_server = TCPServer.new()
+	var err := _server.listen(_port, "127.0.0.1")
+	if err != OK:
+		push_warning("[GodotMCP] Failed to listen on port %d: %s" % [_port, error_string(err)])
+		_server = null
+		return
+	print("[GodotMCP] Listening on 127.0.0.1:%d" % _port)
+
+
+func _stop_server() -> void:
+	if _server:
+		_server.stop()
+		_server = null
+	for conn in _connections:
+		var peer: StreamPeerTCP = conn.peer
+		if peer:
+			peer.disconnect_from_host()
+	_connections.clear()
+
+
+func _process(_delta: float) -> void:
+	if _server == null:
+		return
+
+	# Accept new connections.
+	while _server.is_connection_available():
+		var peer := _server.take_connection()
+		if peer:
+			peer.set_no_delay(true)
+			_connections.append({"peer": peer, "buffer": PackedByteArray()})
+			print("[GodotMCP] Client connected from %s" % str(peer.get_connected_host()))
+
+	# Service existing connections.
+	for i in range(_connections.size() - 1, -1, -1):
+		var conn = _connections[i]
+		var peer: StreamPeerTCP = conn.peer
+		peer.poll()
+		var status := peer.get_status()
+		if status != StreamPeerTCP.STATUS_CONNECTED:
+			print("[GodotMCP] Client disconnected (status=%d)" % status)
+			_connections.remove_at(i)
+			continue
+
+		# Drain available bytes into the per-connection buffer.
+		# PackedByteArray inside a Dictionary is copy-on-write, so we extract
+		# the buffer, mutate it locally, then re-assign.
+		var available := peer.get_available_bytes()
+		if available > 0:
+			var chunk := peer.get_data(available)
+			if chunk[0] == OK:
+				var buf: PackedByteArray = conn.buffer
+				buf.append_array(chunk[1])
+				conn.buffer = buf
+				if buf.size() > RECV_BUF_LIMIT:
+					_send_error(peer, null, "Buffer overflow; closing connection")
+					peer.disconnect_from_host()
+					_connections.remove_at(i)
+					continue
+
+		# Process any complete (newline-terminated) messages in buffer.
+		_process_buffer(conn)
+
+
+func _process_buffer(conn: Dictionary) -> void:
+	var buffer: PackedByteArray = conn.buffer
+	while true:
+		var newline := buffer.find(0x0A)  # \n
+		if newline == -1:
+			break
+		var line := buffer.slice(0, newline)
+		buffer = buffer.slice(newline + 1)
+		conn.buffer = buffer
+		var text := line.get_string_from_utf8()
+		text = text.strip_edges()
+		if text == "":
+			continue
+		_handle_message(conn.peer, text)
+
+
+func _handle_message(peer: StreamPeerTCP, text: String) -> void:
+	var parsed = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_send_error(peer, null, "Invalid JSON or not an object")
+		return
+	var msg: Dictionary = parsed
+	var msg_id = msg.get("id", null)
+	var command = msg.get("command", "")
+	var params = msg.get("params", {})
+	if typeof(params) != TYPE_DICTIONARY:
+		_send_error(peer, msg_id, "params must be an object")
+		return
+	if typeof(command) != TYPE_STRING or command == "":
+		_send_error(peer, msg_id, "command must be a non-empty string")
+		return
+	# Route asynchronously so handlers can `await`.
+	_dispatch_async(peer, msg_id, command, params)
+
+
+func _dispatch_async(peer: StreamPeerTCP, msg_id, command: String, params: Dictionary) -> void:
+	var result = await _router.dispatch(command, params)
+	if typeof(result) != TYPE_DICTIONARY:
+		result = {"status": "ok", "value": result}
+	var envelope := {
+		"id": msg_id,
+		"command": command,
+		"result": result,
+	}
+	_send_json(peer, envelope)
+
+
+func _send_json(peer: StreamPeerTCP, obj: Dictionary) -> void:
+	if peer == null:
+		return
+	if peer.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+		return
+	var text := JSON.stringify(obj) + "\n"
+	var bytes := text.to_utf8_buffer()
+	peer.put_data(bytes)
+
+
+func _send_error(peer: StreamPeerTCP, msg_id, message: String) -> void:
+	_send_json(peer, {
+		"id": msg_id,
+		"result": {"status": "error", "message": message},
+	})

--- a/40k/addons/godot_mcp/plugin.cfg
+++ b/40k/addons/godot_mcp/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot MCP"
+description="MCP server for in-game testing and automation. Exposes screenshot, input simulation, scene state, script execution, and WH40K-specific tools to AI agents over a WebSocket."
+author="Warhammer 40k project"
+version="0.1.0"
+script="plugin.gd"

--- a/40k/addons/godot_mcp/plugin.gd
+++ b/40k/addons/godot_mcp/plugin.gd
@@ -1,0 +1,37 @@
+@tool
+extends EditorPlugin
+
+# Godot MCP editor plugin entry point.
+#
+# Two pieces:
+#   1. The runtime autoload `MCPServer` (declared directly in project.godot)
+#      starts a TCP server on port 9080 inside the running game. It exposes
+#      screenshot, input simulation, scene state, and WH40K commands.
+#   2. This editor plugin starts a small editor-side bridge on port 9081 that
+#      handles commands needing `EditorInterface` — play_scene, stop_scene,
+#      list_scenes, etc.
+#
+# Keeping the runtime autoload in `project.godot` (rather than registering it
+# here via `add_autoload_singleton`) lets the runtime server work even when
+# this editor plugin is disabled, and avoids double-registration during a
+# plugin enable/disable cycle.
+
+var _editor_bridge: Node = null
+
+
+func _enter_tree() -> void:
+	if Engine.is_editor_hint():
+		var EditorBridgeScript := load("res://addons/godot_mcp/editor_bridge.gd")
+		if EditorBridgeScript:
+			_editor_bridge = EditorBridgeScript.new()
+			_editor_bridge.editor_plugin = self
+			add_child(_editor_bridge)
+			_editor_bridge.start()
+			print("[GodotMCP] Editor bridge started")
+
+
+func _exit_tree() -> void:
+	if _editor_bridge:
+		_editor_bridge.stop()
+		_editor_bridge.queue_free()
+		_editor_bridge = null

--- a/40k/project.godot
+++ b/40k/project.godot
@@ -60,6 +60,7 @@ UnitAbilityManager="*res://autoloads/UnitAbilityManager.gd"
 DiceHistoryPanel="*res://autoloads/DiceHistoryPanel.gd"
 DiceSoundManager="*res://autoloads/DiceSoundManager.gd"
 KeybindingManager="*res://autoloads/KeybindingManager.gd"
+MCPServer="*res://addons/godot_mcp/mcp_server.gd"
 
 [display]
 
@@ -75,7 +76,7 @@ theme/custom_font="res://fonts/Rajdhani-SemiBold.ttf"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/gut/plugin.cfg")
+enabled=PackedStringArray("res://addons/godot_mcp/plugin.cfg", "res://addons/gut/plugin.cfg")
 
 [global_script_class_icons]
 

--- a/godot-mcp/package-lock.json
+++ b/godot-mcp/package-lock.json
@@ -14,7 +14,8 @@
         "fs-extra": "^11.2.0"
       },
       "bin": {
-        "godot-mcp": "build/index.js"
+        "godot-mcp": "build/index.js",
+        "godot-mcp-bridge": "build/runtime_bridge.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",

--- a/godot-mcp/package.json
+++ b/godot-mcp/package.json
@@ -4,7 +4,8 @@
   "description": "MCP server for interfacing with Godot game engine. Provides tools for launching the editor, running projects, and capturing debug output.",
   "type": "module",
   "bin": {
-    "godot-mcp": "./build/index.js"
+    "godot-mcp": "./build/index.js",
+    "godot-mcp-bridge": "./build/runtime_bridge.js"
   },
   "files": [
     "build"

--- a/godot-mcp/scripts/build.js
+++ b/godot-mcp/scripts/build.js
@@ -9,6 +9,13 @@ const __dirname = path.dirname(__filename);
 // Make the build/index.js file executable
 fs.chmodSync(path.join(__dirname, '..', 'build', 'index.js'), '755');
 
+// Make the runtime bridge executable too (the WebSocket-style bridge that
+// talks to the Godot addon at 40k/addons/godot_mcp/).
+const bridgePath = path.join(__dirname, '..', 'build', 'runtime_bridge.js');
+if (fs.existsSync(bridgePath)) {
+  fs.chmodSync(bridgePath, '755');
+}
+
 // Copy the scripts directory to the build directory
 try {
   // Ensure the build/scripts directory exists

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -251,13 +251,18 @@ const TOOLS: ToolDef[] = [
   {
     name: 'capture_screenshot',
     description:
-      'Capture the running viewport as PNG. Returns base64 data plus a path under user://test_screenshots/.',
+      'Capture the running viewport as PNG. Returns the image inline (vision-capable hosts see it as a real image) plus a saved path under user://test_screenshots/. Inline copy is downscaled to `max_dim` on the long side; the on-disk file stays at full resolution.',
     inputSchema: {
       type: 'object',
       properties: {
         label: { type: 'string' },
         include_base64: { type: 'boolean', default: true },
         include_path: { type: 'boolean', default: true },
+        max_dim: {
+          type: 'number',
+          description: 'Long-side cap for the inline image (default 1280). Pass 0 to disable scaling.',
+          default: 1280,
+        },
       },
     },
   },
@@ -511,12 +516,29 @@ server.setRequestHandler(CallToolRequestSchema, async req => {
     const msg = err instanceof Error ? err.message : String(err);
     throw new McpError(ErrorCode.InternalError, `Godot bridge error: ${msg}`);
   }
-  // Surface Godot-side errors as MCP tool content rather than rejecting; the
-  // host can decide what to do with them.
+
+  // If Godot returned an image (e.g. capture_screenshot), surface it as a
+  // real MCP image content block so vision-capable hosts can actually see
+  // it. Strip the base64 from the text JSON to avoid duplicating ~MB of
+  // payload as text tokens.
+  const content: Array<{ type: string; [k: string]: unknown }> = [];
+  if (
+    result &&
+    typeof result === 'object' &&
+    typeof (result as any).image_base64 === 'string' &&
+    (result as any).image_base64.length > 0
+  ) {
+    const imageData = (result as any).image_base64 as string;
+    const mimeType = (result as any).image_mime_type ?? 'image/png';
+    const { image_base64: _omit, ...metadata } = result as Record<string, unknown>;
+    content.push({ type: 'text', text: JSON.stringify(metadata, null, 2) });
+    content.push({ type: 'image', data: imageData, mimeType });
+  } else {
+    content.push({ type: 'text', text: JSON.stringify(result, null, 2) });
+  }
+
   return {
-    content: [
-      { type: 'text', text: JSON.stringify(result, null, 2) },
-    ],
+    content,
     isError: result?.status === 'error',
   };
 });

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -1,0 +1,535 @@
+#!/usr/bin/env node
+/**
+ * Godot MCP Runtime Bridge
+ *
+ * Translates MCP stdio JSON-RPC calls from a host (Claude Code/Desktop) into
+ * NDJSON requests over a localhost TCP socket exposed by the Godot addon at
+ * 40k/addons/godot_mcp/. The addon listens on two ports:
+ *
+ *   - 9080 — runtime autoload, available while the game is playing
+ *   - 9081 — editor bridge, available while the Godot editor is open
+ *
+ * This bridge auto-routes commands to whichever port is appropriate based on
+ * a small allow-list of editor-only commands. Everything else goes to 9080.
+ *
+ * Why a separate file: the existing index.ts is the Coding-Solo godot-mcp
+ * variant which spawns the godot CLI per command. This file is the live
+ * companion that talks to a running Godot instance instead, matching the
+ * Part 2 / Part 3 testing tools described in CLAUDE.md.
+ */
+
+import net from 'node:net';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const RUNTIME_HOST = process.env.GODOT_MCP_HOST ?? '127.0.0.1';
+const RUNTIME_PORT = Number(process.env.GODOT_MCP_PORT ?? '9080');
+const EDITOR_PORT = Number(process.env.GODOT_MCP_EDITOR_PORT ?? '9081');
+const REQUEST_TIMEOUT_MS = Number(process.env.GODOT_MCP_TIMEOUT_MS ?? '30000');
+
+const EDITOR_ONLY_COMMANDS = new Set([
+  'play_scene',
+  'play_main_scene',
+  'stop_scene',
+  'get_edited_scene',
+  'list_scenes',
+  'reload_scripts',
+]);
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+  timer: NodeJS.Timeout;
+}
+
+class GodotConnection {
+  private socket: net.Socket | null = null;
+  private buffer = '';
+  private nextId = 1;
+  private pending = new Map<number, PendingRequest>();
+  private connecting: Promise<void> | null = null;
+
+  constructor(private readonly host: string, private readonly port: number) {}
+
+  private async ensureConnected(): Promise<void> {
+    if (this.socket && !this.socket.destroyed) return;
+    if (this.connecting) return this.connecting;
+
+    this.connecting = new Promise((resolve, reject) => {
+      const sock = new net.Socket();
+      sock.setNoDelay(true);
+      sock.once('error', err => {
+        this.connecting = null;
+        reject(err);
+      });
+      sock.once('connect', () => {
+        this.socket = sock;
+        sock.on('data', chunk => this.onData(chunk.toString('utf8')));
+        sock.on('close', () => this.onClose());
+        sock.on('error', err => this.onError(err));
+        this.connecting = null;
+        resolve();
+      });
+      sock.connect(this.port, this.host);
+    });
+
+    return this.connecting;
+  }
+
+  private onData(text: string): void {
+    this.buffer += text;
+    let nl: number;
+    while ((nl = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, nl);
+      this.buffer = this.buffer.slice(nl + 1);
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: any;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const id = parsed?.id;
+      if (typeof id !== 'number') continue;
+      const pend = this.pending.get(id);
+      if (!pend) continue;
+      this.pending.delete(id);
+      clearTimeout(pend.timer);
+      pend.resolve(parsed.result ?? {});
+    }
+  }
+
+  private onClose(): void {
+    this.socket = null;
+    for (const [, pend] of this.pending) {
+      clearTimeout(pend.timer);
+      pend.reject(new Error('Godot socket closed before response'));
+    }
+    this.pending.clear();
+  }
+
+  private onError(err: Error): void {
+    process.stderr.write(`[godot-mcp-bridge] socket error: ${err.message}\n`);
+  }
+
+  async send(command: string, params: Record<string, unknown>): Promise<unknown> {
+    await this.ensureConnected();
+    if (!this.socket) throw new Error('Not connected to Godot');
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, command, params }) + '\n';
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Godot command '${command}' timed out after ${REQUEST_TIMEOUT_MS}ms`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      this.socket!.write(payload, err => {
+        if (err) {
+          clearTimeout(timer);
+          this.pending.delete(id);
+          reject(err);
+        }
+      });
+    });
+  }
+}
+
+const runtime = new GodotConnection(RUNTIME_HOST, RUNTIME_PORT);
+const editor = new GodotConnection(RUNTIME_HOST, EDITOR_PORT);
+
+function pickConnection(command: string): GodotConnection {
+  return EDITOR_ONLY_COMMANDS.has(command) ? editor : runtime;
+}
+
+interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: { type: 'object'; properties: Record<string, any>; required?: string[] };
+}
+
+const TOOLS: ToolDef[] = [
+  {
+    name: 'ping',
+    description: 'Verify the Godot MCP runtime is reachable.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'list_tools',
+    description: 'List every command name registered in the Godot router.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_project_info',
+    description: 'Return project name, main scene, engine version, and viewport size.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_current_scene',
+    description: 'Return the path/name/type of the currently-running scene root.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_scene_state',
+    description:
+      'Dump the running scene tree with positions, visibility, and script-defined properties. Pass `max_depth` to limit recursion.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        max_depth: { type: 'number', default: 10 },
+        include_script_properties: { type: 'boolean', default: true },
+        include_invisible: { type: 'boolean', default: true },
+        root: { type: 'string' },
+      },
+    },
+  },
+  {
+    name: 'get_node_info',
+    description: 'Return type, position, size, visibility, and direct children of a single node.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'get_node_property',
+    description: 'Read a single property of a node by path.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' }, property: { type: 'string' } },
+      required: ['path', 'property'],
+    },
+  },
+  {
+    name: 'set_node_property',
+    description: 'Set a single property on a node by path.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        property: { type: 'string' },
+        value: {},
+      },
+      required: ['path', 'property', 'value'],
+    },
+  },
+  {
+    name: 'call_node_method',
+    description: 'Call a method on a node by path with optional positional args.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string' },
+        method: { type: 'string' },
+        args: { type: 'array', items: {} },
+      },
+      required: ['path', 'method'],
+    },
+  },
+  {
+    name: 'execute_script',
+    description:
+      'Parse and evaluate a one-line GDScript expression against an optional target node. The expression sees the node as `self`.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        code: { type: 'string' },
+        node_path: { type: 'string', default: '/root' },
+        input_names: { type: 'array', items: { type: 'string' } },
+        input_values: { type: 'array' },
+      },
+      required: ['code'],
+    },
+  },
+  {
+    name: 'capture_screenshot',
+    description:
+      'Capture the running viewport as PNG. Returns base64 data plus a path under user://test_screenshots/.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: { type: 'string' },
+        include_base64: { type: 'boolean', default: true },
+        include_path: { type: 'boolean', default: true },
+      },
+    },
+  },
+  {
+    name: 'simulate_click',
+    description: 'Simulate a mouse click at a screen coordinate.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        x: { type: 'number' },
+        y: { type: 'number' },
+        button: { type: 'number', description: 'MouseButton constant; default left.' },
+        double_click: { type: 'boolean', default: false },
+      },
+      required: ['x', 'y'],
+    },
+  },
+  {
+    name: 'simulate_mouse_move',
+    description: 'Move the mouse cursor without clicking.',
+    inputSchema: {
+      type: 'object',
+      properties: { x: { type: 'number' }, y: { type: 'number' } },
+      required: ['x', 'y'],
+    },
+  },
+  {
+    name: 'simulate_drag',
+    description: 'Press at (from_x, from_y), drag through `steps` waypoints, release at (to_x, to_y).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        from_x: { type: 'number' },
+        from_y: { type: 'number' },
+        to_x: { type: 'number' },
+        to_y: { type: 'number' },
+        steps: { type: 'number', default: 10 },
+        button: { type: 'number' },
+      },
+      required: ['from_x', 'from_y', 'to_x', 'to_y'],
+    },
+  },
+  {
+    name: 'simulate_key_press',
+    description: 'Press a keyboard key (Godot keycode int) for a duration.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        keycode: { type: 'number' },
+        duration: { type: 'number', default: 0.05 },
+      },
+      required: ['keycode'],
+    },
+  },
+  {
+    name: 'simulate_action',
+    description: 'Trigger a named InputMap action for a duration.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        action: { type: 'string' },
+        duration: { type: 'number', default: 0.1 },
+      },
+      required: ['action'],
+    },
+  },
+  {
+    name: 'wait_frames',
+    description: 'Yield until N process_frame ticks have elapsed.',
+    inputSchema: {
+      type: 'object',
+      properties: { frames: { type: 'number', default: 1 } },
+    },
+  },
+  {
+    name: 'wait_seconds',
+    description: 'Yield for the given number of seconds (real-time).',
+    inputSchema: {
+      type: 'object',
+      properties: { seconds: { type: 'number', default: 1.0 } },
+    },
+  },
+  {
+    name: 'list_files',
+    description: 'List files inside a res:// directory, optional glob pattern, optional recursive.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', default: 'res://' },
+        pattern: { type: 'string' },
+        recursive: { type: 'boolean', default: false },
+      },
+    },
+  },
+  {
+    name: 'read_script',
+    description: 'Read a script or text file by res:// or absolute path.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+      required: ['path'],
+    },
+  },
+  {
+    name: 'write_script',
+    description: 'Write text to a res:// path. Refuses paths outside res://.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string' }, content: { type: 'string' } },
+      required: ['path', 'content'],
+    },
+  },
+  {
+    name: 'get_log_path',
+    description: 'Return absolute paths for the user logs and screenshots directories.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- Editor-only ---
+  {
+    name: 'play_scene',
+    description:
+      "Editor: play a specific scene file (or main scene if `path` is omitted). Requires the Godot editor to be open with the project loaded.",
+    inputSchema: { type: 'object', properties: { path: { type: 'string' } } },
+  },
+  {
+    name: 'play_main_scene',
+    description: 'Editor: play the project main scene.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'stop_scene',
+    description: 'Editor: stop a running playtest.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_edited_scene',
+    description: 'Editor: return the currently-edited scene root.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'list_scenes',
+    description: 'Editor: list all .tscn / .scn files under a directory.',
+    inputSchema: {
+      type: 'object',
+      properties: { path: { type: 'string', default: 'res://scenes' } },
+    },
+  },
+  {
+    name: 'reload_scripts',
+    description: 'Editor: rescan the project filesystem to pick up new/changed files.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+
+  // --- WH40K ---
+  {
+    name: 'get_board_state',
+    description:
+      'WH40K: return the full board state — phase, active player, players (CP/VP), units (id, owner, models alive, wounds), available actions.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'list_units',
+    description: 'WH40K: list units, optionally filtered by owner or including destroyed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        owner: { type: 'number' },
+        include_destroyed: { type: 'boolean', default: false },
+      },
+    },
+  },
+  {
+    name: 'get_unit_details',
+    description:
+      "WH40K: return a unit's full details — meta, models, weapons, abilities, status flags, attached/embarked.",
+    inputSchema: {
+      type: 'object',
+      properties: { unit_id: { type: 'string' }, unit_name: { type: 'string' } },
+    },
+  },
+  {
+    name: 'get_current_phase',
+    description: 'WH40K: return current phase id, name, active player, and available actions.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'advance_phase',
+    description: 'WH40K: advance to the next phase via PhaseManager.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'transition_to_phase',
+    description: 'WH40K: jump directly to a phase by enum id or name (e.g. "MOVEMENT").',
+    inputSchema: {
+      type: 'object',
+      properties: { phase: { description: 'Enum int or name string' } },
+      required: ['phase'],
+    },
+  },
+  {
+    name: 'select_unit',
+    description:
+      'WH40K: locate a unit token in the running scene and synthesize a left-click on it (UI selection path).',
+    inputSchema: {
+      type: 'object',
+      properties: { unit_id: { type: 'string' }, unit_name: { type: 'string' } },
+    },
+  },
+  {
+    name: 'dispatch_action',
+    description:
+      'WH40K: send a phase action dictionary through the active phase instance (validate_action + process_action).',
+    inputSchema: {
+      type: 'object',
+      properties: { action: { type: 'object' } },
+      required: ['action'],
+    },
+  },
+  {
+    name: 'move_unit_to',
+    description:
+      "WH40K: convenience wrapper that builds a MOVE_UNIT action and dispatches it. The active phase must accept this action shape.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        unit_id: { type: 'string' },
+        dest_x: { type: 'number' },
+        dest_y: { type: 'number' },
+        model_id: { type: 'string' },
+      },
+      required: ['unit_id', 'dest_x', 'dest_y'],
+    },
+  },
+];
+
+const server = new Server(
+  { name: 'godot-mcp-runtime-bridge', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async req => {
+  const { name, arguments: args } = req.params;
+  const conn = pickConnection(name);
+  let result: any;
+  try {
+    result = await conn.send(name, args ?? {});
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new McpError(ErrorCode.InternalError, `Godot bridge error: ${msg}`);
+  }
+  // Surface Godot-side errors as MCP tool content rather than rejecting; the
+  // host can decide what to do with them.
+  return {
+    content: [
+      { type: 'text', text: JSON.stringify(result, null, 2) },
+    ],
+    isError: result?.status === 'error',
+  };
+});
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  process.stderr.write(
+    `[godot-mcp-bridge] ready (runtime=${RUNTIME_HOST}:${RUNTIME_PORT}, editor=${RUNTIME_HOST}:${EDITOR_PORT})\n`,
+  );
+}
+
+main().catch(err => {
+  process.stderr.write(`[godot-mcp-bridge] fatal: ${String(err)}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a complete MCP (Model Context Protocol) server implementation for the Godot game engine, enabling AI assistants to interact with running game instances in real-time. This includes a Node.js bridge that translates MCP stdio protocol to TCP/NDJSON, Godot addon components for runtime and editor integration, and domain-specific handlers for game testing and WH40K mechanics.

## Key Changes

- **Node.js Runtime Bridge** (`godot-mcp/src/runtime_bridge.ts`): New 535-line MCP server that translates stdio JSON-RPC calls from Claude/MCP hosts into NDJSON requests over localhost TCP sockets. Auto-routes commands between runtime (port 9080) and editor (port 9081) ports based on command type.

- **Godot Addon Structure**:
  - `mcp_server.gd`: Runtime autoload that listens on port 9080 inside the running game, dispatches commands via a router, and manages TCP connections with NDJSON protocol.
  - `editor_bridge.gd`: Editor-only bridge on port 9081 handling commands requiring `EditorInterface` (play_scene, stop_scene, list_scenes, reload_scripts).
  - `command_router.gd`: Routes command names to appropriate handler objects with explicit method registration.

- **Handler Modules**:
  - `core_handlers.gd`: Generic Godot tools (project info, scene tree inspection, node properties, script I/O).
  - `testing_handlers.gd`: In-game testing utilities (screenshot capture, input simulation, scene state inspection, script execution, wait primitives).
  - `wh40k_handlers.gd`: Domain-specific WH40K commands (board state, unit details, phase management, action dispatch, unit selection).

- **Plugin Integration** (`plugin.gd`, `plugin.cfg`): Editor plugin that starts the editor bridge and manages lifecycle.

- **Build Configuration**: Updated `godot-mcp/scripts/build.js` to make the runtime bridge executable, and updated `package.json` to include the new bridge binary.

- **Project Setup**: Registered `MCPServer` autoload in `40k/project.godot`.

## Notable Implementation Details

- Wire protocol uses line-delimited JSON (NDJSON) over TCP rather than WebSocket for simplicity on localhost with a trusted client.
- Graceful degradation: handlers check for autoload existence and return structured errors rather than crashing if dependencies are missing.
- Connection pooling with per-connection buffers and overflow protection (8 MB limit).
- Request timeout handling (30s default, configurable via `GODOT_MCP_TIMEOUT_MS`).
- Comprehensive tool definitions with input schemas for MCP introspection.
- Support for async operations (screenshots, input simulation) via `await` in handler methods.

https://claude.ai/code/session_01Xu94PD6WwuLnD1ytA52VQe