### PR TITLE
Game log: render dice rolls as grouped die icons with counts

### DIFF
--- a/40k/scripts/DiceRowVisual.gd
+++ b/40k/scripts/DiceRowVisual.gd
@@ -4,12 +4,24 @@ class_name DiceRowVisual
 # DiceRowVisual - Static inline dice row for embedding inside the game log.
 # Mirrors the color-coding of DiceRollVisual (gold=6, red=1, green=success,
 # gray=fail) but renders a single static frame: no animation, no fade, no sound.
+#
+# Grouped mode (default): instead of drawing every die individually, identical
+# values are grouped. Each distinct face value (1..6) is drawn ONCE as a die
+# icon followed by a "xN" count of how many of that value were rolled. So a
+# roll of [1, 1, 2, 6] renders as: [die-1] x2  [die-2] x1  [die-6] x1.
+# Ungrouped mode draws every die individually (legacy behaviour, used by callers
+# that pass grouped = false).
 
 const DIE_SIZE := 18.0
 const DIE_MARGIN := 3.0
 const DIE_CORNER_RADIUS := 3.0
 const ROW_SPACING := 3.0
 const MAX_DICE_PER_ROW := 10
+
+# Grouped-mode layout
+const COUNT_FONT_SIZE := 11
+const COUNT_GAP := 3.0      # gap between a die icon and its "xN" count
+const GROUP_SPACING := 9.0  # gap between adjacent value-groups
 
 const COLOR_CRITICAL := Color(1.0, 0.84, 0.0)
 const COLOR_FUMBLE := Color(0.9, 0.15, 0.15)
@@ -18,26 +30,66 @@ const COLOR_FAIL := Color(0.35, 0.35, 0.4)
 const COLOR_DIE_TEXT := Color(1.0, 1.0, 1.0)
 const COLOR_DIE_TEXT_DARK := Color(0.1, 0.1, 0.1)
 const COLOR_DIE_NEUTRAL := Color(0.25, 0.45, 0.7)
+const COLOR_COUNT_TEXT := Color(0.85, 0.88, 0.92)
 
 var _rolls: Array = []
 var _threshold: int = 0
 var _use_threshold_colors: bool = true
+var _grouped: bool = true
 
 func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
-func set_dice(rolls: Array, threshold: int = 0, use_threshold_colors: bool = true) -> void:
+func set_dice(rolls: Array, threshold: int = 0, use_threshold_colors: bool = true, grouped: bool = true) -> void:
 	_rolls.clear()
 	for r in rolls:
 		_rolls.append(int(r))
 	_threshold = threshold
 	_use_threshold_colors = use_threshold_colors
+	_grouped = grouped
 	_update_min_size()
 	queue_redraw()
+
+func _get_font() -> Font:
+	# ThemeDB.fallback_font is always available even when the control is not yet
+	# in the tree, which keeps sizing deterministic for headless tests.
+	return ThemeDB.fallback_font
+
+func _count_text(count: int) -> String:
+	return "x%d" % count
+
+func _measure_count(count: int) -> float:
+	var font := _get_font()
+	if font == null:
+		# Fallback estimate if no font is available (shouldn't happen at runtime)
+		return float(_count_text(count).length()) * 6.0
+	return font.get_string_size(_count_text(count), HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE).x
+
+func get_value_groups() -> Array:
+	# Returns an Array of [value, count] pairs for the distinct values present,
+	# sorted ascending by value (1..6). Public so tests can assert grouping.
+	var counts := {}
+	for v in _rolls:
+		counts[v] = int(counts.get(v, 0)) + 1
+	var values := counts.keys()
+	values.sort()
+	var groups := []
+	for v in values:
+		groups.append([int(v), int(counts[v])])
+	return groups
 
 func _update_min_size() -> void:
 	if _rolls.is_empty():
 		custom_minimum_size = Vector2(0, 0)
+		return
+	if _grouped:
+		var groups := get_value_groups()
+		var total_w := 0.0
+		for i in range(groups.size()):
+			total_w += DIE_SIZE + COUNT_GAP + _measure_count(groups[i][1])
+			if i < groups.size() - 1:
+				total_w += GROUP_SPACING
+		custom_minimum_size = Vector2(total_w, DIE_SIZE)
 		return
 	var n: int = _rolls.size()
 	var cols: int = mini(n, MAX_DICE_PER_ROW)
