### PR TITLE
Fix #361 + #362: unblock RAPID INGRESS end-to-end

### DIFF
--- a/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
@@ -305,6 +305,28 @@ func _normalize_action_positions(action: Dictionary) -> Dictionary:
 				var v = _coerce_vector2(p)
 				converted.append(v if v != null else p)
 		out["model_positions"] = converted
+
+	# #361: per_model_paths inside payload — used by APPLY_CHARGE_MOVE,
+	# APPLY_HEROIC_INTERVENTION_MOVE, STAGE_MODEL_MOVE, etc. Each entry is a
+	# {model_id: [pos, pos, ...]} dict; positions need Vector2 conversion or
+	# Measurement.distance_polyline_px silently sums to 0.
+	if out.has("payload") and typeof(out["payload"]) == TYPE_DICTIONARY:
+		var payload: Dictionary = out["payload"]
+		if payload.has("per_model_paths") and typeof(payload["per_model_paths"]) == TYPE_DICTIONARY:
+			var paths: Dictionary = payload["per_model_paths"]
+			var converted_paths: Dictionary = {}
+			for model_id in paths:
+				var path = paths[model_id]
+				if typeof(path) == TYPE_ARRAY:
+					var converted_path: Array = []
+					for p in path:
+						var v = _coerce_vector2(p)
+						converted_path.append(v if v != null else p)
+					converted_paths[model_id] = converted_path
+				else:
+					converted_paths[model_id] = path
+			payload["per_model_paths"] = converted_paths
+			out["payload"] = payload
 	return out
 
 

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -3132,8 +3132,12 @@ func _get_rapid_ingress_eligible_units(player: int) -> Array:
 		if unit.is_empty():
 			continue
 
-		# Skip attached characters — they arrive with their bodyguard
-		if unit.get("attached_to", "") != "":
+		# Skip attached characters — they arrive with their bodyguard.
+		# #362: Dictionary.get(key, default) returns the default ONLY when the key
+		# is missing; if the key exists with value null (which is how this project
+		# stores "not attached"), it returns null. Compare for null AND empty.
+		var attached_to = unit.get("attached_to", "")
+		if attached_to != null and attached_to != "":
 			continue
 
 		var reserve_type = unit.get("reserve_type", "strategic_reserves")


### PR DESCRIPTION
## Summary
Two related fixes uncovered by driving stratagems end-to-end via real action handlers:

**#361** — `_normalize_action_positions` in the MCP bridge now recursively converts the position dicts inside `payload.per_model_paths` to Vector2. Without this, multi-model move actions (APPLY_CHARGE_MOVE, APPLY_HEROIC_INTERVENTION_MOVE) silently no-op through the bridge.

**#362** — `_get_rapid_ingress_eligible_units` had a null-safety bug: `unit.get("attached_to", "")` returns null (not the default) when the key exists with value null, and `null != ""` is true, so every unit was wrongly classified as attached and skipped. RAPID INGRESS was effectively unreachable through normal gameplay.

## Live verification
With the fixes:
- **APPLY_CHARGE_MOVE** end-to-end via MCP: Warboss declares charge, rolls, decline overwatch + reroll, APPLY_CHARGE_MOVE moves him to base-to-base with target. Position update applied; HEROIC_INTERVENTION trigger fires naturally.
- **RAPID INGRESS at P1 R2 movement end**: P2 offered all 9 reserves (Battlewagon, Boyz×3, Ghazghkull, Kommandos, Lootas, Meganobz, Wazbom). Pre-fix: empty list.
- **RAPID INGRESS at P2 R2 movement end**: P1 offered Caladius; USE_RAPID_INGRESS deducts CP, sets `_rapid_ingress_unit_id`, clears awaiting flag.

Both bugs blocking option-B end-to-end stratagem verification are now removed. HEROIC INTERVENTION and RAPID INGRESS are confirmed end-to-end through actual game-flow trigger emission.

Closes #361, closes #362.

## Test plan
- [ ] In a real game: P1 starts with a deep-strike unit in reserves. After P2's R2 movement phase, Rapid Ingress is offered.
- [ ] Charge through the MCP bridge (or any path that builds per_model_paths from JSON arrays) — the move actually applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
