### PR TITLE
Add target ineligibility explanations to shooting UI

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -4287,6 +4287,130 @@ static func get_eligible_targets(actor_unit_id: String, board: Dictionary) -> Di
 
 	return eligible
 
+# Returns a human-readable reason why the given target cannot be shot at by
+# the actor unit. Empty string means the target IS eligible.
+# Mirrors the eligibility checks in get_eligible_targets so the UI can explain
+# why a clicked enemy unit is greyed out (out of range, no LoS, Lone Operative, etc.).
+static func get_target_ineligibility_reason(actor_unit_id: String, target_unit_id: String, board: Dictionary) -> String:
+	var units = board.get("units", {})
+	var actor_unit = units.get(actor_unit_id, {})
+	var target_unit = units.get(target_unit_id, {})
+
+	if actor_unit.is_empty():
+		return "No active shooter"
+	if target_unit.is_empty():
+		return "Invalid target"
+
+	if target_unit.get("owner", 0) == actor_unit.get("owner", 0):
+		return "Cannot target a friendly unit"
+
+	if target_unit.get("attached_to", null) != null:
+		return "Cannot target an attached character — shoot the bodyguard unit"
+
+	var has_alive = false
+	for model in target_unit.get("models", []):
+		if model.get("alive", true):
+			has_alive = true
+			break
+	if not has_alive:
+		return "Target unit is destroyed"
+
+	var target_name = target_unit.get("meta", {}).get("display_name", target_unit.get("meta", {}).get("name", target_unit_id))
+	var actor_owner = actor_unit.get("owner", 0)
+	var target_is_monster_vehicle = is_monster_or_vehicle(target_unit)
+
+	# Cannot target enemies within engagement range of friendly units
+	# (unless the target is a Monster/Vehicle — Big Guns Never Tire applies to the *shooter*,
+	# but the broader rule is that engaged enemies of friends are off-limits to other shooters
+	# except when the target is a Monster/Vehicle, since they can also be targeted normally.)
+	if not target_is_monster_vehicle:
+		if _is_target_in_friendly_engagement(target_unit_id, actor_unit_id, actor_owner, units, board):
+			return "%s is in engagement range with a friendly unit" % target_name
+
+	# Lone Operative
+	if has_lone_operative(target_unit) and target_unit.get("attached_to", null) == null:
+		var attached_chars = target_unit.get("attachment_data", {}).get("attached_characters", [])
+		if attached_chars.is_empty():
+			var min_dist = _get_min_distance_to_target_rules(actor_unit_id, target_unit_id, board)
+			if min_dist > 12.0:
+				return "%s has Lone Operative — must be within 12\" (currently %.1f\")" % [target_name, min_dist]
+
+	# Psychic Veil
+	if target_unit.get("flags", {}).get(EffectPrimitivesData.FLAG_PSYCHIC_VEIL, false):
+		var min_dist = _get_min_distance_to_target_rules(actor_unit_id, target_unit_id, board)
+		if min_dist > 18.0:
+			return "%s has Psychic Veil — must be within 18\" (currently %.1f\")" % [target_name, min_dist]
+
+	# Per-weapon analysis: figure out if it's a range issue, LoS issue, or engagement issue
+	var actor_in_engagement = actor_unit.get("flags", {}).get("in_engagement", false)
+	var actor_is_monster_vehicle = is_monster_or_vehicle(actor_unit)
+	var target_in_er = false
+	if actor_in_engagement:
+		target_in_er = _is_target_within_engagement_range(actor_unit_id, target_unit_id, board)
+
+	var unit_weapons = get_unit_weapons(actor_unit_id, board)
+	var has_any_weapon = false
+	var any_weapon_passed_er_filter = false
+	var any_in_range = false
+	var any_in_los = false
+
+	for model_id in unit_weapons:
+		var actor_model = _get_model_by_id(actor_unit, model_id)
+		if actor_model.is_empty() or not actor_model.get("alive", true):
+			continue
+
+		for weapon_id in unit_weapons[model_id]:
+			has_any_weapon = true
+			var is_pistol = is_pistol_weapon(weapon_id, board)
+
+			# Engagement-range weapon eligibility
+			if actor_in_engagement:
+				if is_pistol:
+					if not target_in_er:
+						continue
+				else:
+					if not actor_is_monster_vehicle:
+						continue
+			any_weapon_passed_er_filter = true
+
+			var weapon_profile = get_weapon_profile(weapon_id, board)
+			var weapon_range = weapon_profile.get("range", 12)
+			var range_px = Measurement.inches_to_px(weapon_range)
+			var is_indirect = has_indirect_fire(weapon_id, board)
+
+			for actor_m in actor_unit.get("models", []):
+				if not actor_m.get("alive", true):
+					continue
+				for target_m in target_unit.get("models", []):
+					if not target_m.get("alive", true):
+						continue
+					var distance = Measurement.model_to_model_distance_px(actor_m, target_m)
+					if distance <= range_px:
+						any_in_range = true
+						if is_indirect:
+							any_in_los = true
+						else:
+							var a_pos = _get_model_position(actor_m)
+							var t_pos = _get_model_position(target_m)
+							if _check_line_of_sight(a_pos, t_pos, board, actor_m, target_m):
+								any_in_los = true
+
+	if not has_any_weapon:
+		return "%s has no usable weapons" % actor_unit.get("meta", {}).get("display_name", actor_unit_id)
+
+	if actor_in_engagement and not any_weapon_passed_er_filter:
+		if actor_is_monster_vehicle:
+			return "No weapons can reach %s while in engagement range" % target_name
+		else:
+			return "Your unit is in engagement range — only Pistols can shoot, and %s is not in your engagement range" % target_name
+
+	if not any_in_range:
+		return "%s is out of range" % target_name
+	if not any_in_los:
+		return "No line of sight to %s" % target_name
+
+	return ""
+
 # Check if target unit is within engagement range (1", or 2" through barricades) of actor unit
 static func _is_target_within_engagement_range(actor_unit_id: String, target_unit_id: String, board: Dictionary) -> bool:
 	var units = board.get("units", {})

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -4008,14 +4008,25 @@ func _handle_board_click(position: Vector2) -> void:
 			dice_log_display.append_text("[color=red]Please select a weapon first![/color]\n")
 		return
 	