@@ -60,48 +112,76 @@ func _get_die_color(value: int) -> Color:
 func _draw() -> void:
 	if _rolls.is_empty():
 		return
+	if _grouped:
+		_draw_grouped()
+	else:
+		_draw_ungrouped()
 
+func _draw_grouped() -> void:
+	var groups := get_value_groups()
+	var font := _get_font()
+	var x := 0.0
+	for g in groups:
+		var value: int = g[0]
+		var count: int = g[1]
+		_draw_die(x, 0.0, value)
+
+		# "xN" count label, vertically centred against the die.
+		var count_str := _count_text(count)
+		var tx := x + DIE_SIZE + COUNT_GAP
+		if font != null:
+			var text_h := font.get_height(COUNT_FONT_SIZE)
+			var ascent := font.get_ascent(COUNT_FONT_SIZE)
+			var ty := (DIE_SIZE - text_h) * 0.5 + ascent
+			draw_string(font, Vector2(tx, ty), count_str, HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE, COLOR_COUNT_TEXT)
+
+		x += DIE_SIZE + COUNT_GAP + _measure_count(count) + GROUP_SPACING
+
+func _draw_ungrouped() -> void:
 	for i in range(_rolls.size()):
 		var value: int = _rolls[i]
 		var col: int = i % MAX_DICE_PER_ROW
 		var row: int = i / MAX_DICE_PER_ROW
 		var x: float = col * (DIE_SIZE + DIE_MARGIN)
 		var y: float = row * (DIE_SIZE + ROW_SPACING)
-		var rect := Rect2(x, y, DIE_SIZE, DIE_SIZE)
-		var bg := _get_die_color(value)
+		_draw_die(x, y, value)
 
-		# Drop shadow
-		var shadow_rect := Rect2(x + 1, y + 1, DIE_SIZE, DIE_SIZE)
-		var shadow_style := StyleBoxFlat.new()
-		shadow_style.bg_color = Color(0.0, 0.0, 0.0, 0.3)
-		shadow_style.set_corner_radius_all(DIE_CORNER_RADIUS)
-		draw_style_box(shadow_style, shadow_rect)
+func _draw_die(x: float, y: float, value: int) -> void:
+	var rect := Rect2(x, y, DIE_SIZE, DIE_SIZE)
+	var bg := _get_die_color(value)
 
-		# Subtle glow for natural 6s
-		if value == 6:
-			var glow_rect := Rect2(x - 2, y - 2, DIE_SIZE + 4, DIE_SIZE + 4)
-			var glow_style := StyleBoxFlat.new()
-			glow_style.bg_color = Color(1.0, 0.84, 0.0, 0.25)
-			glow_style.set_corner_radius_all(DIE_CORNER_RADIUS + 2)
-			draw_style_box(glow_style, glow_rect)
+	# Drop shadow
+	var shadow_rect := Rect2(x + 1, y + 1, DIE_SIZE, DIE_SIZE)
+	var shadow_style := StyleBoxFlat.new()
+	shadow_style.bg_color = Color(0.0, 0.0, 0.0, 0.3)
+	shadow_style.set_corner_radius_all(DIE_CORNER_RADIUS)
+	draw_style_box(shadow_style, shadow_rect)
 
-		# Die face
-		var style := StyleBoxFlat.new()
-		style.bg_color = bg
-		style.set_corner_radius_all(DIE_CORNER_RADIUS)
-		style.set_border_width_all(1)
-		style.border_color = Color(0.0, 0.0, 0.0, 0.6)
-		draw_style_box(style, rect)
+	# Subtle glow for natural 6s
+	if value == 6:
+		var glow_rect := Rect2(x - 2, y - 2, DIE_SIZE + 4, DIE_SIZE + 4)
+		var glow_style := StyleBoxFlat.new()
+		glow_style.bg_color = Color(1.0, 0.84, 0.0, 0.25)
+		glow_style.set_corner_radius_all(DIE_CORNER_RADIUS + 2)
+		draw_style_box(glow_style, glow_rect)
 
-		# Pips
-		var pip_color: Color = COLOR_DIE_TEXT_DARK if value == 6 else COLOR_DIE_TEXT
-		_draw_pips(x, y, value, pip_color)
+	# Die face
+	var style := StyleBoxFlat.new()
+	style.bg_color = bg
+	style.set_corner_radius_all(DIE_CORNER_RADIUS)
+	style.set_border_width_all(1)
+	style.border_color = Color(0.0, 0.0, 0.0, 0.6)
+	draw_style_box(style, rect)
 
