### PR TITLE
Audit: stratagem re-test post #355 — 3 new effects verified, found #356

### DIFF
--- a/40k/test_results/audit_2026_05/AUDIT_REPORT.md
+++ b/40k/test_results/audit_2026_05/AUDIT_REPORT.md
@@ -333,12 +333,31 @@ Coverage legend:
 
 ### Coverage summary
 
+Updated 2026-05-04 after PR #355 added `USE_STRATAGEM` dispatch handlers to non-Command phases.
+
 | Status | Count | Stratagems |
 |---|---|---|
-| ✅ EFFECT VERIFIED LIVE | **4** | INSANE BRAVERY, GO TO GROUND, NEW ORDERS, ARCANE GENETIC ALCHEMY |
+| ✅ EFFECT VERIFIED LIVE | **6** | INSANE BRAVERY, GO TO GROUND, NEW ORDERS, ARCANE GENETIC ALCHEMY, **ARCHEOTECH MUNITIONS**, **UNBRIDLED CARNAGE** |
+| ⚠️ EFFECT FIRES BUT NOT HONORED | **1** | **MULTIPOTENTIALITY** — CP -1 + `effect_fall_back_and_shoot/charge` flags set, but Shooting/Charge phases still gate on `cannot_shoot`/`cannot_charge` and reject the unit. Filed as [#356](https://github.com/BigBobbo/warhammer-40k-godot/issues/356) |
 | 🟡 TRIGGER OFFER ONLY | **6** | COMMAND RE-ROLL, EPIC CHALLENGE, TANK SHOCK, FIRE OVERWATCH, HEROIC INTERVENTION, COUNTER-OFFENSIVE |
 | 🚫 REJECTION VERIFIED | **6** | AVENGE THE FALLEN, VIGILANCE ETERNAL, MOB RULE, 'ERE WE GO, CAREEN, ORKS IS NEVER BEATEN |
-| ❌ NOT TESTED | **8** | SMOKESCREEN, GRENADE, RAPID INGRESS, ARCHEOTECH MUNITIONS, UNWAVERING SENTINELS, MULTIPOTENTIALITY, UNBRIDLED CARNAGE, 'ARD AS NAILS |
+| ❌ TARGET FILTER BLOCKS QUICK TEST | **2** | **UNWAVERING SENTINELS** (phase: fight, requires CUSTODES INFANTRY on objective being targeted), **'ARD AS NAILS** (requires VEHICLE/MONSTER ORKS being targeted — none deployed in standard scenario) |
+| ❌ NEED SCENARIO SETUP | **3** | SMOKESCREEN (needs MOUNTED/BIKER/JUMP PACK target), GRENADE (needs INFANTRY with grenade-equipped weapon — Custodes lack), RAPID INGRESS (needs P1 reserves during P2 movement) |
+
+### Tests added 2026-05-04 (post PR #355)
+
+| ID | Stratagem | Method | Result |
+|---|---|---|---|
+| ss5 | ARCHEOTECH MUNITIONS | USE_STRATAGEM in Shooting phase on Custodes Contemptor | P1 CP 4→3, `effect_lethal_hits=true`, `effect_sustained_hits=true` ✓ |
+| ss6 | MULTIPOTENTIALITY | After Telemon fall-back, USE_STRATAGEM | P1 CP 4→3, `effect_fall_back_and_shoot=true`, `effect_fall_back_and_charge=true` set ✓; **but** subsequent SELECT_SHOOTER on the same unit still rejected with "Unit cannot shoot" → filed [#356](https://github.com/BigBobbo/warhammer-40k-godot/issues/356) |
+| ss7 | UNBRIDLED CARNAGE | USE_STRATAGEM in Fight phase on Warboss B | P2 CP 5→4, `effect_crit_hit_on=5` ✓ |
+| ss8 | UNWAVERING SENTINELS | (attempted) | Not triggerable from current scenarios — phase=fight + requires `on_objective` |
+| ss9 | 'ARD AS NAILS | (attempted) | Not triggerable — requires VEHICLE/MONSTER ORKS target; current P2 deployed list is INFANTRY-only |
+
+### Test infrastructure verified
+- `RulesEngine.set_test_seed(seed)` / `get_test_seed()` round-trip via MCP bridge ✓ (PR #352)
+- `bgnt_penalty_applied: false` for vehicle shooting outside engagement (#337) verified live ✓
+- New `USE_STRATAGEM` handlers in Movement/Shooting/Charge/Fight phases functional (PR #355) ✓
 
 **4 of 24 stratagems** have their effects fully verified end-to-end. **6 stratagems are confirmed to be `implemented: false`** in the engine and gracefully rejected. **6 stratagems** had only their trigger window verified — the actual effect of the stratagem (CP deduction + state change) was not invoked. **8 stratagems** are loaded and `implemented: true`, but their effects were never invoked in any test.
 


### PR DESCRIPTION
Re-tested stratagems unblocked by #355. Updated coverage matrix.

- ✅ EFFECT VERIFIED: ARCHEOTECH MUNITIONS, UNBRIDLED CARNAGE
- ⚠️ FIRES BUT NOT HONORED: MULTIPOTENTIALITY (filed #356 — effect flags set, but cannot_shoot/cannot_charge not overridden)
- ❌ TARGET-FILTER BLOCKED: UNWAVERING SENTINELS (needs CUSTODES INFANTRY on objective being targeted in fight phase), 'ARD AS NAILS (needs VEHICLE/MONSTER ORKS target)

Effect-verified count is now 6/24 (was 4/24).