### PR TITLE
Add split-fire support with per-model range and LoS enforcement

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -1319,6 +1319,20 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 		result.log_text = "Unknown weapon: " + weapon_id
 		return result
 
+	# SPLIT-FIRE / PER-MODEL LOS+RANGE: Re-validate eligibility at resolve time.
+	# Drops models that became ineligible after the player confirmed targets
+	# (deaths, reactive movement, LoS changes).
+	if not model_ids.is_empty():
+		var filt = _filter_eligible_model_ids(model_ids, actor_unit_id, weapon_id, target_unit_id, board)
+		if not filt.dropped.is_empty():
+			print("RulesEngine: [SPLIT-FIRE] Dropped %d ineligible model(s) at resolve time for %s → %s: %s (reasons=%s)" % [
+				filt.dropped.size(), weapon_id, target_unit_id, str(filt.dropped), str(filt.reasons)
+			])
+		model_ids = filt.kept
+		if model_ids.is_empty():
+			result.log_text = "No eligible models in range/LoS for %s → %s" % [weapon_id, target_unit_id]
+			return result
+
 	# Issue #387 Waaagh! Energy: 'Eadbanger gains +S/+D per 5 models in led unit
 	# (and HAZARDOUS at 10+). Mutates profile when applicable.
 	weapon_profile = _apply_waaagh_energy_to_profile(weapon_profile, weapon_id, actor_unit_id, board)
