### PR TITLE
Add static test_mode_seed override to RulesEngine.RNGService (minimal #329 fix)

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -506,12 +506,24 @@ const UNIT_WEAPONS = {
 
 # RNG Service for deterministic dice rolling
 class RNGService:
+	# Test-only static seed override.
+	# When set to a non-negative value, every unseeded RNGService.new() call
+	# derives a deterministic-but-unique seed via hash([test_mode_seed, _test_seed_counter]).
+	# Default (-1) preserves existing behavior: unseeded constructors call randomize().
+	# Multiplayer is unaffected because it always passes an explicit seed_value.
+	# This unblocks deterministic test coverage across phases that don't yet
+	# plumb payload.rng_seed through to RNGService construction.
+	static var test_mode_seed: int = -1
+	static var _test_seed_counter: int = 0
 	var rng: RandomNumberGenerator
 
 	func _init(seed_value: int = -1):
 		rng = RandomNumberGenerator.new()
 		if seed_value >= 0:
 			rng.seed = seed_value
+		elif test_mode_seed >= 0:
+			_test_seed_counter += 1
+			rng.seed = hash([test_mode_seed, _test_seed_counter])
 		else:
 			rng.randomize()
 


### PR DESCRIPTION
## Summary

Minimal fix for #329 — adds a static `test_mode_seed` override on `RulesEngine.RNGService` so test code can pin the entire run deterministically with one line, without touching per-phase plumbing.

- New `static var test_mode_seed: int = -1` and `static var _test_seed_counter: int = 0` on `RNGService`.
- When `RNGService.new()` is called with no `seed_value` AND `test_mode_seed >= 0`, the constructor derives a deterministic-but-unique seed via `hash([test_mode_seed, _test_seed_counter])`.
- Default behavior is unchanged: with `test_mode_seed = -1`, unseeded constructors still call `rng.randomize()`.

**Scope is intentionally minimal.** The per-phase `payload.rng_seed` plumbing for `ChargePhase`, `ShootingPhase`, `FightPhase`, `CommandPhase`, `RollOffPhase`, `StratagemManager`, `FactionAbilityManager`, plus the direct `randi()` calls in `MovementPhase` are NOT addressed here. Those should land in a follow-up PR.

This PR partially addresses #329 but does not fully resolve it — using **Refs #329** rather than **Closes #329**.

## Backward compatibility

- Multiplayer: unchanged. `NetworkManager.get_next_rng_seed()` always passes an explicit `seed_value` to `RNGService.new()`, so the new branch is never hit.
- Single-player runtime: unchanged. `test_mode_seed` defaults to `-1`, so unseeded constructors still call `randomize()`.
- Tests: opt in by setting `RulesEngine.RNGService.test_mode_seed = 42` once. Every subsequent unseeded `RNGService.new()` (across all phases) becomes deterministic.

## Test plan

- [ ] Set `RulesEngine.RNGService.test_mode_seed = 42` and `_test_seed_counter = 0`. Construct two `RNGService.new()` instances and call `roll_d6(6)` on each. Capture the rolls.
- [ ] Reset (`test_mode_seed = 42`, `_test_seed_counter = 0`) and repeat. Verify both runs produce identical roll sequences.
- [ ] Set `test_mode_seed = -1` (default). Construct `RNGService.new()` and verify `roll_d6(6)` produces non-deterministic output across runs (existing behavior preserved).
- [ ] Construct `RNGService.new(seed_value=99)` while `test_mode_seed = 42` is set. Verify the explicit seed wins (multiplayer path unaffected).

## Follow-up

Track the per-phase plumbing fix as a separate issue/PR — that is where every phase reads `action.payload.rng_seed` and forwards it to `RNGService.new()`, plus replacing the bare `randi()` calls in `MovementPhase` and `FactionAbilityManager`.

Refs #329

Generated with [Claude Code](https://claude.com/claude-code)
