### PR TITLE
Fix scout unit selection wedging drag input (followup to #440)

### DIFF
--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6290,6 +6290,8 @@ func _on_unit_selected(index: int) -> void:
 			# for it. Otherwise we'd silently break Confirm/Skip for a unit
 			# the phase still considers "in progress".
 			_scout_active_unit_id = ""
+
+	elif current_phase == GameStateData.Phase.MOVEMENT and movement_controller:
 		# Check if this is a reserve unit arriving as reinforcement
 		var selected_unit = GameState.get_unit(unit_id)
 		if selected_unit.get("status", 0) == GameStateData.UnitStatus.IN_RESERVES:

--- a/40k/tests/scenarios/sp/scout_unit_list_selection_enables_drag.json
+++ b/40k/tests/scenarios/sp/scout_unit_list_selection_enables_drag.json
@@ -1,0 +1,84 @@
+{
+  "id": "scout_unit_list_selection_enables_drag",
+  "covers": [
+    "phases.ScoutPhase.UI.unit_list_selection_enables_drag"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "disable_ai": true,
+  "description": "Regression for: a stray edit in _on_unit_selected (the right-panel unit list handler at Main.gd:6196) collapsed the SCOUT branch into the MOVEMENT branch by deleting the elif separator. After selecting a scout unit from the list, control fell through into the MOVEMENT branch's reserve-unit / movement-controller logic — which sets movement_controller.active_unit_id on a null reference during scout phase and never wires the scout state, leaving _scout_active_unit_id technically set but the unit card / drag input in a broken state. Player report: 'when I select scout units and try to drag them, nothing happens'. This scenario refreshes the scout-phase unit list, then drives _on_unit_selected(0) — the same path the unit-list 'item_selected' signal takes — and asserts (a) _scout_active_unit_id is set, (b) phase has an active scout move, (c) Confirm button is wired and visible, and (d) Confirm click commits state. If the elif is missing, _on_unit_selected will explode or no-op on the scout unit.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').refresh_unit_list()" },
+    { "act": "wait_frames", "frames": 1 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').unit_list.get_item_metadata(0)",
+      "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._on_unit_selected(0)" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._scout_active_unit_id",
+      "equals": "U_WITCHSEEKERS_C" },
+    { "act": "execute_script",
+      "script": "str(PhaseManager.get_current_phase_instance().active_scout_moves.has('U_WITCHSEEKERS_C'))",
+      "equals": "true" },
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').confirm_button.visible",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "str(get_node('/root/Main').confirm_button.pressed.is_connected(get_node('/root/Main')._on_scout_confirm_pressed))",
+      "equals": "true" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m1",
+      "destination": { "x": 900.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m2",
+      "destination": { "x": 960.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m3",
+      "destination": { "x": 1020.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m4",
+      "destination": { "x": 1080.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "click_node",
+      "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton",
+      "emit_pressed": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.x)",
+      "equals": 900.0 },
+    { "act": "screenshot", "label": "scout_unit_list_selection_full_flow" }
+  ]
+}

--- a/40k/tests/scenarios/sp/scout_unit_selection_enables_drag.json
+++ b/40k/tests/scenarios/sp/scout_unit_selection_enables_drag.json
@@ -1,0 +1,82 @@
+{
+  "id": "scout_unit_selection_enables_drag",
+  "covers": [
+    "phases.ScoutPhase.UI.unit_selection_from_panel_enables_drag"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "disable_ai": true,
+  "description": "Bug repro: previously a stray edit collapsed the SCOUT and MOVEMENT branches of _on_unit_selected / _on_unit_stats_panel_unit_selected, so selecting a scout unit fell through into the MOVEMENT branch and either crashed (movement_controller null) or never finished wiring scout state. Result: clicking a scout unit in the list appeared to succeed but you couldn't drag any models. This scenario drives the real unit-selection handler and asserts that immediately afterward (a) _scout_active_unit_id is set, (b) the phase has an active scout move for that unit, and (c) the input guard at line 5114 ('current_phase == SCOUT and _scout_active_unit_id != \"\"') would let drag input through.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._scout_active_unit_id",
+      "equals": "" },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._on_unit_stats_panel_unit_selected('U_WITCHSEEKERS_C', false)" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._scout_active_unit_id",
+      "equals": "U_WITCHSEEKERS_C" },
+    { "act": "execute_script",
+      "script": "str(PhaseManager.get_current_phase_instance().active_scout_moves.has('U_WITCHSEEKERS_C'))",
+      "equals": "true" },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._on_unit_stats_panel_unit_selected('U_WITCHSEEKERS_C', false)" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main')._scout_active_unit_id",
+      "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m1",
+      "destination": { "x": 900.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m2",
+      "destination": { "x": 960.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m3",
+      "destination": { "x": 1020.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m4",
+      "destination": { "x": 1080.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "click_node",
+      "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton",
+      "emit_pressed": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.x)",
+      "equals": 900.0 },
+    { "act": "screenshot", "label": "scout_select_drag_confirm_intact" }
+  ]
+}


### PR DESCRIPTION
## Summary

Followup to #440. The merged PR accidentally deleted one line in `_on_unit_selected` — the `elif current_phase == GameStateData.Phase.MOVEMENT and movement_controller:` separator at `Main.gd:6294`. Without it, the SCOUT branch fell through into the MOVEMENT branch's body, including `movement_controller.active_unit_id = unit_id`. During scout phase `movement_controller` is null, which wedged the handler and left the player unable to drag scout models even after selecting them — the symptom reported after #440 merged.

## Changes

- **`Main.gd:6294`** — Restore the lost `elif current_phase == GameStateData.Phase.MOVEMENT and movement_controller:` line so scout selection exits the unit-selected handler cleanly instead of falling into MOVEMENT-only code paths on a null `movement_controller`.

## Test Coverage

Two new windowed scenarios that drive the actual UI selection handlers (not just dispatch) — these would have caught the original deletion if they had existed:

- **`scout_unit_list_selection_enables_drag.json`** — Drives `_on_unit_selected(0)` (the right-panel `unit_list.item_selected` path that the user actually clicks). Asserts `_scout_active_unit_id` is set, the phase has an active scout move, the Confirm button is wired to `_on_scout_confirm_pressed`, and a real button click commits staged positions into `GameState`.
- **`scout_unit_selection_enables_drag.json`** — Same end-to-end check for the bottom-panel `_on_unit_stats_panel_unit_selected` path.

All six scout scenarios now pass:
```
scout_no_overlap                          PASS
scout_confirm_persists_to_state           PASS
scout_confirm_button_writes_state         PASS
scout_confirm_after_reselect              PASS
scout_unit_selection_enables_drag         PASS
scout_unit_list_selection_enables_drag    PASS
```

https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq)_