### PR TITLE
Fix Confirm button unreachable behind RollLogPanel + UnitStatsPanel overlays

### DIFF
--- a/40k/scripts/RollLogPanel.gd
+++ b/40k/scripts/RollLogPanel.gd
@@ -22,7 +22,12 @@ var _scroll: ScrollContainer = null
 
 func _ready() -> void:
 	name = "RollLogPanel"
-	mouse_filter = Control.MOUSE_FILTER_PASS
+	# IGNORE (not PASS) — the panel is a passive read-out covering the
+	# right 320px of the viewport from y=80 down. PASS would still make
+	# Godot pick this control for input and only propagate to ancestors,
+	# never to lower-z siblings like HUD_Right (where the Undo / Reset /
+	# Confirm buttons live).
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
 	custom_minimum_size = Vector2(PANEL_WIDTH, 0)
 	_sync_viewport_size()
 	var vp := get_viewport()
@@ -32,12 +37,17 @@ func _ready() -> void:
 	_scroll = ScrollContainer.new()
 	_scroll.name = "Scroll"
 	_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	# Roll log is a passive read-out; without IGNORE, the inner ScrollContainer
+	# (default MOUSE_FILTER_STOP) eats clicks on whatever sits under the right
+	# 320px of the viewport — e.g. the Confirm button in HUD_Right.
+	_scroll.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	add_child(_scroll)
 
 	_vbox = VBoxContainer.new()
 	_vbox.name = "Entries"
 	_vbox.add_theme_constant_override("separation", 2)
 	_vbox.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_vbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_scroll.add_child(_vbox)
 
 	var dh = get_node_or_null("/root/DiceHistoryPanel")
@@ -74,6 +84,7 @@ func _append_entry_label(entry: Dictionary) -> void:
 	lbl.add_theme_color_override("font_color", Color(0.95, 0.95, 0.95, 1.0))
 	lbl.add_theme_font_size_override("font_size", 12)
 	lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	_vbox.add_child(lbl)
 
 

--- a/40k/scripts/UnitStatsPanel.gd
+++ b/40k/scripts/UnitStatsPanel.gd
@@ -73,6 +73,24 @@ signal panel_visibility_changed(is_visible: bool)
 func _ready() -> void:
 	print("UnitStatsPanel: _ready() called with 4-section layout")
 
