### PR TITLE
Plumb payload.rng_seed through dice-rolling phases (issue #329)

### DIFF
--- a/40k/autoloads/FactionAbilityManager.gd
+++ b/40k/autoloads/FactionAbilityManager.gd
@@ -1563,9 +1563,9 @@ func use_da_kaptin(player: int, target_unit_id: String) -> Dictionary:
 		return {"success": false, "error": "Target %s is not an eligible Da Kaptin target" % target_unit_id}
 
 	# Roll D3 for mortal wounds
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
-	var d3_roll = rng.randi_range(1, 3)
+	# Issue #329: route through RNGService so static test_mode_seed applies
+	var rng = RulesEngine.RNGService.new()
+	var d3_roll = rng.rng.randi_range(1, 3)
 
 	# Apply mortal wounds
 	var board = GameState.create_snapshot()
@@ -1645,9 +1645,9 @@ func resolve_bionik_workshop(player: int) -> Dictionary:
 		return {"success": false, "error": "Bionik Workshop already resolved for %s" % bearer_id}
 
 	# Roll D3
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
-	var d3_roll = rng.randi_range(1, 3)
+	# Issue #329: route through RNGService so static test_mode_seed applies
+	var rng = RulesEngine.RNGService.new()
+	var d3_roll = rng.rng.randi_range(1, 3)
 
 	var bonus_type = ""
 	var bonus_description = ""

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -516,7 +516,9 @@ func _process_charge_roll(action: Dictionary) -> Dictionary:
 	var charge_data = pending_charges[unit_id]
 
 	# Roll 2D6 for charge distance
-	var rng = RulesEngine.RNGService.new()
+	# Issue #329: honor payload.rng_seed (multiplayer + tests); fall back to test_mode_seed
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var rolls = rng.roll_d6(2)
 	var total_distance = rolls[0] + rolls[1]
 
@@ -732,7 +734,9 @@ func _process_use_ability_reroll(action: Dictionary) -> Dictionary:
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 
 	# Re-roll the 2D6 (free — no CP cost)
-	var rng = RulesEngine.RNGService.new()
+	# Issue #329: honor payload.rng_seed
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var new_rolls = rng.roll_d6(2)
 	var new_total = new_rolls[0] + new_rolls[1]
 
@@ -800,7 +804,9 @@ func _process_use_command_reroll(action: Dictionary) -> Dictionary:
 			return _resolve_charge_roll(unit_id)
 
 	# Re-roll the 2D6
-	var rng = RulesEngine.RNGService.new()
+	# Issue #329: honor payload.rng_seed
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var new_rolls = rng.roll_d6(2)
 	var new_total = new_rolls[0] + new_rolls[1]
 
@@ -973,7 +979,7 @@ func _unit_has_spiked_ram(unit: Dictionary) -> bool:
 			return true
 	return false
 
-func _apply_spiked_ram_if_applicable(unit_id: String, charge_targets: Array, changes: Array) -> void:
+func _apply_spiked_ram_if_applicable(unit_id: String, charge_targets: Array, changes: Array, rng_seed: int = -1) -> void:
 	"""OA-50: If charging unit has Spiked Ram, roll D6 and deal mortal wounds to first charge target."""
 	var unit = get_unit(unit_id)
 	if not _unit_has_spiked_ram(unit):
@@ -991,7 +997,8 @@ func _apply_spiked_ram_if_applicable(unit_id: String, charge_targets: Array, cha
 	var unit_name = unit.get("meta", {}).get("name", unit_id)
 	var target_name = target_unit.get("meta", {}).get("name", target_unit_id)
 
-	var rng = RulesEngine.RNGService.new()
+	# Issue #329: route through RNGService; seed forwarded by caller (action.payload.rng_seed)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var roll = rng.roll_d6(1)[0]
 
 	var mortal_wounds = 0
@@ -1141,10 +1148,12 @@ func _process_apply_charge_move(action: Dictionary) -> Dictionary:
 	# SPIKED RAM (OA-50): After charge move, deal mortal wounds to a charge target.
 	# "Each time this model ends a Charge move, select one enemy unit within Engagement Range
 	# and roll D6: on 2-5 = D3 mortal wounds; on 6 = 3 mortal wounds."
-	_apply_spiked_ram_if_applicable(unit_id, charge_data.targets, changes)
+	# Issue #329: forward action.payload.rng_seed for deterministic test replay
+	var apply_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	_apply_spiked_ram_if_applicable(unit_id, charge_data.targets, changes, apply_seed)
 
 	# OA-36: Piston-driven Brutality — after Charge move, auto-resolve mortal wounds
-	_resolve_piston_driven_brutality_after_charge(unit_id, changes)
+	_resolve_piston_driven_brutality_after_charge(unit_id, changes, apply_seed)
 
 	# Check if Tank Shock is available for the charging player
 	# Per 10e rules: "just after a VEHICLE unit ends a Charge move"
@@ -2526,7 +2535,9 @@ func _process_use_fire_overwatch(action: Dictionary) -> Dictionary:
 
 	# Resolve Overwatch shooting using RulesEngine
 	# Overwatch only hits on unmodified 6s (special rule)
-	var overwatch_result = _resolve_overwatch_shooting(unit_id, enemy_unit_id, player)
+	# Issue #329: forward action.payload.rng_seed
+	var ow_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var overwatch_result = _resolve_overwatch_shooting(unit_id, enemy_unit_id, player, ow_seed)
 
 	# P1-59: Clear out-of-phase flag after overwatch resolves
 	if strat_manager:
@@ -2570,7 +2581,7 @@ func _process_decline_fire_overwatch(action: Dictionary) -> Dictionary:
 
 	return create_result(true, [])
 
-func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: String, player: int) -> Dictionary:
+func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: String, player: int, rng_seed: int = -1) -> Dictionary:
 	"""
 	Resolve Overwatch shooting. Uses the normal shooting resolution but forces
 	all hit rolls to only succeed on unmodified 6s (per 10e Overwatch rules).
@@ -2618,8 +2629,10 @@ func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: Strin
 	}
 
 	# Use RulesEngine.resolve_shoot for full resolution
+	# Issue #329: forward rng_seed from caller (action.payload.rng_seed)
 	var board = game_state_snapshot
-	var rng = RulesEngine.RNGService.new()
+	shoot_action["payload"]["rng_seed"] = rng_seed
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var shoot_result = RulesEngine.resolve_shoot(shoot_action, board, rng)
 
 	var total_damage = 0
@@ -2803,7 +2816,9 @@ func _process_use_heroic_intervention(action: Dictionary) -> Dictionary:
 	}
 
 	# Now auto-roll the charge dice (HI uses a normal 2D6 charge roll)
-	var rng = RulesEngine.RNGService.new()
+	# Issue #329: honor payload.rng_seed
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var rolls = rng.roll_d6(2)
 	var total_distance = rolls[0] + rolls[1]
 
@@ -3014,7 +3029,7 @@ func _is_heroic_intervention_roll_sufficient(unit_id: String, rolled_distance: i
 # OA-36: PISTON-DRIVEN BRUTALITY — Mortal wounds after Charge move
 # ============================================================================
 
-func _resolve_piston_driven_brutality_after_charge(unit_id: String, changes: Array) -> void:
+func _resolve_piston_driven_brutality_after_charge(unit_id: String, changes: Array, rng_seed: int = -1) -> void:
 	"""OA-36: Check if the charging unit has Piston-driven Brutality.
 	If so, auto-resolve mortal wounds against one enemy in Engagement Range.
 	Roll 1D6: on 2-5, D3 MW; on 6, D3+3 MW; on 1, nothing.
