### PR TITLE
Reject scout moves that end on a wall + fix scout drag UI desync

### DIFF
--- a/40k/phases/ScoutPhase.gd
+++ b/40k/phases/ScoutPhase.gd
@@ -226,6 +226,14 @@ func _validate_set_scout_model_dest(action: Dictionary) -> Dictionary:
 	if _scout_position_overlaps_other_units(dest_pos, model, unit_id):
 		return {"valid": false, "errors": ["Model cannot overlap with other models"]}
 
+	# Check wall overlap — a scout move may pass through walls but may not END
+	# overlapping a wall segment (endpoint rule, universal across keywords; same
+	# as movement/charge/deployment). Path-traversal honors keywords separately.
+	var wall_check_model = model.duplicate(true)
+	wall_check_model["position"] = dest_pos
+	if Measurement.model_overlaps_any_wall(wall_check_model):
+		return {"valid": false, "errors": ["Scout move cannot end overlapping a wall"]}
+
 	# Check overlap against already-staged sibling models in this scout move.
 	# Without this, two models in the same unit could be dropped on the same spot.
 	var staged_positions = move_data.get("staged_positions", {})
@@ -296,6 +304,8 @@ func _validate_confirm_scout_move(action: Dictionary) -> Dictionary:
 		var m_pos_v = Vector2(m_pos.x, m_pos.y) if m_pos is Dictionary else m_pos
 		if _scout_position_overlaps_other_units(m_pos_v, m, unit_id):
 			return {"valid": false, "errors": ["Model %s overlaps another model" % mid]}
+		if Measurement.model_overlaps_any_wall(m):
+			return {"valid": false, "errors": ["Model %s ends its scout move overlapping a wall" % mid]}
 
 	# Validate unit coherency after all staged moves are applied
 	# Each model must be within 2" horizontally and 5" vertically of at least

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -11388,16 +11388,11 @@ func _scout_handle_mouse_motion(screen_pos: Vector2) -> void:
 
 	var world_pos = screen_to_world_position(screen_pos)
 
-	# Move the visual token — handle both flat and nested (deployment) token structures
-	if token_layer:
-		for child in token_layer.get_children():
-			var meta_node = child
-			if not child.has_meta("unit_id") and child.get_child_count() > 0:
-				meta_node = child.get_child(0)
-			if meta_node.has_meta("unit_id") and meta_node.get_meta("unit_id") == _scout_active_unit_id \
-			   and meta_node.has_meta("model_id") and meta_node.get_meta("model_id") == _scout_drag_model_id:
-				child.position = world_pos
-				break
+	# NOTE: the real token is intentionally NOT moved during the drag. Only the
+	# translucent ghost follows the cursor (mirrors MovementController). The token
+	# is committed to its new position only after SET_SCOUT_MODEL_DEST is accepted
+	# (see _scout_handle_end_drag). This prevents a visual/state desync where the
+	# token appears moved even though the server rejected the destination.
 
 	# Calculate distance
 	var distance_px = _scout_drag_start_pos.distance_to(world_pos)
@@ -11457,12 +11452,8 @@ func _scout_handle_mouse_release(screen_pos: Vector2) -> void:
 	if result.get("success", false):
 		print("Main: Scout model %s moved to %s" % [_scout_drag_model_id, str(world_pos)])
 		status_label.text = "Scout move: Model placed. Drag more models or Confirm/Skip."
-		# Update staged moves visualization (shows dashed paths for placed models)
-		_scout_update_staged_moves_visual()
-	else:
-		# Move visual token back to original position on failure
-		print("Main: Scout model move failed: ", result.get("errors", []))
-		status_label.text = "Invalid: " + str(result.get("errors", ["Move rejected"]))
+		# Move accepted: commit the real token to the new position now (the token
+		# was left at its origin during the drag — only the ghost followed the cursor).
 		if token_layer:
 			for child in token_layer.get_children():
 				var meta_node = child
@@ -11470,8 +11461,15 @@ func _scout_handle_mouse_release(screen_pos: Vector2) -> void:
 					meta_node = child.get_child(0)
 				if meta_node.has_meta("unit_id") and meta_node.get_meta("unit_id") == _scout_active_unit_id \
 				   and meta_node.has_meta("model_id") and meta_node.get_meta("model_id") == _scout_drag_model_id:
-					child.position = _scout_drag_start_pos
+					child.position = world_pos
 					break
