### PR TITLE
Clarify tool usage with testing-vs-gameplay labels and add get_legal_actions

### DIFF
--- a/40k/addons/godot_mcp/command_router.gd
+++ b/40k/addons/godot_mcp/command_router.gd
@@ -53,7 +53,8 @@ func _register_routes() -> void:
 
 	var wh40k_methods := [
 		"get_board_state", "get_unit_details", "list_units",
-		"get_current_phase", "advance_phase", "transition_to_phase",
+		"get_current_phase", "get_legal_actions",
+		"advance_phase", "transition_to_phase",
 		"select_unit", "dispatch_action", "move_unit_to",
 	]
 	for m in wh40k_methods:

--- a/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
@@ -122,6 +122,30 @@ func get_current_phase(_params: Dictionary) -> Dictionary:
 	return info
 
 
+func get_legal_actions(_params: Dictionary) -> Dictionary:
+	# Return the list of contextually-valid actions the active player can take
+	# right now. Each phase implements get_available_actions() returning rich
+	# dicts (type, unit_id, description, etc.) — exactly the shapes that
+	# dispatch_action expects. This lets the agent enumerate legal moves
+	# instead of guessing action shapes and getting validation rejections.
+	var pm := _autoload("PhaseManager")
+	var gs := _autoload("GameState")
+	if pm == null or gs == null:
+		return {"status": "error", "message": "PhaseManager or GameState not found"}
+	var phase_id: int = gs.state.get("meta", {}).get("phase", -1)
+	var actions: Array = []
+	if pm.has_method("get_available_actions"):
+		actions = pm.get_available_actions()
+	return {
+		"status": "ok",
+		"phase": _phase_name(phase_id),
+		"phase_id": phase_id,
+		"active_player": gs.state.get("meta", {}).get("active_player", 0),
+		"count": actions.size(),
+		"actions": _to_serializable(actions),
+	}
+
+
 func advance_phase(_params: Dictionary) -> Dictionary:
 	var pm := _autoload("PhaseManager")
 	if pm == null:

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -268,7 +268,8 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'simulate_click',
-    description: 'Simulate a mouse click at a screen coordinate.',
+    description:
+      'TESTING ONLY — do NOT use to play the game. Synthesizes an OS-level mouse click at a screen coordinate. Reserved for explicit UI/input regression tests where you must verify that the actual click handlers fire (drag-ghost, button states, _gui_input chains). For normal gameplay use `dispatch_action` instead — it is faster, deterministic, and skips pixel-hunting.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -282,7 +283,8 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'simulate_mouse_move',
-    description: 'Move the mouse cursor without clicking.',
+    description:
+      'TESTING ONLY — do NOT use to play the game. Moves the mouse cursor without clicking. Reserved for hover-state UI tests. For gameplay use `dispatch_action`.',
     inputSchema: {
       type: 'object',
       properties: { x: { type: 'number' }, y: { type: 'number' } },
@@ -291,7 +293,8 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'simulate_drag',
-    description: 'Press at (from_x, from_y), drag through `steps` waypoints, release at (to_x, to_y).',
+    description:
+      'TESTING ONLY — do NOT use to play the game. Press at (from_x, from_y), drag through `steps` waypoints, release at (to_x, to_y). Reserved for verifying drag-and-drop UI (model placement, drag ghost). For gameplay use `dispatch_action` with a MOVE_UNIT / STAGE_MODEL_MOVE payload.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -307,7 +310,8 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'simulate_key_press',
-    description: 'Press a keyboard key (Godot keycode int) for a duration.',
+    description:
+      'TESTING ONLY — do NOT use to play the game. Presses a keyboard key (Godot keycode int) for a duration. Reserved for keybinding regression tests. For gameplay use `dispatch_action`.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -319,7 +323,8 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'simulate_action',
-    description: 'Trigger a named InputMap action for a duration.',
+    description:
+      'TESTING ONLY — do NOT use to play the game. Triggers a named InputMap action for a duration. Reserved for input-action wiring tests. For gameplay use `dispatch_action`.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -421,7 +426,13 @@ const TOOLS: ToolDef[] = [
   {
     name: 'get_board_state',
     description:
-      'WH40K: return the full board state — phase, active player, players (CP/VP), units (id, owner, models alive, wounds), available actions.',
+      'WH40K [PRIMARY play tool]: return the full board state — phase, active player, players (CP/VP), units (id, owner, models alive, wounds), available actions. Call this at the start of every turn to ground reasoning before issuing actions.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'get_legal_actions',
+    description:
+      'WH40K [PRIMARY play tool]: return the contextually-valid action dicts the active player can take RIGHT NOW. Each entry is shaped exactly as `dispatch_action` expects, so you can pick one and forward it. Use this to enumerate legal moves instead of guessing action shapes and getting validation rejections.',
     inputSchema: { type: 'object', properties: {} },
   },
   {
@@ -466,7 +477,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'select_unit',
     description:
-      'WH40K: locate a unit token in the running scene and synthesize a left-click on it (UI selection path).',
+      "WH40K [TESTING-leaning]: locate a unit token in the running scene and synthesize a left-click on it (UI selection path). Use this only when you specifically need the UI's selection signals to fire (highlights, side panel, etc.). For normal play, name the unit_id directly inside a `dispatch_action` payload — no selection step required.",
     inputSchema: {
       type: 'object',
       properties: { unit_id: { type: 'string' }, unit_name: { type: 'string' } },
@@ -475,7 +486,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'dispatch_action',
     description:
-      'WH40K: send a phase action dictionary through the active phase instance (validate_action + process_action).',
+      'WH40K [PRIMARY play tool — use this to take any in-game action]: send a phase action dictionary through the active phase instance (validate_action + process_action). This is the canonical way to play the game programmatically — it skips the UI/mouse layer and goes straight through the same code path the UI buttons use, so it is faster, deterministic, and cheap on tokens. Call `get_legal_actions` first to see valid action dict shapes for the current phase.',
     inputSchema: {
       type: 'object',
       properties: { action: { type: 'object' } },
@@ -485,7 +496,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'move_unit_to',
     description:
-      "WH40K: convenience wrapper that builds a MOVE_UNIT action and dispatches it. The active phase must accept this action shape.",
+      "WH40K [PRIMARY play tool]: convenience wrapper that builds a MOVE_UNIT action and dispatches it. The active phase must accept this action shape — if unsure, call `get_legal_actions` first.",
     inputSchema: {
       type: 'object',
       properties: {

--- a/godot-mcp/tsconfig.json
+++ b/godot-mcp/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "node",
+    "ignoreDeprecations": "5.0",
     "outDir": "./build",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
## Summary
This PR enhances the MCP tool documentation to clearly distinguish between testing-only input simulation tools and primary gameplay tools, and introduces a new `get_legal_actions` tool to help agents enumerate valid moves without guessing action shapes.

## Key Changes

- **Tool documentation overhaul**: Updated descriptions for all input simulation tools (`simulate_click`, `simulate_mouse_move`, `simulate_drag`, `simulate_key_press`, `simulate_action`) to explicitly mark them as "TESTING ONLY" and redirect users to `dispatch_action` for gameplay
- **Primary tool labeling**: Added "[PRIMARY play tool]" markers to `get_board_state`, `dispatch_action`, and `move_unit_to` descriptions with guidance on when to use each
- **New `get_legal_actions` tool**: Implemented a new WH40K tool that returns contextually-valid action dictionaries the active player can take, allowing agents to enumerate legal moves instead of guessing action shapes and receiving validation rejections
- **Updated `select_unit` guidance**: Clarified that it's for testing UI selection signals, not required for normal gameplay
- **TypeScript config**: Added `ignoreDeprecations: "5.0"` to suppress TypeScript 5.0 deprecation warnings
- **Route registration**: Registered the new `get_legal_actions` handler in the command router

## Implementation Details

The `get_legal_actions` handler queries the active phase's `get_available_actions()` method (which each phase implements) and returns the rich action dictionaries in a serializable format. This allows agents to see exactly what action shapes are valid for the current game state before attempting to dispatch them, improving success rates and reducing token waste from validation rejections.

https://claude.ai/code/session_01DPxnHnoswwPjg6j5soFnmG