### PR TITLE
Fix roll-off first-turn assignment + dramatic dice UI

### DIFF
--- a/40k/autoloads/TurnManager.gd
+++ b/40k/autoloads/TurnManager.gd
@@ -28,12 +28,22 @@ func _on_phase_completed(completed_phase: GameStateData.Phase) -> void:
 			_titanic_skip_turns.clear()
 			emit_signal("deployment_phase_complete")
 		GameStateData.Phase.SCOUT:
-			# Scout phase complete - roll-off phase will determine who goes first
-			print("TurnManager: Scout phase complete, advancing to Roll-Off phase")
+			# Scout phase is the last pre-game step before battle round 1's
+			# Command phase. The roll-off (which runs back before Deployment)
+			# decided who takes the first turn and stored it in
+			# meta.first_turn_player. Apply it here so the correct player is
+			# active for the first Command phase.
+			#
+			# This is the fix for "Player 1 always goes first": the active
+			# player is otherwise left over from deployment alternation (which
+			# tends to default to Player 1) and the roll-off result is ignored.
+			_apply_first_turn_player()
 		GameStateData.Phase.SCOUT_MOVES:
-			# Scout Moves complete - ensure Player 1 starts the first Command phase
+			# Scout Moves complete - apply the roll-off result so the player
+			# who won the right to the first turn starts the first Command phase
+			# (previously this hard-coded Player 1, ignoring the roll-off).
 			print("TurnManager: Scout Moves phase complete")
-			GameState.set_active_player(1)
+			_apply_first_turn_player()
 		GameStateData.Phase.ROLL_OFF:
 			# Roll-off phase complete - active player was set by the roll-off choice
 			var first_turn_player = GameState.state.get("meta", {}).get("first_turn_player", 1)
@@ -172,6 +182,16 @@ func alternate_active_player() -> void:
 func _set_active_player(player: int) -> void:
 	GameState.set_active_player(player)
 	emit_signal("deployment_side_changed", player)
+
+func _apply_first_turn_player() -> void:
+	# Set the active player to whoever won the right to the first turn in the
+	# pre-deployment roll-off (meta.first_turn_player, set by RollOffPhase).
+	# Falls back to Player 1 if the roll-off never ran or stored a bad value.
+	var first_turn_player = int(GameState.state.get("meta", {}).get("first_turn_player", 1))
+	if first_turn_player != 1 and first_turn_player != 2:
+		first_turn_player = 1
+	print("TurnManager: Applying roll-off result — Player %d takes the first turn" % first_turn_player)
+	_set_active_player(first_turn_player)
 
 func _handle_deployment_phase_start() -> void:
 	# Issue #377: Per Chapter Approved 2025-26, the defender deploys first.

--- a/40k/dialogs/RollOffDialog.gd
+++ b/40k/dialogs/RollOffDialog.gd
@@ -1,19 +1,25 @@
 extends AcceptDialog
 
-# RollOffDialog - UI for the pre-deployment roll-off (issue #85)
+# RollOffDialog - Dramatic UI for the pre-deployment roll-off (issue #85)
 #
 # 10th edition: BEFORE deployment, both players roll a D6. The winner
 # chooses to be the Attacker or the Defender:
 #   - Defender deploys first (and takes the second turn)
 #   - Attacker deploys second (and takes the first turn)
 #
-# This dialog presents both rolls and (for the winner only) two
-# buttons: "Deploy First" and "Deploy Second". Wins emits
-# `choice_made` with the action payload the host session dispatches.
+# This dialog is presented centre-screen and shows two large animated D6
+# dice — one per player. When the player rolls, both dice tumble through
+# random faces for a beat before settling on the real result; the winning
+# die then glows gold and scales up while the loser's die dims. The winner
+# (if local) is then offered "Deploy First" / "Deploy Second".
 #
-# When the roll ties, the dialog shows the tied rolls and a single
-# "Re-roll" button — the next ROLL_FOR_FIRST_TURN action is dispatched
-# with no `dice_roll` override so the engine re-rolls.
+# When the roll ties, both dice settle on the same value, a red "TIED"
+# banner appears and a single "Re-roll" button is shown.
+#
+# Signal/API contract (consumed by Main.gd + tests/scenarios/85_*):
+#   signals: roll_initiated, choice_made(choice), reroll_requested
+#   methods: setup(local_player), show_result(p1, p2, winner), show_tie(p1, p2)
+#   button node names: RollButton / DeployFirstButton / DeploySecondButton / RerollButton
 
 signal roll_initiated()
 signal choice_made(choice: String)  # "first" (deploy second) or "second" (deploy first)
