### PR TITLE
Fix #359: parse 'excluding X' stratagem target text correctly

### DIFF
--- a/40k/autoloads/FactionStratagemLoader.gd
+++ b/40k/autoloads/FactionStratagemLoader.gd
@@ -443,8 +443,18 @@ func _parse_target(target_text: String) -> Dictionary:
 
 	var t = target_text.to_lower()
 
-	# Determine owner
-	if "enemy" in t:
+	# #359: split off "excluding X" / "except X" clauses BEFORE keyword matching, so
+	# words like "Vehicle" / "Monster" inside the exclusion don't get parsed as required.
+	# Excluded keywords become "not_keyword:X" conditions checked separately.
+	var split = _strip_excluding_clauses(t)
+	var inclusive_t: String = split.stripped
+	var excluded_keywords: Array = split.excluded_keywords
+	for ek in excluded_keywords:
+		result.conditions.append(ek)
+
+	# Determine owner — only based on inclusive text (the exclusion clause may also
+	# contain words like "enemy" e.g. "excluding enemy CHARACTERS").
+	if "enemy" in inclusive_t:
 		result.owner = "enemy"
 
 	# Look for keyword requirements
@@ -459,36 +469,103 @@ func _parse_target(target_text: String) -> Dictionary:
 	]
 
 	for pattern in keyword_patterns:
-		if pattern[0] in t:
+		if pattern[0] in inclusive_t:
 			result.conditions.append(pattern[1])
 
 	# Faction keyword requirements
-	if "adeptus astartes" in t:
+	if "adeptus astartes" in inclusive_t:
 		result.conditions.append("keyword:ADEPTUS ASTARTES")
-	if "adeptus custodes" in t:
+	if "adeptus custodes" in inclusive_t:
 		result.conditions.append("keyword:ADEPTUS CUSTODES")
-	if "orks" in t:
+	if "orks" in inclusive_t:
 		result.conditions.append("keyword:ORKS")
 
-	# Special conditions
-	if "was selected as the target" in t:
+	# Special conditions — also derived from the inclusive zone only.
+	if "was selected as the target" in inclusive_t:
 		result.conditions.append("is_target_of_attack")
-	if "not been selected to shoot" in t:
+	if "not been selected to shoot" in inclusive_t:
 		result.conditions.append("not_shot")
-	if "not been selected to fight" in t:
+	if "not been selected to fight" in inclusive_t:
 		result.conditions.append("not_fought")
-	if "below half-strength" in t or "below its starting strength" in t:
+	if "below half-strength" in inclusive_t or "below its starting strength" in inclusive_t:
 		result.conditions.append("below_starting_strength")
-	if "fell back this phase" in t:
+	if "fell back this phase" in inclusive_t:
 		result.conditions.append("fell_back_this_phase")
-	if "made a charge move this turn" in t:
+	if "made a charge move this turn" in inclusive_t:
 		result.conditions.append("charged_this_turn")
-	if "within engagement range" in t:
+	if "within engagement range" in inclusive_t:
 		result.conditions.append("in_engagement_range")
-	if "within range of an objective" in t:
+	if "within range of an objective" in inclusive_t:
 		result.conditions.append("on_objective")
 
 	return result
