### PR TITLE
Fix formation mode state sync between controller and UI

### DIFF
--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -300,6 +300,11 @@ func begin_deploy(_unit_id: String) -> void:
 		temp_rotations.fill(0.0)
 
 	formation_rotation = 0.0  # Reset formation rotation for new unit
+	# Reset to SINGLE so controller state matches the UI (the formation buttons
+	# in Main are recreated per-unit with "Single" pre-pressed; without this
+	# reset the controller would still think TIGHT/SPREAD is active and
+	# clicking the already-pressed "Single" button wouldn't fire any signal).
+	formation_mode = "SINGLE"
 
 	# MA-15: Reset model type picker state
 	has_model_type_picker = false
@@ -755,6 +760,7 @@ func reset_unit() -> void:
 	selected_model_type = ""
 	_hide_model_type_picker()
 	unit_id = ""
+	formation_mode = "SINGLE"  # Match UI default so next unit starts cleanly
 	_clear_formation_ghosts()  # Clear any formation ghosts
 	_remove_ghost()  # Also removes coherency distance label
 	emit_signal("coherency_warning_changed", false, "")

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -109,6 +109,24 @@
       "status": "covered"
     },
     {
+      "id": "charge.bug.infantry_climb_penalty",
+      "description": "Regression guard (#426): INFANTRY charging through a ruin must not pay the climb penalty. Callers of TerrainManager.calculate_charge_terrain_penalty used to omit unit_keywords, so the helper defaulted to applying the climb cost even to INFANTRY (which can traverse ruins freely). Validated by 'charge_infantry_through_ruins.",
+      "scenarios": [
+        "charge_infantry_through_ruins"
+      ],
+      "last_verified_commit": "bb98da0",
+      "status": "covered"
+    },
+    {
+      "id": "charge.terrain.infantry_traversal",
+      "description": "CHARGE phase: TerrainManager.calculate_charge_terrain_penalty returns 0\" extra distance when the charging unit has the INFANTRY keyword and the intervening terrain is traversable (e.g. ruins), regardless of height_category. Validated by 'charge_infantry_through_ruins.",
+      "scenarios": [
+        "charge_infantry_through_ruins"
+      ],
+      "last_verified_commit": "bb98da0",
+      "status": "covered"
+    },
+    {
       "id": "charge.modifier_primitive",
       "description": "Charge-roll modifier flag (effect_plus_charge) honoured by DECLARE_CHARGE \u2014 'ERE WE GO stratagem path",
       "scenarios": [
@@ -530,6 +548,15 @@
         "85_predeploy_rolloff"
       ],
       "last_verified_commit": "c2781b7",
+      "status": "covered"
+    },
+    {
+      "id": "phases.ScoutPhase.SET_SCOUT_MODEL_DEST.overlap_rejected",
+      "description": "Regression guard (#425): ScoutPhase._validate_set_scout_model_dest rejects a destination that overlaps a sibling model — either a sibling's already-staged scout-move position or an unmoved sibling's original position. A clearly non-overlapping destination still succeeds. Validated by 'scout_no_overlap.",
+      "scenarios": [
+        "scout_no_overlap"
+      ],
+      "last_verified_commit": "817e914",
       "status": "covered"
     },
     {


### PR DESCRIPTION
## Summary
Fixes a state synchronization bug where the `DeploymentController`'s `formation_mode` could become out-of-sync with the UI, preventing formation button clicks from registering when switching between units.

## Key Changes
- **`begin_deploy()`**: Reset `formation_mode` to `"SINGLE"` when deploying a new unit. The UI recreates formation buttons per-unit with "Single" pre-pressed, so the controller must match this state to ensure button signals fire correctly.
- **`reset_unit()`**: Reset `formation_mode` to `"SINGLE"` during unit cleanup to ensure the next unit starts with controller state matching the UI default.

## Implementation Details
The bug occurred because:
1. Formation buttons in the Main UI are recreated for each unit with "Single" pre-pressed
2. If the controller still held a stale `formation_mode` value (e.g., `"TIGHT"` or `"SPREAD"`), clicking the already-pressed "Single" button would not emit a signal
3. This left the controller in an inconsistent state relative to the UI

Both resets ensure the controller's internal state always matches the UI's visual state at unit boundaries, allowing formation changes to work reliably across multiple unit deployments.

https://claude.ai/code/session_01PEe1ZQ4a6NRhybxpQNQhas