@@ -21,21 +27,33 @@ signal reroll_requested()
 
 enum Mode {
 	AWAITING_ROLL,
+	ROLLING,
 	SHOWING_RESULT,
 	SHOWING_TIE,
 }
+
+# How long the dice tumble before settling on the real values.
+const ROLL_ANIM_DURATION := 1.1
+const ROLL_TICK_INTERVAL := 0.06
 
 var _mode: int = Mode.AWAITING_ROLL
 var _winner: int = 0
 var _local_player: int = 0
 var _p1_roll: int = 0
 var _p2_roll: int = 0
+var _pending_tie: bool = false  # true while animating toward a tied result
 
 # UI references built in _build_ui()
 var _content_vbox: VBoxContainer
+var _heading_label: Label
 var _status_label: Label
-var _result_label: RichTextLabel
+var _dice_row: HBoxContainer
+var _p1_die: Control
+var _p2_die: Control
+var _result_banner: RichTextLabel
 var _button_bar: HBoxContainer
+
+var _tick_timer: Timer
 
 
 func _init() -> void:
@@ -44,8 +62,8 @@ func _init() -> void:
 
 func setup(local_player: int) -> void:
 	_local_player = local_player
-	title = "Pre-deployment Roll-off"
-	min_size = DialogConstants.SMALL
+	title = "Determine First Turn"
+	min_size = DialogConstants.MEDIUM
 	get_ok_button().visible = false
 	if not close_requested.is_connected(_on_close_requested):
 		close_requested.connect(_on_close_requested)
@@ -62,25 +80,38 @@ func show_result(p1_roll: int, p2_roll: int, winner: int) -> void:
 	_p1_roll = p1_roll
 	_p2_roll = p2_roll
 	_winner = winner
-	_mode = Mode.SHOWING_RESULT
-	_refresh_for_mode()
+	_pending_tie = false
+	_begin_roll_animation()
 
 
 func show_tie(p1_roll: int, p2_roll: int) -> void:
 	_p1_roll = p1_roll
 	_p2_roll = p2_roll
-	_mode = Mode.SHOWING_TIE
-	_refresh_for_mode()
+	_winner = 0
+	_pending_tie = true
+	_begin_roll_animation()
 
 
 # --- UI construction ---------------------------------------------------------
 
 func _build_ui() -> void:
 	_content_vbox = VBoxContainer.new()
-	_content_vbox.add_theme_constant_override("separation", 12)
+	_content_vbox.name = "Content"
+	_content_vbox.add_theme_constant_override("separation", 14)
+	# Constrain the width so autowrap labels compute their height correctly and
+	# the dialog stays a compact, centre-screen panel (mirrors CommandRerollDialog).
+	_content_vbox.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
 	add_child(_content_vbox)
 
+	_heading_label = Label.new()
+	_heading_label.text = "WHO SEIZES THE INITIATIVE?"
+	_heading_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	_heading_label.add_theme_font_size_override("font_size", 22)
+	_heading_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	_content_vbox.add_child(_heading_label)
+
 	_status_label = Label.new()
+	_status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_status_label.add_theme_font_size_override("font_size", 14)
 	_status_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_PARCHMENT)
 	_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
@@ -93,16 +124,60 @@ func _build_ui() -> void:
 	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	_content_vbox.add_child(sep)
 
-	_result_label = RichTextLabel.new()
-	_result_label.bbcode_enabled = true
-	_result_label.fit_content = true
-	_result_label.custom_minimum_size = Vector2(DialogConstants.SMALL.x - 40, 80)
-	_content_vbox.add_child(_result_label)
+	# Two big dice side by side, each with the player label above it.
+	_dice_row = HBoxContainer.new()
+	_dice_row.alignment = BoxContainer.ALIGNMENT_CENTER
+	_dice_row.add_theme_constant_override("separation", 48)
+	_dice_row.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_content_vbox.add_child(_dice_row)
+
+	_p1_die = _make_die_column(1)
+	_p2_die = _make_die_column(2)
+	_dice_row.add_child(_p1_die.get_parent())
+	_dice_row.add_child(_p2_die.get_parent())
+
+	_result_banner = RichTextLabel.new()
+	_result_banner.bbcode_enabled = true
+	_result_banner.fit_content = true
+	_result_banner.scroll_active = false
+	_result_banner.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 40, 50)
+	_content_vbox.add_child(_result_banner)
 
 	_button_bar = HBoxContainer.new()
