### PR TITLE
Fix #323: skip already-deployed units in deployment auto-timeout

### DIFF
--- a/40k/autoloads/NetworkManager.gd
+++ b/40k/autoloads/NetworkManager.gd
@@ -2220,12 +2220,15 @@ func _auto_deploy_remaining_units_on_timeout() -> void:
 
 	for unit_id in units:
 		var unit = units[unit_id]
-		# Skip units that are already deployed, embarked, attached, or in reserves
+		# Issue #323: only convert units that are still UNDEPLOYED. Anything
+		# already on the board (DEPLOYED/MOVED/SHOT/...) or already routed
+		# (IN_RESERVES, embarked, attached) must be left alone, otherwise the
+		# end-of-Round-3 reserves cleanup will destroy on-table units.
 		if unit.get("embarked_in", null) != null:
 			continue
 		if unit.get("attached_to", null) != null:
 			continue
-		if unit.get("status", 0) != GameStateData.UnitStatus.UNDEPLOYED:
+		if int(unit.get("status", -1)) != GameStateData.UnitStatus.UNDEPLOYED:
 			continue
 
 		# Auto-place into strategic reserves


### PR DESCRIPTION
## Summary
- `NetworkManager._auto_deploy_remaining_units_on_timeout()` was sending units to Strategic Reserves whose `status` field was missing or stringified, because the filter defaulted to `0` (UNDEPLOYED). The end-of-Round-3 reserves cleanup then destroyed those (already-on-table) units.
- Tightened the filter to default missing `status` to `-1` and to cast through `int()`, so only units with `status == UNDEPLOYED` are routed to reserves. Everything DEPLOYED/MOVED/SHOT/CHARGED/FOUGHT/IN_RESERVES is left alone.
- One-line behavioural change at `40k/autoloads/NetworkManager.gd:2231`; `embarked_in` / `attached_to` early-exits and overall control flow are unchanged.

Closes #323.

## Test plan
- [ ] Deploy `U_STRIKE_FORCE_A` at (880, 2200) via `dispatch_action` (DEPLOY_UNIT). Confirm `unit.status == DEPLOYED (2)` and `models[0].position == {x:880, y:2200}`.
- [ ] While other units are still undeployed, call `NetworkManager._auto_deploy_remaining_units_on_timeout()`.
- [ ] Confirm `U_STRIKE_FORCE_A.status` stays `2` and `models[0].position` stays `{x:880, y:2200}`.
- [ ] Confirm the still-undeployed units are placed in Strategic Reserves (`status == 7`).
- [ ] Advance to end of Round 3 and confirm the deployed Strike Force is NOT destroyed by the reserves cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)