### PR TITLE
Fix phantom collision rejections at W40K base-contact boundary (#321)

### DIFF
--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -32,6 +32,11 @@ signal grot_oiler_result(unit_id: String, results: Dictionary)
 
 const ENGAGEMENT_RANGE_INCHES: float = 1.0  # 10e standard ER
 const MOVEMENT_CAP_EPSILON: float = 0.02  # Floating-point tolerance for movement cap checks (< 1px)
+# Bases at the touching boundary (W40K base-to-base contact) should not be flagged as
+# overlapping. Strict `<` comparison in shape collision combined with mm→px rounding
+# (e.g. 32mm → 50.39px diameter at 50px spacing) produces sub-pixel false-positives,
+# which surface as phantom rejections when staging adjacent models in formation.
+const OVERLAP_TOLERANCE_PX: float = 0.5
 
 # Movement state tracking
 var active_moves: Dictionary = {}  # unit_id -> move_data
@@ -5885,9 +5890,30 @@ func _position_overlaps_other_models(unit_id: String, model_id: String, position
 
 			# Check for overlap using the Measurement utility
 			if Measurement.models_overlap(check_model, other_model_check):
+				# Reject sub-pixel false-positives at the touching boundary.
+				# For circular-vs-circular we can do an exact tolerance check;
+				# other shape combinations keep strict behavior.
+				if _is_touching_within_tolerance(check_model, other_model_check):
+					continue
 				return true
 
 	return false
+
+func _is_touching_within_tolerance(model_a: Dictionary, model_b: Dictionary) -> bool:
+	if model_a.get("base_type", "circular") != "circular":
+		return false
+	if model_b.get("base_type", "circular") != "circular":
+		return false
+	var pos_a = model_a.get("position", Vector2.ZERO)
+	var pos_b = model_b.get("position", Vector2.ZERO)
+	if pos_a is Dictionary:
+		pos_a = Vector2(pos_a.get("x", 0), pos_a.get("y", 0))
+	if pos_b is Dictionary:
+		pos_b = Vector2(pos_b.get("x", 0), pos_b.get("y", 0))
+	var radius_a = Measurement.base_radius_px(model_a.get("base_mm", 32))
+	var radius_b = Measurement.base_radius_px(model_b.get("base_mm", 32))
+	var center_distance = pos_a.distance_to(pos_b)
+	return center_distance + OVERLAP_TOLERANCE_PX >= (radius_a + radius_b)
 
 func _position_intersects_terrain(pos: Vector2, model: Dictionary, max_passable_height: float = 0.0) -> bool:
 	# Check against terrain polygons using shape-aware bounds


### PR DESCRIPTION
Closes #321.

## Summary
Allow models in legal W40K base-to-base contact to pass the
`_position_overlaps_other_models` check, fixing the "Cannot end move
on top of another model" rejections seen when staging adjacent models
of the same unit.

## Root cause
The reported symptom — m1/m3/m5 succeed, m2/m4 fail when staging a
5-wide row to a new row at 50px spacing — looks like a parallel-stage
race, but tracing the code shows it is not.

`_position_overlaps_other_models` (MovementPhase.gd:5848) already
consults `active_moves[check_unit_id].staged_moves` before falling
back to `_get_model_position(other_model)` (committed). When m2's
validate runs it correctly sees m1 at its staged destination. The
collision is real geometry, not stale state:

- 32mm base = 32 / 25.4 in = 1.260 in -> 50.394 px diameter.
- Sum of two 32mm radii = 50.394 px.
- Models 50.0 px apart in formation register as overlapping by ~0.4 px
  under the strict `<` in `CircularBase.overlaps_with`.
- m2 vs m1's freshly-staged neighbour (50 px away) trips the check;
  m3 only compares against m1 staged at 100 px and the unstaged
  m2/m4/m5 still on the original row 100+ px diagonal away, so it
  passes; m4 vs m3's staged neighbour trips it again. The pattern is
  deterministic, not racy.

This is the W40K "base contact" (touching) boundary, which is legal.

## Fix
Add `OVERLAP_TOLERANCE_PX = 0.5` and, after `Measurement.models_overlap`
returns true, perform a circle-vs-circle tolerance check via a small
helper `_is_touching_within_tolerance`. Pairs whose center-to-center
distance is within 0.5 px of (r1 + r2) are treated as touching, not
overlapping. Non-circular base combinations keep strict behaviour.

The fix is local to MovementPhase.gd and mirrors the existing
`MOVEMENT_CAP_EPSILON` pattern (0.02 in) for sub-pixel floating-point
tolerance elsewhere in the same file.

## Why not the "consult staged positions" fix proposed in the issue
That fix is already in place — see lines 5876-5882 of MovementPhase.gd
on main. Forcing it harder would not change m2's verdict, because m1
*is* being read at its staged destination. The true blocker is the
strict overlap math at the touching boundary.

## Test plan
- [ ] Load a save with a 5-wide unit on 32mm bases.
- [ ] Begin a normal move and stage all 5 models to a new row at the
      same spacing via batched `STAGE_MODEL_MOVE` dispatches; all 5
      should now stage successfully.
- [ ] Re-confirm that genuine overlap (e.g. dest within ~1 px of
      another model's center) still rejects.
- [ ] Sanity check that movement of single models, mixed-base units,
      and non-circular bases (rectangular/oval) still behave the same.

Generated with [Claude Code](https://claude.com/claude-code)
