### PR TITLE
Fix Measurement.model_outside_board treating local bounds as world coords

### DIFF
--- a/40k/autoloads/Measurement.gd
+++ b/40k/autoloads/Measurement.gd
@@ -239,13 +239,19 @@ func model_outside_board(pos: Vector2, model: Dictionary) -> bool:
 	test_model["position"] = pos
 	# Pull rotation if set; create_base_shape uses model["rotation"]
 	var shape := create_base_shape(test_model)
-	var bounds := shape.get_bounds()
-	# get_bounds() returns a Rect2 in WORLD coordinates around `pos`
-	if bounds.position.x < 0.0 or bounds.position.y < 0.0:
+	# get_bounds() returns a Rect2 in LOCAL coordinates centered around the
+	# origin (e.g. circle of radius r → Rect2(-r, -r, 2r, 2r)). Translate by
+	# `pos` to compare against the board rectangle in world space.
+	var local_bounds := shape.get_bounds()
+	var world_min_x := local_bounds.position.x + pos.x
+	var world_min_y := local_bounds.position.y + pos.y
+	var world_max_x := world_min_x + local_bounds.size.x
+	var world_max_y := world_min_y + local_bounds.size.y
+	if world_min_x < 0.0 or world_min_y < 0.0:
 		return true
-	if bounds.position.x + bounds.size.x > board_w_px:
+	if world_max_x > board_w_px:
 		return true
