### PR TITLE
Persist autoload state across save/load (#338)

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -913,6 +913,21 @@ func create_snapshot() -> Dictionary:
 			snapshot["secondary_missions"] = secondary_data
 			print("[GameState] Adding secondary mission state to snapshot")
 
+	# Issue #338: Add FactionAbilityManager state (once-per-battle locks,
+	# doctrines, masteries, enhancements, banner). Without this, save/load
+	# drops these and lets save-scumming defeat usage restrictions.
+	var faction_ability_mgr = get_node_or_null("/root/FactionAbilityManager")
+	if faction_ability_mgr:
+		snapshot["faction_ability_manager"] = faction_ability_mgr.get_state_for_save()
+		print("[GameState] Adding FactionAbilityManager state to snapshot")
+
+	# Issue #338: Add StratagemManager usage history and active effects.
+	# Without this, once-per-battle/turn/phase stratagem locks reset on load.
+	var stratagem_mgr = get_node_or_null("/root/StratagemManager")
+	if stratagem_mgr and stratagem_mgr.has_method("get_state_for_save"):
+		snapshot["stratagem_manager"] = stratagem_mgr.get_state_for_save()
+		print("[GameState] Adding StratagemManager state to snapshot")
+
 	# SAVE-7: Add AI turn history to snapshot
 	var ai_player = get_node_or_null("/root/AIPlayer")
 	if ai_player and ai_player.enabled:
@@ -1057,6 +1072,23 @@ func load_from_snapshot(snapshot: Dictionary) -> void:
 	else:
 		if state.has("secondary_missions"):
 			print("[GameState] Has secondary_missions but SecondaryMissionManager not available")
+
+	# Issue #338: Restore FactionAbilityManager state if present.
+	# Guarded by has() so old save files (without this key) still load with defaults.
+	var faction_ability_mgr = get_node_or_null("/root/FactionAbilityManager")
+	if state.has("faction_ability_manager") and faction_ability_mgr:
+		print("[GameState] Found FactionAbilityManager data in save, restoring")
+		faction_ability_mgr.load_state(state["faction_ability_manager"])
+	elif state.has("faction_ability_manager"):
+		print("[GameState] Has faction_ability_manager but FactionAbilityManager not available")
+
+	# Issue #338: Restore StratagemManager state if present.
+	var stratagem_mgr = get_node_or_null("/root/StratagemManager")
+	if state.has("stratagem_manager") and stratagem_mgr and stratagem_mgr.has_method("load_state"):
+		print("[GameState] Found StratagemManager data in save, restoring")
+		stratagem_mgr.load_state(state["stratagem_manager"])
+	elif state.has("stratagem_manager"):
+		print("[GameState] Has stratagem_manager but StratagemManager not available")
 
 	# SAVE-7: Restore AI turn history if present
 	var ai_player = get_node_or_null("/root/AIPlayer")

--- a/40k/autoloads/StratagemManager.gd
+++ b/40k/autoloads/StratagemManager.gd
@@ -2399,3 +2399,31 @@ func reset_for_new_game() -> void:
 	_clear_player_faction_stratagems(1)
 	_clear_player_faction_stratagems(2)
 	print("StratagemManager: Reset for new game")
+
+# ============================================================================
+# SAVE/LOAD SUPPORT (Issue #338)
+# Persist per-game member-field state so once-per-battle/turn/phase usage
+# locks survive save/load round-trips. Without this, save-scumming can defeat
+# stratagem usage restrictions.
+# ============================================================================
+
+func get_state_for_save() -> Dictionary:
+	"""Return state data for save games."""
+	return {
+		"usage_history": _usage_history.duplicate(true),
+		"active_effects": active_effects.duplicate(true),
+		"player_faction_stratagems": _player_faction_stratagems.duplicate(true)
+	}
+
+func load_state(data: Dictionary) -> void:
+	"""Restore state from save data. Defaults match initial values for old saves."""
+	_usage_history = data.get("usage_history", {"1": [], "2": []})
+	active_effects = data.get("active_effects", [])
+	_player_faction_stratagems = data.get("player_faction_stratagems", {"1": [], "2": []})
+	print("StratagemManager: State loaded — usage_history sizes: P1=%d P2=%d, active_effects=%d, faction_stratagems: P1=%d P2=%d" % [
+		_usage_history.get("1", []).size(),
+		_usage_history.get("2", []).size(),
+		active_effects.size(),
+		_player_faction_stratagems.get("1", []).size(),
+		_player_faction_stratagems.get("2", []).size()
+	])


### PR DESCRIPTION
## Summary

Closes #338. Three autoloads carry per-game member-field state outside of `state.units` / `state.players` / `state.meta`. Without explicit persistence, save/load silently drops:

- **FactionAbilityManager** — once-per-battle locks (`waaagh_used`, `plant_waaagh_banner_used`), Custodes Martial Mastery (round-locked), detachment doctrines, OA-2 enhancements (Da Kaptin, Bionik Workshop, Razgit), OA-1 loot objective. Had `get_state_for_save` / `load_state` defined but never called.
- **StratagemManager** — `_usage_history` (once-per-battle/turn/phase locks), `active_effects`, `_player_faction_stratagems`. Had **no save/load API at all**.
- **SecondaryMissionManager** — was claimed unwired in the issue, but is actually already wired through `GameState`; verified, no change needed.

Result without fix: save/load lets a player re-call Waaagh!, re-fire Plant the Waaagh! Banner, re-pick a Martial Mastery, and re-use every "once per battle" stratagem — defeating restrictions intended to be game-wide.

### Changes

- `40k/autoloads/StratagemManager.gd` — add `get_state_for_save()` and `load_state(data)` covering `_usage_history`, `active_effects`, `_player_faction_stratagems`. Defaults match the autoload's initial values so old saves load cleanly.
- `40k/autoloads/GameState.gd` — wire `FactionAbilityManager` and `StratagemManager` into `create_snapshot()` and `load_from_snapshot()`, matching the existing pattern used for `SecondaryMissionManager`, `TerrainManager`, and `MeasuringTapeManager`. Top-level keys `faction_ability_manager` and `stratagem_manager` round-trip through `StateSerializer`, which only validates `meta` / `board` / `units` / `players`; extra keys pass through unchanged.
- Backwards compatibility: `state.has(...)` guards mean old save files (without the new keys) still load with the autoloads' default state.

## Test plan

- [ ] As P2 (Orks), dispatch `CALL_WAAAGH`; verify `FactionAbilityManager._waaagh_used == {"1": false, "2": true}`
- [ ] Save the game
- [ ] Manually mutate `_waaagh_used["2"] = false` (simulate any post-save mutation)
- [ ] Load the saved game
- [ ] Verify `_waaagh_used["2"] == true` is restored from the save (previously stayed `false`)
- [ ] `CALL_WAAAGH` again is rejected with "already used"
- [ ] Save/load does not regress: positions, CP, units, terrain still round-trip (existing audit T5.SL1)
- [ ] Spend a once-per-battle stratagem, save, load, verify it remains spent (`_usage_history` round-trip)
- [ ] Old save files (saved before this PR) still load without errors