+
+func _strip_excluding_clauses(t: String) -> Dictionary:
+	"""Find 'excluding X' / 'except X' clauses, capture excluded keywords as
+	'not_keyword:X' conditions, and return the text with those clauses removed.
+
+	An exclusion clause runs from the marker word until the next ')', '.', or
+	' that ' (typical clause separators in WH40K rules text). Returns:
+	  { stripped: String, excluded_keywords: Array<String> }
+	"""
+	var keyword_patterns = [
+		["infantry", "INFANTRY"],
+		["vehicle", "VEHICLE"],
+		["monster", "MONSTER"],
+		["character", "CHARACTER"],
+		["battleline", "BATTLELINE"],
+		["terminator", "TERMINATOR"],
+		["mounted", "MOUNTED"],
+		["grots", "GROTS"],
+		["adeptus astartes", "ADEPTUS ASTARTES"],
+		["adeptus custodes", "ADEPTUS CUSTODES"],
+		["orks", "ORKS"],
+		["anathema psykana", "ANATHEMA PSYKANA"],
+	]
+	var stripped: String = t
+	var excluded: Array = []
+
+	for marker in ["excluding", "except"]:
+		while true:
+			var idx = stripped.find(marker)
+			if idx < 0:
+				break
+
+			# Find clause end: nearest of ')', '.', ' that '. Default to end-of-string.
+			var end_idx = stripped.length()
+			var paren = stripped.find(")", idx)
+			var period = stripped.find(".", idx)
+			var that_after = stripped.find(" that ", idx)
+			for cand in [paren, period, that_after]:
+				if cand > idx and cand < end_idx:
+					end_idx = cand
+
+			# Capture clause text and parse excluded keywords from it.
+			var clause = stripped.substr(idx, end_idx - idx)
+			for pat in keyword_patterns:
+				if pat[0] in clause:
+					var cond = "not_keyword:%s" % pat[1]
+					if not excluded.has(cond):
+						excluded.append(cond)
+
+			# Strip the clause AND the leading "(" if there's one immediately before
+			# (so we don't leave a dangling "(" behind).
+			var strip_start = idx
+			# Walk backward past whitespace and an optional '('.
+			var probe = idx - 1
+			while probe >= 0 and stripped[probe] == " ":
+				probe -= 1
+			if probe >= 0 and stripped[probe] == "(":
+				strip_start = probe
+
+			# Include the trailing ')' if the end was a paren.
+			var strip_end = end_idx
+			if end_idx < stripped.length() and stripped[end_idx] == ")":
+				strip_end = end_idx + 1
+
+			stripped = stripped.substr(0, strip_start) + stripped.substr(strip_end)
+
+	return {"stripped": stripped, "excluded_keywords": excluded}
 
 # ============================================================================
 # EFFECT MAPPING
@@ -698,6 +775,14 @@ static func unit_matches_target(unit: Dictionary, target: Dictionary, context: D
 					break
 			if not found:
 				return false
+
+		elif condition.begins_with("not_keyword:"):
+			# #359: "excluding X" clauses become not_keyword:X conditions —
+			# the unit must NOT have this keyword.
+			var excluded_kw = condition.substr(12)
+			for kw in keywords:
+				if kw.to_upper() == excluded_kw.to_upper():
+					return false
 
 		elif condition == "is_target_of_attack":
 			# This is context-dependent; the unit must be a current target


### PR DESCRIPTION
## Summary
Fixes #359: stratagem target text like "(excluding Grots, Monster and Vehicle units)" was parsed as REQUIRES VEHICLE+MONSTER+GROTS due to substring matching, making 'ARD AS NAILS unreachable.

- New `_strip_excluding_clauses` helper extracts "excluding X" / "except X" clauses, captures the keywords inside as `not_keyword:X` conditions, and removes the clause text before the regular keyword scan.
- `unit_matches_target` gains a `not_keyword:` branch that fails the match when the unit has any excluded keyword.
- All inclusive keyword/condition matching now runs against the stripped target text.

## Live verification
With target_unit_ids = [BOYZ, BATTLEWAGON, GHAZGHKULL]:
- before this PR: 'ARD AS NAILS conditions = `[VEHICLE, MONSTER, ORKS, is_target_of_attack]` — eligible_units = []
- after this PR: conditions = `[not_keyword:VEHICLE, not_keyword:MONSTER, not_keyword:GROTS, keyword:ORKS, is_target_of_attack]` — eligible_units = `[BOYZ]` (Battlewagon and Ghazghkull correctly filtered out)

UNWAVERING SENTINELS and ARCHEOTECH MUNITIONS, both of which exclude "Anathema Psykana", now correctly carry `not_keyword:ANATHEMA PSYKANA`. MULTIPOTENTIALITY (no exclusion clause) is unchanged.

## Test plan
- [ ] In a real game: trigger 'ARD AS NAILS by attacking a Boyz unit while a Battlewagon is also deployed — only Boyz is offered as the target.
- [ ] Trigger UNWAVERING SENTINELS in fight phase against Custodian Guard on an objective — eligible.
- [ ] Confirm pre-existing stratagems with no exclusion clause behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
