### PR TITLE
Fix call_node_method silently failing on non-Array args (#333)

### DIFF
--- a/40k/addons/godot_mcp/handlers/core_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/core_handlers.gd
@@ -133,7 +133,27 @@ func set_node_property(params: Dictionary) -> Dictionary:
 func call_node_method(params: Dictionary) -> Dictionary:
 	var path: String = params.get("path", "")
 	var method: String = params.get("method", "")
-	var args: Array = params.get("args", [])
+	# `args` may arrive as a real JSON Array, as a JSON-encoded String (some
+	# clients/bridges stringify nested arrays), or as a single scalar value.
+	# Normalize all three shapes so a strict-typed Array assignment never
+	# silently fails (see issue #333).
+	var raw_args = params.get("args", [])
+	var args: Array = []
+	if raw_args is Array:
+		args = raw_args
+	elif raw_args is String:
+		var parsed = JSON.parse_string(raw_args)
+		if parsed is Array:
+			args = parsed
+		elif parsed == null and raw_args == "":
+			args = []
+		else:
+			# Either a JSON scalar (e.g. "\"foo\"") or a bare string that
+			# isn't valid JSON. Treat the raw value as a single positional arg.
+			args = [parsed if parsed != null else raw_args]
+	else:
+		# Numbers, bools, dicts, null, etc. — wrap as a single positional arg.
+		args = [raw_args]
 	if path == "" or method == "":
 		return {"status": "error", "message": "Missing 'path' or 'method'"}
 	var node := _resolve_node(path)


### PR DESCRIPTION
## Summary
- Normalize `args` in the MCP `call_node_method` handler so it accepts a real Array, a JSON-encoded String, or a bare scalar — instead of failing the strict-typed `var args: Array = ...` assignment and silently returning `{}` to the caller.
- Root cause: `40k/addons/godot_mcp/handlers/core_handlers.gd:136` used a strict typed assignment that raised a swallowed script error whenever the value arrived as a String, dropping the method call on the floor.

## Test plan
- [ ] From an MCP client, call `call_node_method` with `path: "/root/GameState"`, `method: "initialize_default_state"`, `args: ["crucible_of_battle"]` and confirm it returns `status: "ok"` and the method actually executes (no longer the empty `{}` from #333).
- [ ] Re-run the same call with `args` passed as the JSON string `"[\"crucible_of_battle\"]"` and confirm it succeeds the same way.
- [ ] Call a no-arg method with `args: []` and with `args` omitted; confirm behavior is unchanged.
- [ ] Call with a single non-array scalar `args: "crucible_of_battle"` and confirm it is forwarded as one positional arg rather than failing.
- [ ] Code review: confirm no other handlers regress (only `call_node_method` was edited).

Closes #333

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
