### PR TITLE
Add RulesEngine.set_test_seed/get_test_seed helpers

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -533,6 +533,19 @@ class RNGService:
 			rolls.append(rng.randi_range(1, 6))
 		return rolls
 
+
+# Test/debug helpers exposing RNGService.test_mode_seed via a method, since
+# Expression.parse (used by the MCP bridge's execute_script) can't perform
+# the static-var assignment directly. Pass -1 to disable test mode and
+# resume normal randomization. The counter is reset so each `set_test_seed`
+# call starts a fresh deterministic sequence.
+static func set_test_seed(seed: int) -> void:
+	RNGService.test_mode_seed = seed
+	RNGService._test_seed_counter = 0
+
+static func get_test_seed() -> int:
+	return RNGService.test_mode_seed
+
 # ==========================================
 # SHOOTING MODIFIERS (Phase 1 MVP)
 # ==========================================


### PR DESCRIPTION
## Summary
Adds two static helpers on \`RulesEngine\` that wrap \`RNGService.test_mode_seed\`:

- \`set_test_seed(seed: int)\` — sets the global test seed and resets the internal counter
- \`get_test_seed() -> int\` — reads it

## Why
PR #346 added \`RulesEngine.RNGService.test_mode_seed\` so tests can pin all RNG output. PR #348 plumbed \`payload.rng_seed\` through every phase action and replaced bare \`randi()\` calls with \`RNGService\` instances.

The remaining gap: the MCP bridge's \`execute_script\` uses Godot's \`Expression.parse\`, which can't do assignments. So external test code (audit harness, tooling) can't flip \`test_mode_seed\` directly. Wrapping the assignment in a method makes it callable via either MCP entrypoint:

\`\`\`
get_node('/root/RulesEngine').set_test_seed(42)
# or via call_node_method
\`\`\`

## Behavior
- Default (test_mode_seed = -1): unchanged. \`RNGService.new()\` calls \`randomize()\` as before.
- Set to >= 0: every unseeded \`RNGService.new()\` derives a deterministic-but-unique seed via \`hash([test_mode_seed, counter])\`. Counter resets on each \`set_test_seed\` call.
- Multiplayer: always passes explicit seeds, completely unaffected.

## Test plan
- [x] Static-var assignment via the new method should set the value
- [ ] After \`set_test_seed(42)\`, two \`RNGService.new()\` instances seed differently (counter increments)
- [ ] After \`set_test_seed(-1)\`, behavior reverts to randomize()

## Audit context
This unblocks fully testing the 8 ❌ NOT TESTED stratagems and the 6 🟡 TRIGGER-ONLY stratagems documented in \`40k/test_results/audit_2026_05/AUDIT_REPORT.md\` (especially GRENADE, TANK SHOCK effect, FIRE OVERWATCH effect, COMMAND RE-ROLL effect — all of which need predictable dice).