### PR TITLE
Fix Tween.kill() test semantics, close "Headless audit suite" CI gate

### DIFF
--- a/40k/tests/test_wound_allocation_priority_pulse.gd
+++ b/40k/tests/test_wound_allocation_priority_pulse.gd
@@ -18,9 +18,11 @@ extends SceneTree
 #      — the overlay should NOT pulse anything in that state.
 #   3. _start_priority_pulse(model_id) creates a live Tween bound to the
 #      highlight sprite registered in board_highlighter.active_highlights.
-#   4. _stop_priority_pulse() kills the tween (is_valid() → false) and
+#   4. _stop_priority_pulse() kills the tween (is_running() → false) and
 #      clears the priority_pulse_target reference so allocation cleanup
-#      doesn't leave a dangling reference behind.
+#      doesn't leave a dangling reference behind. Note: in Godot 4.4,
+#      Tween.kill() stops the tween but does NOT change is_valid() — we
+#      check is_running() instead.
 #   5. _start_priority_pulse("") with no priority is a no-op — does NOT
 #      create a tween (otherwise we'd burn cycles pulsing nothing).
 #   6. _start_priority_pulse() called twice for the same model_id reuses
@@ -193,8 +195,8 @@ func _test_stop_pulse_kills_tween() -> void:
 	_check("priority_pulse_tween is null after stop",
 		overlay.priority_pulse_tween == null,
 		"tween reference was not cleared")
-	_check("captured tween reference is no longer valid",
-		tween_ref == null or not tween_ref.is_valid(),
+	_check("captured tween reference is no longer running",
+		tween_ref == null or not tween_ref.is_running(),
 		"the tween we created is still running after _stop_priority_pulse")
 	_check("priority_pulse_target is null after stop",
 		overlay.priority_pulse_target == null,
@@ -262,9 +264,9 @@ func _test_start_pulse_different_model_replaces_tween() -> void:
 	_check("new tween is a different instance",
 		first != second,
 		"_start_priority_pulse re-used the old tween across model switch")
-	_check("old tween was killed when priority shifted",
-		first == null or not first.is_valid(),
-		"old m1 tween is still live after switching priority to m2")
+	_check("old tween was stopped when priority shifted",
+		first == null or not first.is_running(),
+		"old m1 tween is still running after switching priority to m2")
 	_check("target switched to m2's highlight",
 		overlay.priority_pulse_target == ctx["highlights"]["m2"])
 


### PR DESCRIPTION
## Summary

Closes the "Headless audit suite" CI gate that's been red on every
PR in this session's stack. The two failing assertions in
`test_wound_allocation_priority_pulse.gd` were checking
`Tween.is_valid()` returns false after `Tween.kill()`, which is
not actually the case in Godot 4.4.

## Root cause

Minimal repro of Godot 4.4.1's Tween behaviour:

```gdscript
var t = node.create_tween()
t.set_loops()
t.tween_interval(1.0)
print("before kill: is_valid=", t.is_valid(), " is_running=", t.is_running())
t.kill()
print("after kill: is_valid=", t.is_valid(), " is_running=", t.is_running())
```

Output:
```
before kill: is_valid=true  is_running=true
after kill:  is_valid=true  is_running=false
```

`Tween.kill()` stops the tween (`is_running()` → `false`) but the
object remains tracked by the SceneTree until garbage-collected.
`is_valid()` only returns false for tweens that have been
explicitly invalidated by scene tree internals, not for ones
killed by user code.

The tests' INTENT was "after stop, the tween should not be doing
anything" — that's `is_running() == false`. Both assertions
updated to use that.

## Result

```
Audit suite: before  479 passed, 2 failed across 20 tests
            after   481 passed, 0 failed across 20 tests
```

## Files changed

- `40k/tests/test_wound_allocation_priority_pulse.gd` (16 lines —
  2 assertion updates + comment-block clarification of Godot 4.4
  Tween semantics so future readers don't re-introduce the same
  mistake)

## Test plan

- [x] `godot --headless --path 40k --script tests/test_wound_allocation_priority_pulse.gd`
      passes 22/22 (was 20/22)
- [x] Full audit suite passes 481/481 (was 479/481)
- [x] No other test in the audit suite uses `is_valid()` to assert
      tween-was-killed (grep clean)
- [ ] **Reviewer:** the production code in
      `WoundAllocationOverlay.gd:_stop_priority_pulse` correctly
      calls `kill()` on the tween. Confirm we don't also need to
      null the reference and rely on GC, vs the current pattern
      of `if priority_pulse_tween.is_valid(): kill(); priority_pulse_tween = null`
      (the production code is correct — this PR only fixes the
      test's mistaken expectations)

https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3fnbob9uxfxoZnsA8saCr)_