### PR TITLE
Fix #339: Block movement after Strategic Reserves arrival

### DIFF
--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -820,6 +820,12 @@ func _validate_begin_normal_move(action: Dictionary) -> Dictionary:
 	if _is_unit_engaged(unit_id):
 		return {"valid": false, "errors": ["Unit is engaged, must Fall Back instead"]}
 
+	# Issue #339: Units that arrived from Strategic Reserves this turn cannot move further
+	# Per 10e Core Rules, the arrival counts as the unit's move for that turn
+	var arrived_turn = unit.get("arrived_from_reserves_turn", -1)
+	if arrived_turn >= 0 and arrived_turn == GameState.get_battle_round():
+		return {"valid": false, "errors": ["Unit arrived from reserves this turn and cannot move further"]}
+
 	return {"valid": true, "errors": []}
 
 func _validate_begin_advance(action: Dictionary) -> Dictionary:
@@ -853,7 +859,13 @@ func _validate_begin_fall_back(action: Dictionary) -> Dictionary:
 	# Fall Back is only allowed if engaged
 	if not _is_unit_engaged(unit_id):
 		return {"valid": false, "errors": ["Unit is not engaged, use Normal Move instead"]}
-	
+
+	# Issue #339: Units that arrived from Strategic Reserves this turn cannot move further
+	# (Theoretically unreachable since reserves arrive >9" from enemies, but added for robustness)
+	var arrived_turn = unit.get("arrived_from_reserves_turn", -1)
+	if arrived_turn >= 0 and arrived_turn == GameState.get_battle_round():
+		return {"valid": false, "errors": ["Unit arrived from reserves this turn and cannot move further"]}
+
 	return {"valid": true, "errors": []}
 
 func _validate_set_model_dest(action: Dictionary) -> Dictionary:


### PR DESCRIPTION
## Summary

- **Root cause:** A unit placed via `PLACE_REINFORCEMENT` (Strategic Reserves arrival) gets `arrived_from_reserves_turn` set on it, but `MovementPhase._validate_begin_normal_move()` never read that flag. The unit could therefore start a normal move (or advance) on the same turn, on top of the arrival placement.
- **10e rule:** A unit arriving from Strategic Reserves cannot move further that turn; the arrival counts as its move.
- **Fix:** Add an `arrived_from_reserves_turn == GameState.get_battle_round()` check to `_validate_begin_normal_move` (inherited by `_validate_begin_advance` since that delegates to it) and to `_validate_begin_fall_back` for robustness. The flag is intentionally not cleared; it simply stops mattering on the next round when `get_battle_round()` advances.

## Test plan

- [ ] Place a unit via `PLACE_REINFORCEMENT` (Strategic Reserves) on turn N
- [ ] Attempt `BEGIN_NORMAL_MOVE` on the same unit, same turn -> should be rejected with "Unit arrived from reserves this turn and cannot move further"
- [ ] Attempt `BEGIN_ADVANCE` on the same unit, same turn -> should also be rejected
- [ ] On the following battle round, `BEGIN_NORMAL_MOVE` on the same unit should succeed (flag is stale, round has advanced)
- [ ] Regression: units that never arrived from reserves (`arrived_from_reserves_turn` absent / -1) move as before

Closes #339

Generated with [Claude Code](https://claude.com/claude-code)