-	# Check if click is on an eligible target
+	# Find the closest enemy unit model to the click — across ALL enemy units,
+	# not just eligible ones. This lets us distinguish "the player clicked on
+	# an ineligible enemy" from "the player clicked on an eligible enemy".
 	var closest_target = ""
 	var closest_distance = INF
 	var closest_model_pos = Vector2.ZERO
-	
-	
-	for target_id in eligible_targets:
-		var unit = current_phase.get_unit(target_id)
+
+	var actor_unit = GameState.get_unit(active_shooter_id)
+	var actor_owner = actor_unit.get("owner", 0)
+	var all_units = GameState.state.get("units", {})
+
+	for target_id in all_units:
+		var unit = all_units[target_id]
+		# Only consider enemy units that have at least one alive model
+		if unit.get("owner", 0) == actor_owner:
+			continue
+		if unit.get("attached_to", null) != null:
+			# Attached characters are shot through their bodyguard
+			continue
 		for model in unit.get("models", []):
 			if not model.get("alive", true):
 				continue
@@ -4025,11 +4036,22 @@ func _handle_board_click(position: Vector2) -> void:
 				closest_distance = distance
 				closest_target = target_id
 				closest_model_pos = model_pos
-	
+
 	# Use a larger click threshold to make selection easier
 	if closest_target != "" and closest_distance < 500:  # Very large threshold for testing
-		print("[ShootingController] Click detected - assigning target: %s (distance: %.1f)" % [closest_target, closest_distance])
-		_select_target_for_current_weapon(closest_target)
+		if eligible_targets.has(closest_target):
+			print("[ShootingController] Click detected - assigning target: %s (distance: %.1f)" % [closest_target, closest_distance])
+			_select_target_for_current_weapon(closest_target)
+		else:
+			# Player clicked on an ineligible enemy unit — explain why instead of
+			# silently switching to a different unit.
+			var reason = RulesEngine.get_target_ineligibility_reason(active_shooter_id, closest_target, GameState.create_snapshot())
+			if reason == "":
+				reason = "Target cannot be shot"
+			print("[ShootingController] Click on ineligible target %s: %s" % [closest_target, reason])
+			if dice_log_display:
+				dice_log_display.append_text("[color=red]%s[/color]\n" % reason)
+			ToastManager.show_warning(reason)
 	else:
 		# REMOVED FALLBACK: Don't auto-assign first target if click misses
 		# This was causing weapons to be incorrectly reassigned


### PR DESCRIPTION
## Summary
When a player clicks on an enemy unit during the shooting phase that cannot be targeted, the UI now displays a specific reason why (e.g., "out of range", "no line of sight", "in engagement range with a friendly unit") instead of silently ignoring the click or switching to a different target.

## Changes

### RulesEngine.gd
- Added `get_target_ineligibility_reason()` static function that mirrors all eligibility checks from `get_eligible_targets()` and returns a human-readable explanation for why a target cannot be shot
- Checks cover: friendly units, attached characters, destroyed units, engagement range restrictions, Lone Operative distance, Psychic Veil distance, engagement-range weapon filters, range, and line of sight
- Returns empty string if target IS eligible

### ShootingController.gd
- Modified `_handle_board_click()` to search across ALL enemy units (not just eligible ones) to find the closest clicked model
- When a click lands on an ineligible target, calls `get_target_ineligibility_reason()` to fetch the explanation
- Displays the reason via both console log and UI toast notification
- Preserves existing behavior: only assigns target if it's in the eligible list; otherwise explains why it's greyed out

## Implementation Details
- The ineligibility reason function reuses existing helper methods (`_is_target_in_friendly_engagement()`, `_get_min_distance_to_target_rules()`, `_check_line_of_sight()`, etc.) to ensure consistency with the eligibility logic
- Click detection threshold remains at 500px for ease of selection
- Reasons include distance measurements (e.g., "currently 15.2\"") where applicable to help players understand how to make a target eligible

https://claude.ai/code/session_012rfwE6tjC14h7JqBGV46AW