### PR TITLE
Snap nested scout tokens back to state on invalid/uncommitted moves

### DIFF
--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -791,9 +791,26 @@ func _sync_all_token_positions() -> void:
 	# T-049: tween tokens to their state-driven positions instead of snapping
 	# (so opponent / AI moves are visible as smooth animations).
 	for child in token_layer.get_children():
-		if child.has_meta("unit_id") and child.has_meta("model_id"):
-			var unit_id = child.get_meta("unit_id")
-			var model_id = child.get_meta("model_id")
+		# Resolve the node carrying unit/model metadata. Flat tokens (created by
+		# _recreate_unit_visuals) carry the meta on the child itself; NESTED
+		# deployment tokens (wrapper Node2D -> TokenVisual, created by
+		# DeploymentController._create_token_visual) carry it on the first
+		# grandchild. Scout-phase tokens are the nested deployment tokens
+		# because nothing recreates them as flat between deployment and scout,
+		# so we must handle both forms here — otherwise an uncommitted/invalid
+		# scout drag leaves the nested token stranded at the moved position
+		# while GameState keeps the original, and the movement phase then
+		# targets the stale coordinate. We always reposition the direct child
+		# (the wrapper for nested tokens), matching how the drag/reset code
+		# repositions tokens.
+		var meta_node = child
+		if not (child.has_meta("unit_id") and child.has_meta("model_id")) and child.get_child_count() > 0:
+			var inner = child.get_child(0)
+			if inner.has_meta("unit_id") and inner.has_meta("model_id"):
+				meta_node = inner
+		if meta_node.has_meta("unit_id") and meta_node.has_meta("model_id"):
+			var unit_id = meta_node.get_meta("unit_id")
+			var model_id = meta_node.get_meta("model_id")
 			var unit = GameState.get_unit(unit_id)
 			if unit.is_empty():
 				continue

--- a/40k/tests/scenarios/sp/scout_invalid_move_snaps_back_nested.json
+++ b/40k/tests/scenarios/sp/scout_invalid_move_snaps_back_nested.json
@@ -1,0 +1,82 @@
+{
+  "id": "scout_invalid_move_snaps_back_nested",
+  "covers": [
+    "phases.ScoutPhase.UI.invalid_move_snaps_back_nested_token",
+    "Main._sync_all_token_positions.handles_nested_deployment_tokens"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Bug repro + fix proof. Real-play scout tokens are the NESTED deployment tokens (wrapper Node2D -> TokenVisual, meta on the child) created by DeploymentController and never recreated as flat before the scout phase. When a scout move is invalid (per-model SET passes but CONFIRM fails coherency), _on_scout_confirm_pressed shows a toast and calls _sync_all_token_positions() to roll the visual back. Before the fix, _sync_all_token_positions only read unit_id/model_id meta off the DIRECT child, so it skipped nested tokens entirely and left the model stranded at the invalid spot while GameState kept the original position (the user's report: scout looks moved, but movement phase targets the old spot). This scenario deploys U_WITCHSEEKERS_C interactively (producing genuine nested tokens), grants Scouts, stages a coherency-breaking move while moving the real nested token to the invalid spot (mirroring the drag), drives the real confirm handler, and asserts the nested token snaps back to the deployed/state position and GameState is unchanged.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_WITCHSEEKERS_C')" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(880, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(920, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(960, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.confirm()" },
+    { "act": "wait_frames", "frames": 10 },
+
+    { "act": "expect_state", "path": "units.U_WITCHSEEKERS_C.status", "equals": 2 },
+    { "act": "execute_script", "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.x)", "equals": 880.0 },
+
+    { "act": "execute_script",
+      "script": "str(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').get_child(0).has_meta('model_id'))",
+      "equals": "true" },
+    { "act": "execute_script",
+      "script": "str(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').has_meta('model_id'))",
+      "equals": "false" },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+    { "act": "execute_script", "script": "str(GameState.unit_has_scout('U_WITCHSEEKERS_C'))", "equals": "true" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script", "script": "Main.set('_scout_active_unit_id', 'U_WITCHSEEKERS_C')" },
+    { "act": "execute_script", "script": "Main.set('_scout_move_distance', 6.0)" },
+
+    { "act": "dispatch_action", "action": { "type": "BEGIN_SCOUT_MOVE", "unit_id": "U_WITCHSEEKERS_C" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SET_SCOUT_MODEL_DEST",
+      "unit_id": "U_WITCHSEEKERS_C",
+      "model_id": "m1",
+      "destination": { "x": 880.0, "y": 470.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').set('position', Vector2(880, 470))" },
+    { "act": "execute_script",
+      "script": "float(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').position.y)",
+      "equals": 470.0 },
+
+    { "act": "execute_script", "script": "Main._on_scout_confirm_pressed()" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "execute_script",
+      "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.x)",
+      "equals": 880.0 },
+    { "act": "execute_script",
+      "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y)",
+      "equals": 240.0 },
+
+    { "act": "execute_script",
+      "script": "float(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').position.x)",
+      "equals": 880.0 },
+    { "act": "execute_script",
+      "script": "float(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').position.y)",
+      "equals": 240.0 },
+    { "act": "screenshot", "label": "nested_token_snapped_back_after_invalid_scout" }
+  ]
+}


### PR DESCRIPTION
## Summary

Followup to #440 / #442. Fixes the recurring "scout looks moved but the movement phase uses the old spot" bug. The divergence only happens for **invalid or uncommitted** scout moves — valid confirmed moves were never affected.

## Root cause

In real play, scout-phase tokens are the **nested** deployment tokens (wrapper `Node2D` → `TokenVisual`, with `unit_id`/`model_id` meta on the child) created by `DeploymentController`. Nothing recreates them as flat between deployment and the scout phase. But `_sync_all_token_positions()` only read the meta off the **direct** child, so it silently skipped every nested token and never repositioned it.

When a scout move is invalid (each per-model placement passes but `CONFIRM` fails coherency) or is staged and then abandoned, the confirm-failure path shows a toast and calls `_sync_all_token_positions()` to roll the visual back — but the nested token was skipped, leaving it stranded at the invalid spot while `GameState` kept the original position. The movement phase then click-targeted the stale coordinate.

Valid confirmed moves were unaffected because `CONFIRM` success runs `_recreate_unit_visuals()`, which rebuilds flat tokens at the committed positions.

## Changes

- **`Main.gd` `_sync_all_token_positions()`** — Resolve `unit_id`/`model_id` meta from the direct child OR its first grandchild (mirroring the nesting handling already used by `_scout_find_model_at_position`, `_scout_handle_mouse_motion`, and `_scout_reset_previous_unit`) and reposition the direct child. This makes the existing snap-back + toast actually move the model back, and snaps abandoned staged moves back on phase change — matching the movement-phase "illegal move snaps back" behavior.

## Test Coverage

New windowed scenario `scout_invalid_move_snaps_back_nested.json` deploys a unit interactively (producing genuine nested tokens), grants Scouts, stages a coherency-breaking move, drives the real confirm handler, and asserts the nested token snaps back to the deployed/state position while `GameState` is unchanged. Confirmed it **fails without the fix** (token stranded at the invalid spot). All 7 scout scenarios pass.

https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq)_