-	_button_bar.alignment = BoxContainer.ALIGNMENT_END
+	_button_bar.name = "ButtonBar"
+	_button_bar.alignment = BoxContainer.ALIGNMENT_CENTER
 	_button_bar.add_theme_constant_override("separation", 12)
 	_content_vbox.add_child(_button_bar)
+
+	_tick_timer = Timer.new()
+	_tick_timer.one_shot = false
+	_tick_timer.wait_time = ROLL_TICK_INTERVAL
+	_tick_timer.timeout.connect(_on_roll_tick)
+	add_child(_tick_timer)
+
+
+# Builds a VBox containing a "Player N" label and a DiceFace. Returns the
+# DiceFace control (its parent is the column VBox).
+func _make_die_column(player: int) -> Control:
+	var col := VBoxContainer.new()
+	col.alignment = BoxContainer.ALIGNMENT_CENTER
+	col.add_theme_constant_override("separation", 8)
+
+	var name_label := Label.new()
+	name_label.text = "Player %d" % player
+	name_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	name_label.add_theme_font_size_override("font_size", 16)
+	name_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_BONE)
+	col.add_child(name_label)
+
+	var die := DiceFace.new()
+	die.name = "Player%dDie" % player
+	die.custom_minimum_size = Vector2(110, 110)
+	die.value = 1
+	die.pivot_offset = Vector2(55, 55)
+	col.add_child(die)
+
+	return die
 
 
 func _refresh_for_mode() -> void:
@@ -113,56 +188,126 @@ func _refresh_for_mode() -> void:
 
 	match _mode:
 		Mode.AWAITING_ROLL:
-			_status_label.text = "Both players roll a D6 to decide who deploys first."
-			_result_label.text = "[i]The winner chooses to be Attacker or Defender:[/i]\n" + \
-				"  • [b]Defender[/b] deploys first, takes the second turn\n" + \
-				"  • [b]Attacker[/b] deploys second, takes the first turn"
+			_heading_label.text = "WHO SEIZES THE INITIATIVE?"
+			_status_label.text = "Both players roll a D6. Winner chooses to be Attacker (go first) or Defender (deploy first)."
+			_result_banner.text = ""
+			_p1_die.value = 1
+			_p2_die.value = 1
+			_p1_die.highlight = DiceFace.Highlight.NONE
+			_p2_die.highlight = DiceFace.Highlight.NONE
+			_p1_die.modulate = Color.WHITE
+			_p2_die.modulate = Color.WHITE
 			var roll_button := Button.new()
 			roll_button.name = "RollButton"
-			roll_button.text = "Roll for first turn"
+			roll_button.text = "⚄  Roll for First Turn"
 			roll_button.pressed.connect(_on_roll_pressed)
 			WhiteDwarfTheme.apply_primary_button(roll_button)
 			_button_bar.add_child(roll_button)
+		Mode.ROLLING:
+			_heading_label.text = "ROLLING…"
+			_status_label.text = "The dice are cast!"
+			_result_banner.text = ""
 		Mode.SHOWING_RESULT:
