### PR TITLE
Fix: end game after Battle Round 5 (10e), persist meta.game_ended/winner

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -7,6 +7,9 @@ class_name GameStateData
 enum Phase { FORMATIONS, DEPLOYMENT, REDEPLOYMENT, ROLL_OFF, SCOUT, SCOUT_MOVES, COMMAND, MOVEMENT, SHOOTING, CHARGE, FIGHT, SCORING, MORALE }
 enum UnitStatus { UNDEPLOYED, DEPLOYING, DEPLOYED, MOVED, SHOT, CHARGED, FOUGHT, IN_RESERVES }
 
+# 10e Core Rules: "The battle lasts five battle rounds."
+const MAX_BATTLE_ROUNDS: int = 5
+
 # The complete game state as a dictionary
 var state: Dictionary = {}
 
@@ -774,7 +777,9 @@ func advance_battle_round() -> void:
 	print("GameState: Advanced to battle round ", get_battle_round())
 
 func is_game_complete() -> bool:
-	return get_battle_round() > 5
+	if state.get("meta", {}).get("game_ended", false):
+		return true
+	return get_battle_round() > MAX_BATTLE_ROUNDS
 
 # CP Cap — Per core rules FAQ:
 # "Outside of the 1CP players gain at the start of the Command phase,

--- a/40k/autoloads/PhaseManager.gd
+++ b/40k/autoloads/PhaseManager.gd
@@ -249,17 +249,36 @@ func _handle_game_end() -> void:
 	print("PhaseManager: Game completed after 5 battle rounds!")
 	print("PhaseManager: Final battle round: ", GameState.get_battle_round())
 
-	# Score end-of-game burn bonuses for Scorched Earth before marking game ended
+	# Score end-of-game burn bonuses for Scorched Earth before marking game ended.
+	# Idempotent: ScoringPhase calls this first when it detects the final-turn end,
+	# but trigger again here for paths that reach _handle_game_end without it.
 	if MissionManager:
 		MissionManager.score_end_of_game_burn_bonus()
 
 	game_ended = true
+
+	# Persist end-of-game flags to state so saves/replays/MCP queries observe them.
+	if not GameState.state.get("meta", {}).get("game_ended", false):
+		GameState.state["meta"]["game_ended"] = true
+		GameState.state["meta"]["winner"] = _determine_vp_winner()
 
 	# Commit final phase log
 	GameState.commit_phase_log_to_history()
 
 	# Emit completion signal for any listeners that need to know the game ended
 	emit_signal("phase_completed", GameStateData.Phase.SCORING)
+
+func _determine_vp_winner() -> int:
+	if not MissionManager or not MissionManager.has_method("get_vp_summary"):
+		return 0
+	var vp = MissionManager.get_vp_summary()
+	var p1 = int(vp.get("player1", {}).get("total", 0))
+	var p2 = int(vp.get("player2", {}).get("total", 0))
+	if p1 > p2:
+		return 1
+	if p2 > p1:
+		return 2
+	return 0
 
 func _on_phase_action_taken(action: Dictionary) -> void:
 	if game_ended:

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -231,6 +231,12 @@ func _handle_end_turn() -> Dictionary:
 		var battle_round = GameState.get_battle_round()
 		MissionManager.record_vp_snapshot(battle_round)
 
+	# Detect end-of-game: P2 finishing the final battle round (10e: 5 rounds).
+	# Set meta.game_ended/winner in state so saves, replays, MCP queries, and
+	# PhaseManager._handle_game_end() (via is_game_complete()) all observe it.
+	if current_player == 2 and GameState.get_battle_round() >= GameState.MAX_BATTLE_ROUNDS:
+		return _handle_game_end_turn()
+
 	# Reset unit flags for the player whose turn is starting
 	var changes = _create_flag_reset_changes(next_player)
 
@@ -263,6 +269,50 @@ func _handle_end_turn() -> Dictionary:
 		"changes": changes,
 		"message": "Turn ended, control switched to player %d" % next_player
 	}
