### PR TITLE
Filter off-board units from charge target enumeration

### DIFF
--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -1431,6 +1431,12 @@ func _get_eligible_targets_for_unit(unit_id: String) -> Dictionary:
 	for target_id in all_units:
 		var target_unit = all_units[target_id]
 		if target_unit.get("owner", 0) != current_player:  # Enemy unit
+			# Issue #320: Skip off-board units (Reserves / not yet deployed).
+			# _get_model_position() coerces null -> Vector2.ZERO, so distance
+			# checks alone treat reserved units as if they were at (0,0).
+			if not _is_unit_on_board(target_unit):
+				continue
+
 			# T2-9: Only FLY units can charge AIRCRAFT targets
 			var target_keywords = target_unit.get("meta", {}).get("keywords", [])
 			if "AIRCRAFT" in target_keywords and not charger_has_fly:
@@ -2032,6 +2038,15 @@ func _get_model_position(model: Dictionary) -> Vector2:
 	elif pos is Vector2:
 		return pos
 	return Vector2.ZERO
+
+func _is_unit_on_board(unit: Dictionary) -> bool:
+	var status = unit.get("status", 0)
+	if status == GameStateData.UnitStatus.IN_RESERVES or status == GameStateData.UnitStatus.UNDEPLOYED:
+		return false
+	var models = unit.get("models", [])
+	if models.is_empty():
+		return false
+	return models[0].get("position") != null
 
 func _get_model_in_unit(unit_id: String, model_id: String) -> Dictionary:
 	var unit = get_unit(unit_id)


### PR DESCRIPTION
## Summary

ChargePhase.get_available_actions() was listing enemy units that are
off-board (Reserves / undeployed, with position null) as valid
DECLARE_CHARGE targets. In a real session, P1 Custodes Round 2 charge
phase listed Battlewagon, Kommandos, Painboss, Weirdboy, Lootas,
Meganobz, Kaptin Badrukk, Ghazghkull, Nob with Waaagh Banner, and Strike
Force, all in reserves, as charge targets.

### Root cause

_get_eligible_targets_for_unit() only ran a distance check via
_is_target_within_charge_range(). That helper internally calls
_get_model_position(), which coerces a null position to Vector2.ZERO.
As a result, a reserved unit was effectively measured from (0,0) and
could fall inside the on-board chargers range.

### Fix

Add a small _is_unit_on_board() helper and filter targets in
_get_eligible_targets_for_unit() before any distance work. A unit is
considered off-board if its status is IN_RESERVES (7) or UNDEPLOYED
(0), or if it has no models, or if the first models position is null
(defence-in-depth for embarked / not-yet-placed cases). This pattern
mirrors how RulesEngine.get_eligible_targets() already short-circuits
on units with no alive models.

Edit is confined to 40k/phases/ChargePhase.gd. No refactoring, no
behaviour change for on-board enemies.

Closes #320

## Test plan

- [ ] Load a save where Player 1 Custodes are facing Orks with several units in Reserves; open Round 2 charge phase; verify no reserved Ork unit appears in the DECLARE_CHARGE list, and on-board Orks still appear when within range.
- [ ] Verify deployed enemies are still listed (no regression on the happy path).
- [ ] Verify AIRCRAFT filtering still works (FLY-only chargers can target AIRCRAFT, others cannot).

Note: GUT test suite currently fails to load due to a pre-existing
parse error in autoloads/UnitAbilityManager.gd (undeclared
EffectPrimitivesData) that is unrelated to this fix, so a
purpose-built GUT test could not be executed and was not included.
