### PR TITLE
Stop right-HUD buttons from stealing arrow keys from camera pan

### DIFF
--- a/40k/scenes/Main.tscn
+++ b/40k/scenes/Main.tscn
@@ -94,6 +94,7 @@ layout_mode = 2
 
 [node name="UnitListPanel" type="ItemList" parent="HUD_Right/VBoxContainer"]
 layout_mode = 2
+focus_mode = 1
 size_flags_vertical = 3
 
 [node name="UnitCard" type="VBoxContainer" parent="HUD_Right/VBoxContainer"]
@@ -121,16 +122,19 @@ layout_mode = 2
 [node name="UndoButton" type="Button" parent="HUD_Right/VBoxContainer/UnitCard/ButtonContainer"]
 visible = false
 layout_mode = 2
+focus_mode = 1
 text = "Undo"
 
 [node name="ResetButton" type="Button" parent="HUD_Right/VBoxContainer/UnitCard/ButtonContainer"]
 visible = false
 layout_mode = 2
+focus_mode = 1
 text = "Reset Unit"
 
 [node name="ConfirmButton" type="Button" parent="HUD_Right/VBoxContainer/UnitCard/ButtonContainer"]
 visible = false
 layout_mode = 2
+focus_mode = 1
 text = "Confirm"
 
 [node name="UnitStatsPanel" type="PanelContainer" parent="."]

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -4736,6 +4736,16 @@ func _input(event: InputEvent) -> void:
 	if event is InputEventKey and _is_text_input_focused():
 		return
 
+	# Release Control focus on arrow / WASD presses so HUD buttons don't
+	# swallow camera-pan keys for focus navigation. Text inputs are exempt
+	# (handled by the early return above).
+	if event is InputEventKey and event.pressed and not event.echo:
+		match event.keycode:
+			KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_W, KEY_A, KEY_S, KEY_D:
+				var focused = get_viewport().gui_get_focus_owner()
+				if focused != null:
+					focused.release_focus()
+
 	# Handle mouse clicks for scout move placement (ScoutMovesPhase)
 	if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
 		if current_phase == GameStateData.Phase.SCOUT_MOVES and _current_scout_unit_id != "":

--- a/40k/test_results/test_commands/args_log.txt
+++ b/40k/test_results/test_commands/args_log.txt
@@ -1,1 +1,1 @@
-ARGS: []
+ARGS: ["--check-only"]


### PR DESCRIPTION
When a button or ItemList on the right HUD had focus, pressing arrow
keys (or WASD) navigated focus between Controls instead of panning the
camera. Release Control focus on those keys in Main._input(), and mark
the static UnitListPanel / Undo / Reset / Confirm controls as
FOCUS_CLICK so they can no longer be reached via keyboard navigation.