-		# Strike-through X for natural 1s
-		if value == 1:
-			var line_color := Color(1.0, 1.0, 1.0, 0.35)
-			draw_line(Vector2(x + 3, y + 3), Vector2(x + DIE_SIZE - 3, y + DIE_SIZE - 3), line_color, 1.0)
-			draw_line(Vector2(x + DIE_SIZE - 3, y + 3), Vector2(x + 3, y + DIE_SIZE - 3), line_color, 1.0)
+	# Pips
+	var pip_color: Color = COLOR_DIE_TEXT_DARK if value == 6 else COLOR_DIE_TEXT
+	_draw_pips(x, y, value, pip_color)
+
+	# Strike-through X for natural 1s
+	if value == 1:
+		var line_color := Color(1.0, 1.0, 1.0, 0.35)
+		draw_line(Vector2(x + 3, y + 3), Vector2(x + DIE_SIZE - 3, y + DIE_SIZE - 3), line_color, 1.0)
+		draw_line(Vector2(x + DIE_SIZE - 3, y + 3), Vector2(x + 3, y + DIE_SIZE - 3), line_color, 1.0)
 
 func _draw_pips(x: float, y: float, value: int, color: Color) -> void:
 	var pip_radius: float = 2.0

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -252,6 +252,22 @@ func dice_row_has_visual(row_index: int) -> bool:
 			return true
 	return false
 
+func combat_detail_row_has_visual(row_index: int) -> bool:
+	# Test introspection helper: returns true if the collapsible details row at
+	# `row_index` contains a DiceRowVisual child (i.e. the dice array was rendered
+	# as grouped icons instead of inline number badges).
+	if not _current_combat_details_container or not is_instance_valid(_current_combat_details_container):
+		return false
+	if row_index < 0 or row_index >= _current_combat_details_container.get_child_count():
+		return false
+	var row = _current_combat_details_container.get_child(row_index)
+	if row is DiceRowVisualScript:
+		return true
+	for c in row.get_children():
+		if c is DiceRowVisualScript:
+			return true
+	return false
+
 func _build_realtime_dice_row(data: Dictionary, context: String) -> Control:
 	"""Build an HBox row containing prefix label + graphical dice + suffix label."""
 	var rolls_raw = data.get("rolls_raw", [])
@@ -452,20 +468,13 @@ func _start_combat_card(header_text: String, animate: bool) -> void:
 	var toggle_btn = _current_combat_toggle_button
 	card_vbox.add_child(toggle_btn)
 
-	# Collapsible details container
+	# Collapsible details container — holds one row Control per detail line
+	# (text-only or a grouped DiceRowVisual row). Populated by _append_combat_detail.
 	_current_combat_details_container = VBoxContainer.new()
+	_current_combat_details_container.add_theme_constant_override("separation", 2)
 	_current_combat_details_container.visible = false
 	card_vbox.add_child(_current_combat_details_container)
-
-	# Details RichTextLabel
-	_current_combat_details_label = RichTextLabel.new()
-	_current_combat_details_label.bbcode_enabled = true
-	_current_combat_details_label.fit_content = true
-	_current_combat_details_label.scroll_active = false
-	_current_combat_details_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_current_combat_details_label.add_theme_font_size_override("normal_font_size", 10)
-	_current_combat_details_label.add_theme_font_size_override("bold_font_size", 11)
-	_current_combat_details_container.add_child(_current_combat_details_label)
+	_current_combat_details_label = null  # legacy single-label model retired; rows added directly
 
 	# Wire up toggle — capture references for the closure
 	var details_cont = _current_combat_details_container
@@ -485,13 +494,12 @@ func _start_combat_card(header_text: String, animate: bool) -> void:
 		_animate_card_in(card)
 
 func _append_combat_detail(text: String, animate: bool) -> void:
