### PR TITLE
Fix #353: wire USE_STRATAGEM dispatch in Movement/Shooting/Charge/Fight

### DIFF
--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -203,6 +203,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_use_tank_shock(action)
 		"DECLINE_TANK_SHOCK":
 			return _validate_decline_tank_shock(action)
+		"USE_STRATAGEM":
+			return _validate_use_stratagem(action)
 		"END_SHOOTING":
 			# Idempotent no-op: previous phase auto-advanced before END_SHOOTING was dispatched.
 			return {"valid": true}
@@ -251,6 +253,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_use_tank_shock(action)
 		"DECLINE_TANK_SHOCK":
 			return _process_decline_tank_shock(action)
+		"USE_STRATAGEM":
+			return _process_use_stratagem(action)
 		"END_SHOOTING":
 			return create_result(true, [], "")
 		_:
@@ -3197,5 +3201,49 @@ func create_result(success: bool, changes: Array = [], error: String = "", addit
 			result[key] = additional_data[key]
 	else:
 		result["error"] = error
-	
+
 	return result
+
+# ============================================================================
+# STRATAGEM HANDLING (active stratagems with phase: "charge")
+# Mirrors CommandPhase._validate_use_stratagem / _process_use_stratagem.
+# ============================================================================
+
+func _validate_use_stratagem(action: Dictionary) -> Dictionary:
+	var errors = []
+	var stratagem_id = action.get("stratagem_id", "")
+
+	if stratagem_id == "":
+		errors.append("Missing stratagem_id")
+		return {"valid": false, "errors": errors}
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		errors.append("StratagemManager not available")
+		return {"valid": false, "errors": errors}
+
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+	var validation = strat_manager.can_use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not validation.can_use:
+		errors.append(validation.reason)
+		return {"valid": false, "errors": errors}
+
+	return {"valid": true, "errors": []}
+
+func _process_use_stratagem(action: Dictionary) -> Dictionary:
+	var stratagem_id = action.get("stratagem_id", "")
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		return create_result(false, [], "StratagemManager not available")
+
+	var result = strat_manager.use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not result.get("success", false):
+		return create_result(false, [], result.get("error", "Stratagem use failed"))
+
+	var strat_name = result.get("stratagem_name", stratagem_id)
+	print("ChargePhase: Stratagem %s used (target=%s)" % [strat_name, target_unit_id])
+	return create_result(true, result.get("diffs", []), "Used " + strat_name)

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -429,6 +429,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _validate_apply_melee_saves(action)
+		"USE_STRATAGEM":
+			return _validate_use_stratagem(action)
 		"END_CHARGE":
 			# Idempotent no-op: previous phase auto-advanced before END_CHARGE was dispatched.
 			return {"valid": true}
@@ -481,6 +483,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _process_apply_melee_saves(action)
+		"USE_STRATAGEM":
+			return _process_use_stratagem(action)
 		"END_CHARGE":
 			return create_result(true, [], "")
 		_:
@@ -4260,3 +4264,47 @@ func _trigger_unit_animation(unit_id: String, anim_name: String) -> void:
 				for grandchild in child.get_children():
 					if grandchild.has_method("play_animation"):
 						grandchild.play_animation(anim_name)
+
+# ============================================================================
+# STRATAGEM HANDLING (active stratagems with phase: "fight")
+# Mirrors CommandPhase._validate_use_stratagem / _process_use_stratagem.
+# ============================================================================
+
+func _validate_use_stratagem(action: Dictionary) -> Dictionary:
+	var errors = []
+	var stratagem_id = action.get("stratagem_id", "")
+
+	if stratagem_id == "":
+		errors.append("Missing stratagem_id")
+		return {"valid": false, "errors": errors}
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		errors.append("StratagemManager not available")
+		return {"valid": false, "errors": errors}
+
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+	var validation = strat_manager.can_use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not validation.can_use:
+		errors.append(validation.reason)
+		return {"valid": false, "errors": errors}
+
+	return {"valid": true, "errors": []}
+
+func _process_use_stratagem(action: Dictionary) -> Dictionary:
+	var stratagem_id = action.get("stratagem_id", "")
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		return create_result(false, [], "StratagemManager not available")
+
+	var result = strat_manager.use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not result.get("success", false):
+		return create_result(false, [], result.get("error", "Stratagem use failed"))
+
+	var strat_name = result.get("stratagem_name", stratagem_id)
+	print("FightPhase: Stratagem %s used (target=%s)" % [strat_name, target_unit_id])
+	return create_result(true, result.get("diffs", []), "Used " + strat_name)

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -600,6 +600,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_embark_unit(action)
 		"PLACE_REINFORCEMENT":
 			return _validate_place_reinforcement(action)
+		"USE_STRATAGEM":
+			return _validate_use_stratagem(action)
 		"USE_COMMAND_REROLL":
 			if not _awaiting_reroll_decision:
 				return {"valid": false, "errors": ["Not awaiting a Command Re-roll decision"]}
@@ -719,6 +721,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_embark_unit(action)
 		"PLACE_REINFORCEMENT":
 			return _process_place_reinforcement(action)
+		"USE_STRATAGEM":
+			return _process_use_stratagem(action)
 		"USE_COMMAND_REROLL":
 			return _process_use_command_reroll(action)
 		"DECLINE_COMMAND_REROLL":
@@ -7202,3 +7206,47 @@ func _move_attached_characters(bodyguard_id: String, attached_char_ids: Array, e
 		print("[MovementPhase] Moved attached character %s with bodyguard %s" % [char_name, bodyguard_id])
 
 	return changes
+
+# ============================================================================
+# STRATAGEM HANDLING (active stratagems with phase: "movement")
+# Mirrors CommandPhase._validate_use_stratagem / _process_use_stratagem.
+# ============================================================================
+
+func _validate_use_stratagem(action: Dictionary) -> Dictionary:
+	var errors = []
+	var stratagem_id = action.get("stratagem_id", "")
+
+	if stratagem_id == "":
+		errors.append("Missing stratagem_id")
+		return {"valid": false, "errors": errors}
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		errors.append("StratagemManager not available")
+		return {"valid": false, "errors": errors}
+
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+	var validation = strat_manager.can_use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not validation.can_use:
+		errors.append(validation.reason)
+		return {"valid": false, "errors": errors}
+
+	return {"valid": true, "errors": []}
+
+func _process_use_stratagem(action: Dictionary) -> Dictionary:
+	var stratagem_id = action.get("stratagem_id", "")
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		return create_result(false, [], "StratagemManager not available")
+
+	var result = strat_manager.use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not result.get("success", false):
+		return create_result(false, [], result.get("error", "Stratagem use failed"))
+
+	var strat_name = result.get("stratagem_name", stratagem_id)
+	print("MovementPhase: Stratagem %s used (target=%s)" % [strat_name, target_unit_id])
+	return create_result(true, result.get("diffs", []), "Used " + strat_name)

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -316,6 +316,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_decline_reactive_stratagem(action)
 		"USE_GRENADE_STRATAGEM":  # Active player uses GRENADE stratagem
 			return _validate_use_grenade_stratagem(action)
+		"USE_STRATAGEM":  # Active player uses a proactive (non-grenade) stratagem with phase: "shooting"
+			return _validate_use_stratagem(action)
 		"USE_SENTINEL_STORM":  # P1-10: Player uses Sentinel Storm shoot-again
 			return _validate_use_sentinel_storm(action)
 		"DECLINE_SENTINEL_STORM":  # P1-10: Player declines Sentinel Storm
@@ -411,6 +413,9 @@ func process_action(action: Dictionary) -> Dictionary:
 		"USE_GRENADE_STRATAGEM":  # Active player uses GRENADE stratagem
 			print("ShootingPhase: Matched USE_GRENADE_STRATAGEM")
 			return _process_use_grenade_stratagem(action)
+		"USE_STRATAGEM":  # Active player uses a proactive (non-grenade) stratagem with phase: "shooting"
+			print("ShootingPhase: Matched USE_STRATAGEM")
+			return _process_use_stratagem(action)
 		"USE_SENTINEL_STORM":  # P1-10: Player uses Sentinel Storm
 			print("ShootingPhase: Matched USE_SENTINEL_STORM")
 			return _process_use_sentinel_storm(action)
@@ -5762,3 +5767,49 @@ func _trigger_unit_animation(unit_id: String, anim_name: String) -> void:
 				for grandchild in child.get_children():
 					if grandchild.has_method("play_animation"):
 						grandchild.play_animation(anim_name)
+
+# ============================================================================
+# STRATAGEM HANDLING (active stratagems with phase: "shooting")
+# Mirrors CommandPhase._validate_use_stratagem / _process_use_stratagem.
+# Distinct from USE_GRENADE_STRATAGEM (hardcoded grenade carve-out) and
+# USE_REACTIVE_STRATAGEM (defender reactive). This is the generic active path.
+# ============================================================================
+
+func _validate_use_stratagem(action: Dictionary) -> Dictionary:
+	var errors = []
+	var stratagem_id = action.get("stratagem_id", "")
+
+	if stratagem_id == "":
+		errors.append("Missing stratagem_id")
+		return {"valid": false, "errors": errors}
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		errors.append("StratagemManager not available")
+		return {"valid": false, "errors": errors}
+
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+	var validation = strat_manager.can_use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not validation.can_use:
+		errors.append(validation.reason)
+		return {"valid": false, "errors": errors}
+
+	return {"valid": true, "errors": []}
+
+func _process_use_stratagem(action: Dictionary) -> Dictionary:
+	var stratagem_id = action.get("stratagem_id", "")
+	var target_unit_id = action.get("target_unit_id", "")
+	var current_player = get_current_player()
+
+	var strat_manager = get_node_or_null("/root/StratagemManager")
+	if not strat_manager:
+		return create_result(false, [], "StratagemManager not available")
+
+	var result = strat_manager.use_stratagem(current_player, stratagem_id, target_unit_id)
+	if not result.get("success", false):
+		return create_result(false, [], result.get("error", "Stratagem use failed"))
+
+	var strat_name = result.get("stratagem_name", stratagem_id)
+	print("ShootingPhase: Stratagem %s used (target=%s)" % [strat_name, target_unit_id])
+	return create_result(true, result.get("diffs", []), "Used " + strat_name)


### PR DESCRIPTION
## Summary
- Adds a generic `USE_STRATAGEM` action handler to `MovementPhase.gd`, `ShootingPhase.gd`, `ChargePhase.gd`, and `FightPhase.gd`, mirroring the existing CommandPhase pattern (`_validate_use_stratagem` + `_process_use_stratagem`).
- Eligibility (CP cost, phase-window, target legality) is fully delegated to `StratagemManager.can_use_stratagem`; effect application + diffs come from `StratagemManager.use_stratagem`. ~30 lines per phase.
- Distinct from the existing `USE_GRENADE_STRATAGEM` (hardcoded grenade carve-out in Shooting) and `USE_REACTIVE_STRATAGEM` (defender reactive in Shooting) — those paths are unchanged.

This unblocks 3 of the 8 NOT TESTED entries in the audit coverage matrix:
- **ARCHEOTECH MUNITIONS** — Custodes Shield Host, shooting/before_attacks
- **UNBRIDLED CARNAGE** — Orks War Horde, fight/before_attacks
- **MULTIPOTENTIALITY** — Custodes Shield Host, movement/after_fall_back

The 2 reactive-but-untested stratagems (UNWAVERING SENTINELS, ARD AS NAILS) are already invokable via the existing `USE_REACTIVE_STRATAGEM` path and do not need this PR.

Closes #353

## Test plan
- [ ] Dispatch `{type: "USE_STRATAGEM", player: 1, stratagem_id: "faction_ac_shield_host_archeotech_munitions", target_unit_id: "<custodes>"}` during Shooting phase → expect CP -1 and `grant_lethal_hits` + `grant_sustained_hits` flags applied to the target unit.
- [ ] Dispatch `USE_STRATAGEM` for UNBRIDLED CARNAGE during Fight phase before attacks → expect CP -1 and `crit_hit_on: 5` flag applied.
- [ ] Dispatch `USE_STRATAGEM` for MULTIPOTENTIALITY during Movement phase after a Fall Back → expect CP -1 and `fall_back_and_shoot` + `fall_back_and_charge` flags applied.
- [ ] Dispatch `USE_STRATAGEM` outside the stratagem `timing.phase` → expect rejection from `StratagemManager.can_use_stratagem` with a clear `errors` array (no need for per-phase checks since `can_use_stratagem` validates `timing.phase`).
- [ ] Confirm Charge-phase `USE_STRATAGEM` route is reachable (no Charge-phase active stratagems are currently loaded with `implemented: true`, but the route exists for future content).

Generated with [Claude Code](https://claude.com/claude-code)
