### PR TITLE
Update menu defaults: CA2025 02 Layout terrain, Search and Destroy deployment, Custodes cloud P1 army

### DIFF
--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -45,7 +45,7 @@ var terrain_options = [
 	{"id": "layout_6", "name": "Chapter Approved Layout 6"},
 	{"id": "layout_7", "name": "Chapter Approved Layout 7"},
 	{"id": "layout_8", "name": "Chapter Approved Layout 8"},
-	{"id": "layout_parse_test", "name": "Parse Test — Layout 2"},
+	{"id": "layout_parse_test", "name": "CA2025 02 Layout"},
 	{"id": "layout_parse_test_1", "name": "Parse Test — Layout 1"}
 ]
 
@@ -103,9 +103,9 @@ func _ready() -> void:
 	_setup_save_load_dialog()
 
 	# Set defaults
-	terrain_dropdown.selected = 0
+	terrain_dropdown.selected = _find_option_index(terrain_options, "layout_parse_test")
 	mission_dropdown.selected = 0
-	deployment_dropdown.selected = 0
+	deployment_dropdown.selected = _find_option_index(deployment_options, "search_and_destroy")
 
 	# Set default army selections based on available armies
 	_set_default_army_selections()
@@ -296,6 +296,13 @@ func _create_difficulty_dropdowns() -> void:
 	player2_type_dropdown.item_selected.connect(_on_player2_type_changed)
 
 	print("MainMenu: AI difficulty dropdowns created")
+
+func _find_option_index(options: Array, target_id: String) -> int:
+	"""Return the index of the option with the given id, or 0 if not found."""
+	for i in range(options.size()):
+		if options[i].get("id", "") == target_id:
+			return i
+	return 0
 
 func _get_child_index(parent: Node, child_name: String) -> int:
 	"""Get the index of a child node by name."""
@@ -693,7 +700,7 @@ func _on_cloud_armies_loaded(cloud_armies: Array) -> void:
 
 func _apply_preferred_cloud_defaults(p1_current_id: String, p2_current_id: String) -> void:
 	# Preferred cloud army display names (without the trailing date suffix)
-	var p1_preferred_name = "Adeptes Custodes 500 (Cloud)"
+	var p1_preferred_name = "Adeptus Custodes 500 (Cloud)"
 	var p2_preferred_name = "Orks 500 (Cloud)"
 
 	var p1_cloud_index = _find_cloud_army_index_by_name(p1_preferred_name)

--- a/40k/terrain_layouts/layout_parse_test.json
+++ b/40k/terrain_layouts/layout_parse_test.json
@@ -1,6 +1,6 @@
 {
   "id": "layout_parse_test",
-  "name": "Parse Test (Layout 2 image-detected)",
+  "name": "CA2025 02 Layout",
   "description": "Generated from layout2_reference.jpg via tools/detect_pieces.py + tools/detect_to_json.py. Pieces detected by color segmentation, paired with their 180-degree mirror counterparts, then positions/sizes averaged to force exact rotational symmetry around (22, 30). 16 pieces total: 8 gray hatched (tall ruins) and 8 blue (low ruins).",
   "recommended_deployments": [
     "hammer_anvil",

--- a/40k/tests/scenarios/sp/main_menu_defaults.json
+++ b/40k/tests/scenarios/sp/main_menu_defaults.json
@@ -1,0 +1,31 @@
+{
+  "id": "main_menu_defaults",
+  "covers": ["mainmenu.defaults", "terrain.parse_test", "deployment.search_and_destroy"],
+  "description": "Boots the MainMenu scene (no fixture) and asserts the default selections a first-time player sees: terrain defaults to 'CA2025 02 Layout' (layout_parse_test) and deployment defaults to 'Search and Destroy'. Drives the real OptionButton widgets via the live scene root.",
+
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "execute_script",
+      "script": "main.get_script().resource_path",
+      "equals": "res://scripts/MainMenu.gd" },
+
+    { "act": "execute_script",
+      "script": "main.terrain_dropdown.get_item_text(main.terrain_dropdown.selected)",
+      "equals": "CA2025 02 Layout" },
+
+    { "act": "execute_script",
+      "script": "main.terrain_options[main.terrain_dropdown.selected].id",
+      "equals": "layout_parse_test" },
+
+    { "act": "execute_script",
+      "script": "main.deployment_dropdown.get_item_text(main.deployment_dropdown.selected)",
+      "equals": "Search and Destroy" },
+
+    { "act": "execute_script",
+      "script": "main.deployment_options[main.deployment_dropdown.selected].id",
+      "equals": "search_and_destroy" },
+
+    { "act": "screenshot", "label": "main_menu_defaults" }
+  ]
+}


### PR DESCRIPTION
## Summary

Updates the MainMenu default selections a first-time player sees:

- **Rename terrain layout** — "Parse Test — Layout 2" (`layout_parse_test`) is now **"CA2025 02 Layout"**, updated in both the menu dropdown and the layout JSON `name` field.
- **Default terrain** — the terrain dropdown now defaults to `layout_parse_test` (via a new id-based `_find_option_index` helper, robust to list reordering).
- **Default deployment** — the deployment dropdown now defaults to `search_and_destroy` (Search and Destroy) instead of Hammer and Anvil.
- **Default Player 1 army** — fixes a name typo (`"Adeptes" -> "Adeptus"`) so P1 defaults to **"Adeptus Custodes 500 (Cloud)"** when the cloud list is reachable. The existing first-match lookup already picks the first of duplicate lists, and this is handled on the cloud-army path.

## Validation

Added windowed scenario `tests/scenarios/sp/main_menu_defaults.json` that drives the live MainMenu `OptionButton` widgets — **7/7 steps pass**, and the captured screenshot confirms "CA2025 02 Layout" and "Search and Destroy" selected by default.

Note: the P1 cloud-army default was verified at the logic level only — the headless test environment has no live cloud server, so the cloud upgrade fires only in the real app where the cloud army list is reachable.

https://claude.ai/code/session_01HvkfzjM58UNe4Knq2JDpDp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HvkfzjM58UNe4Knq2JDpDp)_