### PR TITLE
Fix grass board texture not rendering in exported builds

### DIFF
--- a/40k/scripts/BoardVisual.gd
+++ b/40k/scripts/BoardVisual.gd
@@ -19,13 +19,13 @@ var _shaders: Dictionary = {
 	"tilepack": preload("res://shaders/tilepack_board.gdshader"),
 }
 
-# Grass textures loaded at runtime (bypasses import system)
-var _grass_basecolor: ImageTexture = null
-var _grass_normal: ImageTexture = null
+# Grass textures (loaded via the resource system so they ship in exports)
+var _grass_basecolor: Texture2D = null
+var _grass_normal: Texture2D = null
 
 # Tilepack textures (two grass tile variants)
-var _tilepack_1: ImageTexture = null
-var _tilepack_2: ImageTexture = null
+var _tilepack_1: Texture2D = null
+var _tilepack_2: Texture2D = null
 
 func _ready() -> void:
 	z_index = -10
@@ -51,16 +51,22 @@ func _load_grass_textures() -> void:
 	else:
 		print("[BoardVisual] WARNING: Failed to load grass normal texture")
 
-func _load_png_as_texture(res_path: String) -> ImageTexture:
-	# Convert res:// path to absolute filesystem path
+func _load_png_as_texture(res_path: String) -> Texture2D:
+	# Prefer the resource system: the imported texture is packed into exported
+	# builds, so it resolves everywhere (editor, headless, and shipped games).
+	var tex := load(res_path) as Texture2D
+	if tex != null:
+		return tex
+	# Fallback: read the raw file from disk. This only works when running from
+	# the project source tree, but keeps grass working if the import is missing.
+	print("[BoardVisual] WARNING: load(%s) returned null, falling back to raw file read" % res_path)
 	var abs_path = ProjectSettings.globalize_path(res_path)
 	var img = Image.new()
 	var err = img.load(abs_path)
 	if err != OK:
 		print("[BoardVisual] ERROR: Could not load image at %s (error %d)" % [abs_path, err])
 		return null
-	var tex = ImageTexture.create_from_image(img)
-	return tex
+	return ImageTexture.create_from_image(img)
 
 func _load_tilepack_textures() -> void:
 	_tilepack_1 = _load_png_as_texture("res://textures/tilepack/tileGrass1.png")

--- a/40k/tests/scenarios/sp/board_grass_texture_loads.json
+++ b/40k/tests/scenarios/sp/board_grass_texture_loads.json
@@ -1,0 +1,54 @@
+{
+  "id": "board_grass_texture_loads",
+  "covers": ["visual.board_style.grass_texture_loads"],
+  "fixture": "audit_baseline_postdeploy",
+  "description": "Regression: the default 'grass' board style must load its tiled image texture via the resource system so it ships in exported builds (the old Image.load(globalize_path()) path only resolved when running from the project source tree). Asserts the live BoardBackground material has the grass shader with a non-null 128x128 Texture2D bound, drives a player-facing board-style switch (grass -> felt -> grass) through SettingsService.set_board_style (same call the Settings dropdown makes), and re-asserts the grass texture re-binds. Captures the rendered grass board.",
+
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.board_style",
+      "equals": "grass" },
+
+    { "act": "execute_script",
+      "script": "main.board_view.board_style",
+      "equals": "grass" },
+
+    { "act": "execute_script",
+      "script": "main.board_view.get_node(\"BoardBackground\").material.shader.resource_path",
+      "equals": "res://shaders/grass_board.gdshader" },
+
+    { "act": "execute_script",
+      "script": "main.board_view.get_node(\"BoardBackground\").material.get_shader_parameter(\"grass_texture\") != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.board_view.get_node(\"BoardBackground\").material.get_shader_parameter(\"grass_texture\").get_width()",
+      "equals": 128 },
+
+    { "act": "screenshot", "label": "01_grass_board" },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_board_style(\"felt\")" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script",
+      "script": "main.board_view.board_style",
+      "equals": "felt" },
+    { "act": "screenshot", "label": "02_felt_board" },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_board_style(\"grass\")" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script",
+      "script": "main.board_view.board_style",
+      "equals": "grass" },
+    { "act": "execute_script",
+      "script": "main.board_view.get_node(\"BoardBackground\").material.get_shader_parameter(\"grass_texture\") != null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.board_view.get_node(\"BoardBackground\").material.get_shader_parameter(\"grass_texture\").get_width()",
+      "equals": 128 },
+    { "act": "screenshot", "label": "03_grass_reapplied" }
+  ]
+}


### PR DESCRIPTION
## Problem

The default `grass` board texture doesn't show up. The procedural board styles (`mud`, `desert`, `stone`, `felt`) work fine because they generate their look entirely in-shader and need no asset. `grass` and `tilepack` are the only styles that tile a real image, and `grass` is the one selected by default — so the board appears blank/untextured.

## Root cause

In `BoardVisual.gd`, the image-based styles were loaded with:

```gdscript
var abs_path = ProjectSettings.globalize_path(res_path)
img.load(abs_path)   # raw read off the OS filesystem
```

This only resolves when running from the project source tree. In an exported build:

- `globalize_path("res://...")` points outside the `.pck`, and
- the raw PNG isn't shipped — Godot packs the imported `.ctex`, not the source `.png` (`export_filter="all_resources"`).

So the load fails, `_grass_basecolor` is `null`, the shader gets no texture, and the board shows no grass.

## Fix

Load through the resource system (`load(res_path)`), which uses the imported texture that *is* packed into exports and resolves everywhere (editor, headless, shipped builds). The old raw-file read is kept as a fallback. Texture fields widened from `ImageTexture` to `Texture2D`.

This keeps the intended look (real tiled grass image, not procedural) — it just makes the image load reliably.

## Validation

- Confirmed grass loads via `load()` (returns a valid 128×128 `CompressedTexture2D`) and renders.
- Added windowed scenario `40k/tests/scenarios/sp/board_grass_texture_loads.json` (**17/17 pass**):
  - asserts the live `BoardBackground` material has the grass shader with a non-null 128×128 texture bound,
  - drives a player-facing board-style switch (`grass` → `felt` → `grass`) through `SettingsService.set_board_style` (the same call the Settings dropdown makes),
  - re-asserts the grass texture re-binds,
  - captures screenshots of the rendered grass board.

Run: `bash 40k/tests/run_scenarios.sh tests/scenarios/sp/board_grass_texture_loads.json`

https://claude.ai/code/session_016UTJLCTo7MHY93x23UR6ER

---
_Generated by [Claude Code](https://claude.ai/code/session_016UTJLCTo7MHY93x23UR6ER)_