### PR TITLE
Expose parse-test layouts in terrain dropdown

### DIFF
--- a/40k/autoloads/TerrainManager.gd
+++ b/40k/autoloads/TerrainManager.gd
@@ -49,8 +49,13 @@ func _ready() -> void:
 
 func _preload_layout_metadata() -> void:
 	# Load metadata (name, description, recommended deployments) from all layout JSON files
+	var ids_to_load: Array = []
 	for i in range(1, 9):
-		var layout_id = "layout_%d" % i
+		ids_to_load.append("layout_%d" % i)
+	# Parse-test layouts (catalog-based parser output, see tools/PARSE_TERRAIN_GUIDE.md)
+	ids_to_load.append("layout_parse_test")
+	ids_to_load.append("layout_parse_test_1")
+	for layout_id in ids_to_load:
 		var json_path = "res://terrain_layouts/%s.json" % layout_id
 		if FileAccess.file_exists(json_path):
 			var file = FileAccess.open(json_path, FileAccess.READ)
@@ -62,7 +67,7 @@ func _preload_layout_metadata() -> void:
 					var data = json.data
 					_layout_metadata[layout_id] = {
 						"id": data.get("id", layout_id),
-						"name": data.get("name", "Layout %d" % i),
+						"name": data.get("name", layout_id),
 						"description": data.get("description", ""),
 						"recommended_deployments": data.get("recommended_deployments", [])
 					}
@@ -77,6 +82,9 @@ func get_all_layout_ids() -> Array:
 		var layout_id = "layout_%d" % i
 		if _layout_metadata.has(layout_id):
 			ids.append(layout_id)
+	for extra_id in ["layout_parse_test", "layout_parse_test_1"]:
+		if _layout_metadata.has(extra_id):
+			ids.append(extra_id)
 	return ids
 
 func get_recommended_deployments(layout_id: String) -> Array:

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -44,7 +44,9 @@ var terrain_options = [
 	{"id": "layout_5", "name": "Chapter Approved Layout 5"},
 	{"id": "layout_6", "name": "Chapter Approved Layout 6"},
 	{"id": "layout_7", "name": "Chapter Approved Layout 7"},
-	{"id": "layout_8", "name": "Chapter Approved Layout 8"}
+	{"id": "layout_8", "name": "Chapter Approved Layout 8"},
+	{"id": "layout_parse_test", "name": "Parse Test — Layout 2"},
+	{"id": "layout_parse_test_1", "name": "Parse Test — Layout 1"}
 ]
 
 var mission_options = [


### PR DESCRIPTION
## Summary

Adds the two parse-test layouts (created by the catalog-based terrain parser in PR #429) as selectable options in the terrain dropdown on the main menu. Non-destructive — the existing 8 Chapter Approved layouts are unchanged.

## Changes

- `40k/scripts/MainMenu.gd`: appends two new entries to `terrain_options`:
  - **Parse Test — Layout 1** (loads `layout_parse_test_1.json`)
  - **Parse Test — Layout 2** (loads `layout_parse_test.json`)
- `40k/autoloads/TerrainManager.gd`: `_preload_layout_metadata()` and `get_all_layout_ids()` now also load/expose the parse-test ids alongside the existing `layout_1`..`layout_8`.

## Test plan

- [ ] Start the game from MainMenu
- [ ] Open the terrain dropdown — verify two new entries appear at the bottom
- [ ] Select **Parse Test — Layout 1**, start a game, verify the catalog-based Layout 1 terrain loads
- [ ] Select **Parse Test — Layout 2**, verify Layout 2 terrain loads

https://claude.ai/code/session_0123oL2pwGXLrCB8jbgEeXcK

---
_Generated by [Claude Code](https://claude.ai/code/session_0123oL2pwGXLrCB8jbgEeXcK)_