### PR TITLE
Fix cloud army dual fetch hang by tracking multiple in-flight requests

### DIFF
--- a/40k/autoloads/ArmyListManager.gd
+++ b/40k/autoloads/ArmyListManager.gd
@@ -14,8 +14,7 @@ var available_armies: Array = []
 var cloud_army_names: Array = []  # Names of armies available in cloud storage
 var cloud_army_cache: Dictionary = {}  # Cache of downloaded cloud army data: army_name -> army_data
 var _cloud_armies_connected: bool = false  # Whether CloudStorage signals are connected
-var _pending_cloud_fetch: String = ""  # Army name currently being fetched
-var _pending_cloud_player: int = 1  # Player for pending cloud fetch
+var _pending_cloud_fetches: Dictionary = {}  # army_name -> player for all in-flight cloud fetches
 
 func _ready() -> void:
 	scan_available_armies()
@@ -443,8 +442,7 @@ func fetch_cloud_army(army_name: String, player: int = 1) -> void:
 		CloudStorage.request_failed.connect(_on_cloud_request_failed)
 		_cloud_armies_connected = true
 
-	_pending_cloud_fetch = army_name
-	_pending_cloud_player = player
+	_pending_cloud_fetches[army_name] = player
 	print("ArmyListManager: Fetching cloud army '%s' for player %d" % [army_name, player])
 	CloudStorage.get_army(army_name)
 
@@ -485,20 +483,24 @@ func _on_cloud_army_downloaded(army_name: String, army_data: Dictionary) -> void
 	cloud_army_cache[army_name] = army_data
 
 	# If this was a pending fetch, process and emit
-	if army_name == _pending_cloud_fetch:
-		var processed = _process_army_data(army_data.duplicate(true), _pending_cloud_player)
-		_pending_cloud_fetch = ""
+	if _pending_cloud_fetches.has(army_name):
+		var player = _pending_cloud_fetches[army_name]
+		_pending_cloud_fetches.erase(army_name)
+		var processed = _process_army_data(army_data.duplicate(true), player)
 		cloud_army_fetched.emit(army_name, processed)
 
 func _on_cloud_request_failed(operation: String, error: String) -> void:
 	if operation == "list_armies":
 		print("ArmyListManager: Failed to list cloud armies: %s" % error)
 		cloud_armies_loaded.emit([])
-	elif operation == "get_army" and not _pending_cloud_fetch.is_empty():
-		var army_name = _pending_cloud_fetch
-		_pending_cloud_fetch = ""
-		print("ArmyListManager: Failed to fetch cloud army '%s': %s" % [army_name, error])
-		cloud_army_fetch_failed.emit(army_name, error)
+	elif operation == "get_army" and not _pending_cloud_fetches.is_empty():
+		# CloudStorage.request_failed does not include the failing army name; fail all
+		# currently in-flight cloud army fetches so waiting callers don't hang.
+		var pending_names = _pending_cloud_fetches.keys()
+		_pending_cloud_fetches.clear()
+		for army_name in pending_names:
+			print("ArmyListManager: Failed to fetch cloud army '%s': %s" % [army_name, error])
+			cloud_army_fetch_failed.emit(army_name, error)
 
 func _process_army_data(army_data: Dictionary, player: int) -> Dictionary:
 	## Process raw army JSON data the same way load_army_list does (set owner, status, flags, etc.)

