### PR TITLE
Make cloud game saves a shared/central store (fix online saves on itch)

### DIFF
--- a/40k/autoloads/CloudStorage.gd
+++ b/40k/autoloads/CloudStorage.gd
@@ -59,15 +59,37 @@ func _ready() -> void:
 
 func _init_player_id() -> void:
 	if OS.has_feature("web"):
-		# Web: use localStorage for player ID persistence
+		# Web: try localStorage first for player ID persistence. On itch.io the game
+		# runs in a third-party iframe where the browser may partition or block
+		# localStorage, so we keep a user:// (IndexedDB-backed) copy as a fallback.
+		# Note: saves are now a shared/central store, so a fresh/unstable player ID
+		# no longer hides previously-saved games — it only affects ownership labels.
 		var stored_id = JavaScriptBridge.eval("localStorage.getItem('w40k_player_id')")
 		if stored_id != null and str(stored_id) != "null" and str(stored_id).length() > 8:
 			player_id = str(stored_id)
 			print("CloudStorage: Loaded player ID from localStorage: ", player_id.substr(0, 8), "...")
 		else:
-			player_id = _generate_uuid()
-			JavaScriptBridge.eval("localStorage.setItem('w40k_player_id', '%s')" % player_id)
-			print("CloudStorage: Generated new player ID: ", player_id.substr(0, 8), "...")
+			# Fall back to a user:// copy if localStorage was empty/blocked
+			var id_path = "user://player_id.txt"
+			if FileAccess.file_exists(id_path):
+				var file = FileAccess.open(id_path, FileAccess.READ)
+				if file:
+					var file_id = file.get_as_text().strip_edges()
+					file.close()
+					if file_id.length() > 8:
+						player_id = file_id
+						print("CloudStorage: Loaded player ID from user:// fallback: ", player_id.substr(0, 8), "...")
+
+			if player_id.is_empty():
+				player_id = _generate_uuid()
+				print("CloudStorage: Generated new player ID: ", player_id.substr(0, 8), "...")
+
+			# Persist to both localStorage and user:// (each is best-effort)
+			JavaScriptBridge.eval("try { localStorage.setItem('w40k_player_id', '%s'); } catch (e) {}" % player_id)
+			var out_file = FileAccess.open(id_path, FileAccess.WRITE)
+			if out_file:
+				out_file.store_string(player_id)
+				out_file.close()
 	else:
 		# Desktop: use file for player ID persistence
 		var id_path = "user://player_id.txt"

