### PR TITLE
Place model type picker inside unit card instead of screen overlay

### DIFF
--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -2650,22 +2650,31 @@ func _get_placed_indices() -> Array:
 	return placed
 
 func _show_model_type_picker(model_profiles: Dictionary, models: Array) -> void:
-	"""Create and display the model type picker panel."""
+	"""Create and display the model type picker panel inside the right-hand unit card,
+	next to the Deploy Formation controls."""
 	_hide_model_type_picker()
-
-	# Create a CanvasLayer so the panel is in screen space (not world space)
-	model_type_picker_canvas = CanvasLayer.new()
-	model_type_picker_canvas.name = "ModelTypePickerCanvas"
-	model_type_picker_canvas.layer = 10  # Above game elements
-	get_tree().root.add_child(model_type_picker_canvas)
 
 	var PickerScript = load("res://scripts/ModelTypePickerPanel.gd")
 	model_type_picker_panel = PickerScript.new()
 	model_type_picker_panel.name = "ModelTypePickerPanel"
-	model_type_picker_canvas.add_child(model_type_picker_panel)
 
-	# Position on left side of screen
-	model_type_picker_panel.position = Vector2(20, 200)
+	# Try to host the picker inside the right-hand unit card (next to FormationControls).
+	# Fall back to a screen-space CanvasLayer if the unit card isn't available.
+	var unit_card = _get_unit_card_node()
+	if unit_card:
+		unit_card.add_child(model_type_picker_panel)
+		# Place the picker immediately after the FormationControls row if present.
+		var formation_controls = unit_card.get_node_or_null("FormationControls")
+		if formation_controls:
+			var target_idx = formation_controls.get_index() + 1
+			unit_card.move_child(model_type_picker_panel, target_idx)
+	else:
+		model_type_picker_canvas = CanvasLayer.new()
+		model_type_picker_canvas.name = "ModelTypePickerCanvas"
+		model_type_picker_canvas.layer = 10
+		get_tree().root.add_child(model_type_picker_canvas)
+		model_type_picker_canvas.add_child(model_type_picker_panel)
+		model_type_picker_panel.position = Vector2(20, 200)
 
 	# Setup with current data
 	var placed = _get_placed_indices()
@@ -2674,7 +2683,14 @@ func _show_model_type_picker(model_profiles: Dictionary, models: Array) -> void:
 	# Connect selection signal
 	model_type_picker_panel.model_type_selected.connect(_on_model_type_selected)
 
-	print("[DeploymentController] MA-15: Model type picker shown")
+	print("[DeploymentController] MA-15: Model type picker shown (parented to %s)" % ("UnitCard" if unit_card else "CanvasLayer"))
+
+func _get_unit_card_node() -> Node:
+	"""Locate the right-hand UnitCard VBox in the Main scene, if available."""
+	var main_scene = get_tree().current_scene
+	if main_scene == null:
+		return null
+	return main_scene.get_node_or_null("HUD_Right/VBoxContainer/UnitCard")
 
 func _hide_model_type_picker() -> void:
 	"""Remove the model type picker panel."""

--- a/40k/tests/scenarios/sp/screenshot_model_type_picker_unit_card.json
+++ b/40k/tests/scenarios/sp/screenshot_model_type_picker_unit_card.json
@@ -1,0 +1,24 @@
+{
+  "id": "screenshot_model_type_picker_unit_card",
+  "covers": [
+    "deployment.model_type_picker.unit_card_placement"
+  ],
+  "fixture": "audit_378_formations",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Visual: starts deploying U_LOOTAS_A (which has 3 model_types: loota_deffgun, loota_kmb, spanner) and captures a screenshot to show the Select Model Type picker rendered inside the right-hand unit card next to the Deploy Formation Single/Spread/Tight buttons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "screenshot", "label": "01_deployment_phase_ready" },
+
+    { "act": "execute_script", "script": "Main.show_unit_card('U_LOOTAS_A')" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_LOOTAS_A')" },
+    { "act": "wait_frames", "frames": 12 },
+
+    { "act": "screenshot", "label": "02_picker_in_unit_card" },
+
+    { "act": "execute_script", "script": "'has_picker=' + str(Main.deployment_controller.has_model_type_picker) + ' parent=' + (Main.deployment_controller.model_type_picker_panel.get_parent().name if Main.deployment_controller.model_type_picker_panel else 'null')" }
+  ]
+}


### PR DESCRIPTION
## Summary
Refactors the model type picker UI to be parented inside the right-hand unit card panel (next to the Deploy Formation controls) instead of appearing as a screen-space overlay. Falls back gracefully to the original CanvasLayer approach if the unit card is unavailable.

## Key Changes
- **Refactored `_show_model_type_picker()`**: Now attempts to locate and parent the picker panel inside the UnitCard node; only creates a CanvasLayer fallback if the unit card is not found
- **Added `_get_unit_card_node()`**: New helper method that locates the right-hand UnitCard VBox via the scene tree path `HUD_Right/VBoxContainer/UnitCard`
- **Improved positioning logic**: When parented to the unit card, the picker is positioned immediately after the FormationControls row using `move_child()` for proper layout ordering
- **Enhanced logging**: Updated debug output to indicate which parent the picker was attached to (UnitCard vs CanvasLayer)
- **Added windowed scenario**: New test scenario `screenshot_model_type_picker_unit_card.json` that validates the picker renders correctly inside the unit card during deployment

## Implementation Details
- The picker is now a child of the unit card's VBox, allowing it to flow naturally with other UI elements rather than floating over the screen
- The fallback CanvasLayer path preserves backward compatibility if the unit card structure is unavailable (e.g., in different scenes or during testing)
- The scenario captures screenshots and verifies the picker's parent node to ensure correct placement

https://claude.ai/code/session_01A5ay4xi8rVmgfDqoz4MEvC