-	if bounds.position.y + bounds.size.y > board_h_px:
+	if world_max_y > board_h_px:
 		return true
 	return false
 

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -46,9 +46,10 @@
     },
     {
       "id": "autoloads.Measurement.model_outside_board",
-      "description": "Measurement.model_outside_board(pos, model): single source of truth for the off-board rule. Builds a base shape at pos, checks the bounding rect against the battlefield (SettingsService.get_board_width_px/get_board_height_px). Returns false safely if SettingsService is missing.",
+      "description": "Measurement.model_outside_board(pos, model): single source of truth for the off-board rule. Builds a base shape at pos, translates the local bounds by pos, and checks the resulting world-space bounding rect against the battlefield (SettingsService.get_board_width_px/get_board_height_px). Returns false safely if SettingsService is missing.",
       "scenarios": [
-        "87_no_offboard_deploy"
+        "87_no_offboard_deploy",
+        "blade_champion_in_zone_deploy"
       ],
       "last_verified_commit": "4c0f14f",
       "status": "covered"
@@ -165,9 +166,28 @@
       "id": "deployment.no_offboard_placement",
       "description": "Issue #87: no part of any model may extend off the battlefield. Enforced via Measurement.model_outside_board, called from DeploymentController/MovementController/ChargeController/FightController and from DeploymentPhase._validate_model_position as defence-in-depth against dispatched DEPLOY_UNIT actions.",
       "scenarios": [
-        "87_no_offboard_deploy"
+        "87_no_offboard_deploy",
+        "blade_champion_in_zone_deploy"
       ],
       "last_verified_commit": "4c0f14f",
+      "status": "covered"
+    },
+    {
+      "id": "deployment.in_zone_placement_succeeds",
+      "description": "Inverse of deployment.no_offboard_placement: a model whose base lies wholly inside the active player's deployment zone must be placed without tripping the off-board check. Regression guard for the Blade Champion bug where Measurement.model_outside_board treated shape.get_bounds() (local-space, centered on origin) as world coords and so rejected every placement.",
+      "scenarios": [
+        "blade_champion_in_zone_deploy"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "deployment.ui_try_place_at",
+      "description": "DeploymentController.try_place_at(world_pos): the controller entry point invoked by the player's click on the board during the Deployment phase. Verifies that a valid in-zone click populates temp_positions / spawns the preview token instead of being silently rejected by an upstream guard (e.g. Measurement.model_outside_board).",
+      "scenarios": [
+        "blade_champion_in_zone_deploy"
+      ],
+      "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {

--- a/40k/tests/scenarios/sp/blade_champion_in_zone_deploy.json
+++ b/40k/tests/scenarios/sp/blade_champion_in_zone_deploy.json
@@ -1,0 +1,53 @@
+{
+  "id": "blade_champion_in_zone_deploy",
+  "covers": [
+    "deployment.in_zone_placement_succeeds",
+    "deployment.ui_try_place_at",
+    "autoloads.Measurement.model_outside_board"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Bug repro: deploying a 40mm-base CHARACTER (Blade Champion) at a position fully INSIDE Player 1's hammer_anvil zone must succeed. Before the fix, Measurement.model_outside_board treated shape.get_bounds() (local coords centered on origin) as world coords, so every model's min-x/min-y was negative and the off-board check fired for any placement — the user could not deploy anywhere. Validates both the UI path (DeploymentController.try_place_at, what the player's click invokes — produces a 'Models cannot be placed off the board' toast on regression) and the engine path (DEPLOY_UNIT action).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "expect_state", "path": "units.U_BLADE_CHAMPION_A.status", "equals": 0 },
+
+    { "act": "screenshot", "label": "00_before_deploy" },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_BLADE_CHAMPION_A')" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "Main.deployment_controller.unit_id", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(880, 240))" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "str(Main.deployment_controller.temp_positions[0])", "equals": "(880.0, 240.0)" },
+    { "act": "screenshot", "label": "01_blade_champion_ghost_placed_via_ui" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DEPLOY_UNIT",
+      "unit_id": "U_BLADE_CHAMPION_A",
+      "model_positions": [{ "x": 880, "y": 240 }],
+      "model_rotations": [0]
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.U_BLADE_CHAMPION_A.status", "equals": 2 },
+    { "act": "screenshot", "label": "02_blade_champion_committed" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DEPLOY_UNIT",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_positions": [
+        { "x": -50, "y": 240 },
+        { "x":  60, "y": 240 },
+        { "x": 120, "y": 240 },
+        { "x": 180, "y": 240 },
+        { "x": 240, "y": 240 }
+      ],
+      "model_rotations": [0, 0, 0, 0, 0]
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": false },
+    { "act": "screenshot", "label": "03_offboard_still_rejected" }
+  ]
+}


### PR DESCRIPTION
## Summary
Fixed a critical bug in `Measurement.model_outside_board()` where shape bounds in local coordinates were incorrectly compared directly against world-space board boundaries, causing all unit deployments to fail with "Models cannot be placed off the board" errors.

## Changes
- **Measurement.gd**: Corrected the off-board detection logic to properly translate local shape bounds to world coordinates before comparing against board dimensions
  - `shape.get_bounds()` returns a `Rect2` in local coordinates centered on the origin (e.g., a 40mm-radius circle yields `Rect2(-40, -40, 80, 80)`)
  - Added explicit translation: `world_min = local_bounds.position + pos` and `world_max = world_min + local_bounds.size`
  - Updated all four boundary checks (min-x, min-y, max-x, max-y) to use the correctly transformed world coordinates

- **New scenario**: `blade_champion_in_zone_deploy.json` validates the fix end-to-end
  - Tests the UI path: `DeploymentController.try_place_at()` placing a 40mm-base CHARACTER at a valid in-zone position
  - Tests the engine path: `DEPLOY_UNIT` action with the same position
  - Confirms that valid placements succeed and invalid (off-board) placements still reject correctly
  - Covers three test cases: UI ghost placement, engine deployment success, and off-board rejection

## Implementation Details
The bug manifested because every model's local bounds have negative min coordinates (the shape is centered on origin), so the original code `if bounds.position.x < 0.0` would always trigger regardless of the actual world position. The fix properly accounts for the position offset when determining world-space bounds.

https://claude.ai/code/session_01X4JWyhA3hNKrphQ9wnUAMv