--- a/server/relay-server.js
+++ b/server/relay-server.js
@@ -89,8 +89,19 @@ const stmts = {
     ORDER BY gs.updated_at DESC
   `),
   getSave: db.prepare(`
-    SELECT save_name, metadata, game_data, created_at, updated_at
+    SELECT save_name, metadata, game_data, created_at, updated_at, player_id AS owner_id
     FROM game_saves WHERE player_id = ? AND save_name = ?
+  `),
+  // Shared/central saves: every save is visible to every player (see handleSaves).
+  // The user has opted into a public save store, so listing and loading are not
+  // scoped to the player_id that created the save.
+  listAllSaves: db.prepare(`
+    SELECT save_name, metadata, created_at, updated_at, player_id AS owner_id
+    FROM game_saves ORDER BY updated_at DESC
+  `),
+  getSaveByName: db.prepare(`
+    SELECT save_name, metadata, game_data, created_at, updated_at, player_id AS owner_id
+    FROM game_saves WHERE save_name = ? ORDER BY updated_at DESC LIMIT 1
   `),
   getSharedSave: db.prepare(`
     SELECT gs.save_name, gs.metadata, gs.game_data, gs.created_at, gs.updated_at
@@ -209,6 +220,17 @@ function authenticatePlayer(req, res) {
     return null;
   }
   // Upsert player record
+  const now = Date.now();
+  stmts.upsertPlayer.run(playerId, now, now);
+  return playerId;
+}
+
+// Like authenticatePlayer but never rejects the request. Returns the player id
+// when a valid one is supplied (so we can label ownership), otherwise null.
+// Used for read-only endpoints that are public/shared.
+function optionalPlayer(req) {
+  const playerId = req.headers['x-player-id'];
+  if (!playerId || playerId.length < 8) return null;
   const now = Date.now();
   stmts.upsertPlayer.run(playerId, now, now);
   return playerId;
@@ -371,56 +393,61 @@ function handlePlayers(req, res) {
 }
 
 async function handleSaves(req, res, saveName) {
-  const playerId = authenticatePlayer(req, res);
-  if (!playerId) return;
+  // Reads are public/shared: every save is listable and loadable by anyone,
+  // regardless of which player_id created it. This keeps saves usable on the
+  // itch.io web build, where the browser may partition/clear the per-session
+  // player_id (third-party iframe storage), which previously made saves
+  // "disappear" between sessions. A player_id is still used to label ownership
+  // when one is supplied. Writes (PUT/DELETE) still require a player_id.
+  if (req.method === 'GET') {
+    const requesterId = optionalPlayer(req);
 
-  if (!saveName) {
-    // GET /api/saves - list all saves (own + shared)
-    if (req.method !== 'GET') {
-      sendError(res, 405, 'Method not allowed');
+    if (!saveName) {
+      // GET /api/saves - list every save in the shared store
+      const allSaves = stmts.listAllSaves.all();
+      const result = allSaves.map((s) => ({
+        save_name: s.save_name,
+        metadata: JSON.parse(s.metadata),
+        created_at: s.created_at,
+        updated_at: s.updated_at,
+        ownership: (requesterId && s.owner_id === requesterId) ? 'own' : 'shared',
+        owner_id: s.owner_id,
+      }));
+      sendJSON(res, 200, { saves: result });
       return;
     }
-    const ownSaves = stmts.listOwnSaves.all(playerId);
-    const sharedSaves = stmts.listSharedSaves.all(playerId, playerId);
-    const allSaves = [...ownSaves, ...sharedSaves];
-    // Parse metadata JSON for each save
-    const result = allSaves.map((s) => ({
-      save_name: s.save_name,
-      metadata: JSON.parse(s.metadata),
-      created_at: s.created_at,
-      updated_at: s.updated_at,
-      ownership: s.ownership,
-      owner_id: s.owner_id,
-    }));
-    sendJSON(res, 200, { saves: result });
+
+    // GET /api/saves/:name - load a save by name.
+    // If owner_id is supplied, load that player's exact copy; otherwise load
+    // the most recently updated save with this name across all players.
+    const urlObj = new URL(req.url, `http://${req.headers.host}`);
+    const ownerId = urlObj.searchParams.get('owner_id');
+    let save;
+    if (ownerId) {
+      save = stmts.getSave.get(ownerId, saveName);
+    } else {
+      save = stmts.getSaveByName.get(saveName);
+    }
+    if (!save) {
+      sendError(res, 404, 'Save not found');
+      return;
+    }
+    sendJSON(res, 200, {
+      save_name: save.save_name,
+      metadata: JSON.parse(save.metadata),
+      game_data: save.game_data,
+      created_at: save.created_at,
+      updated_at: save.updated_at,
+      owner_id: save.owner_id,
+    });
     return;
   }
 
+  // Writes require a registered player_id.
+  const playerId = authenticatePlayer(req, res);
+  if (!playerId) return;
+
   switch (req.method) {
-    case 'GET': {
-      // Check for owner_id query param (shared save access)
-      const urlObj = new URL(req.url, `http://${req.headers.host}`);
-      const ownerId = urlObj.searchParams.get('owner_id');
-      let save;
-      if (ownerId && ownerId !== playerId) {
-        // Loading a shared save — verify participation
-        save = stmts.getSharedSave.get(playerId, ownerId, saveName);
-      } else {
-        save = stmts.getSave.get(playerId, saveName);
-      }
-      if (!save) {
-        sendError(res, 404, 'Save not found');
-        return;
-      }
-      sendJSON(res, 200, {
-        save_name: save.save_name,
-        metadata: JSON.parse(save.metadata),
-        game_data: save.game_data,
-        created_at: save.created_at,
-        updated_at: save.updated_at,
-      });
-      break;
-    }
     case 'PUT': {
       const body = await parseBody(req);
       if (!body || !body.metadata || !body.game_data) {


### PR DESCRIPTION
## Problem

Online saving never worked on the itch.io web build. Game saves were scoped to a per-session `player_id`. On itch the game runs in a third-party iframe, where browsers partition or clear `localStorage`, so `w40k_player_id` was regenerated each session — players saved under one id but listed/loaded under another, making saves appear to vanish. (Army lists already avoided this because their GET endpoints were made public earlier.)

## Change

Make game saves a shared/central store, mirroring the existing public army-list endpoints. The user has opted into public saves for now ("accessible for all players… not restricted to the same saver").

**Server (`server/relay-server.js`)**
- `GET /api/saves` and `GET /api/saves/:name` are now public/shared. Listing returns every save; loading by name returns the most recently updated save with that name (an `owner_id` query param still loads a specific player's copy).
- Reads no longer require `X-Player-ID`; it's used only to label ownership when present. Writes (PUT/DELETE) still require a `player_id`.

**Client (`40k/autoloads/CloudStorage.gd`)**
- Web `player_id` now falls back to a `user://` (IndexedDB) copy when `localStorage` is empty/blocked, and storage writes are wrapped to tolerate exceptions, giving a more stable id for ownership labels.

## Verification

Ran the relay server locally against a temp DB:
- A different player id — and a fully anonymous client — can list and load a save created by another player.
- Name collisions resolve most-recent-wins (so shared slots like `quicksave` behave as one central slot).
- `PUT` without a valid id still returns 401.

GDScript change parse-checked with Godot 4.4.1 (no script errors).

## Deploy

Merging to main triggers both auto-deploy workflows: `deploy-server.yml` (fly.io, on `server/**`) and `deploy-web.yml` (itch.io via Butler, on `40k/**`).

https://claude.ai/code/session_013WUQM65VbdqJHTSFjTxd6h

---
_Generated by [Claude Code](https://claude.ai/code/session_013WUQM65VbdqJHTSFjTxd6h)_