+
+func _handle_game_end_turn() -> Dictionary:
+	# Score Scorched Earth end-of-game burn bonuses BEFORE determining the winner
+	# so the bonus VP counts toward the result.
+	if MissionManager and MissionManager.has_method("score_end_of_game_burn_bonus"):
+		MissionManager.score_end_of_game_burn_bonus()
+
+	var winner := _determine_winner()
+
+	print("ScoringPhase: Final battle round complete — game ended. Winner: %s" % (
+		"Draw" if winner == 0 else "Player %d" % winner))
+
+	var game_event_log = get_node_or_null("/root/GameEventLog")
+	if game_event_log:
+		var msg = "Game ended after %d battle rounds — %s" % [
+			GameState.MAX_BATTLE_ROUNDS,
+			"Draw" if winner == 0 else "Player %d wins" % winner,
+		]
+		game_event_log.add_info_entry(msg)
+
+	var changes := [
+		{"op": "set", "path": "meta.game_ended", "value": true},
+		{"op": "set", "path": "meta.winner", "value": winner},
+	]
+
+	return {
+		"success": true,
+		"changes": changes,
+		"message": "Game ended after %d battle rounds" % GameState.MAX_BATTLE_ROUNDS,
+		"game_ended": true,
+		"winner": winner,
+	}
+
+func _determine_winner() -> int:
+	if not MissionManager or not MissionManager.has_method("get_vp_summary"):
+		return 0
+	var vp = MissionManager.get_vp_summary()
+	var p1 = int(vp.get("player1", {}).get("total", 0))
+	var p2 = int(vp.get("player2", {}).get("total", 0))
+	if p1 > p2:
+		return 1
+	if p2 > p1:
+		return 2
+	return 0
 
 func _create_flag_reset_changes(player: int) -> Array:
 	"""Create state changes to reset per-turn action flags for a player's units"""


### PR DESCRIPTION
## Summary
- Detects end-of-game (P2 ending the final battle round) in `ScoringPhase._handle_end_turn` and emits `meta.game_ended` / `meta.winner` state diffs instead of incrementing `battle_round` to 6 and starting another command phase.
- Adds `GameState.MAX_BATTLE_ROUNDS = 5` and updates `is_game_complete()` to also return `true` when `meta.game_ended` is set, so the existing `PhaseManager._on_phase_completed -> _handle_game_end` pipeline still fires (sets `PhaseManager.game_ended`, surfaces the existing `GameOverDialog` via `Main._on_phase_completed`).
- `PhaseManager._handle_game_end` now also persists `meta.game_ended` / `meta.winner` to state as a safety net.

Closes #319

## Why this shape
Most of the end-game machinery already existed:
- `PhaseManager.game_ended: bool` (in-memory) plus `_handle_game_end()` wired off the scoring phase's completion signal.
- `GameState.is_game_complete()` returning `battle_round > 5` as the trigger.
- `Main._on_phase_completed -> _show_game_over_dialog` and `_determine_vp_winner` for the UI.
- `MissionManager.score_end_of_game_burn_bonus()` for Scorched Earth.

What was missing:
1. The "game ended" signal lived only on the `PhaseManager` instance — `state.meta.game_ended` was never set, so saves, replays, and MCP queries always saw `false`.
2. The trigger relied on `battle_round` overflowing past 5, which leaked the overflow value (Round 6) into the UI before the dialog could appear.

I considered three shapes:
1. **Wire the existing `_handle_game_end` to write to state** — minimal but still leaks `battle_round = 6` to the snapshot before `is_game_complete()` flips.
2. **Stop incrementing `battle_round` at the boundary, set `meta.game_ended` directly in the action result, and teach `is_game_complete()` to honour that flag** — chosen. The state diff is the canonical path through `BasePhase.execute_action -> PhaseManager.apply_state_changes`, so saves, replays, MCP queries, and `_handle_game_end` all observe the end synchronously. `battle_round` clamps at 5 (matches the rules).
3. **Add a dedicated `GAME_OVER` phase enum** — heavier than needed; `Main` already shows a dialog and the existing controllers gate themselves on `GameState.is_game_complete()`.

Path 2 also keeps shape (1) as a fallback in `PhaseManager._handle_game_end` (writes `meta.game_ended` if not already set) for legacy flows, e.g. loading a save where `battle_round` had already overflowed before the fix.

## Test plan
- [x] Direct unit-style verification (headless GDScript): `MAX_BATTLE_ROUNDS == 5`; `is_game_complete()` returns `true` when `meta.game_ended` is set OR when `battle_round > 5`; `_handle_game_end_turn()` returns `success=true`, `game_ended=true`, and the two expected state diffs; `battle_round` and `active_player` are not mutated.
- [ ] Full 5-round playthrough via UI: confirm that after P2's `END_SCORING` in Round 5, `state.meta.battle_round == 5`, `state.meta.game_ended == true`, `state.meta.winner` matches VP totals, and the `GameOverDialog` appears (existing `Main._on_phase_completed` path, no UI changes in this PR).
- [ ] Existing `test_e2e_workflow.test_five_round_game_simulation` still passes — assertion is `battle_round >= 5`, which holds (now exactly 5).
