### PR TITLE
Add setting to let the computer auto-allocate wounds

### DIFF
--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -41,6 +41,14 @@ var colorblind_mode: String = "none"
 # Unit label visibility — toggle the name text shown underneath models
 var show_unit_labels: bool = true
 
+# Gameplay settings
+# When true, the computer automatically chooses which wounded/destroyed models
+# are removed during wound allocation instead of prompting the local player.
+# Per 10e rules the *defending* player makes this choice; until a proper
+# defender-driven flow exists, this lets the player delegate the choice to the
+# computer so the attacker isn't forced to pick the opponent's casualties.
+var auto_allocate_wounds: bool = false
+
 # Board texture style: "grass", "mud", "desert", "stone", "felt", "tilepack", "none"
 var board_style: String = "grass"
 
@@ -55,6 +63,7 @@ signal audio_settings_changed()
 signal unit_labels_visibility_changed(visible: bool)
 signal board_style_changed(new_style: String)
 signal ruins_style_changed(new_style: String)
+signal auto_allocate_wounds_changed(enabled: bool)
 
 # P3-111: Settings config file path
 const SETTINGS_FILE_PATH: String = "user://settings.cfg"
@@ -247,6 +256,15 @@ func set_ruins_style(style: String) -> void:
 	_save_settings()
 	print("[SettingsService] Ruins style set to %s" % style)
 
+func get_auto_allocate_wounds() -> bool:
+	return auto_allocate_wounds
+
+func set_auto_allocate_wounds(enabled: bool) -> void:
+	auto_allocate_wounds = enabled
+	auto_allocate_wounds_changed.emit(auto_allocate_wounds)
+	_save_settings()
+	print("[SettingsService] auto_allocate_wounds set to %s" % str(enabled))
+
 func set_unit_visual_style_setting(style: String) -> void:
 	if style not in ["letter", "enhanced", "style_a", "style_b", "classic"]:
 		print("[SettingsService] Invalid visual style: %s" % style)
@@ -285,6 +303,9 @@ func _save_settings() -> void:
 	config.set_value("save_load", "autosave_on_round_end", autosave_on_round_end)
 	config.set_value("save_load", "autosave_on_phase_transition", autosave_on_phase_transition)
 
+	# Gameplay
+	config.set_value("gameplay", "auto_allocate_wounds", auto_allocate_wounds)
+
 	var err = config.save(SETTINGS_FILE_PATH)
 	if err != OK:
 		print("[SettingsService] Failed to save settings: error %d" % err)
@@ -320,5 +341,8 @@ func _load_settings() -> void:
 	save_measurements = config.get_value("save_load", "save_measurements", false)
 	autosave_on_round_end = config.get_value("save_load", "autosave_on_round_end", true)
 	autosave_on_phase_transition = config.get_value("save_load", "autosave_on_phase_transition", false)
+
+	# Gameplay
+	auto_allocate_wounds = config.get_value("gameplay", "auto_allocate_wounds", false)
 
 	print("[SettingsService] Settings loaded from %s" % SETTINGS_FILE_PATH)

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -29,6 +29,8 @@ var _colorblind_dropdown: OptionButton
 var _board_style_dropdown: OptionButton
 var _ruins_style_dropdown: OptionButton
 
+var _auto_allocate_checkbox: CheckBox
+
 var _close_button: Button
 var _return_to_menu_button: Button
 var _save_load_button: Button
@@ -105,7 +107,7 @@ func _build_ui() -> void:
 	tab_bar.add_theme_constant_override("separation", 5)
 	vbox.add_child(tab_bar)
 
-	var tab_names = ["Audio", "Visual", "Controls"]
+	var tab_names = ["Audio", "Visual", "Gameplay", "Controls"]
 	for i in range(tab_names.size()):
 		var tab_btn = Button.new()
 		tab_btn.text = tab_names[i]
