### PR TITLE
Reposition phase strip to bottom of screen with side margins

### DIFF
--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2748,27 +2748,30 @@ func _setup_round_indicator() -> void:
 	print("Main: P3-109: Round indicator created in top bar (enhanced)")
 
 func _setup_phase_strip() -> void:
-	var hud_bottom = get_node_or_null("HUD_Bottom")
-	if not hud_bottom:
-		return
-
+	# Place the phase progress strip at the bottom of the screen, sandwiched
+	# horizontally between the GameLogPanel (340 px on the left) and the
+	# HUD_Right phase-actions panel (400 px on the right). It sits just above
+	# the UnitStatsPanel header (40 px tall) at the very bottom.
 	_phase_strip_panel = PanelContainer.new()
 	_phase_strip_panel.name = "PhaseStrip"
 	_phase_strip_panel.anchor_left = 0.0
 	_phase_strip_panel.anchor_right = 1.0
 	_phase_strip_panel.anchor_top = 1.0
 	_phase_strip_panel.anchor_bottom = 1.0
-	_phase_strip_panel.offset_top = 0.0
-	_phase_strip_panel.offset_bottom = 30.0
+	_phase_strip_panel.offset_left = GameLogPanelScript.PANEL_WIDTH
+	_phase_strip_panel.offset_right = -400.0
+	_phase_strip_panel.offset_top = -70.0
+	_phase_strip_panel.offset_bottom = -40.0
+	_phase_strip_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	var strip_style = StyleBoxFlat.new()
 	strip_style.bg_color = Color(0.06, 0.05, 0.04, 0.92)
 	strip_style.border_color = Color(WhiteDwarfTheme.WH_GOLD, 0.3)
-	strip_style.border_width_bottom = 1
+	strip_style.border_width_top = 1
 	strip_style.set_content_margin_all(0)
 	strip_style.content_margin_left = 4
 	strip_style.content_margin_right = 4
 	_phase_strip_panel.add_theme_stylebox_override("panel", strip_style)
-	hud_bottom.add_child(_phase_strip_panel)
+	add_child(_phase_strip_panel)
 
 	_phase_strip_container = HBoxContainer.new()
 	_phase_strip_container.alignment = BoxContainer.ALIGNMENT_CENTER

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2748,10 +2748,9 @@ func _setup_round_indicator() -> void:
 	print("Main: P3-109: Round indicator created in top bar (enhanced)")
 
 func _setup_phase_strip() -> void:
-	# Place the phase progress strip at the bottom of the screen, sandwiched
-	# horizontally between the GameLogPanel (340 px on the left) and the
-	# HUD_Right phase-actions panel (400 px on the right). It sits just above
-	# the UnitStatsPanel header (40 px tall) at the very bottom.
+	# Place the phase progress strip flush with the bottom of the screen,
+	# sandwiched horizontally between the GameLogPanel (340 px on the left)
+	# and the HUD_Right phase-actions panel (400 px on the right).
 	_phase_strip_panel = PanelContainer.new()
 	_phase_strip_panel.name = "PhaseStrip"
 	_phase_strip_panel.anchor_left = 0.0
@@ -2760,8 +2759,8 @@ func _setup_phase_strip() -> void:
 	_phase_strip_panel.anchor_bottom = 1.0
 	_phase_strip_panel.offset_left = GameLogPanelScript.PANEL_WIDTH
 	_phase_strip_panel.offset_right = -400.0
-	_phase_strip_panel.offset_top = -70.0
-	_phase_strip_panel.offset_bottom = -40.0
+	_phase_strip_panel.offset_top = -30.0
+	_phase_strip_panel.offset_bottom = 0.0
 	_phase_strip_panel.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	var strip_style = StyleBoxFlat.new()
 	strip_style.bg_color = Color(0.06, 0.05, 0.04, 0.92)

--- a/40k/tests/scenarios/visual/T_phase_strip_bottom.json
+++ b/40k/tests/scenarios/visual/T_phase_strip_bottom.json
@@ -30,10 +30,10 @@
       "equals": -400.0 },
     { "act": "execute_script",
       "script": "get_node(\"/root/Main/PhaseStrip\").offset_top",
-      "equals": -70.0 },
+      "equals": -30.0 },
     { "act": "execute_script",
       "script": "get_node(\"/root/Main/PhaseStrip\").offset_bottom",
-      "equals": -40.0 },
+      "equals": 0.0 },
 
     { "act": "execute_script",
       "script": "String(get_node(\"/root/Main/PhaseStrip\").get_parent().name)",

--- a/40k/tests/scenarios/visual/T_phase_strip_bottom.json
+++ b/40k/tests/scenarios/visual/T_phase_strip_bottom.json
@@ -1,0 +1,44 @@
+{
+  "id": "T_phase_strip_bottom",
+  "covers": ["ui.phase_strip_position"],
+  "fixture": "co_pretrigger",
+  "transition_to_phase": 7,
+  "description": "Phase progress strip (Command -> Movement -> ... -> Score) is anchored at the bottom of the screen, sandwiched horizontally between the GameLogPanel (340px on the left) and the HUD_Right phase-actions panel (400px on the right), instead of spanning the full width at the top.",
+
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "get_node_or_null(\"/root/Main/PhaseStrip\") != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").visible",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").anchor_top",
+      "equals": 1.0 },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").anchor_bottom",
+      "equals": 1.0 },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").offset_left",
+      "equals": 340.0 },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").offset_right",
+      "equals": -400.0 },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").offset_top",
+      "equals": -70.0 },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/PhaseStrip\").offset_bottom",
+      "equals": -40.0 },
+
+    { "act": "execute_script",
+      "script": "String(get_node(\"/root/Main/PhaseStrip\").get_parent().name)",
+      "equals": "Main" },
+
+    { "act": "screenshot", "label": "phase_strip_at_bottom" }
+  ]
+}


### PR DESCRIPTION
## Summary
Relocates the phase progress strip (Command → Movement → ... → Score) from the top of the screen to the bottom, positioning it flush against the bottom edge and constraining it horizontally between the GameLogPanel (340px left margin) and the HUD_Right phase-actions panel (400px right margin).

## Changes
- **Phase strip positioning**: Changed from top-anchored (offset_top: 0, offset_bottom: 30) to bottom-anchored (offset_top: -30, offset_bottom: 0)
- **Horizontal constraints**: Added left offset of 340px (GameLogPanelScript.PANEL_WIDTH) and right offset of -400px to sandwich the strip between side panels
- **Parent node**: Moved from HUD_Bottom to Main scene root for proper layering and positioning
- **Border styling**: Flipped border from bottom to top to align with new bottom-screen position
- **Mouse interaction**: Added MOUSE_FILTER_IGNORE to prevent the strip from intercepting input events
- **Visual test**: Added comprehensive windowed scenario (`T_phase_strip_bottom.json`) that validates:
  - PhaseStrip node exists and is visible
  - Anchor and offset values match expected bottom-screen positioning
  - Parent is Main node
  - Screenshot capture for visual verification

## Implementation Details
The phase strip now uses anchor-based positioning (anchor_top: 1.0, anchor_bottom: 1.0) to pin itself to the bottom of the viewport, with offset values creating the 30px height and side margins. This approach ensures the strip remains properly positioned regardless of screen resolution changes.

https://claude.ai/code/session_01BYMfjUhSdby8BAv28K8jKY