+		# Update staged moves visualization (shows dashed paths for placed models)
+		_scout_update_staged_moves_visual()
+	else:
+		# Move rejected: the real token never moved (only the ghost did), so there is
+		# nothing to revert — just surface the error. This is the desync fix.
+		print("Main: Scout model move failed: ", result.get("errors", []))
+		status_label.text = "Invalid: " + str(result.get("errors", ["Move rejected"]))
 
 	_scout_drag_model_id = ""
 	_scout_selected_model_data = {}

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -560,6 +560,15 @@
       "status": "covered"
     },
     {
+      "id": "phases.ScoutPhase.SET_SCOUT_MODEL_DEST.wall_rejected",
+      "description": "Regression guard: ScoutPhase._validate_set_scout_model_dest (and _validate_confirm_scout_move) reject a scout destination whose base overlaps a terrain wall, matching the movement/charge/deployment endpoint rule. Scout moves may pass through walls but may not end on one. Closes the server-side gap that, combined with the Main.gd drag handler moving the real token live, produced a visual/state desync. Validated by 'scout_cannot_end_on_wall.",
+      "scenarios": [
+        "scout_cannot_end_on_wall"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "phases.ShootingPhase._can_unit_shoot",
       "description": "ShootingPhase._can_unit_shoot: returns true unless the unit has a hard blocker (Fell Back without override, etc.). Battle-shock no longer blocks shooting in 10e. Validated by '383_battleshock_can_shoot.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/scout_cannot_end_on_wall.json
+++ b/40k/tests/scenarios/sp/scout_cannot_end_on_wall.json
@@ -1,0 +1,57 @@
+{
+  "id": "scout_cannot_end_on_wall",
+  "covers": ["phases.ScoutPhase.SET_SCOUT_MODEL_DEST.wall_rejected"],
+  "fixture": "audit_baseline_postdeploy",
+  "disable_ai": true,
+  "description": "Regression: a Scout move may not END overlapping a terrain wall, mirroring movement/charge/deployment. Before the fix, ScoutPhase._validate_set_scout_model_dest and _validate_confirm_scout_move never called Measurement.model_overlaps_any_wall, so scout drops onto walls were accepted server-side. Combined with the Main.gd drag handler moving the real token live, this produced a visual/state desync the player reported: the model appears on the wall but the move was not registered, so the movement phase targets the old position. This scenario injects a ruin wall at y=200 within scout range of Witchseekers C (models start at y=50, enemies are ~57\" south so the >9\" check is satisfied), then asserts SET_SCOUT_MODEL_DEST onto the wall is rejected while a clear destination is accepted.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+    { "act": "execute_script",
+      "script": "GameState.unit_has_scout('U_WITCHSEEKERS_C')",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.append({\"id\": \"injected_scout_wall\", \"type\": \"ruins\", \"polygon\": PackedVector2Array([Vector2(820, 180), Vector2(1000, 180), Vector2(1000, 220), Vector2(820, 220)]), \"height_category\": \"medium\", \"position\": Vector2(910, 200), \"size\": Vector2(180, 40), \"rotation\": 0.0, \"can_move_through\": {\"INFANTRY\": true, \"VEHICLE\": false, \"MONSTER\": false}, \"walls\": [{\"id\": \"injected_scout_wall_seg\", \"type\": \"solid\", \"blocks_los\": true, \"start\": Vector2(820, 200), \"end\": Vector2(1000, 200), \"blocks_movement\": {\"INFANTRY\": false, \"VEHICLE\": true, \"MONSTER\": true}}]})"
+    },
+    { "act": "screenshot", "label": "01_scout_phase_with_injected_wall" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "BEGIN_SCOUT_MOVE",
+      "unit_id": "U_WITCHSEEKERS_C"
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m1",
+      "destination": { "x": 900.0, "y": 200.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": false },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().active_scout_moves['U_WITCHSEEKERS_C']['staged_positions'].has('m1')",
+      "equals": false },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m1",
+      "destination": { "x": 900.0, "y": 120.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().active_scout_moves['U_WITCHSEEKERS_C']['staged_positions'].get('m1', {}).get('x', -1)",
+      "equals": 900.0 },
+    { "act": "screenshot", "label": "02_scout_wall_rejected_clear_accepted" }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #448 (merged), which enforced the wall-endpoint rule for movement, charge, and deployment. This PR extends the same rule to the **scout phase** and fixes a visual/state desync the player reported during scout moves.

## Changes

**1. Server-side wall check — `ScoutPhase.gd`**
- `_validate_set_scout_model_dest` and `_validate_confirm_scout_move` never called `Measurement.model_overlaps_any_wall`, so scout was the one remaining phase that *accepted* a model ending on a wall. Added the endpoint check to both. Scout moves may still pass through walls; only the final position is rejected.

**2. Scout drag UI desync — `Main.gd`**
- The scout drag handler moved the **real token** live during mouse motion and relied on a revert-on-failure, unlike `MovementController` (which keeps the real token still and only moves a translucent ghost). On a rejected move the token was left sitting at the rejected spot while game state kept the old position, so the movement phase targeted a different location than the one shown.
- Scout drag is now **ghost-only**: the real token stays at its origin during the drag and is committed to the new position only after `SET_SCOUT_MODEL_DEST` is accepted. On rejection nothing moved, so there is nothing to desync.

## Validation — windowed scenario (godot_mcp ScenarioRunner)

- `scout_cannot_end_on_wall.json` — 17/17. Injects a ruin wall within scout range of Witchseekers C, asserts `SET_SCOUT_MODEL_DEST` onto the wall is rejected and **not staged**, while a clear destination is accepted and staged.

`coverage.json` updated with the new `phases.ScoutPhase.SET_SCOUT_MODEL_DEST.wall_rejected` tile.

The wall-endpoint rule is now enforced consistently across deployment, movement, charge, and scout — at both the client UI layer and the server-authoritative validators.

## Test plan

- [x] `scout_cannot_end_on_wall` scenario passes (17/17)
- [x] Branch is up to date with latest `main` (merged in, no conflicts)
- [ ] Pre-existing "Coverage matrix validation" CI check is red on `main` (unrelated coverage drift, not introduced here)

https://claude.ai/code/session_01FMJKAsYa4D1gpAoRyHoYdm

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMJKAsYa4D1gpAoRyHoYdm)_