### PR TITLE
Fix dispatch_action: apply diffs + accept JSON [x,y] positions

### DIFF
--- a/40k/addons/godot_mcp/command_router.gd
+++ b/40k/addons/godot_mcp/command_router.gd
@@ -32,7 +32,7 @@ func _register_routes() -> void:
 	_routes["list_tools"] = [self, "_list_tools"]
 
 	var core_methods := [
-		"get_project_info", "get_project_setting", "list_files",
+		"get_project_info", "get_project_setting", "list_files", "list_scenes",
 		"get_current_scene", "get_node_info", "get_node_property",
 		"set_node_property", "call_node_method",
 		"read_script", "write_script",

--- a/40k/addons/godot_mcp/handlers/core_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/core_handlers.gd
@@ -43,6 +43,16 @@ func list_files(params: Dictionary) -> Dictionary:
 	return {"status": "ok", "path": path, "files": results}
 
 
+func list_scenes(params: Dictionary) -> Dictionary:
+	# Recursively enumerate `*.tscn` scene files under the given root. Default
+	# root is `res://`. Implemented runtime-side so it works from a running
+	# game without needing the editor bridge.
+	var path: String = params.get("path", "res://")
+	var results: Array = []
+	_walk(path, "*.tscn", true, results)
+	return {"status": "ok", "path": path, "scenes": results}
+
+
 func _walk(dir_path: String, pattern: String, recursive: bool, out: Array) -> void:
 	var dir := DirAccess.open(dir_path)
 	if dir == null:

--- a/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
@@ -233,9 +233,11 @@ func select_unit(params: Dictionary) -> Dictionary:
 # --- Action dispatch (movement / shooting / etc) ----------------------
 
 func dispatch_action(params: Dictionary) -> Dictionary:
-	# Sends a phase action through PhaseManager's current phase instance.
-	# This is the same path that the in-game UI uses for player actions, so
-	# any validation, state mutation, and UI refresh happens normally.
+	# Sends a phase action through PhaseManager's current phase instance via
+	# BasePhase.execute_action(), which is the same wrapper the UI uses:
+	# validate -> process_action -> PhaseManager.apply_state_changes ->
+	# refresh phase snapshot -> emit `action_taken`. Calling `process_action`
+	# directly skips diff application and silently corrupts phase state.
 	var pm := _autoload("PhaseManager")
 	if pm == null:
 		return {"status": "error", "message": "PhaseManager autoload not found"}
@@ -246,8 +248,27 @@ func dispatch_action(params: Dictionary) -> Dictionary:
 	if typeof(action) != TYPE_DICTIONARY or action.is_empty():
 		return {"status": "error", "message": "Missing 'action' dict"}
 
-	# Many phases expose `validate_action` and `process_action` (see BasePhase).
-	# Fall back gracefully if the phase doesn't.
+	# JSON has no Vector2 so callers send positions as `[x, y]` arrays. Convert
+	# the well-known position-shaped fields to Vector2 before phases see them
+	# (typed `position: Vector2` parameters won't auto-coerce from Array and
+	# silently fail validation).
+	action = _normalize_action_positions(action)
+
+	# Prefer execute_action when available (BasePhase). It returns the
+	# process_action result on success, or {success: false, errors: [...]} on
+	# validation failure — surface either as a structured response.
+	if current.has_method("execute_action"):
+		var result = current.execute_action(action)
+		if typeof(result) == TYPE_DICTIONARY and result.get("success", true) == false:
+			return {
+				"status": "error",
+				"message": "Phase rejected action: %s" % str(result.get("errors", [])),
+				"result": _to_serializable(result),
+			}
+		return {"status": "ok", "result": _to_serializable(result)}
+
+	# Fallback for phases that don't extend BasePhase: validate + process,
+	# but note that diffs won't be applied to GameState in this branch.
 	if current.has_method("validate_action"):
 		var validation = current.validate_action(action)
 		if typeof(validation) == TYPE_DICTIONARY and validation.get("valid", true) == false:
@@ -259,7 +280,49 @@ func dispatch_action(params: Dictionary) -> Dictionary:
 	if current.has_method("process_action"):
 		var result = current.process_action(action)
 		return {"status": "ok", "result": _to_serializable(result)}
-	return {"status": "error", "message": "Active phase has no process_action()"}
+	return {"status": "error", "message": "Active phase has no execute_action() or process_action()"}
+
+
+func _normalize_action_positions(action: Dictionary) -> Dictionary:
+	# Convert JSON-friendly `[x, y]` arrays into Vector2 for the action fields
+	# phases declare with Vector2 types. Returns a shallow copy to avoid
+	# mutating the caller's dict.
+	var out: Dictionary = action.duplicate(true)
+	# Single-position fields
+	for key in ["position", "destination", "dest", "target_position", "stage_position"]:
+		if out.has(key):
+			var v = _coerce_vector2(out[key])
+			if v != null:
+				out[key] = v
+	# Array-of-positions fields
+	if out.has("model_positions") and typeof(out["model_positions"]) == TYPE_ARRAY:
+		var positions: Array = out["model_positions"]
+		var converted: Array = []
+		for p in positions:
+			if p == null:
+				converted.append(null)
+			else:
+				var v = _coerce_vector2(p)
+				converted.append(v if v != null else p)
+		out["model_positions"] = converted
+	return out
+
+
+func _coerce_vector2(value):
+	# Accept Vector2 as-is; convert [x, y] arrays or {"x":_, "y":_} dicts.
+	if typeof(value) == TYPE_VECTOR2:
+		return value
+	if typeof(value) == TYPE_ARRAY and value.size() >= 2:
+		var x = value[0]
+		var y = value[1]
+		if (typeof(x) == TYPE_INT or typeof(x) == TYPE_FLOAT) and (typeof(y) == TYPE_INT or typeof(y) == TYPE_FLOAT):
+			return Vector2(float(x), float(y))
+	if typeof(value) == TYPE_DICTIONARY and value.has("x") and value.has("y"):
+		var x = value["x"]
+		var y = value["y"]
+		if (typeof(x) == TYPE_INT or typeof(x) == TYPE_FLOAT) and (typeof(y) == TYPE_INT or typeof(y) == TYPE_FLOAT):
+			return Vector2(float(x), float(y))
+	return null
 
 
 func move_unit_to(params: Dictionary) -> Dictionary:

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -38,7 +38,6 @@ const EDITOR_ONLY_COMMANDS = new Set([
   'play_main_scene',
   'stop_scene',
   'get_edited_scene',
-  'list_scenes',
   'reload_scripts',
 ]);
 
@@ -410,10 +409,10 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'list_scenes',
-    description: 'Editor: list all .tscn / .scn files under a directory.',
+    description: 'List all .tscn scene files under a directory (recursive). Default root is res://.',
     inputSchema: {
       type: 'object',
-      properties: { path: { type: 'string', default: 'res://scenes' } },
+      properties: { path: { type: 'string', default: 'res://' } },
     },
   },
   {
@@ -432,7 +431,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'get_legal_actions',
     description:
-      'WH40K [PRIMARY play tool]: return the contextually-valid action dicts the active player can take RIGHT NOW. Each entry is shaped exactly as `dispatch_action` expects, so you can pick one and forward it. Use this to enumerate legal moves instead of guessing action shapes and getting validation rejections.',
+      "WH40K [PRIMARY play tool]: return the contextually-valid action dicts the active player can take RIGHT NOW. For most phases each entry is shaped exactly as `dispatch_action` expects — pick one and forward it. EXCEPTION: in DEPLOYMENT, DEPLOY_UNIT entries name the deployable unit only; the caller must add `model_positions` (and optional `model_rotations`) before dispatching. Same for STAGE_MODEL_MOVE-style sub-actions in MOVEMENT — get_legal_actions surfaces the openers (BEGIN_NORMAL_MOVE, BEGIN_ADVANCE), not per-model placements.",
     inputSchema: { type: 'object', properties: {} },
   },
   {
@@ -486,7 +485,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'dispatch_action',
     description:
-      'WH40K [PRIMARY play tool — use this to take any in-game action]: send a phase action dictionary through the active phase instance (validate_action + process_action). This is the canonical way to play the game programmatically — it skips the UI/mouse layer and goes straight through the same code path the UI buttons use, so it is faster, deterministic, and cheap on tokens. Call `get_legal_actions` first to see valid action dict shapes for the current phase.',
+      'WH40K [PRIMARY play tool — use this to take any in-game action]: send a phase action dictionary through `BasePhase.execute_action` on the active phase instance. This validates, processes, applies the resulting state diffs to GameState, refreshes the phase snapshot, and emits `action_taken` — i.e. exactly what the UI does. Position fields (`position`, `destination`, `dest`, `model_positions`, etc.) accept JSON `[x, y]` arrays or `{x, y}` dicts and are converted to Vector2 server-side. Call `get_legal_actions` first to see valid action dict shapes for the current phase.',
     inputSchema: {
       type: 'object',
       properties: { action: { type: 'object' } },


### PR DESCRIPTION
## Summary
- `dispatch_action` was calling `process_action` directly, skipping `BasePhase.execute_action`. That wrapper is what applies the returned diffs via `PhaseManager.apply_state_changes`, refreshes the phase snapshot, and emits `action_taken`. Result: every dispatch came back `{success: true, changes: [...]}` but `GameState` was never updated. The phase instance still mutated its own internal counters during `process_action`, so a "no-op" dispatch silently corrupted phase memory while leaving GameState behind.
- Position fields typed as `Vector2` silently rejected the `[x, y]` arrays callers had to send (JSON has no `Vector2`). The validation failure surfaced as `{result: {}, status: "ok"}` — empty result, no error visible. Added a normalizer that converts `[x, y]` arrays and `{x, y}` dicts to `Vector2` for the well-known position fields.
- `list_scenes` was routed to a non-existent editor bridge on port 9081, so it always errored with `ECONNREFUSED`. Implemented it runtime-side in `CoreHandlers` (reuses `_walk` with a `*.tscn` filter), registered it in `command_router`, and dropped it from `EDITOR_ONLY_COMMANDS`.
- Updated tool descriptions: `get_legal_actions` now states honestly that `DEPLOY_UNIT` openers don't carry positions (caller must supply `model_positions`); `dispatch_action` description mentions the `execute_action` path and the `[x,y] → Vector2` normalization.

## Verification (against a running game)
After the fix, via `dispatch_action`:

1. **Diffs applied.** `CONFIRM_FORMATIONS` for P1 returned diffs `{meta.formations_p1_confirmed: true, meta.active_player: 2}`. After dispatch, `GameState.state.meta.active_player == 2` (was 1 before).
2. **JSON `[x,y]` accepted.** `DEPLOY_UNIT {model_positions: [[160, 240]]}` deployed Shield-Captain — `units.U_SHIELD_CAPTAIN_A.status == 2` and the model's position is `{x: 160, y: 240}`. Same call rejected with empty `{result: {}, status: "ok"}` before.
3. **Validation errors surface.** Dispatching `DEPLOY_UNIT` for a unit not owned by the active player now returns `{status: "error", message: "Phase rejected action: ...", result: {success: false, errors: [...]}}` instead of silently returning `ok`.
4. **`list_scenes` works.** Direct TCP test:
   ```
   echo '{"id":1,"command":"list_scenes","params":{"path":"res://scenes"}}' | nc 127.0.0.1 9080
   ```
   Returns the seven `.tscn` files under `res://scenes/`. (Updated `list_scenes` MCP tool description picks up after restarting the bridge node process.)
5. `npm run build` in `godot-mcp/` succeeds.

## Test plan
- [ ] Restart the registered MCP bridge so the rebuilt JS bundle loads (the existing one is gitignored).
- [ ] Open the project in Godot, start a battle from the main menu (or `change_scene_to_file("res://scenes/Main.tscn")`).
- [ ] Run a few `dispatch_action` calls covering `CONFIRM_FORMATIONS`, `DEPLOY_UNIT` (with `[[x,y]]` positions), `BEGIN_NORMAL_MOVE`. Verify `GameState` mutates (e.g. unit `status`, `meta.active_player`, `unit.flags.movement_active`).
- [ ] Send a deliberately-invalid action (out-of-zone position, wrong player) and confirm `status: "error"` with structured errors.
- [ ] `list_scenes` returns scene paths from the runtime port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)