@@ -2209,6 +2223,19 @@ static func _resolve_assignment(assignment: Dictionary, actor_unit_id: String, b
 	if weapon_profile.is_empty():
 		result.log_text = "Unknown weapon: " + weapon_id
 		return result
+
+	# SPLIT-FIRE / PER-MODEL LOS+RANGE: Re-validate eligibility at resolve time.
+	# (Auto-resolve path — same safety-net as the dice-by-dice resolve path.)
+	if not model_ids.is_empty():
+		var filt = _filter_eligible_model_ids(model_ids, actor_unit_id, weapon_id, target_unit_id, board)
+		if not filt.dropped.is_empty():
+			print("RulesEngine: [SPLIT-FIRE][auto-resolve] Dropped %d ineligible model(s) for %s → %s: %s (reasons=%s)" % [
+				filt.dropped.size(), weapon_id, target_unit_id, str(filt.dropped), str(filt.reasons)
+			])
+		model_ids = filt.kept
+		if model_ids.is_empty():
+			result.log_text = "No eligible models in range/LoS for %s → %s" % [weapon_id, target_unit_id]
+			return result
 
 	# Issue #387 Waaagh! Energy: 'Eadbanger gains +S/+D per 5 models in led unit
 	# (and HAZARDOUS at 10+). Mutates profile when applicable.
@@ -6900,6 +6927,160 @@ static func count_models_in_half_range(
 			models_in_half_range += 1
 
 	return models_in_half_range
+
+# SPLIT-FIRE / PER-MODEL LOS+RANGE (Issue #split-fire):
+# For a given (actor_unit, weapon, target_unit), determine which individual
+# alive models carrying that weapon can legally fire it at the target right
+# now — i.e. they are within weapon range AND have Line of Sight (or the
+# weapon is Indirect Fire). Engagement-range / Pistol restrictions are
+# unit-level and are gated upstream by get_eligible_targets; this helper
+# trusts that and only checks per-model range + LoS.
+#
+# Returns a dictionary with the shape:
+#   {
+#     "eligible": Array[String],   # model_ids that can fire this weapon at the target
+#     "reasons":  Dictionary       # { model_id: "out_of_range" | "no_los" | "dead" }
+#                                  # (only carriers of this weapon appear in reasons)
+#     "distances": Dictionary      # { model_id: edge-to-edge distance in inches to nearest target model }
+#   }
+#
+# Used by:
+#  - ShootingController/ShootingPhase to cap the split-fire "how many to this target?" picker
+#  - _resolve_assignment_until_wounds to re-validate at resolve time (drops models that
+#    became ineligible between assignment and resolve)
+static func get_eligible_shooter_models(
+	actor_unit_id: String,
+	weapon_id: String,
+	target_unit_id: String,
+	board: Dictionary
+) -> Dictionary:
+	var result := {"eligible": [], "reasons": {}, "distances": {}}
+
+	var units = board.get("units", {})
+	var actor_unit = units.get(actor_unit_id, {})
+	var target_unit = units.get(target_unit_id, {})
+	if actor_unit.is_empty() or target_unit.is_empty():
+		return result
+
+	var weapon_profile = get_weapon_profile(weapon_id, board)
+	if weapon_profile.is_empty():
+		return result
+
+	var weapon_range_inches = float(weapon_profile.get("range", 12))
+	var is_indirect = has_indirect_fire(weapon_id, board)
+
+	var unit_weapons = get_unit_weapons(actor_unit_id, board)
+	var target_models = target_unit.get("models", [])
+
+	# Pre-compute alive target models so we don't repeat the filter per shooter
+	var alive_targets: Array = []
+	for tm in target_models:
+		if tm.get("alive", true):
+			alive_targets.append(tm)
+
+	for model_id in unit_weapons:
+		# Only consider models that actually carry this weapon
+		if not (weapon_id in unit_weapons[model_id]):
+			continue
+
+		var actor_model = _get_model_by_id(actor_unit, model_id)
+		if actor_model.is_empty():
+			continue
+		if not actor_model.get("alive", true):
+			result.reasons[model_id] = "dead"
+			continue
+
+		var actor_pos = _get_model_position(actor_model)
+		# EnhancedLineOfSight treats Vector2.ZERO as "invalid position"
+		# project-wide. Real game state never places a model at the board
+		# origin, but test fixtures sometimes do — when actor_pos is unset,
+		# we still do the range check below but skip per-model LoS so we
+		# don't false-positive a "no LoS" reason.
+		var actor_pos_unset: bool = (actor_pos == Vector2.ZERO)
+
+		# Find nearest alive target model by edge-to-edge distance
+		var nearest_inches := INF
+		var nearest_target: Dictionary = {}
+		for tm in alive_targets:
+			var edge_px = Measurement.model_to_model_distance_px(actor_model, tm)
+			var edge_inches = Measurement.px_to_inches(edge_px)
+			if edge_inches < nearest_inches:
+				nearest_inches = edge_inches
+				nearest_target = tm
+
+		if nearest_target.is_empty():
+			result.reasons[model_id] = "out_of_range"
+			continue
+
+		result.distances[model_id] = nearest_inches
+
+		# Range check
+		if nearest_inches > weapon_range_inches:
+			result.reasons[model_id] = "out_of_range"
+			continue
+
+		# LoS check (skipped for Indirect Fire weapons OR when actor position
+		# is the engine's invalid-position sentinel)
+		if is_indirect or actor_pos_unset:
+			result.eligible.append(model_id)
+			continue
+
+		# Per-model LoS: this specific actor model must see at least one alive
+		# target model (we test against the nearest first since it's likeliest
+		# to be visible; if not, sweep the rest).
+		var target_pos = _get_model_position(nearest_target)
+		var has_los := false
+		if target_pos != Vector2.ZERO:
+			has_los = _check_line_of_sight(actor_pos, target_pos, board, actor_model, nearest_target)
+		if not has_los:
+			for tm in alive_targets:
+				if tm == nearest_target:
+					continue
+				var tpos = _get_model_position(tm)
+				if tpos == Vector2.ZERO:
+					continue
+				if _check_line_of_sight(actor_pos, tpos, board, actor_model, tm):
+					has_los = true
+					break
+
+		if has_los:
+			result.eligible.append(model_id)
+		else:
+			result.reasons[model_id] = "no_los"
+
+	return result
+
+# SPLIT-FIRE / PER-MODEL LOS+RANGE: Resolve-time filter. Returns the subset of
+# the requested model_ids that are still eligible to fire weapon_id at
+# target_unit_id, plus the list that was dropped (for logging).
+static func _filter_eligible_model_ids(
+	model_ids: Array,
+	actor_unit_id: String,
+	weapon_id: String,
+	target_unit_id: String,
+	board: Dictionary
+) -> Dictionary:
+	var eligibility = get_eligible_shooter_models(actor_unit_id, weapon_id, target_unit_id, board)
+
+	# DEFENSIVE FALLBACK: If eligibility returned zero candidates AND zero
+	# reasons, the unit has no weapon-carrier data the engine can parse
+	# (common in headless test fixtures that don't populate unit.meta.weapons).
+	# In that case the caller's model_ids are the source of truth — trust them
+	# and don't filter, so legacy code paths and fixtures keep working.
+	if eligibility.eligible.is_empty() and eligibility.reasons.is_empty():
+		return {"kept": model_ids.duplicate(), "dropped": [], "reasons": {}}
+
+	var eligible_set := {}
+	for mid in eligibility.eligible:
+		eligible_set[mid] = true
+	var kept: Array = []
+	var dropped: Array = []
+	for mid in model_ids:
+		if eligible_set.has(mid):
+			kept.append(mid)
+		else:
+			dropped.append(mid)
+	return {"kept": kept, "dropped": dropped, "reasons": eligibility.reasons}
 
 # Validation function to check if unit has weapons
 static func unit_has_weapons(unit_id: String) -> bool:

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -837,18 +837,47 @@ func _process_assign_target(action: Dictionary) -> Dictionary:
 	var weapon_id = payload.get("weapon_id", "")
 	var target_unit_id = payload.get("target_unit_id", "")
 	var model_ids = payload.get("model_ids", [])
-	
-	# Remove any existing assignment for this weapon
-	pending_assignments = pending_assignments.filter(func(a): return a.weapon_id != weapon_id)
-	
-	# Add new assignment
-	pending_assignments.append({
-		"weapon_id": weapon_id,
-		"target_unit_id": target_unit_id,
-		"model_ids": model_ids
-	})
 
-	log_phase_message("Assigned %s to target %s" % [weapon_id, target_unit_id])
+	# SPLIT-FIRE: A single weapon_id may now have multiple pending assignments
+	# (different targets). Enforce the invariant that no physical model_id is
+	# assigned twice for the same weapon_id — strip any model_ids that already
+	# appear in another pending assignment of the same weapon.
+	var already_assigned_models: Array = []
+	for a in pending_assignments:
+		if a.get("weapon_id", "") == weapon_id and a.get("target_unit_id", "") != target_unit_id:
+			for mid in a.get("model_ids", []):
+				if mid not in already_assigned_models:
+					already_assigned_models.append(mid)
+
+	var filtered_model_ids: Array = []
+	for mid in model_ids:
+		if mid not in already_assigned_models:
+			filtered_model_ids.append(mid)
+
+	# If an assignment already exists for this (weapon, target), merge into it
+	# rather than appending a duplicate.
+	var existing_index := -1
+	for i in range(pending_assignments.size()):
+		var a = pending_assignments[i]
+		if a.get("weapon_id", "") == weapon_id and a.get("target_unit_id", "") == target_unit_id:
+			existing_index = i
+			break
+
+	if existing_index >= 0:
+		var existing = pending_assignments[existing_index]
+		var combined: Array = existing.get("model_ids", []).duplicate()
+		for mid in filtered_model_ids:
+			if mid not in combined:
+				combined.append(mid)
+		existing["model_ids"] = combined
+	else:
+		pending_assignments.append({
+			"weapon_id": weapon_id,
+			"target_unit_id": target_unit_id,
+			"model_ids": filtered_model_ids
+		})
+
+	log_phase_message("Assigned %s × %d to target %s" % [weapon_id, filtered_model_ids.size(), target_unit_id])
 
 	# Issue #386 Big Booms: roll concussive wave on supa-kannon target selection.
 	# Trigger phrase: "just after selecting a target for this model's supa-kannon".
@@ -876,11 +905,20 @@ func _process_assign_target(action: Dictionary) -> Dictionary:
 func _process_clear_assignment(action: Dictionary) -> Dictionary:
 	var payload = action.get("payload", {})
 	var weapon_id = payload.get("weapon_id", "")
-	
-	pending_assignments = pending_assignments.filter(func(a): return a.weapon_id != weapon_id)
-	
-	log_phase_message("Cleared assignment for %s" % weapon_id)
-	
+	var target_unit_id = payload.get("target_unit_id", "")
+
+	# SPLIT-FIRE: If target_unit_id is given, clear only the matching
+	# (weapon, target) pending assignment; otherwise clear every assignment
+	# for that weapon (legacy "clear weapon" semantics).
+	if target_unit_id != "":
+		pending_assignments = pending_assignments.filter(
+			func(a): return not (a.weapon_id == weapon_id and a.target_unit_id == target_unit_id)
+		)
+		log_phase_message("Cleared assignment for %s → %s" % [weapon_id, target_unit_id])
+	else:
+		pending_assignments = pending_assignments.filter(func(a): return a.weapon_id != weapon_id)
+		log_phase_message("Cleared all assignments for %s" % weapon_id)
+
 	return create_result(true, [])
 
 func _process_clear_all_assignments(action: Dictionary) -> Dictionary:

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -4209,6 +4209,7 @@ func _open_split_fire_picker(weapon_id: String, target_id: String, split: Dictio
 		ineligible_remaining_count += 1
 
 	var dialog := AcceptDialog.new()
+	dialog.name = "SplitFirePicker"
 	dialog.title = "Split Fire: %s → %s" % [weapon_name, target_name]
 	dialog.dialog_hide_on_ok = true
 
@@ -4230,6 +4231,7 @@ func _open_split_fire_picker(weapon_id: String, target_id: String, split: Dictio
 	spin_label.text = "Send:"
 	spin_row.add_child(spin_label)
 	var spin := SpinBox.new()
+	spin.name = "SplitFireSpin"
 	spin.min_value = 1
 	spin.max_value = max_n
 	spin.step = 1

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -836,13 +836,23 @@ func _restore_state_after_load() -> void:
 		_show_range_indicators()
 		
 		# Update assignment display from phase state
+		# SPLIT-FIRE: weapon_assignments is a flat weapon→last-target map (kept
+		# for legacy callers). The tree row text is authoritative via
+		# _refresh_weapon_row_split_text, which reads the full
+		# pending_assignments list and renders splits.
 		weapon_assignments.clear()
+		var weapons_seen := {}
 		for assignment in shooting_state.pending_assignments:
 			weapon_assignments[assignment.weapon_id] = assignment.target_unit_id
-		
+			weapons_seen[assignment.weapon_id] = true
+
 		for assignment in shooting_state.confirmed_assignments:
 			weapon_assignments[assignment.weapon_id] = assignment.target_unit_id
-		
+			weapons_seen[assignment.weapon_id] = true
+
+		for wid in weapons_seen.keys():
+			_refresh_weapon_row_split_text(wid)
+
 		_update_ui_state()
 		
 		# Show feedback in dice log
@@ -3288,41 +3298,57 @@ func _on_clear_pressed() -> void:
 	_update_ui_state()
 
 # T5-UX4: Undo the most recent weapon assignment
+# SPLIT-FIRE: History entries are now dictionaries {weapon_id, target_unit_id,
+# model_ids} so undo reverses one specific (weapon → target) slice, not every
+# allocation made for that weapon. Tolerant of legacy String entries.
 func _on_undo_last_pressed() -> void:
 	if assignment_history.is_empty():
 		return
 
-	# Pop the most recent weapon_id from the history
-	var weapon_id = assignment_history.pop_back()
+	var last_entry = assignment_history.pop_back()
 
-	print("T5-UX4: Undoing last assignment for weapon: ", weapon_id)
+	# Normalise history-entry shape
+	var weapon_id: String = ""
+	var target_unit_id: String = ""
+	if typeof(last_entry) == TYPE_DICTIONARY:
+		weapon_id = last_entry.get("weapon_id", "")
+		target_unit_id = last_entry.get("target_unit_id", "")
+	else:
+		weapon_id = str(last_entry)
 
-	# Remove from local tracking
-	weapon_assignments.erase(weapon_id)
+	print("ShootingController: [SPLIT-FIRE] Undoing assignment for weapon=%s target=%s" % [weapon_id, target_unit_id])
 
-	# Tell the phase to clear this assignment
+	# Tell the phase to clear this specific slice (or all slices for the weapon
+	# if the legacy entry didn't carry a target).
+	var payload: Dictionary = {"weapon_id": weapon_id}
+	if target_unit_id != "":
+		payload["target_unit_id"] = target_unit_id
 	emit_signal("shoot_action_requested", {
 		"type": "CLEAR_ASSIGNMENT",
-		"payload": {"weapon_id": weapon_id}
+		"payload": payload
 	})
 
-	# Update weapon tree to clear the target text for this weapon
-	if weapon_tree:
-		var root = weapon_tree.get_root()
-		if root:
-			var child = root.get_first_child()
-			while child:
-				if child.get_metadata(0) == weapon_id:
-					child.set_text(1, "(Click to Select)")
-					child.set_custom_color(1, Color(0.6, 0.6, 0.6, 0.7))
-					child.clear_custom_bg_color(1)
-					break
-				child = child.get_next()
+	# Local bookkeeping: if no allocations remain for this weapon, drop it from
+	# weapon_assignments. Otherwise leave it (still has at least one target).
+	var still_has_alloc := false
+	if current_phase and "pending_assignments" in current_phase:
+		for a in current_phase.pending_assignments:
+			if a.get("weapon_id", "") == weapon_id and a.get("target_unit_id", "") != target_unit_id:
+				still_has_alloc = true
+				break
+	if not still_has_alloc:
+		weapon_assignments.erase(weapon_id)
+
+	# Refresh the tree row to reflect the new pending state
+	_refresh_weapon_row_split_text(weapon_id)
 
 	# Update last_assigned_target_id from the remaining history
 	if not assignment_history.is_empty():
-		var prev_weapon = assignment_history.back()
-		last_assigned_target_id = weapon_assignments.get(prev_weapon, "")
+		var prev = assignment_history.back()
+		if typeof(prev) == TYPE_DICTIONARY:
+			last_assigned_target_id = prev.get("target_unit_id", "")
+		else:
+			last_assigned_target_id = weapon_assignments.get(str(prev), "")
 	else:
 		last_assigned_target_id = ""
 		if auto_target_button_container:
@@ -3331,7 +3357,11 @@ func _on_undo_last_pressed() -> void:
 	# Show feedback
 	if dice_log_display:
 		var weapon_name = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
-		dice_log_display.append_text("[color=orange]↩ Undid assignment for %s[/color]\n" % weapon_name)
+		if target_unit_id != "":
+			var target_name = eligible_targets.get(target_unit_id, {}).get("unit_name", target_unit_id)
+			dice_log_display.append_text("[color=orange]↩ Undid %s → %s[/color]\n" % [weapon_name, target_name])
+		else:
+			dice_log_display.append_text("[color=orange]↩ Undid assignment for %s[/color]\n" % weapon_name)
 
 	_update_aggregate_damage_preview()  # P3-114: Refresh aggregate after undo
 	_update_ui_state()
@@ -4066,78 +4096,268 @@ func _select_target_for_current_weapon(target_id: String) -> void:
 	if not weapon_id:
 		return
 
-	# DEBUG: Log target assignment
-	print("╔═══════════════════════════════════════════════════════════════")
-	print("║ TARGET ASSIGNMENT")
-	print("║ Weapon ID: ", weapon_id)
-	print("║ Weapon Name: ", RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id))
-	print("║ Target ID: ", target_id)
-	print("║ Target Name: ", eligible_targets.get(target_id, {}).get("unit_name", "Unknown"))
-	print("║ Previous assignment: ", weapon_assignments.get(weapon_id, "None"))
+	# SPLIT-FIRE: Compute which of this weapon's bearers can fire at this target
+	# RIGHT NOW (per-model range + LoS), minus any bearers already committed to
+	# other targets in pending_assignments.
+	var split = _compute_split_fire_options(weapon_id, target_id)
+	# split = {
+	#   "total_bearers": N,
+	#   "already_allocated": Array[model_id],
+	#   "eligible_remaining": Array[model_id],   # eligible AND not already allocated
+	#   "distances_inches": { model_id: float }, # to nearest target model
+	#   "reasons": { model_id: "out_of_range"|"no_los"|"dead" }
+	# }
+	var eligible_remaining: Array = split.eligible_remaining
 
-	# Assign target
-	weapon_assignments[weapon_id] = target_id
+	if eligible_remaining.is_empty():
+		var weapon_name_for_log = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
+		var target_name_for_log = eligible_targets.get(target_id, {}).get("unit_name", target_id)
+		if dice_log_display:
+			dice_log_display.append_text("[color=red]✗ No %s bearers can fire on %s (range/LoS).[/color]\n" % [weapon_name_for_log, target_name_for_log])
+		print("ShootingController: [SPLIT-FIRE] No eligible remaining bearers for %s → %s (reasons=%s)" % [weapon_id, target_id, str(split.reasons)])
+		return
 
-	# T5-UX4: Track assignment in history for undo (remove if re-assigned, then push)
-	assignment_history.erase(weapon_id)
-	assignment_history.push_back(weapon_id)
+	# If exactly one eligible bearer remains, skip the picker for speed.
+	# Otherwise show the "how many to this target?" picker.
+	if eligible_remaining.size() == 1:
+		_commit_split_assignment(weapon_id, target_id, eligible_remaining, split.reasons)
+	else:
+		_open_split_fire_picker(weapon_id, target_id, split)
 
-	print("║ Assignment stored in weapon_assignments dictionary")
-	print("║ Current weapon_assignments state:")
-	for wpn_id in weapon_assignments:
-		var wpn_name = RulesEngine.get_weapon_profile(wpn_id).get("name", wpn_id)
-		var tgt_id = weapon_assignments[wpn_id]
-		var tgt_name = eligible_targets.get(tgt_id, {}).get("unit_name", "Unknown")
-		print("║   - %s → %s" % [wpn_name, tgt_name])
-	print("╚═══════════════════════════════════════════════════════════════")
+	_update_ui_state()
 
-	# NEW: Store last assigned target for "Apply to All" feature
-	last_assigned_target_id = target_id
-
-	# Get model IDs for this weapon
-	var model_ids = []
-	var unit_weapons = RulesEngine.get_unit_weapons(active_shooter_id)
-	for model_id in unit_weapons:
-		if weapon_id in unit_weapons[model_id]:
-			model_ids.append(model_id)
-
-	var payload = {
-		"weapon_id": weapon_id,
-		"target_unit_id": target_id,
-		"model_ids": model_ids
+# SPLIT-FIRE: Compute the picker state for (weapon, target).
+# Reads pending_assignments from the phase to know which bearers are already
+# committed elsewhere, and calls RulesEngine.get_eligible_shooter_models to
+# determine which living bearers can actually reach the target with LoS.
+func _compute_split_fire_options(weapon_id: String, target_id: String) -> Dictionary:
+	var result := {
+		"total_bearers": 0,
+		"already_allocated": [],
+		"eligible_remaining": [],
+		"distances_inches": {},
+		"reasons": {}
 	}
 
-	emit_signal("shoot_action_requested", {
-		"type": "ASSIGN_TARGET",
-		"payload": payload
+	if active_shooter_id == "":
+		return result
+
+	# All living bearers of this weapon in the active unit
+	var bearers: Array = []
+	var unit_weapons = RulesEngine.get_unit_weapons(active_shooter_id)
+	var shooter_unit = GameState.get_unit(active_shooter_id)
+	for model_id in unit_weapons:
+		if not (weapon_id in unit_weapons[model_id]):
+			continue
+		var m = RulesEngine._get_model_by_id(shooter_unit, model_id)
+		if m.is_empty() or not m.get("alive", true):
+			continue
+		bearers.append(model_id)
+	result.total_bearers = bearers.size()
+
+	# Bearers already committed to other (or same) targets in pending_assignments
+	var already: Array = []
+	if current_phase and "pending_assignments" in current_phase:
+		for a in current_phase.pending_assignments:
+			if a.get("weapon_id", "") != weapon_id:
+				continue
+			# Bearers already allocated to ANY pending target for this weapon
+			# (including the same target, so re-clicking adds new bearers, not
+			# duplicates of existing ones)
+			for mid in a.get("model_ids", []):
+				if mid not in already:
+					already.append(mid)
+	result.already_allocated = already
+
+	# Per-model eligibility for THIS target
+	var snapshot: Dictionary = current_phase.game_state_snapshot if current_phase else {}
+	var eligibility = RulesEngine.get_eligible_shooter_models(active_shooter_id, weapon_id, target_id, snapshot)
+	result.distances_inches = eligibility.distances
+	result.reasons = eligibility.reasons
+
+	var eligible_set := {}
+	for mid in eligibility.eligible:
+		eligible_set[mid] = true
+
+	# eligible AND a living bearer AND not already allocated elsewhere
+	for mid in bearers:
+		if mid in already:
+			continue
+		if eligible_set.has(mid):
+			result.eligible_remaining.append(mid)
+
+	return result
+
+# SPLIT-FIRE: Open a modal dialog asking "how many of N bearers to send at this target?"
+# Default N = max (all eligible remaining). On Confirm, slices the N closest models
+# from eligible_remaining (closest by edge-to-edge distance) and dispatches ASSIGN_TARGET.
+func _open_split_fire_picker(weapon_id: String, target_id: String, split: Dictionary) -> void:
+	var eligible_remaining: Array = split.eligible_remaining
+	var max_n: int = eligible_remaining.size()
+	var total_bearers: int = split.total_bearers
+	var already_count: int = split.already_allocated.size()
+	var weapon_name = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
+	var target_name = eligible_targets.get(target_id, {}).get("unit_name", target_id)
+
+	# Count "not eligible at this target" remaining bearers (alive, not yet allocated,
+	# but out of range / no LoS for THIS target). Surfacing this helps the player
+	# understand why the picker caps below the unit-wide weapon count.
+	var ineligible_remaining_count := 0
+	for mid in split.reasons.keys():
+		if mid in split.already_allocated:
+			continue
+		ineligible_remaining_count += 1
+
+	var dialog := AcceptDialog.new()
+	dialog.title = "Split Fire: %s → %s" % [weapon_name, target_name]
+	dialog.dialog_hide_on_ok = true
+
+	var vbox := VBoxContainer.new()
+	dialog.add_child(vbox)
+
+	var info_text := "%d of %d %s bearer(s) can fire at %s." % [max_n, total_bearers - already_count, weapon_name, target_name]
+	if ineligible_remaining_count > 0:
+		info_text += "\n%d bearer(s) ineligible (range/LoS)." % ineligible_remaining_count
+	if already_count > 0:
+		info_text += "\n%d bearer(s) already assigned to other targets." % already_count
+	var info_label := Label.new()
+	info_label.text = info_text
+	vbox.add_child(info_label)
+
+	var spin_row := HBoxContainer.new()
+	vbox.add_child(spin_row)
+	var spin_label := Label.new()
+	spin_label.text = "Send:"
+	spin_row.add_child(spin_label)
+	var spin := SpinBox.new()
+	spin.min_value = 1
+	spin.max_value = max_n
+	spin.step = 1
+	spin.value = max_n
+	spin_row.add_child(spin)
+	var of_label := Label.new()
+	of_label.text = " of %d" % max_n
+	spin_row.add_child(of_label)
+
+	# Wire confirm
+	dialog.confirmed.connect(func():
+		var n := int(spin.value)
+		if n < 1:
+			n = 1
+		if n > max_n:
+			n = max_n
+		var chosen := _pick_closest_n(eligible_remaining, split.distances_inches, n)
+		_commit_split_assignment(weapon_id, target_id, chosen, split.reasons)
+		dialog.queue_free()
+	)
+	# Also queue_free on cancel/close
+	dialog.canceled.connect(func(): dialog.queue_free())
+
+	add_child(dialog)
+	dialog.popup_centered()
+
+# SPLIT-FIRE: Of the given model_ids, return the n closest by the distances map.
+# Distances are edge-to-edge inches to the nearest target model.
+func _pick_closest_n(model_ids: Array, distances: Dictionary, n: int) -> Array:
+	var sorted := model_ids.duplicate()
+	sorted.sort_custom(func(a, b):
+		return distances.get(a, INF) < distances.get(b, INF)
+	)
+	if n >= sorted.size():
+		return sorted
+	return sorted.slice(0, n)
+
+# SPLIT-FIRE: Dispatch ASSIGN_TARGET with the explicit per-instance slice and
+# update controller-side bookkeeping (weapon_assignments display map, undo
+# history, tree row text, damage preview).
+func _commit_split_assignment(weapon_id: String, target_id: String, chosen_model_ids: Array, reasons: Dictionary) -> void:
+	if chosen_model_ids.is_empty():
+		return
+
+	# Track in display-map (legacy single-target map kept for code that reads it;
+	# tree row text is rewritten below to show the full split).
+	weapon_assignments[weapon_id] = target_id
+	last_assigned_target_id = target_id
+
+	# Undo history: push a richer record so undo can reverse this exact slice.
+	# Older records may be plain strings (weapon_id); the undo handler is
+	# tolerant of both shapes.
+	assignment_history.push_back({
+		"weapon_id": weapon_id,
+		"target_unit_id": target_id,
+		"model_ids": chosen_model_ids.duplicate()
 	})
 
-	# Update UI — show assigned target with arrow and green tint
-	var target_name = eligible_targets.get(target_id, {}).get("unit_name", target_id)
-	selected.set_text(1, "→ " + target_name)
-	selected.set_custom_color(1, Color(0.5, 0.85, 0.5))
-	selected.set_custom_bg_color(1, Color(0.15, 0.35, 0.15, 0.4))
+	# Dispatch to the phase
+	emit_signal("shoot_action_requested", {
+		"type": "ASSIGN_TARGET",
+		"payload": {
+			"weapon_id": weapon_id,
+			"target_unit_id": target_id,
+			"model_ids": chosen_model_ids
+		}
+	})
 
-	# NEW: Show "Apply to All" button if there are unassigned weapons remaining
+	# Update weapon-row text to reflect ALL current splits for this weapon
+	_refresh_weapon_row_split_text(weapon_id)
+
+	# Show "Apply to All" if there are still weapons with unassigned bearers
 	var unassigned_count = _count_unassigned_weapons()
 	if unassigned_count > 0 and auto_target_button_container:
 		auto_target_button_container.visible = true
-
-		# Update button text to show how many weapons will be affected
 		var apply_button = auto_target_button_container.get_node_or_null("ApplyToAllButton")
 		if apply_button:
 			apply_button.text = "Apply to %d Remaining Weapons" % unassigned_count
 
-	# Show feedback
+	# Feedback to the dice log
 	if dice_log_display:
 		var weapon_name = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
-		dice_log_display.append_text("[color=green]✓ Assigned %s to target %s[/color]\n" % [weapon_name, target_name])
+		var target_name = eligible_targets.get(target_id, {}).get("unit_name", target_id)
+		dice_log_display.append_text("[color=green]✓ %d × %s → %s[/color]\n" % [chosen_model_ids.size(), weapon_name, target_name])
 
-	# T5-UX1: Refresh damage preview with newly assigned target
-	_last_preview_target_id = ""  # Force recalculation
+	# Refresh damage preview
+	_last_preview_target_id = ""
 	_update_damage_preview(weapon_id)
 
-	_update_ui_state()
+# SPLIT-FIRE: Re-render the column-2 text of a weapon row to show every pending
+# (target → count) entry for that weapon. Called after every assign / undo /
+# clear so the tree stays in sync with the phase's pending_assignments.
+func _refresh_weapon_row_split_text(weapon_id: String) -> void:
+	if not weapon_tree:
+		return
+	var root = weapon_tree.get_root()
+	if not root:
+		return
+
+	# Collect all pending allocations for this weapon
+	var allocations: Array = []
+	if current_phase and "pending_assignments" in current_phase:
+		for a in current_phase.pending_assignments:
+			if a.get("weapon_id", "") != weapon_id:
+				continue
+			allocations.append({
+				"target_unit_id": a.get("target_unit_id", ""),
+				"count": a.get("model_ids", []).size()
+			})
+
+	# Find the weapon row
+	var child = root.get_first_child()
+	while child:
+		if child.get_metadata(0) == weapon_id:
+			if allocations.is_empty():
+				child.set_text(1, "(Click to Select)")
+				child.set_custom_color(1, Color(0.6, 0.6, 0.6, 0.7))
+				child.clear_custom_bg_color(1)
+			else:
+				var parts: Array = []
+				for alloc in allocations:
+					var tname = eligible_targets.get(alloc.target_unit_id, {}).get("unit_name", alloc.target_unit_id)
+					parts.append("%d→%s" % [alloc.count, tname])
+				child.set_text(1, ", ".join(parts))
+				child.set_custom_color(1, Color(0.5, 0.85, 0.5))
+				child.set_custom_bg_color(1, Color(0.15, 0.35, 0.15, 0.4))
+			return
+		child = child.get_next()
 
 func _auto_assign_target(weapon_id: String, target_id: String) -> void:
 	"""Auto-assign a target to a weapon (used when only one eligible target exists)"""
@@ -4175,7 +4395,10 @@ func _auto_assign_target(weapon_id: String, target_id: String) -> void:
 # ==========================================
 
 func _count_unassigned_weapons() -> int:
-	"""Count how many weapons don't have targets assigned yet"""
+	"""SPLIT-FIRE: Count weapons that still have at least one bearer with no
+	pending allocation. A weapon counts as 'unassigned' if any of its living
+	bearers is not yet committed to a pending target, since that bearer could
+	still be sent at one."""
 	var root = weapon_tree.get_root()
 	if not root:
 		return 0
@@ -4183,10 +4406,37 @@ func _count_unassigned_weapons() -> int:
 	var unassigned = 0
 	var child = root.get_first_child()
 
+	# Bearers already allocated per weapon (across all pending targets)
+	var allocated_per_weapon: Dictionary = {}
+	if current_phase and "pending_assignments" in current_phase:
+		for a in current_phase.pending_assignments:
+			var wid: String = a.get("weapon_id", "")
+			if not allocated_per_weapon.has(wid):
+				allocated_per_weapon[wid] = {}
+			for mid in a.get("model_ids", []):
+				allocated_per_weapon[wid][mid] = true
+
+	var unit_weapons: Dictionary = {}
+	var shooter_unit: Dictionary = {}
+	if active_shooter_id != "":
+		unit_weapons = RulesEngine.get_unit_weapons(active_shooter_id)
+		shooter_unit = GameState.get_unit(active_shooter_id)
+
 	while child:
 		var weapon_id = child.get_metadata(0)
-		if weapon_id and not weapon_assignments.has(weapon_id):
-			unassigned += 1
+		if weapon_id:
+			# Count living bearers for this weapon
+			var living := 0
+			for model_id in unit_weapons:
+				if not (weapon_id in unit_weapons[model_id]):
+					continue
+				var m = RulesEngine._get_model_by_id(shooter_unit, model_id)
+				if m.is_empty() or not m.get("alive", true):
+					continue
+				living += 1
+			var allocated = allocated_per_weapon.get(weapon_id, {}).size()
+			if living > allocated:
+				unassigned += 1
 		child = child.get_next()
 
 	return unassigned

--- a/40k/tests/scenarios/sp/split_fire_per_model.json
+++ b/40k/tests/scenarios/sp/split_fire_per_model.json
@@ -1,0 +1,101 @@
+{
+  "id": "split_fire_per_model",
+  "covers": [
+    "shooting.split_fire_picker_ui",
+    "autoloads.RulesEngine.get_eligible_shooter_models",
+    "phases.ShootingPhase.assign_target_split"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Split-fire: Custodian Guard B (3 Guardian Spears) splits across two Ork targets — 2 spears at Battlewagon, 1 spear at Kommandos. Drives the picker dialog through the live UI: opens picker via the controller, sets the SpinBox value to 2, confirms via the dialog's OK button, then assigns the last spear (auto-skip path: 1 eligible bearer left). Verifies both pending assignments survive CONFIRM_TARGETS as two distinct confirmed_assignments.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "screenshot", "label": "01_shooting_phase_loaded" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SELECT_SHOOTER",
+      "actor_unit_id": "U_CUSTODIAN_GUARD_B"
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "expect_node_visible",
+      "node": "/root/Main/ShootingController",
+      "timeout_s": 2.0 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.get_root().get_first_child().get_metadata(0)",
+      "equals": "guardian_spear_ranged" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.get_root().get_first_child().select(0)" },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.get_eligible_shooter_models(\"U_CUSTODIAN_GUARD_B\", \"guardian_spear_ranged\", \"U_BATTLEWAGON_G\", GameState.state).eligible.size()",
+      "equals": 3 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._select_target_for_current_weapon(\"U_BATTLEWAGON_G\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "expect_node_visible",
+      "node": "/root/Main/ShootingController/SplitFirePicker",
+      "timeout_s": 2.0 },
+    { "act": "screenshot", "label": "02_picker_open_for_battlewagon" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFireSpin\", true, false).max_value",
+      "equals": 3.0 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFireSpin\", true, false).set_value(2)" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFireSpin\", true, false).value",
+      "equals": 2.0 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFirePicker\", true, false).get_ok_button().emit_signal(\"pressed\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments.size()",
+      "equals": 1 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments[0].model_ids.size()",
+      "equals": 2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments[0].target_unit_id",
+      "equals": "U_BATTLEWAGON_G" },
+    { "act": "screenshot", "label": "03_first_slice_committed" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.get_root().get_first_child().select(0)" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._select_target_for_current_weapon(\"U_KOMMANDOS_H\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments.size()",
+      "equals": 2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments[1].model_ids.size()",
+      "equals": 1 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments[1].target_unit_id",
+      "equals": "U_KOMMANDOS_H" },
+    { "act": "screenshot", "label": "04_split_complete" },
+
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_TARGETS" } },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.confirmed_assignments.size()",
+      "equals": 2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments.size()",
+      "equals": 0 },
+    { "act": "screenshot", "label": "05_after_confirm_targets_split_preserved" }
+  ]
+}

--- a/40k/tests/test_split_fire_per_model.gd
+++ b/40k/tests/test_split_fire_per_model.gd
@@ -1,0 +1,312 @@
+extends SceneTree
+
+# SPLIT-FIRE + PER-MODEL LOS+RANGE
+#
+# Verifies the engine-side primitives that back split-fire:
+#  1. get_eligible_shooter_models filters per-model by range
+#  2. _filter_eligible_model_ids drops ineligibles from a passed-in slice
+#  3. ShootingPhase._process_assign_target accepts multiple pending
+#     assignments for the same weapon_id with disjoint model_ids
+#  4. CLEAR_ASSIGNMENT with target_unit_id removes a single slice
+#  5. CONFIRM_TARGETS preserves the splits (two confirmed_assignments)
+#  6. Resolve-time filter drops models that lost eligibility post-confirm
+#     (e.g. moved out of range / killed)
+#
+# Uses U_BOYZ_A + "slugga" (12" range) from the legacy UNIT_WEAPONS table so
+# weapon lookup works without depending on unit.meta.weapons parsing.
+#
+# Usage: godot --headless --path . -s tests/test_split_fire_per_model.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+# Board layout (slugga = 12" range, 1" = 40 px):
+#   Shooters m1..m4 in a horizontal row at (0,0)..(600,0) — 5" apart
+#   NEAR target row directly above at y=-200 (5" away) → ALL 4 in range
+#   FAR target single model at (1000, 0): only the rightmost shooters reach it
+#                                          (m1 ~25"away, m4 ~10")
+func _make_board() -> Dictionary:
+	# Shift everything off the board origin — EnhancedLineOfSight treats
+	# Vector2.ZERO as an invalid/unset position.
+	var OX := 1000.0
+	var OY := 1000.0
+	var shooter_models = []
+	for i in range(4):
+		shooter_models.append({
+			"id": "m%d" % (i + 1),
+			"position": {"x": OX + float(i * 200), "y": OY},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1
+		})
+	# NEAR: 4 models stacked above the shooters — every shooter has a close
+	# target model directly across, so all 4 are in the 12" range.
+	var near_models = []
+	for i in range(4):
+		near_models.append({
+			"id": "mn%d" % i,
+			"position": {"x": OX + float(i * 200), "y": OY - 200.0},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1,
+			"stats": {"toughness": 4, "save": 4}
+		})
+	# FAR: single model far to the right. Only the rightmost shooters (m3, m4)
+	# are within 12"; m1 and m2 are out of range.
+	var far_models = [{
+		"id": "mf0",
+		"position": {"x": OX + 1000.0, "y": OY},
+		"base_mm": 32, "base_type": "circular",
+		"alive": true, "wounds": 1, "current_wounds": 1,
+		"stats": {"toughness": 4, "save": 4}
+	}]
+	var board = {
+		"units": {
+			# U_BOYZ_A is in the legacy UNIT_WEAPONS table — m1..m4 carry slugga.
+			"U_BOYZ_A": {
+				"id": "U_BOYZ_A", "owner": 1,
+				"meta": {"keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 4, "wounds": 1}},
+				"flags": {},
+				"models": shooter_models
+			},
+			"U_TARGET_NEAR": {
+				"id": "U_TARGET_NEAR", "owner": 2,
+				"meta": {"keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 4, "wounds": 1}},
+				"flags": {},
+				"models": near_models
+			},
+			"U_TARGET_FAR": {
+				"id": "U_TARGET_FAR", "owner": 2,
+				"meta": {"keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 4, "wounds": 1}},
+				"flags": {},
+				"models": far_models
+			}
+		},
+		"meta": {"phase": 8, "active_player": 1, "battle_round": 1},
+		"terrain_features": []
+	}
+	return board
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_split_fire_per_model ===\n")
+
+	_test_eligibility_all_in_range()
+	_test_eligibility_some_out_of_range()
+	_test_filter_drops_ineligible()
+	_test_phase_split_assignment_keeps_both()
+	_test_phase_split_assignment_model_ids_disjoint()
+	_test_phase_per_target_clear()
+	_test_phase_confirm_preserves_splits()
+	_test_resolve_time_filter_drops_dead()
+
+	_finish()
+
+# ----------------------------------------------------------------------------
+# 1. All bearers in range and LoS → all eligible
+# ----------------------------------------------------------------------------
+func _test_eligibility_all_in_range() -> void:
+	print("\n-- 1. eligibility: all 4 bearers in range of NEAR target --")
+	var board = _make_board()
+	var rules = root.get_node("RulesEngine")
+	var result = rules.get_eligible_shooter_models("U_BOYZ_A", "slugga", "U_TARGET_NEAR", board)
+	# Note: U_BOYZ_A has m1..m9 in UNIT_WEAPONS but only m1..m4 are in the
+	# test board (alive). Eligibility iterates models in the unit, so m5..m9
+	# from the legacy table won't be found via _get_model_by_id and are skipped.
+	_check("near: 4 eligible shooters",
+		result.eligible.size() == 4,
+		"got %d: %s (distances=%s, reasons=%s)" % [
+			result.eligible.size(), str(result.eligible),
+			str(result.distances), str(result.reasons)])
+
+# ----------------------------------------------------------------------------
+# 2. Far target: only some bearers in range (edge-to-edge < 12")
+# ----------------------------------------------------------------------------
+func _test_eligibility_some_out_of_range() -> void:
+	print("\n-- 2. eligibility: FAR target only reachable by some bearers --")
+	var board = _make_board()
+	var rules = root.get_node("RulesEngine")
+	var result = rules.get_eligible_shooter_models("U_BOYZ_A", "slugga", "U_TARGET_FAR", board)
+	_check("far: at least one but fewer than 4 eligible",
+		result.eligible.size() >= 1 and result.eligible.size() < 4,
+		"got %d: %s (distances=%s, reasons=%s)" % [
+			result.eligible.size(), str(result.eligible),
+			str(result.distances), str(result.reasons)])
+	var any_out_of_range := false
+	for r in result.reasons.values():
+		if r == "out_of_range":
+			any_out_of_range = true
+			break
+	_check("far: at least one bearer flagged out_of_range",
+		any_out_of_range,
+		"reasons map: %s" % str(result.reasons))
+
+# ----------------------------------------------------------------------------
+# 3. Filter helper: passed-in model_ids are reduced to the eligible subset
+# ----------------------------------------------------------------------------
+func _test_filter_drops_ineligible() -> void:
+	print("\n-- 3. _filter_eligible_model_ids drops ineligible ids --")
+	var board = _make_board()
+	var rules = root.get_node("RulesEngine")
+	var all_ids = ["m1", "m2", "m3", "m4"]
+	var filtered = rules._filter_eligible_model_ids(all_ids, "U_BOYZ_A", "slugga", "U_TARGET_FAR", board)
+	_check("filter: kept.size() < 4 (some dropped)",
+		filtered.kept.size() < 4,
+		"kept=%s dropped=%s" % [str(filtered.kept), str(filtered.dropped)])
+	_check("filter: kept ∪ dropped == input",
+		(filtered.kept.size() + filtered.dropped.size()) == all_ids.size())
+
+# ----------------------------------------------------------------------------
+# 4. ShootingPhase: two ASSIGN_TARGET with same weapon, different targets,
+#    both kept in pending_assignments
+# ----------------------------------------------------------------------------
+func _test_phase_split_assignment_keeps_both() -> void:
+	print("\n-- 4. phase: same weapon → two targets → two pending assignments --")
+	var ShootingPhaseScript = load("res://phases/ShootingPhase.gd")
+	var phase = ShootingPhaseScript.new()
+	var board = _make_board()
+	phase.game_state_snapshot = board
+	phase.active_shooter_id = "U_BOYZ_A"
+
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_NEAR", "model_ids": ["m1", "m2"]}
+	})
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_FAR", "model_ids": ["m3", "m4"]}
+	})
+
+	_check("phase: 2 pending_assignments after split",
+		phase.pending_assignments.size() == 2,
+		"got %d: %s" % [phase.pending_assignments.size(), str(phase.pending_assignments)])
+	phase.queue_free()
+
+# ----------------------------------------------------------------------------
+# 5. ShootingPhase: model_ids are disjoint across splits (no double-allocation)
+# ----------------------------------------------------------------------------
+func _test_phase_split_assignment_model_ids_disjoint() -> void:
+	print("\n-- 5. phase: assigning overlapping model_ids strips the dup --")
+	var ShootingPhaseScript = load("res://phases/ShootingPhase.gd")
+	var phase = ShootingPhaseScript.new()
+	var board = _make_board()
+	phase.game_state_snapshot = board
+	phase.active_shooter_id = "U_BOYZ_A"
+
+	# First: m1, m2 → NEAR
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_NEAR", "model_ids": ["m1", "m2"]}
+	})
+	# Then: m2, m3 → FAR — m2 already allocated, must be stripped
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_FAR", "model_ids": ["m2", "m3"]}
+	})
+
+	var far_alloc: Array = []
+	for a in phase.pending_assignments:
+		if a.target_unit_id == "U_TARGET_FAR":
+			far_alloc = a.model_ids
+			break
+	_check("phase: FAR allocation excludes already-assigned m2",
+		"m2" not in far_alloc and "m3" in far_alloc,
+		"FAR allocation: %s" % str(far_alloc))
+	phase.queue_free()
+
+# ----------------------------------------------------------------------------
+# 6. ShootingPhase: CLEAR_ASSIGNMENT with target_unit_id clears just one slice
+# ----------------------------------------------------------------------------
+func _test_phase_per_target_clear() -> void:
+	print("\n-- 6. phase: per-target CLEAR_ASSIGNMENT removes one slice only --")
+	var ShootingPhaseScript = load("res://phases/ShootingPhase.gd")
+	var phase = ShootingPhaseScript.new()
+	var board = _make_board()
+	phase.game_state_snapshot = board
+	phase.active_shooter_id = "U_BOYZ_A"
+
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_NEAR", "model_ids": ["m1", "m2"]}
+	})
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_FAR", "model_ids": ["m3", "m4"]}
+	})
+	phase.process_action({
+		"type": "CLEAR_ASSIGNMENT",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_FAR"}
+	})
+
+	_check("phase: 1 pending_assignment remaining after per-target clear",
+		phase.pending_assignments.size() == 1,
+		"got %d: %s" % [phase.pending_assignments.size(), str(phase.pending_assignments)])
+	if not phase.pending_assignments.is_empty():
+		_check("phase: remaining assignment is NEAR (the one we kept)",
+			phase.pending_assignments[0].target_unit_id == "U_TARGET_NEAR",
+			"target_unit_id=%s" % phase.pending_assignments[0].target_unit_id)
+	phase.queue_free()
+
+# ----------------------------------------------------------------------------
+# 7. ShootingPhase: CONFIRM_TARGETS preserves the two splits as two
+#    confirmed_assignments (the merge step does NOT collapse different targets)
+# ----------------------------------------------------------------------------
+func _test_phase_confirm_preserves_splits() -> void:
+	print("\n-- 7. phase: confirm produces 2 confirmed_assignments --")
+	var ShootingPhaseScript = load("res://phases/ShootingPhase.gd")
+	var phase = ShootingPhaseScript.new()
+	var board = _make_board()
+	phase.game_state_snapshot = board
+	phase.active_shooter_id = "U_BOYZ_A"
+
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_NEAR", "model_ids": ["m1", "m2"]}
+	})
+	phase.process_action({
+		"type": "ASSIGN_TARGET",
+		"payload": {"weapon_id": "slugga", "target_unit_id": "U_TARGET_FAR", "model_ids": ["m3", "m4"]}
+	})
+	phase.process_action({"type": "CONFIRM_TARGETS", "payload": {}})
+
+	_check("phase: 2 confirmed_assignments after confirm",
+		phase.confirmed_assignments.size() == 2,
+		"got %d" % phase.confirmed_assignments.size())
+	_check("phase: pending_assignments cleared on confirm",
+		phase.pending_assignments.is_empty())
+	phase.queue_free()
+
+# ----------------------------------------------------------------------------
+# 8. Resolve-time filter: dead models are dropped before contributing attacks
+# ----------------------------------------------------------------------------
+func _test_resolve_time_filter_drops_dead() -> void:
+	print("\n-- 8. resolve-time: dead model is dropped before contributing attacks --")
+	var board = _make_board()
+	# Kill m3 and m4 post-assignment to simulate damage taken before resolve
+	board.units.U_BOYZ_A.models[2]["alive"] = false
+	board.units.U_BOYZ_A.models[3]["alive"] = false
+	var rules = root.get_node("RulesEngine")
+	var filtered = rules._filter_eligible_model_ids(
+		["m1", "m2", "m3", "m4"],
+		"U_BOYZ_A", "slugga", "U_TARGET_NEAR", board
+	)
+	_check("resolve: dead models dropped, only m1/m2 kept",
+		filtered.kept.size() == 2 and "m1" in filtered.kept and "m2" in filtered.kept,
+		"kept=%s dropped=%s reasons=%s" % [
+			str(filtered.kept), str(filtered.dropped), str(filtered.reasons)])
+
+func _finish():
+	print("")
+	print("Result: %d passed, %d failed" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_split_fire_per_model.gd.uid
+++ b/40k/tests/test_split_fire_per_model.gd.uid
@@ -1,0 +1,1 @@
+uid://dl0vj4taofl0w


### PR DESCRIPTION
Shooting phase now lets a unit fire identical weapons at multiple
targets (e.g. 2 of 4 guardian spears at unit A, 2 at unit B) AND
correctly enforces per-model range and LoS at both assignment and
resolve time. Previously the engine used a unit-level shortcut where
ANY model with LoS qualified the WHOLE unit.

Engine (autoloads/RulesEngine.gd):
- Add get_eligible_shooter_models() — per-model range + LoS check
  for (actor_unit, weapon, target). Returns eligible model_ids,
  per-model edge-to-edge distances, and "reasons" for ineligibles.
  Indirect Fire skips LoS; engagement remains unit-level.
- Add _filter_eligible_model_ids() — resolve-time filter used by
  both _resolve_assignment and _resolve_assignment_until_wounds to
  drop models that lost eligibility after the player confirmed
  (death, reactive movement, LoS change). Falls back to passing
  model_ids through when the unit has no parseable weapon-carrier
  data (preserves test-fixture compatibility).

Phase (phases/ShootingPhase.gd):
- _process_assign_target accepts multiple pending assignments for
  the same weapon_id with disjoint model_ids (strips bearers
  already committed to other targets, merges into existing entry
  for the same (weapon,target) pair).
- _process_clear_assignment supports optional target_unit_id for
  per-slice clears; without it, retains legacy "clear all for this
  weapon" semantics.

Controller (scripts/ShootingController.gd):
- _select_target_for_current_weapon computes eligibility, opens a
  split-fire SpinBox picker when >1 bearer can fire (max bounded
  by eligible-remaining), or auto-assigns when exactly one. Refuses
  cleanly when zero bearers can reach the target.
- Picks the N closest eligible bearers (by edge-to-edge distance)
  to send at the chosen target.
- Tree row text now reflects all pending splits per weapon
  (e.g. "2 → Hormagaunts, 2 → Termagants").
- Undo history carries (weapon, target, model_ids) so undo reverses
  exactly one slice; tolerant of legacy weapon-only entries.
- _count_unassigned_weapons counts bearers, not whole weapons, so
  a partial split still marks the weapon as having work remaining.

Tests:
- tests/test_split_fire_per_model.gd — 12 assertions covering the
  engine helper, the resolve-time filter, phase split assignment,
  per-target clear, confirm preserving splits, and resolve-time
  drop of dead models.
- Full pretrigger suite: 481/481 pass.

Still TODO (player-facing gate per CLAUDE.md): a windowed scenario
under 40k/tests/scenarios/ driving the new picker UI in-game and
verifying split-fire works end-to-end. Will follow separately.