-	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_details_label:
-		# Append to current combat card's collapsible section
-		if _current_combat_details_text != "":
-			_current_combat_details_text += "\n"
-		_current_combat_details_text += _style_combat_detail(text.strip_edges())
-		_current_combat_details_label.text = ""
-		_current_combat_details_label.append_text("[color=#B0B8C0]%s[/color]" % _current_combat_details_text)
+	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_details_container and is_instance_valid(_current_combat_details_container):
+		# Append a per-line row to the current combat card's collapsible section.
+		# Lines containing a dice array [..] render the dice as grouped icons via
+		# DiceRowVisual; other lines render as styled text.
+		var row := _build_combat_detail_line(text.strip_edges())
+		_current_combat_details_container.add_child(row)
 	else:
 		# Orphaned detail — create standalone card
 		var card = _make_simple_entry_card(text, "combat_detail", EntryCategory.COMBAT)
@@ -499,6 +507,38 @@ func _append_combat_detail(text: String, animate: bool) -> void:
 		_card_count += 1
 		if animate:
 			_animate_card_in(card)
+
+func _build_combat_detail_line(text: String) -> Control:
+	"""Build a Control for one combat-detail line. If the line contains a dice
+	array (e.g. 'rolled [1, 1, 2, 6]'), render the array as a grouped DiceRowVisual
+	(one die icon per value + xN count); otherwise render styled text."""
+	var dice_match = _dice_regex.search(text)
+	if dice_match == null:
+		# No dice — single styled label.
+		var label := RichTextLabel.new()
+		label.bbcode_enabled = true
+		label.fit_content = true
+		label.scroll_active = false
+		label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		label.add_theme_font_size_override("normal_font_size", 10)
+		label.add_theme_font_size_override("bold_font_size", 11)
+		label.append_text("[color=#B0B8C0]%s[/color]" % _highlight_keywords(text))
+		return label
+
+	# Split the line around the dice array: [prefix] [dice icons] [suffix]
+	var threshold := _extract_threshold(text)
+	var prefix_text := text.substr(0, dice_match.get_start()).strip_edges()
+	var suffix_text := text.substr(dice_match.get_end()).strip_edges()
+
+	var rolls := []
+	for d in dice_match.get_string(1).split(","):
+		var dval := d.strip_edges()
+		if dval != "":
+			rolls.append(int(dval))
+
+	var prefix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(prefix_text) if prefix_text != "" else ""
+	var suffix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(suffix_text) if suffix_text != "" else ""
+	return _make_dice_row(prefix_bbcode, rolls, threshold, threshold > 0, suffix_bbcode)
 
 func _finalize_combat_card(text: String, animate: bool) -> void:
 	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_summary_label:
@@ -855,10 +895,7 @@ func _style_combat_detail(text: String) -> String:
 	var styled = text
 
 	# Extract threshold from line context (e.g. "needed 3+", "Save 4+", "Pain 5+")
-	var threshold := 0
-	var threshold_match = _threshold_regex.search(text)
-	if threshold_match:
-		threshold = int(threshold_match.get_string(1))
+	var threshold := _extract_threshold(text)
 
 	# Replace dice roll arrays [1, 3, 5, 6] with colored dice badges
 	var dice_results = _dice_regex.search_all(styled)
@@ -874,7 +911,18 @@ func _style_combat_detail(text: String) -> String:
 		var replacement = " ".join(dice_badges)
 		styled = styled.substr(0, m.get_start()) + replacement + styled.substr(m.get_end())
 
-	# Highlight keywords
+	return _highlight_keywords(styled)
+
+func _extract_threshold(text: String) -> int:
+	"""Pull the success threshold out of a detail line (e.g. 'needed 3+' -> 3)."""
+	var threshold_match = _threshold_regex.search(text)
+	if threshold_match:
+		return int(threshold_match.get_string(1))
+	return 0
+
+func _highlight_keywords(text: String) -> String:
+	"""Apply BBCode color highlights to combat keywords (no dice substitution)."""
+	var styled = text
 	styled = styled.replace("DEVASTATING WOUNDS", "[color=#FF4444]DEVASTATING WOUNDS[/color]")
 	styled = styled.replace("DEVASTATING", "[color=#FF4444]DEVASTATING[/color]")
 	styled = styled.replace("Lethal Hits", "[color=#FF8844]Lethal Hits[/color]")
@@ -883,7 +931,6 @@ func _style_combat_detail(text: String) -> String:
 	styled = styled.replace("Invulnerable Save", "[color=#BB88FF]Invulnerable Save[/color]")
 	styled = styled.replace("Re-rolls:", "[color=#88BBFF]Re-rolls:[/color]")
 	styled = styled.replace("Torrent", "[color=#FF8844]Torrent[/color]")