@@ -159,6 +161,23 @@ func _build_ui() -> void:
 	_animation_speed_slider = _add_slider_row(visual_content, "Animation Speed:", 0.25, 3.0, 0.25, "_on_animation_speed_changed")
 	_animation_speed_label = _get_last_value_label()
 	_colorblind_dropdown = _add_dropdown_row(visual_content, "Colorblind Mode:", ["None", "Protanopia (Red-Green)", "Deuteranopia (Green-Red)", "Tritanopia (Blue-Yellow)"], "_on_colorblind_changed")
+
+	# ── Gameplay Tab ──
+	var gameplay_scroll = _create_tab_scroll()
+	gameplay_scroll.visible = false
+	content_area.add_child(gameplay_scroll)
+	_tab_containers.append(gameplay_scroll)
+
+	var gameplay_content = gameplay_scroll.get_child(0) as VBoxContainer
+	_add_section_header(gameplay_content, "Wound Allocation")
+	_auto_allocate_checkbox = _add_checkbox_row(gameplay_content, "Computer allocates wounds (auto-remove models)", "_on_auto_allocate_wounds_toggled")
+	var auto_alloc_help = Label.new()
+	auto_alloc_help.text = "When enabled, the computer chooses which wounded models are removed instead of asking you to click each one. The defending player normally makes this choice."
+	auto_alloc_help.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	auto_alloc_help.custom_minimum_size = Vector2(620, 0)
+	auto_alloc_help.add_theme_font_size_override("font_size", 12)
+	auto_alloc_help.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
+	gameplay_content.add_child(auto_alloc_help)
 
 	# ── Controls Tab ──
 	var controls_scroll = _create_tab_scroll()
@@ -463,6 +482,10 @@ func _load_current_settings() -> void:
 	if cb_index >= 0:
 		_colorblind_dropdown.selected = cb_index
 
+	# Gameplay
+	if _auto_allocate_checkbox:
+		_auto_allocate_checkbox.button_pressed = SettingsService.auto_allocate_wounds
+
 func _connect_signals() -> void:
 	# Update in-game-only button visibility
 	_return_to_menu_button.visible = show_return_to_menu
@@ -536,6 +559,13 @@ func _on_colorblind_changed(index: int) -> void:
 	var modes = ["none", "protanopia", "deuteranopia", "tritanopia"]
 	if index >= 0 and index < modes.size():
 		SettingsService.set_colorblind_mode(modes[index])
+
+# ============================================================================
+# Gameplay Callbacks
+# ============================================================================
+
+func _on_auto_allocate_wounds_toggled(pressed: bool) -> void:
+	SettingsService.set_auto_allocate_wounds(pressed)
 
 # ============================================================================
 # Button Callbacks

--- a/40k/scripts/WoundAllocationOverlay.gd
+++ b/40k/scripts/WoundAllocationOverlay.gd
@@ -522,6 +522,13 @@ func _start_wound_allocation() -> void:
 	# Enable input
 	set_process_input(true)
 
+	# Auto-allocation: when the player has opted to let the computer choose which
+	# models are removed, pick a valid target and resolve the wound automatically
+	# instead of waiting for a manual click on the board.
+	if _is_auto_allocate_enabled():
+		_auto_allocate_current_wound()
+		return
+
 	print("WoundAllocationOverlay: Wound allocation started - awaiting input")
 	print("  - Overlay visible: ", visible)
 	print("  - Overlay in tree: ", is_inside_tree())
@@ -1557,6 +1564,78 @@ func _is_valid_selection(model_id: String) -> bool:
 	# Otherwise, any alive model is valid (non-character bodyguard models, or characters if bodyguard dead)
 	var model = _get_model_by_id(model_id)
 	return model.get("alive", true) if not model.is_empty() else false
