### PR TITLE
Loop follow-ups: wait_for_tweens + grid eval + critic-reliability + playbook gates

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -241,6 +241,32 @@ func _execute_step(i: int, act: String, step: Dictionary) -> Dictionary:
 			for j in range(n):
 				await get_tree().process_frame
 			rec["pass"] = true
+		"wait_for_tweens":
+			# Wait until all active Tweens on the current scene complete,
+			# or until timeout_s elapses (default 5s). Use this between
+			# dispatch_actions in scenarios where the per-step screenshot
+			# would otherwise capture mid-tween state — e.g. camera pans,
+			# token repositioning, dialog opens. Returns pass with the
+			# observed tween-clear time, fail on timeout.
+			var timeout_s := float(step.get("timeout_s", 10.0))
+			var elapsed := 0.0
+			var poll_s := 0.05
+			var tree := get_tree()
+			while elapsed < timeout_s:
+				var any_running := false
+				for tw in tree.get_processed_tweens():
+					if tw.is_valid() and tw.is_running():
+						any_running = true
+						break
+				if not any_running:
+					rec["pass"] = true
+					rec["tween_clear_at"] = elapsed
+					break
+				await tree.create_timer(poll_s).timeout
+				elapsed += poll_s
+			if not rec.has("pass"):
+				rec["pass"] = false
+				rec["error"] = "wait_for_tweens: %.2fs elapsed, tweens still running" % elapsed
 		"screenshot":
 			rec.merge(await _do_screenshot(step), true)
 		"dispatch_action":

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -72,6 +72,16 @@ Each step is a dict with an `act` field plus act-specific keys.
   { "act": "wait_frames", "frames": 3 }
   ```
 
+- `wait_for_tweens`: block until all SceneTree-managed Tweens finish
+  (or `timeout_s` elapses, default 10s). Use between rapid
+  `dispatch_action` steps when the per-step screenshot would otherwise
+  capture mid-tween state (camera pans, token reposition, dialog open).
+  Pass records `tween_clear_at` (seconds elapsed before clear) on
+  success. Fail is non-fatal but logged.
+  ```json
+  { "act": "wait_for_tweens", "timeout_s": 5.0 }
+  ```
+
 - `dispatch_action`: drive a phase action through the current phase instance.
   Use sparingly — bypasses UI. Prefer `click_unit` / `click_button` for player
   paths. Result captured as `last_action_result` for downstream

--- a/scripts/loop/critic_prompt.md
+++ b/scripts/loop/critic_prompt.md
@@ -64,3 +64,38 @@ If nothing is wrong, emit `[]` exactly.
 - "No dialog visible" after a `wait_seconds` or `expect_state` step is
   NOT a finding by itself — those steps don't change the UI. Only flag
   when the scenario clearly intends a dialog to appear.
+
+## Known limitations (be conservative)
+
+The validation runs (`validation_2026-05-19.md`,
+`validation_unattended_2026-05-19.md`) surfaced two recurring
+failure modes for the critic — flag these in your own output by
+defaulting to lower severity when uncertain:
+
+1. **Multimodal Claude is unreliable at fine color discrimination
+   on downsampled screenshots.** Goldens are saved at 480×270.
+   Distinguishing parchment-amber from peach-orange or gold-blue
+   from sky-blue at that resolution is genuinely hard. If you
+   think you see a color regression but cannot name the specific
+   colors confidently, downgrade severity to `medium` and frame
+   the observation in luminance terms ("brighter/darker") not hue
+   terms ("red vs orange").
+
+2. **Hallucinated findings on clean runs.** When the diff prefilter
+   reports no drift, your sanity-check critique should default to
+   `[]`. Only emit findings when you can point at a SPECIFIC pixel
+   region (use the per-tile-distance hint from the goldens report
+   when present) that differs from the golden in a way the
+   scenario JSON's intent would notice. "The dialog title looks
+   garbled" without supporting evidence in the goldens-report
+   per-tile distances is the hallucination class to avoid.
+
+## Severity discipline
+
+The fixer prompt instructs the fixer to address `high` first,
+then `medium`, and to ignore `low` on the first iteration. So:
+- Be generous with `low` — they cost nothing.
+- Be strict with `high` — only when a player would visibly notice
+  the feature is broken.
+- `medium` is the catch-all for "this looks off but doesn't block
+  play."

--- a/scripts/loop/grid_size_evaluation.md
+++ b/scripts/loop/grid_size_evaluation.md
@@ -1,0 +1,68 @@
+# Grid pHash size evaluation — 3×3 vs 4×4
+
+Empirical comparison of grid granularity for the diff prefilter,
+filed as the reviewer-checkbox follow-up from PR #403.
+
+## Methodology
+
+Same scenario (`367_designate_warlord`), same regressions tested
+in PR #403's empirical table, plus a sweep against 6 other
+scenarios to detect false-positive rate.
+
+## Sensitivity (regression detection)
+
+| Regression | 3×3 | 4×4 |
+|---|---|---|
+| Clean (no regression) | drift 0, hd=0 | drift 0, hd=0 |
+| Button text `"Confirm F" → "C"` | drift 0, hd=4 (**miss**) | drift 12, hd=8 (catch) |
+| Parchment color swap (parchment → green) | drift 12, hd=8 (catch) | drift 12, hd=10 (catch) |
+
+4×4 catches the button-text regression that 3×3 misses (4×4 tiles
+are smaller, so the button area dominates one tile's hash).
+
+## Specificity (false-positive sweep)
+
+| Scenario | 3×3 | 4×4 |
+|---|---|---|
+| `runner_smoke` | drift 0, hd=0 | drift 0, hd=0 |
+| `376_da_jump_bounds` | drift 0, hd=0 | drift 0, hd=0 |
+| `378_leader_pairing_formations` | drift 0, hd=0 | drift 0, hd=0 |
+| `382_cp_grant_both_players` | drift 0 | **drift 7/7, hd=14 (false positive)** |
+| `383_battleshock_can_shoot` | drift 0, hd=2 | drift 0, hd=2 |
+| `387_waaagh_energy_eadbanger` | drift 0, hd=2 | drift 0, hd=2 |
+| `charge_congestion` | drift 0 | **drift 2/5, hd=20 (false positive)** |
+
+4×4 introduces 2 new false positives.
+
+## Decision
+
+**3×3 stays as default.** The button-text-class regression sits at
+the noise floor where small text changes live; the per-step
+threshold override mechanism (`_thresholds.json:per_step`) is the
+right escape hatch for scenarios that need to catch text-level
+regressions.
+
+Trading 1-2 false positives per ~25 scenarios for tighter
+sensitivity is the wrong direction. A loop that fails on real PRs
+because the unchanged battlefield happened to land differently
+across tile boundaries erodes trust — the prefilter is supposed to
+filter signal from noise, not produce noise of its own.
+
+The per-step override remains the right tool for scenarios
+specifically testing text content or fine UI detail. The default
+should optimise for false-positive avoidance, which 3×3 does.
+
+## What 3×3 cannot catch
+
+Documented limitations of the 3×3 grid at 480×270 golden resolution:
+- Single-word text changes in already-text-dense regions
+- 1-2px border color changes (sub-pixel at 480×270)
+- Equal-luminance color swaps (pHash blindness)
+
+These are filed as separate follow-ups:
+- Higher-resolution goldens (stop downsampling) — the obvious fix
+  for the latter two
+- Per-step threshold tuning for text-sensitive scenarios — already
+  supported
+
+The grid size itself is the wrong knob for these problems.

--- a/scripts/loop/playbook.md
+++ b/scripts/loop/playbook.md
@@ -18,6 +18,28 @@ isolated — no shared workspace, no cross-contamination.
   - 30-min wall clock budget
 - An anti-cycle log of `{iteration, edited_files}` accumulated as you go
 
+## Preserving regressed state between phases
+
+Critical: **the regressed state must be committed to the loop
+branch before the critic is invoked.** Lesson from
+`validation_2026-05-19.md`: the fixer agent may run against an
+already-clean working directory if the host session leaves the
+regression uncommitted between critic and fixer phases (linters
+and other tooling can revert uncommitted changes). When that
+happens the fixer can't find what it's fixing and either
+hallucinates a fix or correctly diagnoses a different latent bug.
+
+Workflow:
+1. If iteration 1 begins on a branch with uncommitted changes:
+   commit them first (as `[loop] state for critic round` or
+   similar) so the critic and fixer both work against committed
+   state.
+2. Fixer commits its fix on top.
+3. If the loop fails, the regression-commit and fixer-commit stay
+   on the loop branch as the audit trail.
+4. If the loop succeeds, the regression-commit and fixer-commit
+   net to zero and can be squashed before PR creation if desired.
+
 ## Per-scenario loop
 
 ```