-
 	return styled
 
 func _make_die_badge(value: int, threshold: int) -> String:

--- a/40k/tests/scenarios/sp/dice_grouped_log_render.json
+++ b/40k/tests/scenarios/sp/dice_grouped_log_render.json
@@ -1,0 +1,62 @@
+{
+  "id": "dice_grouped_log_render",
+  "covers": ["ui.log.inline_dice_graphics", "ui.log.grouped_dice_icons"],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Verify dice rolls in the GameLogPanel render as GROUPED die icons (one icon per distinct value plus an 'xN' count) instead of a flat array of numbers. Drives both the real-time roll path (DiceHistoryPanel.roll_recorded -> _current_combat_dice_container) and the combat-detail text path (a 'rolled [1, 1, 2, 6]' line -> _current_combat_details_container). Asserts each path mounts a DiceRowVisual whose get_value_groups() collapses duplicate values, then reveals the details and captures a screenshot of the grouped icons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Test Shooter shoots Test Target', 'combat_header', false)" },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_dice_container != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "DiceHistoryPanel.roll_recorded.emit({'data': {'context': 'to_hit', 'rolls_raw': [1, 1, 2, 6], 'threshold': '3+', 'successes': 1}})" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_dice_container.get_child_count()",
+      "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.dice_row_has_visual(0)",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('  To Hit: needed 3+ — rolled [1, 1, 2, 6] — 1/4 hit', 'combat_detail', false)" },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('    Modifiers: +1 to hit', 'combat_detail', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_details_container.get_child_count()",
+      "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.combat_detail_row_has_visual(0)",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.combat_detail_row_has_visual(1)",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_details_container.set_visible(true)" },
+
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "grouped_dice_icons_in_log" }
+  ]
+}

--- a/40k/tests/test_inline_dice_log.gd
+++ b/40k/tests/test_inline_dice_log.gd
@@ -21,8 +21,11 @@ func _initialize() -> void:
 	_test_dice_row_visual_basic()
 	_test_dice_row_visual_empty()
 	_test_dice_row_visual_threshold_colors()
-	_test_dice_row_visual_wrap_size()
+	_test_dice_row_visual_grouping()
+	_test_dice_row_visual_grouped_single_row()
+	_test_dice_row_visual_ungrouped_wrap_size()
 	_test_game_log_panel_records_dice_row()
+	_test_game_log_panel_detail_dice_row()
 	_test_game_log_panel_skips_when_no_combat()
 
 	print("\n=== Result: %d passed / %d failed ===" % [_passed, _failed])
@@ -60,16 +63,41 @@ func _test_dice_row_visual_threshold_colors() -> void:
 	_check("die value 2 (<threshold 3) -> FAIL gray", d._get_die_color(2) == DiceRowVisualScript.COLOR_FAIL)
 	d.free()
 
-func _test_dice_row_visual_wrap_size() -> void:
+func _test_dice_row_visual_grouping() -> void:
+	# [1, 1, 2, 6] -> three groups: (1 x2), (2 x1), (6 x1), sorted ascending.
 	var d = DiceRowVisualScript.new()
-	# 25 dice should wrap to 3 rows (MAX_DICE_PER_ROW=10)
+	d.set_dice([1, 1, 2, 6], 3, true)
+	var groups = d.get_value_groups()
+	_check("grouping yields 3 distinct values", groups.size() == 3,
+		"got %s" % str(groups))
+	_check("group order/values/counts correct",
+		groups == [[1, 2], [2, 1], [6, 1]],
+		"got %s" % str(groups))
+	d.free()
+
+func _test_dice_row_visual_grouped_single_row() -> void:
+	# 25 identical dice collapse to one group -> a single-row (DIE_SIZE tall) icon.
+	var d = DiceRowVisualScript.new()
 	var rolls := []
 	for i in range(25):
 		rolls.append(4)
 	d.set_dice(rolls, 3, true)
