### PR TITLE
Hide procedural Silhouette placeholder that drew a white circle on every model

### DIFF
--- a/40k/scripts/TokenVisual.gd
+++ b/40k/scripts/TokenVisual.gd
@@ -252,6 +252,13 @@ func _t15_make_silhouette() -> Sprite2D:
 	s.modulate = Color(1, 1, 1, 0.85)
 	s.position = Vector2(0, 0)
 	s.z_index = 1
+	# The procedural silhouette is a placeholder that renders as a white shape
+	# (a disc for infantry, etc.) at the model center. It exists purely so the
+	# T15 scenario can assert the node/texture/category are wired up; it was
+	# never meant to be a visible gameplay element. Keep the node (with its
+	# texture + silhouette_category) for those assertions but don't render it,
+	# so it no longer shows a white circle in the middle of every model.
+	s.visible = false
 	return s
 
 


### PR DESCRIPTION
## Problem

Every model showed a small white circle in its center.

## Cause

Each `TokenVisual` was getting a child `Sprite2D` named `Silhouette` (the "T15" feature) created at the model's center with a white-on-transparent procedural texture and a white modulate (`Color(1,1,1,0.85)`). For the default `infantry` category the texture is a filled disc, so it rendered as a small white circle in the middle of every model — in all view modes, since it's a child node independent of the letter/classic/enhanced draw paths. It only ever existed so the `T15_silhouettes` scenario could assert the node/texture/category were wired up before real art assets landed; it was never meant to be a visible gameplay element.

## Fix

`40k/scripts/TokenVisual.gd`: set the `Silhouette` sprite to `visible = false`. The node, its 32×32 texture, and the `silhouette_category` string are all still created — only rendering is suppressed.

## Why this preserves the test functionality

- `T15_silhouettes` asserts the node exists, `texture != null`, `texture.get_width() == 32`, and a valid `silhouette_category` — none require visibility. It passes **8/8**.
- `expect_baseline_unchanged` is a file-integrity check on `_baseline.json`, not a pixel comparison, so it's unaffected.
- The PR-time visual-regression loop is explicitly non-blocking ("signal, not gate").

## Verification

- Drove the live UI via the MCP scenario bridge: forcing the sprite visible/red proved it renders exactly at the model center (the white circle); with the fix the center shows no white disc — confirmed with before/after screenshots and a passing `pixel_diff`.
- Full `--visual` suite: 39 passed, 3 failed (`T23`, `T27`, `T45`). Verified by stashing the change that those 3 fail **identically on the unmodified branch** — pre-existing failures (`/root/Main/EndPhaseButton` not found in the headless env), unrelated to this change. This change adds **zero** new failures.

https://claude.ai/code/session_013kjEn47nK7LiG2p7YvKwfA

---
_Generated by [Claude Code](https://claude.ai/code/session_013kjEn47nK7LiG2p7YvKwfA)_