### PR TITLE
golden_diff: 3×3 grid pHash + resolution parity, fixes false-negative drift

### DIFF
--- a/scripts/loop/golden_diff.py
+++ b/scripts/loop/golden_diff.py
@@ -100,6 +100,66 @@ def _phash(path: str):
         return imagehash.phash(img)
 
 
+# Grid pHash — splits the image into ROWS×COLS tiles, hashes each
+# independently, and returns the list. The 64-bit pHash applied to a
+# full game screenshot was empirically too coarse to catch
+# dialog-section-scale regressions (the unchanged battlefield
+# dominated the low-frequency signature). Computing one pHash per
+# tile means a regression in any one region produces a high
+# per-tile distance even if 8/9 tiles still match.
+GRID_ROWS = 3
+GRID_COLS = 3
+
+
+def _phash_grid(path: str, target_size: tuple = None):
+    """Return a list of GRID_ROWS*GRID_COLS pHashes, one per tile.
+
+    If target_size is provided, the image is resized to that size
+    BEFORE tiling — this gives resolution parity between the current
+    screenshot (1920×1080) and the blessed golden (480×270, see bless
+    branch below). Without this the tile boundaries fall at different
+    image content and the hashes are not comparable.
+    """
+    from PIL import Image
+    import imagehash
+    with Image.open(path) as src:
+        if target_size and src.size != target_size:
+            img = src.resize(target_size, Image.LANCZOS)
+        else:
+            img = src.copy()
+        w, h = img.size
+        tw = w // GRID_COLS
+        th = h // GRID_ROWS
+        hashes = []
+        for r in range(GRID_ROWS):
+            for c in range(GRID_COLS):
+                left = c * tw
+                top = r * th
+                right = w if c == GRID_COLS - 1 else left + tw
+                bottom = h if r == GRID_ROWS - 1 else top + th
+                tile = img.crop((left, top, right, bottom))
+                hashes.append(imagehash.phash(tile))
+        return hashes
+
+
+def _grid_distance(g1: list, g2: list) -> tuple:
+    """Return (max_tile_distance, per_tile_distances).
+
+    Max is the worst tile's Hamming distance — any single tile
+    drifting trips the threshold. The per-tile list is recorded in
+    the report for diagnostics.
+    """
+    per_tile = [int(a - b) for a, b in zip(g1, g2)]
+    return max(per_tile), per_tile
+
+
+def _golden_size(golden_abs: str) -> tuple:
+    """Return the (w, h) of the golden image, for resolution parity."""
+    from PIL import Image
+    with Image.open(golden_abs) as img:
+        return img.size
+
+
 def _golden_name(scenario_id: str, step: dict) -> str:
     rel = step.get("per_step_screenshot", "")
     return os.path.basename(rel)
@@ -191,9 +251,18 @@ def main() -> int:
             entry["hamming_distance"] = None
             summary["missing_golden"] += 1
         else:
-            d = _phash(shot_abs) - _phash(golden_abs)
-            entry["hamming_distance"] = int(d)
-            if d <= threshold:
+            # Resolution parity: bless saves goldens at 1/4 resolution
+            # (see bless branch above). Resize the current screenshot
+            # down to match before hashing — otherwise the tile-grid
+            # boundaries fall at different image content and tile
+            # hashes are not comparable.
+            target = _golden_size(golden_abs)
+            cur_grid = _phash_grid(shot_abs, target_size=target)
+            gold_grid = _phash_grid(golden_abs)
+            max_d, per_tile = _grid_distance(cur_grid, gold_grid)
+            entry["hamming_distance"] = max_d
+            entry["per_tile_distances"] = per_tile
+            if max_d <= threshold:
                 entry["status"] = "match"
                 summary["match"] += 1
             else:


### PR DESCRIPTION
## Summary

Fixes the diff prefilter so it actually catches normal-PR-sized
visual regressions. Previously the prefilter was effectively
blind — see PR #402's validation report for the full
investigation.

## Bugs fixed

### 1. Resolution mismatch (bless ↔ diff)

`golden_diff.py:173-185` (bless path) downsamples blessed
screenshots to **1/4 resolution** (480×270 from 1920×1080) before
saving. `golden_diff.py:194` (diff path) phashed the **raw
1920×1080 screenshot** against the **480×270 golden**. pHash
normalises both to a 32×32 DCT internally, so the resulting
signatures matched even when content differed catastrophically.

Fix: resize the current screenshot down to the golden's dimensions
before hashing.

### 2. Whole-image pHash dominated by unchanged battlefield

The 64-bit pHash of a full game screenshot was dominated by the
large constant battlefield area. Dialog-section-scale regressions
(button text, panel missing, even blanking the entire dialog body)
produced Hamming distances ≤ threshold 4.

Fix: split each image into a 3×3 grid, pHash each tile
independently, take the **max** per-tile distance. Any region
drifting trips drift — the battlefield can't dilute the dialog
signal.

## Empirical results

Same scenario (367_designate_warlord), same regressions tested in
the validation:

| Regression | OLD hd | NEW hd_max |
|---|---:|---:|
| Clean (no regression) | 2-4 | 0 |
| Button text `"Confirm F" → "C"` | 2 | 4 (still borderline) |
| Dialog `min/max_size` halved | 4 | **28** |
| `_build_warlord_section()` removed | 4 | **36** |
| Empty `_build_ui()` (early `return`) | **0** | **24** |

The catastrophic case — blanking the entire dialog body — went from
**hd=0** (false negative) to **hd=24** with 12/12 steps drifting and
exit code 1. The diff is now usable.

## Sweep against existing scenarios

| Scenario | Result | Notes |
|---|---|---|
| `367_designate_warlord` | drift 0/12 | clean |
| `runner_smoke` | drift 0/11 | clean |
| `376_da_jump_bounds` | drift 0/11 | clean |
| `378_leader_pairing_formations` | drift 0/12 | clean |
| `horde_movement` | drift 3/3 (max hd=28) | **legit drift surfaced** |
| `co_offer_after_charge` | drift 2/20 (max hd=8) | **legit drift surfaced** |

The two drifting scenarios are showing **genuine** timing-dependent
rendering differences that the old pHash was averaging out. Both
need a follow-up (extra settle frames, or per-scenario threshold
bumps in `_thresholds.json`). Filed as a known issue, not a
blocker for this PR.

## What's new in the report JSON

Each result entry now carries a `per_tile_distances: [int×9]` array
in row-major order. A reviewer can see which 3×3 cell of the screen
drifted — useful for triaging "is this UI region the regression or
the battlefield?"

## Test plan

- [x] Clean run against `367_designate_warlord` produces 0 distance
      across all 9 tiles for all 12 steps
- [x] 3 substantive regressions trip drift at hd 24-36
- [x] 4/6 swept scenarios remain clean
- [x] 2/6 swept scenarios surface legit drift (expected, separate
      follow-up needed)
- [x] Bless path unchanged — existing 240 goldens at 480×270 still
      work (current screenshot is resized to match before tiling)
- [ ] **Reviewer:** confirm the 3×3 grid is the right granularity;
      4×4 might catch button-text regressions cleanly but risks
      more platform-drift false positives

Targets `claude/bless-25-scenarios` (PR #401) as base because
`golden_diff.py` doesn't exist on `main` yet. After #401 merges,
this rebases cleanly onto `main`.

https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr)_