### PR TITLE
Defer normal move action dispatch until confirm button

### DIFF
--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -1068,24 +1068,16 @@ func _on_normal_move_pressed() -> void:
 	if setting_radio_programmatically:
 		return
 
-	print("Normal move button pressed for unit: ", active_unit_id)
+	print("Normal move radio pressed for unit: ", active_unit_id)
 	if active_unit_id == "":
 		print("No unit selected!")
 		# Try to help the user
 		if unit_list and unit_list.get_item_count() > 0:
 			print("Please select a unit from the list first")
 		return
-	
-	print("Creating BEGIN_NORMAL_MOVE action for unit: ", active_unit_id)
-	var action = {
-		"type": "BEGIN_NORMAL_MOVE",
-		"actor_unit_id": active_unit_id,
-		"payload": {}
-	}
-	print("Emitting move_action_requested signal with action: ", action)
-	emit_signal("move_action_requested", action)
-	print("Signal emitted, waiting for phase response...")
-	_refresh_confirm_mode_button_enable()  # issue #51
+
+	# Don't dispatch BEGIN_NORMAL_MOVE yet — wait for "Confirm Movement Mode" button
+	_refresh_confirm_mode_button_enable()
 
 func _on_advance_pressed() -> void:
 	# Ignore if we're setting the radio programmatically
@@ -1188,6 +1180,12 @@ func _on_confirm_mode_pressed() -> void:
 
 	# Dispatch the actual movement action based on selected mode
 	match selected_mode:
+		"NORMAL":
+			emit_signal("move_action_requested", {
+				"type": "BEGIN_NORMAL_MOVE",
+				"actor_unit_id": active_unit_id,
+				"payload": {}
+			})
 		"ADVANCE":
 			emit_signal("move_action_requested", {
 				"type": "BEGIN_ADVANCE",
@@ -1256,9 +1254,11 @@ func _refresh_confirm_mode_button_enable() -> void:
 	if not confirm_mode_button:
 		return
 	var selected_mode = _get_selected_movement_mode()
-	var needs_confirm = selected_mode in ["ADVANCE", "REMAIN_STATIONARY"]
+	var needs_confirm = selected_mode in ["NORMAL", "ADVANCE", "REMAIN_STATIONARY"]
 	var any_radio_enabled := false
-	if advance_radio and not advance_radio.disabled:
+	if normal_radio and not normal_radio.disabled:
+		any_radio_enabled = true
+	elif advance_radio and not advance_radio.disabled:
 		any_radio_enabled = true
 	elif stationary_radio and not stationary_radio.disabled:
 		any_radio_enabled = true
@@ -1321,6 +1321,9 @@ func _reset_mode_selection_for_new_unit(unit_id: String) -> void:
 			setting_radio_programmatically = true
 			normal_radio.button_pressed = true
 			setting_radio_programmatically = false
+
+		# Refresh the Confirm Movement Mode button now that NORMAL is selected
+		_refresh_confirm_mode_button_enable()
 
 		# Hide advance roll label
 		if advance_roll_label:

--- a/40k/test_results/test_commands/args_log.txt
+++ b/40k/test_results/test_commands/args_log.txt
@@ -1,1 +1,1 @@
-ARGS: ["--check-only"]
+ARGS: []


### PR DESCRIPTION
## Summary
Refactor the movement mode selection flow to defer dispatching the `BEGIN_NORMAL_MOVE` action until the player explicitly confirms their movement mode choice via the "Confirm Movement Mode" button, rather than dispatching immediately when the normal move radio button is pressed.

## Key Changes
- **MovementController.gd `_on_normal_move_pressed()`**: Removed immediate action dispatch logic. The function now only updates UI state and calls `_refresh_confirm_mode_button_enable()` without emitting `move_action_requested`.
- **MovementController.gd `_on_confirm_mode_pressed()`**: Added `"NORMAL"` case to the movement mode match statement to dispatch `BEGIN_NORMAL_MOVE` when the confirm button is pressed with normal mode selected.
- **MovementController.gd `_refresh_confirm_mode_button_enable()`**: Updated to include `"NORMAL"` in the `needs_confirm` list and added a check for `normal_radio` being enabled before checking other radio buttons.
- **MovementController.gd `_reset_mode_selection_for_new_unit()`**: Added call to `_refresh_confirm_mode_button_enable()` after setting the normal radio button to ensure the confirm button state is updated when a new unit is selected.
- **test_results/test_commands/args_log.txt**: Removed `--check-only` flag from test arguments (transitive test infrastructure change).

## Implementation Details
This change unifies the movement mode workflow: all movement modes (NORMAL, ADVANCE, REMAIN_STATIONARY) now follow the same pattern of being selected via radio button and then confirmed via the confirm button before dispatching their respective actions. This provides consistent UX and ensures the confirm button is always the gating mechanism for movement action dispatch.

https://claude.ai/code/session_01XQAT6aKCTgUNKjve8dfmV2