### PR TITLE
Fix #322: make END_<PrevPhase> idempotent on the receiving phase

### DIFF
--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -203,6 +203,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_use_tank_shock(action)
 		"DECLINE_TANK_SHOCK":
 			return _validate_decline_tank_shock(action)
+		"END_SHOOTING":
+			# Idempotent no-op: previous phase auto-advanced before END_SHOOTING was dispatched.
+			return {"valid": true}
 		_:
 			return {"valid": false, "errors": ["Unknown action type: " + action_type]}
 
@@ -248,6 +251,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_use_tank_shock(action)
 		"DECLINE_TANK_SHOCK":
 			return _process_decline_tank_shock(action)
+		"END_SHOOTING":
+			return create_result(true, [], "")
 		_:
 			return create_result(false, [], "Unknown action type: " + action_type)
 

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -558,6 +558,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 		"END_COMMAND":
 			# END_COMMAND is always valid in command phase
 			pass
+		"END_SCORING", "END_TURN":
+			# Idempotent no-op: previous phase auto-advanced before END_SCORING was dispatched.
+			pass
 		"BATTLE_SHOCK_TEST":
 			errors = _validate_battle_shock_test(action)
 		"USE_STRATAGEM":
@@ -639,6 +642,8 @@ func process_action(action: Dictionary) -> Dictionary:
 	match action.get("type", ""):
 		"END_COMMAND":
 			return _handle_end_command()
+		"END_SCORING", "END_TURN":
+			return {"success": true, "changes": []}
 		"BATTLE_SHOCK_TEST":
 			return _handle_battle_shock_test(action)
 		"USE_STRATAGEM":

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -429,6 +429,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _validate_apply_melee_saves(action)
+		"END_CHARGE":
+			# Idempotent no-op: previous phase auto-advanced before END_CHARGE was dispatched.
+			return {"valid": true}
 		_:
 			return {"valid": false, "errors": ["Unknown action type: " + action_type]}
 
@@ -478,6 +481,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _process_apply_melee_saves(action)
+		"END_CHARGE":
+			return create_result(true, [], "")
 		_:
 			return create_result(false, [], "Unknown action type: " + action_type)
 

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -672,6 +672,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 		"DEBUG_MOVE":
 			# Already validated by base class
 			return {"valid": true}
+		"END_COMMAND":
+			# Idempotent no-op: previous phase auto-advanced before END_COMMAND was dispatched.
+			return {"valid": true}
 		_:
 			return {"valid": false, "errors": ["Unknown action type: " + action_type]}
 
@@ -763,6 +766,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_use_scatter(action)
 		"DECLINE_SCATTER":
 			return _process_decline_scatter(action)
+		"END_COMMAND":
+			return create_result(true, [], "")
 		_:
 			return create_result(false, [], "Unknown action type: " + action_type)
 

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -149,6 +149,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 	match action_type:
 		"END_SCORING", "END_TURN":  # Support both for backward compatibility
 			pass
+		"END_FIGHT":
+			# Idempotent no-op: previous phase auto-advanced before END_FIGHT was dispatched.
+			pass
 		"DISCARD_SECONDARY":
 			var mission_index = action.get("mission_index", -1)
 			if mission_index < 0:
@@ -171,6 +174,8 @@ func process_action(action: Dictionary) -> Dictionary:
 	match action.get("type", ""):
 		"END_SCORING", "END_TURN":
 			return _handle_end_turn()
+		"END_FIGHT":
+			return {"success": true, "changes": []}
 		"DISCARD_SECONDARY":
 			return _handle_discard_secondary(action)
 		"ACROBATIC_ESCAPE_VANISH":

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -348,6 +348,9 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_perform_ritual_action(action)
 		"PERFORM_TERRAFORM_ACTION":  # Terraform: unit terraforms an objective
 			return _validate_perform_terraform_action(action)
+		"END_MOVEMENT":
+			# Idempotent no-op: previous phase auto-advanced before END_MOVEMENT was dispatched.
+			return {"valid": true}
 		_:
 			return {"valid": false, "errors": ["Unknown action type: " + action_type]}
 
@@ -456,6 +459,9 @@ func process_action(action: Dictionary) -> Dictionary:
 		"PERFORM_TERRAFORM_ACTION":  # Terraform: terraform an objective
 			print("ShootingPhase: Matched PERFORM_TERRAFORM_ACTION")
 			return _process_perform_terraform_action(action)
+		"END_MOVEMENT":
+			print("ShootingPhase: Matched END_MOVEMENT (no-op, phase already advanced)")
+			return create_result(true, [], "")
 		_:
 			print("ShootingPhase: NO MATCH - returning error")
 			return create_result(false, [], "Unknown action type: " + action_type)


### PR DESCRIPTION
## Summary
- Fixes #322: batched MCP playthroughs were failing with `Phase rejected action: ["Unknown action type: END_<PHASE>"]` whenever a per-unit action (e.g. the last `SKIP_CHARGE`) auto-advanced the phase before a queued `END_<PHASE>` reached the now-stale phase.
- Each phase now accepts the immediately-preceding phase's `END_<PrevPhase>` action as a success no-op in both `validate_action` and `process_action`.

## Approach (A)
Three options were considered:

- **A. Make `END_<PrevPhase>` idempotent on the target phase.** Chosen.
- B. Trap the failure in `wh40k_handlers.dispatch_action`. Rejected: feels like an MCP-layer kludge for a phase-layer contract issue.
- C. Have `PhaseManager.get_available_actions()` filter out `END_<PHASE>` when the phase is about to auto-advance. Rejected: the phase doesn't easily know it's going to auto-advance without simulating the next action.

Approach A keeps the allowlist tight: each phase accepts only the immediate predecessor's `END_<PrevPhase>` token (not arbitrary stale actions), so the existing strict "Unknown action type" guard still catches genuinely bogus payloads. The contract becomes: "if you ever wanted to end phase X, and X is over, you got what you wanted."

## Files changed
All edits are in `40k/phases/*.gd` — only the `validate_action` and `process_action` `match` blocks:

| File | Accepts (no-op) |
|---|---|
| `MovementPhase.gd` | `END_COMMAND` |
| `ShootingPhase.gd` | `END_MOVEMENT` |
| `ChargePhase.gd` | `END_SHOOTING` |
| `FightPhase.gd` | `END_CHARGE` |
| `ScoringPhase.gd` | `END_FIGHT` |
| `CommandPhase.gd` | `END_SCORING`, `END_TURN` |

Total diff: +31 lines across 6 files.

## Test plan
- [ ] In CHARGE phase, batch-dispatch `SKIP_CHARGE` for every eligible unit followed by `END_CHARGE` in the same batch. Last `SKIP_CHARGE` should auto-advance to FIGHT, and `END_CHARGE` should now return `{success: true}` from FIGHT instead of "Unknown action type".
- [ ] Same batch shape on FIGHT -> SCORING (`END_FIGHT` while in SCORING) and SCORING -> COMMAND (`END_SCORING` while in next-turn COMMAND).
- [ ] Confirm normal end-phase actions (`END_CHARGE` while still in CHARGE) still trigger their original handlers (they're matched first in `match` order).
- [ ] Confirm a genuinely unknown action type (e.g. `FOO_BAR`) still returns the "Unknown action type" rejection.

Closes #322