+
+func _is_auto_allocate_enabled() -> bool:
+	"""Whether the local player has opted to let the computer allocate wounds.
+	Per 10e the defending player chooses casualties; this setting delegates that
+	choice to the computer so the player isn't forced to pick models one-by-one."""
+	var settings = get_node_or_null("/root/SettingsService")
+	if settings == null:
+		return false
+	return settings.get("auto_allocate_wounds") == true
+
+func _auto_allocate_current_wound() -> void:
+	"""Computer picks a valid model for the current wound and resolves it.
+	Mirrors a defender click: priority wounded model first, otherwise the first
+	selectable model (lowest index), respecting CHARACTER protection / precision."""
+	var model_id = _auto_pick_model_id()
+
+	if model_id == "":
+		# No valid model remains (unit wiped) — nothing left to allocate.
+		print("WoundAllocationOverlay: Auto-allocate found no valid model — completing allocation")
+		_complete_allocation()
+		return
+
+	# Reflect that the computer is making the choice in the UI.
+	if instruction_label:
+		instruction_label.text = "[center][b][color=cyan]Computer is allocating wounds…[/color][/b]\n[color=white]Auto-selecting %s[/color][/center]" % _get_model_display_name(model_id)
+
+	# Brief pause so the highlighted target is visible before the save is rolled,
+	# then drive the same path a manual click would take.
+	await get_tree().create_timer(0.4).timeout
+	if not is_inside_tree():
+		return
+	if not awaiting_selection:
+		# State changed underneath us (e.g. overlay closed) — bail.
+		return
+	_on_model_clicked(model_id)
+
+func _auto_pick_model_id() -> String:
+	"""Return the model_id the computer should allocate the next wound to, or ""
+	if no valid model exists. Honours 10e priority: a wounded model that must
+	take the next wound is selected first; otherwise the first selectable model."""
+	# Priority wounded model (and precision-targeted characters) are forced.
+	var priority = get_priority_model_id()
+	if priority != "" and _is_valid_selection(priority):
+		return priority
+
+	# Otherwise pick the first selectable bodyguard model (lowest index).
+	var models = target_unit.get("models", [])
+	for i in range(models.size()):
+		var model = models[i]
+		if not model.get("alive", true):
+			continue
+		var mid = model.get("id", "m%d" % i)
+		if _is_valid_selection(mid):
+			return mid
+
+	# Finally, consider attached character models (selectable once bodyguard is
+	# dead, or during precision wounds).
+	var attached_chars = target_unit.get("attachment_data", {}).get("attached_characters", [])
+	for char_id in attached_chars:
+		var char_unit = GameState.get_unit(char_id)
+		if char_unit.is_empty():
+			continue
+		var char_models = char_unit.get("models", [])
+		for j in range(char_models.size()):
+			var char_model = char_models[j]
+			if not char_model.get("alive", true):
+				continue
+			var composite_id = "%s:%s" % [char_id, char_model.get("id", "m%d" % j)]
+			if _is_valid_selection(composite_id):
+				return composite_id
+
+	return ""
 
 func get_priority_model_id() -> String:
 	"""T5-V7: Return the model_id of the "priority wounded" model — the one

--- a/40k/tests/scenarios/sp/auto_allocate_wounds.json
+++ b/40k/tests/scenarios/sp/auto_allocate_wounds.json
@@ -1,0 +1,45 @@
+{
+  "id": "auto_allocate_wounds",
+  "covers": [
+    "settings.auto_allocate_wounds",
+    "scripts.WoundAllocationOverlay.auto_allocate",
+    "autoloads.SettingsService.set_auto_allocate_wounds"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Auto-allocate wounds setting: when enabled, the WoundAllocationOverlay picks which models are removed for the player instead of waiting for board clicks. Enables the setting, then drives the real save-resolution entry point (ShootingController._on_saves_required) with a 4-wound, AP-3 attack against Boyz F (5+ save -> auto-fail at 8+). With the setting ON the overlay resolves all 4 wounds automatically with NO clicks, killing 4 Boyz. Verifies the setting is stored, the overlay was created, and the casualties landed in GameState.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_auto_allocate_wounds(true)" },
+    { "act": "execute_script",
+      "script": "SettingsService.auto_allocate_wounds",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))",
+      "equals": 20 },
+    { "act": "screenshot", "label": "01_before_auto_allocation" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(4, \"U_BOYZ_F\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Auto-Alloc Test Gun\", \"ap\": -3, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "is_instance_valid(main.get_node(\"ShootingController\").active_allocation_overlay)",
+      "equals": true },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "screenshot", "label": "02_overlay_auto_allocating" },
+
+    { "act": "wait_seconds", "seconds": 9.0 },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))",
+      "equals": 16 },
+    { "act": "screenshot", "label": "03_after_auto_allocation_4_boyz_removed" }
+  ]
+}

--- a/40k/tests/scenarios/sp/auto_allocate_wounds_off.json
+++ b/40k/tests/scenarios/sp/auto_allocate_wounds_off.json
@@ -1,0 +1,44 @@
+{
+  "id": "auto_allocate_wounds_off",
+  "covers": [
+    "settings.auto_allocate_wounds",
+    "scripts.WoundAllocationOverlay.auto_allocate",
+    "autoloads.SettingsService.set_auto_allocate_wounds"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Auto-allocate wounds OFF (default behaviour): with the setting disabled the WoundAllocationOverlay must wait for the player to click models — it must NOT auto-resolve. Disables the setting, drives ShootingController._on_saves_required with a 4-wound attack against Boyz F, waits, and verifies the overlay is still awaiting selection with no wounds allocated and no casualties applied.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_auto_allocate_wounds(false)" },
+    { "act": "execute_script",
+      "script": "SettingsService.auto_allocate_wounds",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))",
+      "equals": 20 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(4, \"U_BOYZ_F\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Auto-Alloc Test Gun\", \"ap\": -3, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+    { "act": "wait_seconds", "seconds": 3.0 },
+
+    { "act": "execute_script",
+      "script": "is_instance_valid(main.get_node(\"ShootingController\").active_allocation_overlay)",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").active_allocation_overlay.awaiting_selection",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").active_allocation_overlay.allocation_history.size()",
+      "equals": 0 },
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))",
+      "equals": 20 },
+    { "act": "screenshot", "label": "01_overlay_waiting_for_player_no_auto" }
+  ]
+}


### PR DESCRIPTION
## Summary

When a unit takes wounds, the `WoundAllocationOverlay` normally asks the local player to click each model to remove. Per 10e rules this is the **defending** player's choice, but the game currently routes it through whoever is at the keyboard (often the attacker), which is incorrect and tedious.

This adds an opt-in **"Computer allocates wounds"** gameplay setting. When enabled, the overlay auto-selects which models are removed instead of waiting for a board click — delegating the casualty choice to the computer until a proper defender-driven flow exists.

## Changes

- **`SettingsService.gd`** — new persisted `auto_allocate_wounds` flag (defaults off) with setter, change signal, and save/load wiring under a new `gameplay` config section.
- **`SettingsMenu.gd`** — new **Gameplay** tab with the toggle and explanatory help text.
- **`WoundAllocationOverlay.gd`** — auto-pick + auto-resolve path gated on the setting. The auto-pick respects the same 10e rules a manual click would: priority wounded model first, then the first selectable model, honouring CHARACTER protection and Precision. The panel shows *"Computer is allocating wounds… Auto-selecting m2"* so it's clear what's happening. When off, nothing changes.

## Validation (windowed scenarios)

Two new scenarios drive the real `ShootingController` → overlay path against the running UI:

- **`auto_allocate_wounds.json`** (15/15 pass) — enables the setting, fires a 4-wound AP-3 attack at a 20-model Boyz unit (saves auto-fail at 8+, deterministic). The overlay resolves all 4 wounds with **zero clicks**, the computer picks models m1–m4, and `GameState` drops 20→16 alive.
- **`auto_allocate_wounds_off.json`** (12/12 pass) — with the setting disabled, the overlay stays in `awaiting_selection`, `allocation_history` is empty, and no casualties land — proving the setting genuinely gates the behavior.

## Future work

The auto-pick currently uses a simple "first available, wounded-first" heuristic. When a smarter casualty-selection AI is desired, `_auto_pick_model_id()` in `WoundAllocationOverlay.gd` is the single place to upgrade.

https://claude.ai/code/session_01EReRkdedU76mExwvyNCRuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EReRkdedU76mExwvyNCRuJ)_