+	_check("25 identical dice -> 1 group", d.get_value_groups() == [[4, 25]],
+		"got %s" % str(d.get_value_groups()))
+	_check("grouped row is one die tall", d.custom_minimum_size.y == DiceRowVisualScript.DIE_SIZE,
+		"got y=%s expected %s" % [str(d.custom_minimum_size.y), str(DiceRowVisualScript.DIE_SIZE)])
+	d.free()
+
+func _test_dice_row_visual_ungrouped_wrap_size() -> void:
+	# Legacy ungrouped mode still wraps 25 dice to 3 rows (MAX_DICE_PER_ROW=10).
+	var d = DiceRowVisualScript.new()
+	var rolls := []
+	for i in range(25):
+		rolls.append(4)
+	d.set_dice(rolls, 3, true, false)
 	var expected_rows := 3
 	var expected_h := expected_rows * DiceRowVisualScript.DIE_SIZE + (expected_rows - 1) * DiceRowVisualScript.ROW_SPACING
-	_check("25 dice -> 3-row min height", d.custom_minimum_size.y == expected_h,
+	_check("ungrouped 25 dice -> 3-row min height", d.custom_minimum_size.y == expected_h,
 		"got y=%s expected %s" % [str(d.custom_minimum_size.y), str(expected_h)])
 	d.free()
 
@@ -112,6 +140,33 @@ func _test_game_log_panel_records_dice_row() -> void:
 			has_dice_visual = true
 			break
 	_check("appended row contains a DiceRowVisual", has_dice_visual)
+
+	panel.queue_free()
+
+func _test_game_log_panel_detail_dice_row() -> void:
+	# A combat-detail line containing a dice array must render the array as a
+	# grouped DiceRowVisual row in the collapsible details container — NOT as a
+	# plain "[1, 1, 2, 6]" number array.
+	var panel = GameLogPanelScript.new()
+	get_root().add_child(panel)
+	panel._ready()
+	panel._create_card("Test shooter shoots Target", "combat_header", false)
+
+	if panel._current_combat_details_container == null:
+		_check("combat card creates details container", false, "container is null")
+		panel.queue_free()
+		return
+	_check("combat card creates details container", true)
+
+	# A dice-bearing detail line -> grouped DiceRowVisual row.
+	panel._create_card("  To Hit: needed 3+ — rolled [1, 1, 2, 6] — 2/4 hit", "combat_detail", false)
+	# A text-only detail line -> plain label (no DiceRowVisual).
+	panel._create_card("    Modifiers: +1 to hit", "combat_detail", false)
+
+	_check("two detail rows added", panel._current_combat_details_container.get_child_count() == 2,
+		"got %d" % panel._current_combat_details_container.get_child_count())
+	_check("dice detail line rendered as grouped DiceRowVisual", panel.combat_detail_row_has_visual(0))
+	_check("text-only detail line has no DiceRowVisual", not panel.combat_detail_row_has_visual(1))
 
 	panel.queue_free()
 


### PR DESCRIPTION
## Summary

The game log previously showed dice rolls as a flat array of numbers (e.g. `[1, 1, 2, 6]`). They now render as **one die-face icon per distinct value followed by an `xN` count**, so `[1, 1, 2, 6]` shows as die-1 ×2, die-2 ×1, die-6 ×1.

## Changes

- **`DiceRowVisual.gd`** — Added a grouped rendering mode (now the default). Identical values collapse into a single die icon + count via `get_value_groups()`. The legacy per-die layout is retained behind `grouped=false`. Uses `xN` rather than `×N` so the count always renders cleanly regardless of font glyph coverage. Existing color coding (gold 6s, red struck-through 1s, green/gray by threshold) is preserved.
- **`GameLogPanel.gd`** — Routes combat-detail dice arrays through a grouped `DiceRowVisual` row instead of inline number badges; splits keyword highlighting into a reusable helper; adds a `combat_detail_row_has_visual()` introspection helper. The real-time dice path picks up grouping automatically via the shared component.
- **Tests** — Extended the headless smoke test (`test_inline_dice_log.gd`, 19/19 passing) for grouping correctness, single-row collapse, legacy ungrouped wrapping, and both the real-time and combat-detail rendering paths.

## Validation

- **Headless**: `test_inline_dice_log.gd` — 19/19 pass.
- **Windowed** (per the project's feature-validation gate): added `tests/scenarios/sp/dice_grouped_log_render.json`, which drives both dice paths against the running UI and is screenshot-verified — 17/17 steps pass. The pre-existing `inline_dice_log_render` scenario still passes (16/16).

https://claude.ai/code/session_01FV82ccuMANj6XMB6PjyrUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV82ccuMANj6XMB6PjyrUM)_