@@ -45,7 +67,16 @@ while iter < LOOP_MAX_ITERATIONS:
          If goldens missing for this scenario: --bless run, commit goldens
          Else: scenario is clean — exit the loop, open PR if any
          intermediate fixer commits exist
-       Else:
+       Else, before going to FIXER, filter the critique:
+       - If any entries have severity == "high": pass ONLY the high
+         entries to the fixer. The validation runs
+         (validation_unattended_2026-05-19.md) showed the critic
+         can mis-describe medium-severity findings; high-severity
+         findings have been more reliable.
+       - If no high entries but some medium: pass medium entries.
+       - If ONLY low entries: treat as clean and exit the loop.
+         `low` entries are nits (off-by-1px, capitalisation) that
+         don't justify a code commit in iteration 1.
        → FIXER round, iter += 1
 
     4. FIXER round — invoke the fixer subagent (see below).


### PR DESCRIPTION
## Summary

Batches four follow-ups from the validation work into one PR:

1. **`wait_for_tweens` step type** (item 4 from punch list)
2. **3×3 vs 4×4 grid evaluation** (item 5 — reviewer checkbox from #403)
3. **Critic-reliability mitigations** (item 6)
4. **Preserve regressed state between phases** (item 7)

All four are small/contained. None block on each other; batching for
review economy.

## Item 4: `wait_for_tweens` step type

`40k/autoloads/ScenarioRunner.gd`: new step type that blocks until
all SceneTree-managed Tweens finish (or `timeout_s` elapses, default
10s). Records `tween_clear_at` (seconds) on pass.

```json
{ "act": "wait_for_tweens", "timeout_s": 5.0 }
```

Designed so scenarios like `co_offer_after_charge` and
`horde_movement` (currently on the skip_diff list per #404) can
insert explicit settle points between rapid `dispatch_action` calls
and opt back into perceptual-hash diff. This PR delivers the
mechanism only — opting the scenarios back in happens in a separate
PR after authors update + re-bless them.

Empirical: with a fresh fixture load, tweens typically clear in
3-5 seconds. 10-second default gives headroom while still
surfacing runaway/infinite tween loops as failures.

## Item 5: Grid size evaluation

`scripts/loop/grid_size_evaluation.md` (new) — table at the
top:

| Regression | 3×3 | 4×4 |
|---|---|---|
| Button text | drift 0, hd=4 (miss) | drift 12, hd=8 (catch) |
| Parchment color swap | drift 12, hd=8 (catch) | drift 12, hd=10 (catch) |

| Clean scenario | 3×3 | 4×4 |
|---|---|---|
| `382_cp_grant_both_players` | drift 0 | **drift 7/7 (false positive)** |
| `charge_congestion` | drift 0 | **drift 2/5 (false positive)** |

**Decision**: 3×3 stays as default. The button-text class sits at
the noise floor; per-step threshold overrides in `_thresholds.json`
are the right escape hatch. 1-2 false positives across the library
isn't worth marginal sensitivity gain.

## Item 6: Critic-reliability mitigations

`scripts/loop/critic_prompt.md` — added "Known limitations" section
documenting the two recurring critic failure modes surfaced in
validation:

- **Color discrimination on 480×270 goldens is unreliable** — frame
  findings in luminance terms ("brighter/darker") when uncertain,
  default to medium severity
- **Hallucinated findings on clean runs** — default to `[]` when the
  diff prefilter reports no drift, only emit when pointing at a
  specific tile region

Plus severity-discipline guidance aligned with the fixer's
"high first, ignore low on iter 1" rule.

The bigger structural fix (stop downsampling goldens) is deferred
to item 10 (platform-specific golden architecture) where it can be
discussed alongside the platform-coupling decision.

## Item 7: Preserve regressed state between phases

`scripts/loop/playbook.md` — codifies the lesson from
`validation_2026-05-19.md`: **commit the regression to the loop
branch BEFORE invoking the critic**. Otherwise linters/tooling can
revert uncommitted changes and the fixer agent either hallucinates
a fix or correctly diagnoses a different bug (this happened in PR
#402 — net positive there because the fixer found a real latent
bug, but unreliable as the standard workflow).

Also adds the critique-filtering rule from item 6 to the playbook's
decision tree: pass `high` to fixer first, fall back to `medium`,
treat `low`-only as clean.

## Test plan

- [x] `wait_for_tweens` smoke test on `audit_367_warlord` fixture:
      tweens clear at ~3s, step passes
- [x] `wait_for_tweens` with 2s timeout against same fixture:
      correctly fails with `"wait_for_tweens: 2.00s elapsed,
      tweens still running"`
- [x] 3×3 vs 4×4 sweep across 7 representative scenarios with
      results in `grid_size_evaluation.md`
- [x] Schema doc (`40k/tests/scenarios/_schema.md`) updated with
      `wait_for_tweens` entry
- [ ] **Reviewer:** confirm the playbook's severity-filtering rule
      is the right default; alternative is to let the fixer prompt
      handle severity discipline (it already does) and not
      filter at the playbook level

https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr)_