-			_status_label.text = "Roll result"
-			var p1_marker := " " if _p1_roll < _p2_roll else "✓"
-			var p2_marker := " " if _p2_roll < _p1_roll else "✓"
-			_result_label.text = (
-				"[b]Player 1[/b] rolled [b]%d[/b] %s\n" % [_p1_roll, p1_marker] +
-				"[b]Player 2[/b] rolled [b]%d[/b] %s\n" % [_p2_roll, p2_marker] +
-				"\n[color=#D49761][b]Player %d wins the roll-off.[/b][/color]" % _winner
+			_heading_label.text = "FIRST TURN DECIDED"
+			_status_label.text = "Roll-off result"
+			var winner_color := "#D49761"
+			_result_banner.text = (
+				"[center][color=%s][b]Player %d wins the roll-off — %d vs %d![/b][/color][/center]"
+				% [winner_color, _winner, _p1_roll, _p2_roll]
 			)
 			if _winner == _local_player:
 				var first_button := Button.new()
 				first_button.name = "DeployFirstButton"
 				first_button.text = "Deploy first (Defender)"
 				first_button.pressed.connect(_on_deploy_first_pressed)
-				WhiteDwarfTheme.apply_primary_button(first_button)
+				WhiteDwarfTheme.apply_secondary_button(first_button)
 				_button_bar.add_child(first_button)
 
 				var second_button := Button.new()
 				second_button.name = "DeploySecondButton"
-				second_button.text = "Deploy second (Attacker)"
+				second_button.text = "Go first (Attacker)"
 				second_button.pressed.connect(_on_deploy_second_pressed)
-				WhiteDwarfTheme.apply_secondary_button(second_button)
+				WhiteDwarfTheme.apply_primary_button(second_button)
 				_button_bar.add_child(second_button)
 			else:
 				var waiting := Label.new()
-				waiting.text = "Waiting for Player %d to choose..." % _winner
+				waiting.text = "Waiting for Player %d to choose…" % _winner
 				waiting.add_theme_color_override("font_color",
 					WhiteDwarfTheme.WH_BONE)
 				_button_bar.add_child(waiting)
 		Mode.SHOWING_TIE:
-			_status_label.text = "Roll-off tied — must re-roll."
-			_result_label.text = "[b]Player 1[/b] rolled [b]%d[/b]\n" % _p1_roll + \
-				"[b]Player 2[/b] rolled [b]%d[/b]\n" % _p2_roll + \
-				"\n[color=#9A1115][b]TIED at %d — re-roll required.[/b][/color]" % _p1_roll
+			_heading_label.text = "A DEAD HEAT!"
+			_status_label.text = "Both warlords matched — the gods demand a re-roll."
+			_result_banner.text = (
+				"[center][color=#9A1115][b]TIED at %d — re-roll required![/b][/color][/center]"
+				% _p1_roll
+			)
 			var reroll_button := Button.new()
 			reroll_button.name = "RerollButton"
-			reroll_button.text = "Re-roll"
+			reroll_button.text = "⟳  Re-roll"
 			reroll_button.pressed.connect(_on_reroll_pressed)
 			WhiteDwarfTheme.apply_primary_button(reroll_button)
 			_button_bar.add_child(reroll_button)
+
+
+# --- Roll animation ----------------------------------------------------------
+
+func _begin_roll_animation() -> void:
+	_mode = Mode.ROLLING
+	_refresh_for_mode()
+	# Clear any prior highlight while tumbling.
+	_p1_die.highlight = DiceFace.Highlight.NONE
+	_p2_die.highlight = DiceFace.Highlight.NONE
+	_p1_die.modulate = Color.WHITE
+	_p2_die.modulate = Color.WHITE
+	_tick_timer.start()
+	# Settle after the tumble duration, then reveal the real result.
+	var settle := get_tree().create_timer(ROLL_ANIM_DURATION)
+	settle.timeout.connect(_on_roll_settle)
+
+
+func _on_roll_tick() -> void:
+	# Tumble: show random faces and give each die a little jitter.
+	_p1_die.value = randi_range(1, 6)
+	_p2_die.value = randi_range(1, 6)
+	_p1_die.rotation = randf_range(-0.18, 0.18)
+	_p2_die.rotation = randf_range(-0.18, 0.18)
+
+
+func _on_roll_settle() -> void:
+	_tick_timer.stop()
+	_p1_die.value = _p1_roll
+	_p2_die.value = _p2_roll
+	_p1_die.rotation = 0.0
+	_p2_die.rotation = 0.0
+
+	if _pending_tie:
+		_mode = Mode.SHOWING_TIE
+		_p1_die.highlight = DiceFace.Highlight.TIE
+		_p2_die.highlight = DiceFace.Highlight.TIE
+		_refresh_for_mode()
+		_pop_die(_p1_die)
+		_pop_die(_p2_die)
+		return
+
+	# Highlight winner gold, dim the loser, and give the winner a pop.
+	var winner_die: Control = _p1_die if _winner == 1 else _p2_die
+	var loser_die: Control = _p2_die if _winner == 1 else _p1_die
+	winner_die.highlight = DiceFace.Highlight.WINNER
+	loser_die.highlight = DiceFace.Highlight.LOSER
+	loser_die.modulate = Color(0.6, 0.6, 0.6, 1.0)
+	_mode = Mode.SHOWING_RESULT
+	_refresh_for_mode()
+	_pop_die(winner_die)
+
+
+# A quick scale-up-and-settle "pop" so the reveal feels dramatic.
+func _pop_die(die: Control) -> void:
+	die.scale = Vector2(0.6, 0.6)
+	var tween := create_tween()
+	tween.set_trans(Tween.TRANS_BACK).set_ease(Tween.EASE_OUT)
+	tween.tween_property(die, "scale", Vector2(1.25, 1.25), 0.18)
+	tween.tween_property(die, "scale", Vector2(1.0, 1.0), 0.12)
 
 
 # --- Signal handlers ---------------------------------------------------------
@@ -178,8 +323,7 @@ func _on_deploy_first_pressed() -> void:
 
 
 func _on_deploy_second_pressed() -> void:
-	# "Deploy second" = attacker = CHOOSE_TURN_ORDER choice "first" (go
-	# first in turn order).
+	# "Deploy second / go first" = attacker = CHOOSE_TURN_ORDER choice "first".
 	emit_signal("choice_made", "first")
 
 
@@ -190,3 +334,86 @@ func _on_reroll_pressed() -> void:
 func _on_close_requested() -> void:
 	# Ignore close attempts — the roll-off must complete to proceed.
 	pass
+
+
+# -----------------------------------------------------------------------------
+# DiceFace — a Control that draws a single D6 face with pips, themed to match
+# the parchment/gold White Dwarf styling. `value` (1-6) drives the pip layout;
+# `highlight` tints the face for winner/loser/tie states.
+# -----------------------------------------------------------------------------
+class DiceFace extends Control:
+	enum Highlight { NONE, WINNER, LOSER, TIE }
+
+	var value: int = 1:
+		set(v):
+			value = clampi(v, 1, 6)
+			queue_redraw()
+	var highlight: int = Highlight.NONE:
+		set(h):
+			highlight = h
+			queue_redraw()
+
+	func _draw() -> void:
+		var sz := size
+		var rect := Rect2(Vector2.ZERO, sz)
+
+		# Face colour + border depend on highlight state.
+		var face_color := Color(0.922, 0.882, 0.780)   # WH_PARCHMENT
+		var border_color := Color(0.833, 0.588, 0.376)  # WH_GOLD
+		var border_w := 3.0
+		match highlight:
+			Highlight.WINNER:
+				face_color = Color(1.0, 0.93, 0.74)
+				border_color = Color(1.0, 0.78, 0.30)
+				border_w = 6.0
+			Highlight.LOSER:
+				face_color = Color(0.78, 0.75, 0.66)
+				border_color = Color(0.55, 0.50, 0.42)
+			Highlight.TIE:
+				border_color = Color(0.604, 0.067, 0.082)  # WH_RED
+				border_w = 5.0
+
+		# Soft drop shadow for depth.
+		var shadow_rect := Rect2(rect.position + Vector2(4, 5), rect.size)
+		_draw_round_rect(shadow_rect, Color(0, 0, 0, 0.35), 14.0)
+		# Die body + border.
+		_draw_round_rect(rect, face_color, 14.0)
+		_draw_round_rect_outline(rect, border_color, 14.0, border_w)
+
+		# Pips.
+		var pip_color := Color(0.12, 0.10, 0.09)
+		var pip_r: float = min(sz.x, sz.y) * 0.085
+		for p in _pip_positions(value):
+			draw_circle(Vector2(p.x * sz.x, p.y * sz.y), pip_r, pip_color)
+
+	# Normalised pip positions (0..1) for each die value.
+	func _pip_positions(v: int) -> Array:
+		var c := Vector2(0.5, 0.5)
+		var tl := Vector2(0.28, 0.28)
+		var tr := Vector2(0.72, 0.28)
+		var bl := Vector2(0.28, 0.72)
+		var br := Vector2(0.72, 0.72)
+		var ml := Vector2(0.28, 0.5)
+		var mr := Vector2(0.72, 0.5)
+		match v:
+			1: return [c]
+			2: return [tl, br]
+			3: return [tl, c, br]
+			4: return [tl, tr, bl, br]
+			5: return [tl, tr, c, bl, br]
+			6: return [tl, tr, ml, mr, bl, br]
+		return [c]
+
+	func _draw_round_rect(rect: Rect2, color: Color, radius: float) -> void:
+		var sb := StyleBoxFlat.new()
+		sb.bg_color = color
+		sb.set_corner_radius_all(int(radius))
+		draw_style_box(sb, rect)
+
+	func _draw_round_rect_outline(rect: Rect2, color: Color, radius: float, width: float) -> void:
+		var sb := StyleBoxFlat.new()
+		sb.bg_color = Color(0, 0, 0, 0)
+		sb.set_corner_radius_all(int(radius))
+		sb.set_border_width_all(int(width))
+		sb.border_color = color
+		draw_style_box(sb, rect)

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6923,6 +6923,7 @@ func _show_roll_off_dialog(local_player: int) -> void:
 	var dialog_script = preload("res://dialogs/RollOffDialog.gd")
 	roll_off_dialog = AcceptDialog.new()
 	roll_off_dialog.set_script(dialog_script)
+	roll_off_dialog.name = "RollOffDialog"
 	roll_off_dialog.exclusive = true
 	add_child(roll_off_dialog)
 	roll_off_dialog.setup(local_player)

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -49,6 +49,8 @@ TESTS=(
     "tests/test_test_mode_handler_command_dedupe.gd"
     "tests/test_test_mode_handler_transition.gd"
     "tests/test_rng_determinism_extended.gd"
+    "tests/test_roll_off_first_turn_applied.gd"
+    "tests/test_roll_off_dialog.gd"
 )
 
 FAILED=0

--- a/40k/tests/scenarios/sp/85b_rolloff_dramatic.json
+++ b/40k/tests/scenarios/sp/85b_rolloff_dramatic.json
@@ -1,0 +1,30 @@
+{
+  "id": "85b_rolloff_dramatic",
+  "covers": [
+    "deployment.predeploy_roll_off",
+    "ui.RollOffDialog.animated_dice",
+    "ui.RollOffDialog.RollButton",
+    "phases.RollOffPhase.ROLL_FOR_FIRST_TURN",
+    "phases.RollOffPhase.CHOOSE_TURN_ORDER"
+  ],
+  "fixture": "audit_367_warlord",
+  "transition_to_phase": 3,
+  "disable_ai": true,
+  "rng_seed": 2,
+  "description": "Issue: validate the pre-deployment roll-off is driven by the REAL player path (clicking the on-screen 'Roll for First Turn' button) and that the dramatic animated dice render and settle on the rolled values. Capture the result, then have the winner pick a turn order via the real button.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 3 },
+    { "act": "screenshot", "label": "01_dice_awaiting" },
+
+    { "act": "click_node", "node": "/root/Main/RollOffDialog/Content/ButtonBar/RollButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 1.6 },
+    { "act": "expect_state", "path": "meta.roll_off_winner", "equals": 1 },
+    { "act": "screenshot", "label": "02_dice_settled_winner" },
+
+    { "act": "click_node", "node": "/root/Main/RollOffDialog/Content/ButtonBar/DeploySecondButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "expect_state", "path": "meta.first_turn_player", "equals": 1 },
+    { "act": "screenshot", "label": "03_p1_goes_first" }
+  ]
+}

--- a/40k/tests/test_roll_off_dialog.gd
+++ b/40k/tests/test_roll_off_dialog.gd
@@ -1,0 +1,82 @@
+extends SceneTree
+
+# Validates the dramatic RollOffDialog: dice render with the rolled values,
+# the animation settles into the correct mode, the winner is highlighted, and
+# the winner is offered the deploy-order choice. Tie shows a Re-roll button.
+#
+# Usage: godot --headless --path . -s tests/test_roll_off_dialog.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_roll_off_dialog ===\n")
+
+	var dialog_script = load("res://dialogs/RollOffDialog.gd")
+	_check("RollOffDialog.gd loads (parses)", dialog_script != null)
+	if dialog_script == null:
+		_finish()
+		return
+
+	var dialog = AcceptDialog.new()
+	dialog.set_script(dialog_script)
+	root.add_child(dialog)
+	dialog.setup(1)  # local player = 1
+
+	# Awaiting-roll state exposes the Roll button.
+	_check("RollButton present before rolling",
+		dialog.find_child("RollButton", true, false) != null)
+
+	# --- P1 wins 5 vs 3 -----------------------------------------------------
+	dialog.show_result(5, 3, 1)
+	await create_timer(1.4).timeout
+
+	_check("After settle: P1 die shows 5",
+		dialog._p1_die.value == 5, "value=%d" % dialog._p1_die.value)
+	_check("After settle: P2 die shows 3",
+		dialog._p2_die.value == 3, "value=%d" % dialog._p2_die.value)
+	_check("Winner die (P1) highlighted as WINNER",
+		dialog._p1_die.highlight == dialog._p1_die.Highlight.WINNER)
+	_check("Loser die (P2) highlighted as LOSER",
+		dialog._p2_die.highlight == dialog._p2_die.Highlight.LOSER)
+	_check("Local winner offered Deploy First",
+		dialog.find_child("DeployFirstButton", true, false) != null)
+	_check("Local winner offered Go First (attacker)",
+		dialog.find_child("DeploySecondButton", true, false) != null)
+
+	# choice_made('first') must be emitted when "Go first (Attacker)" pressed.
+	var got_choice := {"v": ""}
+	dialog.choice_made.connect(func(c): got_choice.v = c)
+	dialog.find_child("DeploySecondButton", true, false).emit_signal("pressed")
+	_check("Go-first button emits choice_made('first')",
+		got_choice.v == "first", "got=%s" % got_choice.v)
+
+	# --- Tie 4 vs 4 ---------------------------------------------------------
+	dialog.show_tie(4, 4)
+	await create_timer(1.4).timeout
+	_check("Tie: both dice show 4",
+		dialog._p1_die.value == 4 and dialog._p2_die.value == 4)
+	_check("Tie: Re-roll button present",
+		dialog.find_child("RerollButton", true, false) != null)
+	_check("Tie: dice highlighted as TIE",
+		dialog._p1_die.highlight == dialog._p1_die.Highlight.TIE)
+
+	dialog.queue_free()
+	_finish()
+
+func _finish() -> void:
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_roll_off_first_turn_applied.gd
+++ b/40k/tests/test_roll_off_first_turn_applied.gd
@@ -1,0 +1,121 @@
+extends SceneTree
+
+# Regression test: the pre-deployment roll-off result must actually decide
+# who takes the first turn.
+#
+# Bug: RollOffPhase correctly computed meta.first_turn_player, but nothing
+# applied it as the active player when battle round 1 began. The active
+# player was left over from deployment alternation (which tends to default
+# to Player 1), so "Player 1 always went first" regardless of the roll-off.
+#
+# Fix: TurnManager._on_phase_completed(SCOUT) (and SCOUT_MOVES) now call
+# _apply_first_turn_player(), which sets the active player to
+# meta.first_turn_player.
+#
+# Usage: godot --headless --path . -s tests/test_roll_off_first_turn_applied.gd
+
+const GSD = preload("res://autoloads/GameState.gd")
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_roll_off_first_turn_applied ===\n")
+
+	_test_rolloff_phase_computes_first_turn()
+	_test_scout_complete_applies_first_turn()
+	_test_fallback_when_no_rolloff()
+
+	_finish()
+
+# ----------------------------------------------------------------------------
+# RollOffPhase: a P2 win followed by "go first" must set first_turn_player = 2
+# ----------------------------------------------------------------------------
+func _test_rolloff_phase_computes_first_turn() -> void:
+	print("\n-- RollOffPhase computes first_turn_player from the dice --")
+	var RollOffPhase = load("res://phases/RollOffPhase.gd")
+	var phase = RollOffPhase.new()
+	phase._on_phase_enter()
+
+	# Force P2 to win the roll (3 vs 5).
+	var roll_result = phase.process_action({"type": "ROLL_FOR_FIRST_TURN", "dice_roll": [3, 5]})
+	_check("Roll-off with [3,5] → P2 wins",
+		roll_result.get("winner", 0) == 2,
+		"winner=%s" % str(roll_result.get("winner")))
+
+	# Winner chooses to go first (attacker / deploy second).
+	var choice_result = phase.process_action({"type": "CHOOSE_TURN_ORDER", "choice": "first"})
+	_check("Winner P2 chooses 'first' → first_turn_player = 2",
+		choice_result.get("first_turn_player", 0) == 2,
+		"first_turn_player=%s" % str(choice_result.get("first_turn_player")))
+
+	# The emitted changes must set meta.first_turn_player = 2.
+	var changes = choice_result.get("changes", [])
+	var found_ftp := false
+	for c in changes:
+		if c.get("path", "") == "meta.first_turn_player":
+			found_ftp = c.get("value", -1) == 2
+	_check("changes set meta.first_turn_player = 2", found_ftp)
+
+# ----------------------------------------------------------------------------
+# TurnManager: when SCOUT completes, the active player becomes
+# meta.first_turn_player (the roll-off winner), not the deployment leftover.
+# ----------------------------------------------------------------------------
+func _test_scout_complete_applies_first_turn() -> void:
+	print("\n-- Scout completion applies the roll-off first-turn player --")
+	var game_state = root.get_node("GameState")
+	var turn_mgr = root.get_node("TurnManager")
+
+	# Roll-off decided Player 2 goes first.
+	game_state.state["meta"]["first_turn_player"] = 2
+	# Simulate the "Player 1 leftover" deployment state the bug produced.
+	game_state.set_active_player(1)
+	_check("Pre-condition: active player is the leftover P1",
+		game_state.get_active_player() == 1)
+
+	# Scout phase finishing is the last gate before battle round 1.
+	turn_mgr._on_phase_completed(GSD.Phase.SCOUT)
+	_check("After SCOUT complete → active player is the roll-off winner (P2)",
+		game_state.get_active_player() == 2,
+		"active=%s" % str(game_state.get_active_player()))
+
+	# And it must work the other way too (P1 won the roll-off).
+	game_state.state["meta"]["first_turn_player"] = 1
+	game_state.set_active_player(2)
+	turn_mgr._on_phase_completed(GSD.Phase.SCOUT)
+	_check("Roll-off winner P1 → active player becomes P1",
+		game_state.get_active_player() == 1,
+		"active=%s" % str(game_state.get_active_player()))
+
+# ----------------------------------------------------------------------------
+# Safety: if the roll-off never ran (no meta.first_turn_player), fall back to P1.
+# ----------------------------------------------------------------------------
+func _test_fallback_when_no_rolloff() -> void:
+	print("\n-- Missing first_turn_player falls back to P1 --")
+	var game_state = root.get_node("GameState")
+	var turn_mgr = root.get_node("TurnManager")
+
+	game_state.state["meta"].erase("first_turn_player")
+	game_state.set_active_player(2)
+	turn_mgr._on_phase_completed(GSD.Phase.SCOUT)
+	_check("No first_turn_player → active player defaults to P1",
+		game_state.get_active_player() == 1,
+		"active=%s" % str(game_state.get_active_player()))
+
+func _finish() -> void:
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_roll_off_first_turn_applied.gd.uid
+++ b/40k/tests/test_roll_off_first_turn_applied.gd.uid
@@ -1,0 +1,1 @@
+uid://b0n5pbo6jigj4


### PR DESCRIPTION
## Problem

Player 1 always appeared to go first. The pre-deployment roll-off *did* run and correctly compute the winner (`meta.first_turn_player`), but nothing ever applied that result as the active player when battle round 1 began. The active player was left over from deployment alternation (which sets the defender active, then alternates) and tended to land on Player 1. `TurnManager` even had a stale handler that hard-coded `set_active_player(1)` before the first Command phase.

## Changes

- **`TurnManager.gd`** — when the Scout phase completes (the last gate before the first Command phase), set the active player to `meta.first_turn_player` (the roll-off winner) via a new `_apply_first_turn_player()` helper, with a Player-1 fallback if the roll-off never ran. Also fixes the stale Scout-Moves handler that hard-coded Player 1.
- **`RollOffDialog.gd`** — redesigned into a dramatic centre-screen reveal: two large D6 dice (drawn with pips, parchment faces, gold borders, drop shadows) tumble through random faces, settle on the rolled values, then the winner's die glows gold and pops while the loser's dims. Ties show a red banner + Re-roll button.
- **`Main.gd`** — name the dialog node so windowed scenarios can drive the real buttons.

## Validation

- `tests/test_roll_off_first_turn_applied.gd` (7/7) — roll-off result is applied as the active player for battle round 1, both directions + fallback.
- `tests/test_roll_off_dialog.gd` (12/12) — dice render rolled values, winner highlighted, choice/re-roll buttons exposed.
- `tests/scenarios/sp/85b_rolloff_dramatic.json` — windowed scenario drives the **real** on-screen Roll button and turn-order choice end-to-end (per the project's feature-validation rule).
- Existing `85_predeploy_rolloff` and `377_defender_deploys_first` scenarios still pass.

https://claude.ai/code/session_017rMSrubjVaDzykUUe3d664

---
_Generated by [Claude Code](https://claude.ai/code/session_017rMSrubjVaDzykUUe3d664)_