### PR TITLE
Fix #356: honor effect_fall_back_and_shoot in shooting eligibility

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -3260,14 +3260,17 @@ static func validate_shoot(action: Dictionary, board: Dictionary) -> Dictionary:
 	# Check this BEFORE the cannot_shoot flag, since Advanced units CAN shoot (with restrictions)
 	var actor_advanced = flags.get("advanced", false)
 
-	# Units that Fell Back cannot shoot (unless special rules)
+	# Units that Fell Back cannot shoot (unless special rules like fall_back_and_shoot)
 	if flags.get("fell_back", false):
-		errors.append("Unit cannot shoot (fell back)")
-		return {"valid": false, "errors": errors}
+		if not EffectPrimitivesData.has_effect_fall_back_and_shoot(actor_unit):
+			errors.append("Unit cannot shoot (fell back)")
+			return {"valid": false, "errors": errors}
 
 	# Legacy cannot_shoot flag check - but skip if unit advanced (since advanced units CAN shoot)
+	# or has the fall_back_and_shoot effect overriding the post-Fall-Back lockout
 	if flags.get("cannot_shoot", false) and not actor_advanced:
-		errors.append("Unit cannot shoot")
+		if not (flags.get("fell_back", false) and EffectPrimitivesData.has_effect_fall_back_and_shoot(actor_unit)):
+			errors.append("Unit cannot shoot")
 
 	# PISTOL RULES: Check if actor is in engagement range
 	var actor_in_engagement = flags.get("in_engagement", false)

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -2905,8 +2905,12 @@ func _can_unit_shoot(unit: Dictionary) -> bool:
 			print("ShootingPhase: Unit %s fell back but has fall_back_and_shoot effect — eligible to shoot" % unit.get("id", "unknown"))
 
 	# Check other restriction flags (but skip for advanced units handled above)
+	# fall_back_and_shoot effect (e.g., MULTIPOTENTIALITY) overrides the cannot_shoot lockout from Fall Back
 	if flags.get("cannot_shoot", false):
-		return false
+		if flags.get("fell_back", false) and EffectPrimitivesData.has_effect_fall_back_and_shoot(unit):
+			print("ShootingPhase: Unit %s fell back but has fall_back_and_shoot effect — overriding cannot_shoot" % unit.get("id", "unknown"))
+		else:
+			return false
 
 	# Check if this is a transport with firing deck capability
 	if unit.has("transport_data") and unit.transport_data.get("firing_deck", 0) > 0:


### PR DESCRIPTION
## Summary
- ShootingPhase._can_unit_shoot and RulesEngine.validate_shoot now bypass the post-Fall-Back \`cannot_shoot\` lockout when the unit has \`effect_fall_back_and_shoot\` set.
- Mirrors the existing ChargePhase pattern that already honors \`effect_fall_back_and_charge\`.
- Live-verified: with the override flag set, \`SELECT_SHOOTER\` against a \`fell_back=true, cannot_shoot=true\` Custodian Guard now passes the gate (rejection moves to the next downstream check, e.g. \"no eligible targets\"); the new debug \`overriding cannot_shoot\` print fires.

Closes #356.

## Test plan
- [ ] Use MULTIPOTENTIALITY in a real game: Custodes unit Falls Back in P1 Movement, fire stratagem, advance to Shooting → unit is selectable to shoot.
- [ ] Verify a \`fell_back=true\` unit WITHOUT \`effect_fall_back_and_shoot\` is still correctly rejected with \"Unit cannot shoot\".
- [ ] Confirm Charge phase behavior unchanged (existing override path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)