@@ -3054,7 +3069,8 @@ func _resolve_piston_driven_brutality_after_charge(unit_id: String, changes: Arr
 	log_phase_message("PISTON-DRIVEN BRUTALITY: %s targets %s within Engagement Range" % [unit_name, target_name])
 
 	# Resolve via RulesEngine
-	var rng_service = RulesEngine.RNGService.new()
+	# Issue #329: forward seed from action.payload.rng_seed (caller passes it through)
+	var rng_service = RulesEngine.RNGService.new(rng_seed)
 	var result = RulesEngine.resolve_piston_driven_brutality(
 		unit_id, target_id, temp_snapshot, rng_service
 	)

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -22,7 +22,7 @@ signal command_reroll_completed(original_rolls: Array, new_rolls: Array, context
 var _units_needing_test: Array = []
 var _units_tested: Array = []
 var _units_auto_passed: Array = []  # Units that auto-passed via Insane Bravery
-var _rng: RandomNumberGenerator
+var _rng  # RulesEngine.RNGService — picks up test_mode_seed via PR #346
 var _awaiting_reroll_decision: bool = false
 var _reroll_pending_unit_id: String = ""
 var _reroll_pending_roll: Dictionary = {}  # Stores {die1, die2, unit_id, leadership}
@@ -30,8 +30,8 @@ var _newly_drawn_missions: Array = []  # Missions drawn this phase, for review d
 var _fix_dat_armour_up_used: Array = []  # Units that used Fix Dat Armour Up this command phase
 
 func _init():
-	_rng = RandomNumberGenerator.new()
-	_rng.randomize()
+	# Issue #329: route through RNGService so static test_mode_seed applies
+	_rng = RulesEngine.RNGService.new()
 
 func _on_phase_enter() -> void:
 	phase_type = GameStateData.Phase.COMMAND
@@ -697,16 +697,19 @@ func _handle_battle_shock_test(action: Dictionary) -> Dictionary:
 	var leadership = unit.get("meta", {}).get("stats", {}).get("leadership", 7)
 
 	# Roll 2D6 (allow override for testing via dice_roll parameter)
+	# Issue #329: honor payload.rng_seed when supplied; otherwise reuse persistent _rng
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng_inst = RulesEngine.RNGService.new(rng_seed) if rng_seed >= 0 else _rng
 	var die1: int
 	var die2: int
 	if action.has("dice_roll"):
 		# Accept pre-set roll for deterministic testing
 		var roll = action.get("dice_roll", [])
-		die1 = roll[0] if roll.size() > 0 else _rng.randi_range(1, 6)
-		die2 = roll[1] if roll.size() > 1 else _rng.randi_range(1, 6)
+		die1 = roll[0] if roll.size() > 0 else rng_inst.rng.randi_range(1, 6)
+		die2 = roll[1] if roll.size() > 1 else rng_inst.rng.randi_range(1, 6)
 	else:
-		die1 = _rng.randi_range(1, 6)
-		die2 = _rng.randi_range(1, 6)
+		die1 = rng_inst.rng.randi_range(1, 6)
+		die2 = rng_inst.rng.randi_range(1, 6)
 
 	var roll_total = die1 + die2
 
@@ -919,8 +922,11 @@ func _handle_use_command_reroll(action: Dictionary) -> Dictionary:
 			return _resolve_battle_shock_test(unit_id, old_roll.die1, old_roll.die2)
 
 	# Re-roll 2D6
-	var new_die1 = _rng.randi_range(1, 6)
-	var new_die2 = _rng.randi_range(1, 6)
+	# Issue #329: honor payload.rng_seed; fall back to persistent _rng (RNGService)
+	var reroll_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var reroll_rng = RulesEngine.RNGService.new(reroll_seed) if reroll_seed >= 0 else _rng
+	var new_die1 = reroll_rng.rng.randi_range(1, 6)
+	var new_die2 = reroll_rng.rng.randi_range(1, 6)
 	var new_total = new_die1 + new_die2
 
 	log_phase_message("COMMAND RE-ROLL: Battle-shock re-rolled from %d (%d+%d) → %d (%d+%d)" % [
@@ -1580,9 +1586,10 @@ func _handle_use_grot_orderly(action: Dictionary) -> Dictionary:
 	bodyguard_unit_id = go_info.bodyguard_unit_id
 
 	# Roll D3 to determine how many models to return
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
-	var d3_roll = rng.randi_range(1, 3)
+	# Issue #329: route through RNGService so payload.rng_seed and test_mode_seed apply
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng = RulesEngine.RNGService.new(rng_seed)
+	var d3_roll = rng.rng.randi_range(1, 3)
 	var destroyed_count = go_info.destroyed_count
 	var models_to_return = mini(d3_roll, destroyed_count)
 

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -1284,7 +1284,9 @@ func _is_defender_human_player() -> bool:
 
 # P0-58: Interactive path — resolve hits and wounds, then emit saves_required for defender
 func _process_roll_dice_interactive(melee_action: Dictionary) -> Dictionary:
-	var rng_service = RulesEngine.RNGService.new()
+	# Issue #329: honor melee_action.payload.rng_seed
+	var rdi_seed: int = melee_action.get("payload", {}).get("rng_seed", -1)
+	var rng_service = RulesEngine.RNGService.new(rdi_seed)
 	var result = RulesEngine.resolve_melee_attacks_interactive(melee_action, game_state_snapshot, rng_service)
 
 	if not result.success:
@@ -1357,7 +1359,9 @@ func _process_roll_dice_interactive(melee_action: Dictionary) -> Dictionary:
 
 # Original auto-resolve path (for AI defenders)
 func _process_roll_dice_auto(melee_action: Dictionary) -> Dictionary:
-	var rng_service = RulesEngine.RNGService.new()
+	# Issue #329: honor melee_action.payload.rng_seed
+	var rda_seed: int = melee_action.get("payload", {}).get("rng_seed", -1)
+	var rng_service = RulesEngine.RNGService.new(rda_seed)
 	var result = RulesEngine.resolve_melee_attacks(melee_action, game_state_snapshot, rng_service)
 
 	# Debug logging for state changes
@@ -1556,7 +1560,9 @@ func _process_apply_melee_saves(action: Dictionary) -> Dictionary:
 
 		# Apply damage using RulesEngine
 		if not save_results.is_empty():
-			var fnp_rng = RulesEngine.RNGService.new()
+			# Issue #329: honor action.payload.rng_seed
+			var ams_seed: int = action.get("payload", {}).get("rng_seed", -1)
+			var fnp_rng = RulesEngine.RNGService.new(ams_seed)
 			var damage_result = RulesEngine.apply_save_damage(
 				save_results,
 				save_data,
@@ -1680,7 +1686,9 @@ func _process_apply_melee_saves(action: Dictionary) -> Dictionary:
 			var hs_target_id = sd.get("target_unit_id", "")
 			var hs_target_name = sd.get("target_unit_name", "Unknown")
 			print("[FightPhase] OA-19: HOLD STILL AND SAY 'AARGH!' — applying %d mortal wounds to %s" % [hs_mw, hs_target_name])
-			var hs_rng = RulesEngine.RNGService.new()
+			# Issue #329: honor action.payload.rng_seed
+			var hs_seed: int = action.get("payload", {}).get("rng_seed", -1)
+			var hs_rng = RulesEngine.RNGService.new(hs_seed)
 			var hs_result = RulesEngine.apply_mortal_wounds(hs_target_id, hs_mw, game_state_snapshot, hs_rng)
 			all_diffs.append_array(hs_result.get("diffs", []))
 			var hs_casualties = hs_result.get("casualties", 0)

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -445,13 +445,13 @@ func _check_thievin_scavengers() -> void:
 		return
 
 	# Roll 1D6 per qualifying objective
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
+	# Issue #329: route through RNGService so static test_mode_seed applies
+	var rng = RulesEngine.RNGService.new()
 	var rolls: Array = []
 	var any_success = false
 
 	for obj in qualifying_objectives:
-		var roll = rng.randi_range(1, 6)
+		var roll = rng.rng.randi_range(1, 6)
 		rolls.append({"objective_id": obj.id, "roll": roll, "success": roll >= 4})
 		if roll >= 4:
 			any_success = true
@@ -1546,7 +1546,9 @@ func _process_use_command_reroll(action: Dictionary) -> Dictionary:
 		print("MovementPhase: WARNING — StratagemManager not found, cannot deduct CP")
 
 	# Re-roll D6
-	var rng_service = RulesEngine.RNGService.new()
+	# Issue #329: honor payload.rng_seed
+	var reroll_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng_service = RulesEngine.RNGService.new(reroll_seed)
 	var new_rolls = rng_service.roll_d6(1)
 	var new_advance = new_rolls[0]
 
@@ -1748,7 +1750,9 @@ func _process_use_fire_overwatch(action: Dictionary) -> Dictionary:
 		strat_manager.set_out_of_phase_active(true, player, unit_id)
 
 	# Resolve Overwatch shooting using RulesEngine
-	var ow_shooting_result = _resolve_overwatch_shooting(unit_id, enemy_unit_id, player)
+	# Issue #329: forward action.payload.rng_seed
+	var mov_ow_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var ow_shooting_result = _resolve_overwatch_shooting(unit_id, enemy_unit_id, player, mov_ow_seed)
 
 	# P1-59: Clear out-of-phase flag after overwatch resolves
 	if strat_manager:
@@ -1938,7 +1942,9 @@ func _process_use_bomb_squigs(action: Dictionary) -> Dictionary:
 		print("║ P2-25: Bomb Squig #%d used" % squig_index)
 
 	# Resolve: roll 1D6, on 3+ the target suffers D3 mortal wounds
-	var result = _resolve_bomb_squigs(unit_id, target_unit_id)
+	# Issue #329: forward action.payload.rng_seed
+	var bs_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var result = _resolve_bomb_squigs(unit_id, target_unit_id, bs_seed)
 
 	var all_changes = cached_changes.duplicate()
 	all_changes.append_array(result.get("diffs", []))
@@ -2047,7 +2053,9 @@ func _process_use_deff_from_above(action: Dictionary) -> Dictionary:
 		return create_result(true, cached_changes, "", {"dice": cached_dice})
 
 	# Resolve: roll D6 per model in unit, on 4+ = 1 mortal wound each
-	var result = _resolve_deff_from_above(unit_id, target_unit_id)
+	# Issue #329: forward action.payload.rng_seed
+	var dfa_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var result = _resolve_deff_from_above(unit_id, target_unit_id, dfa_seed)
 
 	var all_changes = cached_changes.duplicate()
 	all_changes.append_array(result.get("diffs", []))
@@ -2163,11 +2171,11 @@ func _get_units_moved_over(unit_id: String, move_data: Dictionary) -> Array:
 
 	return result
 
-func _resolve_deff_from_above(unit_id: String, target_unit_id: String) -> Dictionary:
+func _resolve_deff_from_above(unit_id: String, target_unit_id: String, rng_seed: int = -1) -> Dictionary:
 	"""Resolve Deff from Above: roll D6 per model in unit, 4+ = 1 mortal wound each.
 	Returns {diffs: Array, mortal_wounds: int, casualties: int, rolls: Array, log_text: String}."""
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
+	# Issue #329: route through RNGService; seed forwarded by caller (action.payload.rng_seed)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 
 	var unit = get_unit(unit_id)
 	var unit_name = unit.get("meta", {}).get("name", unit_id)
@@ -2183,7 +2191,7 @@ func _resolve_deff_from_above(unit_id: String, target_unit_id: String) -> Dictio
 	var rolls = []
 	var mortal_wounds = 0
 	for i in range(alive_models):
-		var roll = rng.randi_range(1, 6)
+		var roll = rng.rng.randi_range(1, 6)
 		rolls.append(roll)
 		if roll >= 4:
 			mortal_wounds += 1
@@ -2572,12 +2580,10 @@ func _process_use_mekaniak(action: Dictionary) -> Dictionary:
 	var mekaniak_changes = []
 
 	# Roll D3 for healing
-	var rng = RulesEngine.rng if RulesEngine else null
-	var d3_roll = 0
-	if rng:
-		d3_roll = rng.roll_d3()
-	else:
-		d3_roll = (randi() % 3) + 1
+	# Issue #329: route through RNGService; honor action.payload.rng_seed
+	var mek_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var mek_rng = RulesEngine.RNGService.new(mek_seed)
+	var d3_roll = mek_rng.rng.randi_range(1, 3)
 	print("MovementPhase: Mekaniak D3 heal roll = %d" % d3_roll)
 
 	# Find the target model and heal up to D3 wounds
@@ -2856,7 +2862,10 @@ func _process_use_grot_oiler(action: Dictionary) -> Dictionary:
 	var heal_changes = []
 
 	# Roll D3 for healing amount
-	var d6_roll = randi() % 6 + 1
+	# Issue #329: route through RNGService; honor action.payload.rng_seed
+	var go_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var go_rng = RulesEngine.RNGService.new(go_seed)
+	var d6_roll = go_rng.rng.randi_range(1, 6)
 	var d3_result = int(ceil(float(d6_roll) / 2.0))  # 1-2=1, 3-4=2, 5-6=3
 	print("MovementPhase: Grot Oiler D3 roll — D6=%d → D3=%d" % [d6_roll, d3_result])
 	log_phase_message("GROT OILER: D3 roll — D6=%d → D3=%d wounds to heal" % [d6_roll, d3_result])
@@ -3029,13 +3038,13 @@ func _get_unit_center(unit: Dictionary) -> Variant:
 		center += p
 	return center / positions.size()
 
-func _resolve_bomb_squigs(unit_id: String, target_unit_id: String) -> Dictionary:
+func _resolve_bomb_squigs(unit_id: String, target_unit_id: String, rng_seed: int = -1) -> Dictionary:
 	"""Resolve Bomb Squigs: roll 1D6, on 3+ target suffers D3 mortal wounds.
 	Returns {diffs: Array, mortal_wounds: int, casualties: int, success: bool, roll: int, log_text: String}."""
-	var rng = RandomNumberGenerator.new()
-	rng.randomize()
+	# Issue #329: route through RNGService; seed forwarded by caller (action.payload.rng_seed)
+	var rng = RulesEngine.RNGService.new(rng_seed)
 
-	var roll = rng.randi_range(1, 6)
+	var roll = rng.rng.randi_range(1, 6)
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 	var target_name = get_unit(target_unit_id).get("meta", {}).get("name", target_unit_id)
 
@@ -3053,7 +3062,7 @@ func _resolve_bomb_squigs(unit_id: String, target_unit_id: String) -> Dictionary
 		}
 
 	# D3 mortal wounds
-	var mortal_wounds = rng.randi_range(1, 3)
+	var mortal_wounds = rng.rng.randi_range(1, 3)
 	print("║ P2-25: Bomb Squigs — HIT! D3 = %d mortal wounds on %s" % [mortal_wounds, target_name])
 
 	# Apply mortal wounds to target
@@ -3483,7 +3492,7 @@ func _process_place_rapid_ingress_reinforcement(action: Dictionary) -> Dictionar
 	log_phase_message("=== END_MOVEMENT COMPLETE (post-Rapid Ingress) ===")
 	return create_result(true, changes)
 
-func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: String, player: int) -> Dictionary:
+func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: String, player: int, rng_seed: int = -1) -> Dictionary:
 	"""
 	Resolve Overwatch shooting. Uses the normal shooting resolution but forces
 	all hit rolls to only succeed on unmodified 6s (per 10e Overwatch rules).
@@ -3531,8 +3540,10 @@ func _resolve_overwatch_shooting(shooting_unit_id: String, target_unit_id: Strin
 	}
 
 	# Use RulesEngine.resolve_shoot for full resolution
+	# Issue #329: forward rng_seed from caller (action.payload.rng_seed)
 	var board = game_state_snapshot
-	var rng = RulesEngine.RNGService.new()
+	shoot_action["payload"]["rng_seed"] = rng_seed
+	var rng = RulesEngine.RNGService.new(rng_seed)
 	var shoot_result = RulesEngine.resolve_shoot(shoot_action, board, rng)
 
 	log_phase_message("FIRE OVERWATCH result: %s fired at %s — %s" % [

--- a/40k/phases/RollOffPhase.gd
+++ b/40k/phases/RollOffPhase.gd
@@ -10,7 +10,7 @@ const BasePhase = preload("res://phases/BasePhase.gd")
 # - If tied, re-roll until there is a winner
 # - The player who goes first is the Attacker; the other is the Defender
 
-var _rng: RandomNumberGenerator
+var _rng  # RulesEngine.RNGService — picks up test_mode_seed via PR #346
 var _player1_roll: int = 0
 var _player2_roll: int = 0
 var _roll_off_winner: int = 0  # Player who won the roll-off (gets to choose)
@@ -19,8 +19,8 @@ var _roll_complete: bool = false
 var _choice_made: bool = false
 
 func _init():
-	_rng = RandomNumberGenerator.new()
-	_rng.randomize()
+	# Issue #329: route through RNGService so static test_mode_seed applies
+	_rng = RulesEngine.RNGService.new()
 
 func _on_phase_enter() -> void:
 	phase_type = GameStateData.Phase.ROLL_OFF
@@ -106,13 +106,16 @@ func _handle_roll_for_first_turn(action: Dictionary) -> Dictionary:
 	var p1_roll: int
 	var p2_roll: int
 
+	# Issue #329: honor payload.rng_seed when provided; fall back to persistent _rng
+	var rng_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var rng_inst = RulesEngine.RNGService.new(rng_seed) if rng_seed >= 0 else _rng
 	if action.has("dice_roll"):
 		var rolls = action.get("dice_roll", [])
-		p1_roll = rolls[0] if rolls.size() > 0 else _rng.randi_range(1, 6)
-		p2_roll = rolls[1] if rolls.size() > 1 else _rng.randi_range(1, 6)
+		p1_roll = rolls[0] if rolls.size() > 0 else rng_inst.rng.randi_range(1, 6)
+		p2_roll = rolls[1] if rolls.size() > 1 else rng_inst.rng.randi_range(1, 6)
 	else:
-		p1_roll = _rng.randi_range(1, 6)
-		p2_roll = _rng.randi_range(1, 6)
+		p1_roll = rng_inst.rng.randi_range(1, 6)
+		p2_roll = rng_inst.rng.randi_range(1, 6)
 
 	_player1_roll = p1_roll
 	_player2_roll = p2_roll

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -55,7 +55,7 @@ var awaiting_pulsa_rokkit: bool = false  # OA-31: True when waiting for Pulsa Ro
 var shooty_power_trip_pending_unit: String = ""  # OA-37: Unit awaiting Shooty Power Trip decision
 var awaiting_shooty_power_trip: bool = false  # OA-37: True when waiting for Shooty Power Trip response
 var _targets_hit_by_shooter: Dictionary = {}  # P1-11: Track which enemy units were hit { target_unit_id: hit_count }
-var _rng = RandomNumberGenerator.new()  # P1-11: RNG for battle-shock tests
+var _rng = RulesEngine.RNGService.new()  # P1-11: RNG for battle-shock tests (issue #329: routes through test_mode_seed)
 
 func _init():
 	phase_type = GameStateData.Phase.SHOOTING
@@ -993,16 +993,20 @@ func _process_resolve_shooting(action: Dictionary) -> Dictionary:
 	emit_signal("dice_rolled", resolution_start_block)
 
 	# Build full shoot action for RulesEngine
+	# Issue #329: forward action.payload.rng_seed into the dispatched shoot_action so RulesEngine
+	# routes it through RNGService (deterministic when test_mode_seed or explicit seed is set)
+	var rs_seed: int = action.get("payload", {}).get("rng_seed", -1)
 	var shoot_action = {
 		"type": "SHOOT",
 		"actor_unit_id": active_shooter_id,
 		"payload": {
-			"assignments": confirmed_assignments
+			"assignments": confirmed_assignments,
+			"rng_seed": rs_seed
 		}
 	}
 
 	# Resolve with RulesEngine UP TO WOUNDS (interactive saves)
-	var rng_service = RulesEngine.RNGService.new()
+	var rng_service = RulesEngine.RNGService.new(rs_seed)
 	var result = RulesEngine.resolve_shoot_until_wounds(shoot_action, game_state_snapshot, rng_service)
 
 	if not result.success:
@@ -1076,7 +1080,7 @@ func _process_resolve_shooting(action: Dictionary) -> Dictionary:
 		var hazardous_weapons_on_miss = result.get("hazardous_weapons", [])
 		if not hazardous_weapons_on_miss.is_empty():
 			print("║ HAZARDOUS: Processing %d hazardous weapon check(s) despite miss" % hazardous_weapons_on_miss.size())
-			var haz_rng = RulesEngine.RNGService.new()
+			var haz_rng = RulesEngine.RNGService.new(rs_seed)  # Issue #329: forward seed
 			for haz_weapon in hazardous_weapons_on_miss:
 				var haz_result = RulesEngine.resolve_hazardous_check(
 					active_shooter_id,
@@ -1796,6 +1800,8 @@ func _process_shoot(action: Dictionary) -> Dictionary:
 	# Does NOT emit UI signals (weapon_order_required, next_weapon_confirmation_required,
 	# saves_required) to avoid creating orphaned dialogs during AI play.
 	var unit_id = action.get("actor_unit_id", "")
+	# Issue #329: extract action.payload.rng_seed once for all sub-rolls in this method
+	var ps_seed: int = action.get("payload", {}).get("rng_seed", -1)
 
 	print("╔═══════════════════════════════════════════════════════════════")
 	print("║ AI SHOOT (atomic): Starting for unit %s" % unit_id)
@@ -1873,17 +1879,17 @@ func _process_shoot(action: Dictionary) -> Dictionary:
 	# OA-37: AI auto-use Shooty Power Trip if available
 	var ability_mgr_spt_ai = get_node_or_null("/root/UnitAbilityManager")
 	if ability_mgr_spt_ai and ability_mgr_spt_ai.has_shooty_power_trip(unit_id):
-		var ai_d6_roll = _rng.randi_range(1, 6)
+		var ai_d6_roll = _rng.rng.randi_range(1, 6)
 		var ai_spt_unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 		print("║ AI SHOOT: OA-37 Shooty Power Trip — auto-rolling for %s (D6 = %d)" % [unit_id, ai_d6_roll])
 
 		if ai_d6_roll <= 2:
 			# 1-2: D3 mortal wounds to self
-			var ai_d3_roll = _rng.randi_range(1, 6)
+			var ai_d3_roll = _rng.rng.randi_range(1, 6)
 			var ai_mortal_wounds = ((ai_d3_roll - 1) / 2) + 1
 			print("║ AI SHOOT: OA-37 Shooty Power Trip — D3 mortal wounds to self (D3 = %d, MW = %d)" % [ai_d3_roll, ai_mortal_wounds])
 
-			var ai_rng_service = RulesEngine.RNGService.new()
+			var ai_rng_service = RulesEngine.RNGService.new(ps_seed)  # Issue #329: forward seed
 			var ai_mw_result = RulesEngine.apply_mortal_wounds(unit_id, ai_mortal_wounds, game_state_snapshot, ai_rng_service)
 			var ai_mw_diffs = ai_mw_result.get("diffs", [])
 			if not ai_mw_diffs.is_empty():
@@ -1952,15 +1958,17 @@ func _process_shoot(action: Dictionary) -> Dictionary:
 	log_phase_message("AI: Confirmed %d weapon assignments for %s" % [confirmed_assignments.size(), unit_id])
 
 	# Step 3: Resolve shooting (hits + wounds) via RulesEngine
+	# Issue #329: forward action.payload.rng_seed to RulesEngine
 	var shoot_action = {
 		"type": "SHOOT",
 		"actor_unit_id": active_shooter_id,
 		"payload": {
-			"assignments": confirmed_assignments
+			"assignments": confirmed_assignments,
+			"rng_seed": ps_seed
 		}
 	}
 
-	var rng_service = RulesEngine.RNGService.new()
+	var rng_service = RulesEngine.RNGService.new(ps_seed)
 	var result = RulesEngine.resolve_shoot_until_wounds(shoot_action, game_state_snapshot, rng_service)
 
 	if not result.success:
@@ -1997,7 +2005,7 @@ func _process_shoot(action: Dictionary) -> Dictionary:
 	var hazardous_weapons = result.get("hazardous_weapons", [])
 	if not hazardous_weapons.is_empty():
 		print("║ AI SHOOT: Processing %d hazardous weapon check(s)" % hazardous_weapons.size())
-		var haz_rng = RulesEngine.RNGService.new()
+		var haz_rng = RulesEngine.RNGService.new(ps_seed)  # Issue #329: forward seed
 		for haz_weapon in hazardous_weapons:
 			var haz_result = RulesEngine.resolve_hazardous_check(
 				active_shooter_id,
@@ -4044,8 +4052,8 @@ func _resolve_sanctified_flames_battle_shock(shooter_unit_id: String, target_uni
 		return []
 
 	# Roll 2D6 for Battle-shock test
-	var die1 = _rng.randi_range(1, 6)
-	var die2 = _rng.randi_range(1, 6)
+	var die1 = _rng.rng.randi_range(1, 6)
+	var die2 = _rng.rng.randi_range(1, 6)
 	var roll_total = die1 + die2
 	var test_passed = roll_total >= leadership
 
@@ -4260,7 +4268,7 @@ func _resolve_throat_slittas(unit_id: String) -> Dictionary:
 		var rolls: Array = []
 		var mortal_wounds = 0
 		for i in range(models_in_range):
-			var roll = _rng.randi_range(1, 6)
+			var roll = _rng.rng.randi_range(1, 6)
 			rolls.append(roll)
 			if roll >= 5:
 				mortal_wounds += 1
@@ -4740,7 +4748,10 @@ func _process_use_shooty_power_trip(action: Dictionary) -> Dictionary:
 	shooty_power_trip_pending_unit = ""
 
 	# Roll D6 to determine effect
-	var d6_roll = _rng.randi_range(1, 6)
+	# Issue #329: honor payload.rng_seed; fall back to persistent _rng
+	var spt_seed: int = action.get("payload", {}).get("rng_seed", -1)
+	var spt_rng = RulesEngine.RNGService.new(spt_seed) if spt_seed >= 0 else _rng
+	var d6_roll = spt_rng.rng.randi_range(1, 6)
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 	var diffs = []
 	var effect_name = ""
@@ -4750,13 +4761,13 @@ func _process_use_shooty_power_trip(action: Dictionary) -> Dictionary:
 	if d6_roll <= 2:
 		# 1-2: D3 mortal wounds to self
 		effect_name = "self_damage"
-		var d3_roll = _rng.randi_range(1, 6)
+		var d3_roll = spt_rng.rng.randi_range(1, 6)
 		var mortal_wounds = ((d3_roll - 1) / 2) + 1  # 1-2→1, 3-4→2, 5-6→3
 		print("║ OA-37: Result 1-2 — D3 mortal wounds to self (D3 roll = %d, MW = %d)" % [d3_roll, mortal_wounds])
 
 		# Apply mortal wounds to the unit
 		var board = game_state_snapshot
-		var rng_service = RulesEngine.RNGService.new()
+		var rng_service = RulesEngine.RNGService.new(spt_seed)
 		var mw_result = RulesEngine.apply_mortal_wounds(unit_id, mortal_wounds, board, rng_service)
 		diffs.append_array(mw_result.get("diffs", []))
 
@@ -4879,6 +4890,8 @@ func _process_apply_saves(action: Dictionary) -> Dictionary:
 	print("║ resolution_state: ", resolution_state)
 	print("║ pending_save_data.size(): ", pending_save_data.size())
 	print("╚═══════════════════════════════════════════════════════════════")
+	# Issue #329: extract action.payload.rng_seed once for all sub-rolls in this method
+	var pas_seed: int = action.get("payload", {}).get("rng_seed", -1)
 
 	var payload = action.get("payload", {})
 	var save_results_list = payload.get("save_results_list", [])
@@ -4931,7 +4944,7 @@ func _process_apply_saves(action: Dictionary) -> Dictionary:
 			save_data["devastating_damage"] = devastating_damage
 
 		# Apply damage using RulesEngine (with RNG for Feel No Pain rolls)
-		var fnp_rng = RulesEngine.RNGService.new()
+		var fnp_rng = RulesEngine.RNGService.new(pas_seed)  # Issue #329: forward seed
 		var damage_result = RulesEngine.apply_save_damage(
 			save_results,
 			save_data,
@@ -5091,7 +5104,7 @@ func _process_apply_saves(action: Dictionary) -> Dictionary:
 		print("╔═══════════════════════════════════════════════════════════════")
 		print("║ HAZARDOUS CHECK — Processing %d hazardous weapon(s)" % pending_hazardous_weapons.size())
 		print("╚═══════════════════════════════════════════════════════════════")
-		var haz_rng = RulesEngine.RNGService.new()
+		var haz_rng = RulesEngine.RNGService.new(pas_seed)  # Issue #329: forward seed
 		for haz_weapon in pending_hazardous_weapons:
 			var haz_result = RulesEngine.resolve_hazardous_check(
 				active_shooter_id,


### PR DESCRIPTION
## Summary
- Plumb `payload.rng_seed` through every phase that rolls dice (Shooting, Charge, Fight, Command, RollOff)
- Replace direct `RandomNumberGenerator`/`randi()`/`randomize()` calls with `RulesEngine.RNGService` instances so the static `test_mode_seed` (added in PR #346) applies across the codebase
- StratagemManager and FactionAbilityManager dice now route through RNGService

## Behavior change
- **Default runtime**: unchanged. Without `test_mode_seed` set, RNGService still calls `randomize()` so dice are non-deterministic.
- **Multiplayer**: unchanged. Existing `payload.rng_seed` plumbing in MovementPhase already works; this PR extends the same pattern.
- **Test code**: setting `RulesEngine.RNGService.test_mode_seed = N` at session start now produces fully reproducible runs across all phases and abilities.

## Test plan
- [ ] Run a fresh game, observe dice; behavior unchanged
- [ ] Set test_mode_seed=42 at start; replay the same actions; observe identical dice sequences across two runs
- [ ] Multiplayer determinism (existing) still works

Closes #329