--- a/40k/tests/test_cloud_army_dual_fetch.gd
+++ b/40k/tests/test_cloud_army_dual_fetch.gd
@@ -1,0 +1,120 @@
+extends SceneTree
+
+# Regression test for the "Downloading armies..." freeze when both players
+# select a cloud-saved army list.
+#
+# Bug: ArmyListManager.fetch_cloud_army() previously tracked the in-flight
+# request with a single _pending_cloud_fetch String. When the lobby called
+# fetch_cloud_army() twice in a row (one per player), the second call
+# overwrote the first; when the first HTTP response arrived,
+# _on_cloud_army_downloaded() saw army_name != _pending_cloud_fetch and
+# never emitted cloud_army_fetched. The lobby's _cloud_fetch_count never
+# decremented to zero, so the game never started.
+#
+# Fix: _pending_cloud_fetches is now Dictionary<army_name, player>, so
+# every in-flight download can be matched on completion.
+#
+# Usage: godot --headless --path . -s tests/test_cloud_army_dual_fetch.gd
+
+var passed := 0
+var failed := 0
+var received: Array = []  # [{name, player_owner_of_first_unit}]
+
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+
+func _init():
+	create_timer(0.1).timeout.connect(_run_tests)
+
+
+func _run_tests() -> void:
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_cloud_army_dual_fetch ===\n")
+	_test_dual_pending_fetch_completes_both()
+	_test_failure_clears_all_pending()
+	_finish()
+
+
+func _on_fetched(army_name: String, army_data: Dictionary) -> void:
+	# Capture the player by inspecting the first unit's owner (set by _process_army_data).
+	var first_owner = -1
+	if army_data.has("units") and army_data.units is Dictionary:
+		for unit_id in army_data.units:
+			first_owner = army_data.units[unit_id].get("owner", -1)
+			break
+	received.append({"name": army_name, "owner": first_owner})
+
+
+func _on_fetch_failed(army_name: String, _error: String) -> void:
+	received.append({"name": army_name, "owner": -999})
+
+
+func _test_dual_pending_fetch_completes_both() -> void:
+	print("\n-- dual pending fetches both emit cloud_army_fetched --")
+	var alm = root.get_node_or_null("ArmyListManager")
+	_check("ArmyListManager autoload present", alm != null)
+	if alm == null:
+		return
+
+	received.clear()
+	alm.cloud_army_cache.clear()
+	alm._pending_cloud_fetches.clear()
+	if not alm.cloud_army_fetched.is_connected(_on_fetched):
+		alm.cloud_army_fetched.connect(_on_fetched)
+
+	# Seed two in-flight fetches directly (bypassing CloudStorage HTTP layer).
+	alm._pending_cloud_fetches["ArmyA"] = 1
+	alm._pending_cloud_fetches["ArmyB"] = 2
+
+	var sample_units = {"u1": {"status": "UNDEPLOYED", "models": []}}
+	alm._on_cloud_army_downloaded("ArmyA", {"units": sample_units.duplicate(true)})
+	alm._on_cloud_army_downloaded("ArmyB", {"units": sample_units.duplicate(true)})
+
+	_check("two cloud_army_fetched signals fired", received.size() == 2,
+		"got %d" % received.size())
+	var saw_a := false
+	var saw_b := false
+	for r in received:
+		if r.name == "ArmyA":
+			saw_a = true
+			_check("ArmyA processed for player 1", r.owner == 1, "owner=%d" % r.owner)
+		elif r.name == "ArmyB":
+			saw_b = true
+			_check("ArmyB processed for player 2", r.owner == 2, "owner=%d" % r.owner)
+	_check("ArmyA signal received", saw_a)
+	_check("ArmyB signal received", saw_b)
+	_check("pending dict drained", alm._pending_cloud_fetches.is_empty())
+
+
+func _test_failure_clears_all_pending() -> void:
+	print("\n-- get_army failure fails all in-flight fetches --")
+	var alm = root.get_node_or_null("ArmyListManager")
+	if alm == null:
+		return
+
+	received.clear()
+	alm._pending_cloud_fetches.clear()
+	if not alm.cloud_army_fetch_failed.is_connected(_on_fetch_failed):
+		alm.cloud_army_fetch_failed.connect(_on_fetch_failed)
+
+	alm._pending_cloud_fetches["ArmyA"] = 1
+	alm._pending_cloud_fetches["ArmyB"] = 2
+
+	alm._on_cloud_request_failed("get_army", "boom")
+
+	_check("two cloud_army_fetch_failed signals fired", received.size() == 2,
+		"got %d" % received.size())
+	_check("pending dict cleared on failure", alm._pending_cloud_fetches.is_empty())
+
+
+func _finish() -> void:
+	print("\n=== Summary: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Summary
Fixes a regression where selecting cloud-saved armies for both players would freeze the lobby at "Downloading armies..." indefinitely. The bug occurred because `ArmyListManager` tracked only a single in-flight cloud fetch; when two fetches were initiated in quick succession, the second would overwrite the first, causing the first HTTP response to be ignored.

## Changes
- **Replace single-fetch tracking with multi-fetch dictionary**: Changed `_pending_cloud_fetch` (String) and `_pending_cloud_player` (int) to a single `_pending_cloud_fetches` Dictionary mapping army names to player IDs. This allows every in-flight download to be matched on completion.

- **Update `fetch_cloud_army()`**: Now stores the player mapping in the dictionary instead of overwriting a single pending state.

- **Update `_on_cloud_army_downloaded()`**: Checks if the completed army is in the pending dictionary (rather than comparing to a single string), retrieves the correct player, and erases the entry after processing.

- **Update `_on_cloud_request_failed()`**: When a `get_army` operation fails, now fails all currently in-flight fetches (since CloudStorage doesn't provide the specific failing army name). This prevents callers from hanging indefinitely waiting for responses that will never arrive.

- **Add regression test**: New headless test `test_cloud_army_dual_fetch.gd` validates that:
  - Two simultaneous cloud army fetches both emit `cloud_army_fetched` signals
  - Each fetch is processed with the correct player owner
  - Failure of a `get_army` operation clears all pending fetches and emits failure signals for each

## Implementation Details
The fix is minimal and surgical: the core logic remains unchanged; only the data structure for tracking in-flight requests is upgraded from a single value to a dictionary. This ensures that concurrent fetch requests don't interfere with each other while maintaining backward compatibility with the signal API.

https://claude.ai/code/session_012MYqymiqnPwqU7znamsL6E