+	# The panel is anchored BOTTOM_WIDE and sits on top of HUD_Right's
+	# bottom edge (which holds Undo / Reset / Confirm). With the default
+	# MOUSE_FILTER_STOP on the panel and its passive containers, clicks
+	# on the Confirm button get eaten by the Spacer/Header inside this
+	# panel before they can reach HUD_Right. Mark the empty
+	# layout-only containers IGNORE so Godot's input pick walks past
+	# them; the ToggleButton keeps its own STOP and stays clickable.
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var _vbox := get_node_or_null("VBox") as Control
+	if _vbox:
+		_vbox.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var _header := get_node_or_null("VBox/Header") as Control
+	if _header:
+		_header.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var _spacer := get_node_or_null("VBox/Header/Spacer") as Control
+	if _spacer:
+		_spacer.mouse_filter = Control.MOUSE_FILTER_IGNORE
+
 	# Apply gothic panel styling
 	_apply_gothic_theme()
 

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -191,6 +191,33 @@
       "status": "covered"
     },
     {
+      "id": "deployment.confirm_button_input_path",
+      "description": "End-to-end input path for the Deployment phase Confirm button (HUD_Right/.../ConfirmButton): after a model is placed, a real simulated mouse click on the button must reach _on_confirm_pressed and commit the unit (status -> DEPLOYED). Regression guard for later-z overlay panels (RollLogPanel, UnitStatsPanel) eating the click via default MOUSE_FILTER_STOP.",
+      "scenarios": [
+        "deploy_confirm_button_clickable"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ui.overlays.RollLogPanel_no_input_blocking",
+      "description": "RollLogPanel (T35) is a passive read-out occupying the right 320px of the viewport from y=80 down. It must be MOUSE_FILTER_IGNORE so it never consumes clicks that should reach HUD_Right (Undo / Reset / Confirm) or lower-z controls.",
+      "scenarios": [
+        "deploy_confirm_button_clickable"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ui.overlays.UnitStatsPanel_no_input_blocking",
+      "description": "UnitStatsPanel is anchored BOTTOM_WIDE and overlaps the bottom strip of HUD_Right where the deployment buttons live. The panel and its layout-only descendants (VBox, Header, Spacer) must be MOUSE_FILTER_IGNORE so the deployment buttons remain reachable; the ToggleButton keeps its own STOP so the panel still toggles.",
+      "scenarios": [
+        "deploy_confirm_button_clickable"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "deployment.predeploy_roll_off",
       "description": "Pre-deployment roll-off (issue #85): both players roll a D6. The winner chooses to be Attacker or Defender \u2014 Defender deploys first and takes the second turn, Attacker deploys second and takes the first turn.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/deploy_confirm_button_clickable.json
+++ b/40k/tests/scenarios/sp/deploy_confirm_button_clickable.json
@@ -1,0 +1,36 @@
+{
+  "id": "deploy_confirm_button_clickable",
+  "covers": [
+    "deployment.confirm_button_input_path",
+    "ui.overlays.RollLogPanel_no_input_blocking",
+    "ui.overlays.UnitStatsPanel_no_input_blocking"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Regression guard: after the player places a unit's models in their deployment zone, the Undo / Reset / Confirm buttons in HUD_Right must accept real mouse clicks. Two later-z overlays cover the right-bottom corner of the viewport where those buttons live: T35 RollLogPanel (right 320px, y=80..bottom) and UnitStatsPanel (full width, bottom 40-44px). With the default mouse_filter, either overlay (or its inner ScrollContainer / Spacer) consumes the click and confirm() never fires. This scenario drives the full UI path: begin_deploy -> try_place_at -> click_node(ConfirmButton via simulated mouse press) -> expect status=DEPLOYED.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+    { "act": "expect_state", "path": "units.U_BLADE_CHAMPION_A.status", "equals": 0 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/RollLogPanel", "timeout_s": 2.0 },
+    { "act": "expect_node_property", "node": "/root/Main/RollLogPanel", "property": "mouse_filter", "equals": 2 },
+    { "act": "expect_node_property", "node": "/root/Main/UnitStatsPanel", "property": "mouse_filter", "equals": 2 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_BLADE_CHAMPION_A')" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(880, 240))" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "str(Main.deployment_controller.temp_positions[0])", "equals": "(880.0, 240.0)" },
+    { "act": "screenshot", "label": "01_model_placed_ready_to_confirm" },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton", "timeout_s": 2.0 },
+    { "act": "expect_node_property", "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton", "property": "disabled", "equals": false },
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton" },
+    { "act": "wait_frames", "frames": 30 },
+
+    { "act": "expect_state", "path": "units.U_BLADE_CHAMPION_A.status", "equals": 2 },
+    { "act": "screenshot", "label": "02_confirm_clicked_unit_deployed" }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #416. The deployment fix let players place a model in their zone, but the Confirm button below the deployment-buttons row was still unclickable — two later-z overlay panels were intercepting the click.

## Root cause

`RollLogPanel` (T35) covers the right 320px of the viewport from y=80 down, and `UnitStatsPanel` covers the bottom 40-44px full-width. Both were created with the default `MOUSE_FILTER_STOP` on their passive layout containers (PanelContainer / VBox / Header / Spacer / ScrollContainer).

Godot delivers each click to the topmost control with `STOP` or `PASS`. `PASS` only propagates to *ancestors*, never to lower-z *siblings* — so a click intended for `HUD_Right/.../ConfirmButton` was eaten by `RollLogPanel` (PASS, propagated nowhere) or by `UnitStatsPanel`'s `Spacer` (default STOP), and `_on_confirm_pressed` never fired.

## Fix

Mark the panels and their passive descendants `MOUSE_FILTER_IGNORE` so Godot's input pick walks past them and lands on `HUD_Right`'s button. Interactive children (UnitStatsPanel's `ToggleButton`, HUD_Right buttons) keep their own `STOP` and stay clickable.

## Validation

`tests/scenarios/sp/deploy_confirm_button_clickable.json` drives the full UI path:

1. `begin_deploy('U_BLADE_CHAMPION_A')`
2. `try_place_at(Vector2(880, 240))`
3. `click_node` on ConfirmButton (real simulated mouse press — *not* `emit_pressed`, so the input has to actually traverse the overlays)
4. asserts unit status transitions to `DEPLOYED`

The test fails on the regression and passes after the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4JWyhA3hNKrphQ9wnUAMv)_