### PR TITLE
Reset initial command points to 0 for both players

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -41,8 +41,8 @@ func initialize_default_state(deployment_type: String = "hammer_anvil") -> void:
 		},
 		"units": {},  # Start empty, will be populated by army loading
 		"players": {
-			"1": {"cp": 3, "vp": 0, "primary_vp": 0, "secondary_vp": 0, "bonus_cp_gained_this_round": 0},
-			"2": {"cp": 3, "vp": 0, "primary_vp": 0, "secondary_vp": 0, "bonus_cp_gained_this_round": 0}
+			"1": {"cp": 0, "vp": 0, "primary_vp": 0, "secondary_vp": 0, "bonus_cp_gained_this_round": 0},
+			"2": {"cp": 0, "vp": 0, "primary_vp": 0, "secondary_vp": 0, "bonus_cp_gained_this_round": 0}
 		},
 		"factions": {},  # New field for faction data
 		"unit_visuals": {},  # Maps unit_id -> {"color": "RRGGBB", "label": ""}


### PR DESCRIPTION
## Summary
Adjust the default game state initialization to set both players' starting command points (CP) to 0 instead of 3.

## Changes
- Modified `initialize_default_state()` in `GameState.gd` to initialize player 1's CP from 3 to 0
- Modified `initialize_default_state()` in `GameState.gd` to initialize player 2's CP from 3 to 0

## Details
This change affects the initial state created when a new game is set up with the default deployment type. Players will now begin with 0 command points rather than 3, aligning with the intended game balance or rule implementation.

All other player state fields (VP, primary/secondary VP, bonus CP tracking) remain unchanged.

https://claude.ai/code/session_01MGz4bJQtwW8L2KA8oGiAEa