### PR TITLE
Enhance godot-mcp bridge (verify_delivery, log/snapshot tools, multi-line execute_script)

### DIFF
--- a/40k/addons/godot_mcp/README.md
+++ b/40k/addons/godot_mcp/README.md
@@ -94,7 +94,9 @@ The wire protocol is one JSON object per line:
 - `get_project_info`, `get_project_setting`, `list_files`
 - `get_current_scene`, `get_node_info`, `get_node_property`, `set_node_property`,
   `call_node_method`
-- `read_script`, `write_script` (refuses paths outside `res://`)
+- `read_script`, `write_script` — `write_script` refuses paths outside `res://`
+  (and outside `GODOT_MCP_ALLOWED_WRITE_PATHS` when that env is set), and
+  refuses to overwrite an existing file unless `overwrite: true` is passed.
 
 ### Core testing
 - `capture_screenshot` — PNG to `user://test_screenshots/<label>.png` plus an
@@ -106,11 +108,27 @@ The wire protocol is one JSON object per line:
   `simulate_key_press`, `simulate_action`
 - `get_scene_state` — recursive tree dump with positions, visibility, and
   script-defined properties
-- `execute_script` — evaluate a one-line GDScript expression against an
-  optional target node
+- `execute_script` — evaluate GDScript against an optional target node.
+  Single-line code uses an `Expression` (node visible as `self`); multi-line
+  code, or any call with `multiline: true`, is compiled into a throwaway
+  script so full statements work (`var`/`if`/`for`/`return`, method calls,
+  autoloads by global name). In compiled mode the node is the `node` param;
+  `return <value>` to send a result back.
 - `wait_frames`, `wait_seconds`
 - `get_log_path` — returns absolute paths of `user://logs` and
   `user://test_screenshots`
+- `read_debug_log` — read the newest `user://logs/debug_*.log` bucketed into
+  errors/warnings/info/debug so you can assert "no errors fired" after driving
+  a feature. Supports `tail`, `since_marker` (only lines after a marker's last
+  occurrence), and `levels` filtering. Flushes DebugLogger's buffer first.
+- `scene_snapshot` / `diff_snapshot` — capture a compact path→state index of
+  the live tree to `user://mcp_snapshots/<label>.json`, then diff two
+  snapshots (or one snapshot vs. the live tree) to prove only the intended
+  nodes moved. Reports added / removed / changed nodes with field-level diffs.
+- `chain_verify` — anti-overconfidence gate: given a `claim`, returns 5
+  adversarial challenge questions plus live log error/warning counts to
+  reconcile before closing a task. Encodes the "pin tests aren't validation"
+  rule from `CLAUDE.md`.
 
 ### Editor-only (port 9081)
 - `play_scene`, `play_main_scene`, `stop_scene`, `get_edited_scene`,
@@ -125,6 +143,30 @@ The wire protocol is one JSON object per line:
 - `dispatch_action` — runs a phase action through `validate_action` /
   `process_action` on the active phase instance
 - `move_unit_to` — convenience wrapper that builds a `MOVE_UNIT` action
+- `verify_delivery` — one-call end-to-end gate. Checks (1) scene-tree
+  integrity, (2) `GameState` + required autoloads present, (3) the debug log
+  has no `ERROR` lines (optionally `since_marker`), and (4) caller
+  `assertions` — GDScript expressions evaluated over live state (autoloads
+  reachable by name; bare expressions auto-returned; pass `expect` for
+  equality or rely on truthiness). Returns `passed: false` if any required
+  check fails. Use it as the final gate after driving a feature live.
+
+## Security model
+
+The addon's threat model is **trusted localhost** — the only client is the
+MCP bridge on `127.0.0.1`, and requests are correlated to responses by `id`
+over a private TCP socket, so there is no response-forgery vector to defend
+against (this is why the addon does *not* need the random output markers that
+stdout-scraping MCP servers like `godot-mcp-enhanced` use). The applicable
+hardening, borrowed from that project's security model, is:
+
+- **Path confinement.** `write_script` only writes under `res://`, and under
+  `GODOT_MCP_ALLOWED_WRITE_PATHS` (comma-separated `res://` prefixes) when set
+  — mirroring `ALLOWED_PROJECT_PATHS`. Unset = all `res://` allowed.
+- **Overwrite confirmation.** `write_script` refuses to clobber an existing
+  file unless `overwrite: true` — the "confirmation token for destructive
+  operations" pattern. Overwriting source is the main destructive risk the
+  bridge exposes.
 
 ## Implementation notes
 

--- a/40k/addons/godot_mcp/README.md
+++ b/40k/addons/godot_mcp/README.md
@@ -111,9 +111,10 @@ The wire protocol is one JSON object per line:
 - `execute_script` — evaluate GDScript against an optional target node.
   Single-line code uses an `Expression` (node visible as `self`); multi-line
   code, or any call with `multiline: true`, is compiled into a throwaway
-  script so full statements work (`var`/`if`/`for`/`return`, method calls,
-  autoloads by global name). In compiled mode the node is the `node` param;
-  `return <value>` to send a result back.
+  script so full statements work (`var`/`if`/`for`/`return`, autoloads by
+  global name). In compiled mode the target is the `node` param and the scene
+  tree is the `tree` param — call node/tree methods on those (e.g.
+  `tree.get_node_count()`), not bare. `return <value>` to send a result back.
 - `wait_frames`, `wait_seconds`
 - `get_log_path` — returns absolute paths of `user://logs` and
   `user://test_screenshots`

--- a/40k/addons/godot_mcp/command_router.gd
+++ b/40k/addons/godot_mcp/command_router.gd
@@ -46,7 +46,8 @@ func _register_routes() -> void:
 		"simulate_key_press", "simulate_action",
 		"get_scene_state", "execute_script",
 		"wait_frames", "wait_seconds",
-		"get_log_path",
+		"get_log_path", "read_debug_log",
+		"scene_snapshot", "diff_snapshot", "chain_verify",
 	]
 	for m in testing_methods:
 		_routes[m] = [_testing, m]
@@ -56,6 +57,7 @@ func _register_routes() -> void:
 		"get_current_phase", "get_legal_actions",
 		"advance_phase", "transition_to_phase",
 		"select_unit", "dispatch_action", "move_unit_to",
+		"verify_delivery",
 	]
 	for m in wh40k_methods:
 		_routes[m] = [_wh40k, m]

--- a/40k/addons/godot_mcp/handlers/core_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/core_handlers.gd
@@ -180,17 +180,45 @@ func read_script(params: Dictionary) -> Dictionary:
 
 
 func write_script(params: Dictionary) -> Dictionary:
-	# Note: only allowed within `res://` so we don't write outside the project.
+	# Guarded write. The addon's threat model is trusted-localhost, but two
+	# cheap guards (borrowed from godot-mcp-enhanced's security model) prevent
+	# the most common foot-guns:
+	#   * res:// confinement + optional GODOT_MCP_ALLOWED_WRITE_PATHS allow-list
+	#     (mirrors ALLOWED_PROJECT_PATHS — when unset, all res:// paths allowed).
+	#   * overwrite confirmation: refuse to clobber an existing file unless the
+	#     caller passes overwrite:true (the "confirmation token for destructive
+	#     operations" pattern). Overwriting source is the main destructive risk
+	#     this bridge exposes.
 	var path: String = params.get("path", "")
 	var content: String = params.get("content", "")
 	if path == "" or not path.begins_with("res://"):
 		return {"status": "error", "message": "Path must be under res://"}
+
+	var allow_env := OS.get_environment("GODOT_MCP_ALLOWED_WRITE_PATHS")
+	if allow_env != "":
+		var allowed := false
+		for prefix in allow_env.split(",", false):
+			var p := prefix.strip_edges()
+			if p != "" and path.begins_with(p):
+				allowed = true
+				break
+		if not allowed:
+			return {"status": "error", "message": "Path %s is outside GODOT_MCP_ALLOWED_WRITE_PATHS" % path}
+
+	var exists := FileAccess.file_exists(path)
+	if exists and not bool(params.get("overwrite", false)):
+		return {
+			"status": "error",
+			"message": "Refusing to overwrite existing file without overwrite:true — %s" % path,
+			"exists": true,
+		}
+
 	var f := FileAccess.open(path, FileAccess.WRITE)
 	if f == null:
 		return {"status": "error", "message": "Cannot open file for writing: %s" % path}
 	f.store_string(content)
 	f.close()
-	return {"status": "ok", "path": path, "bytes_written": content.length()}
+	return {"status": "ok", "path": path, "bytes_written": content.length(), "overwritten": exists}
 
 
 # --- Helpers --------------------------------------------------------------

--- a/40k/addons/godot_mcp/handlers/testing_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/testing_handlers.gd
@@ -387,14 +387,19 @@ func execute_script(params: Dictionary) -> Dictionary:
 
 func _execute_script_compiled(code: String, target: Object) -> Dictionary:
 	# Wrap the user code in a function body so multi-line statements compile.
-	# `node` is the resolved target; autoloads are reachable by their global
-	# names. The body may `return <value>`; with no return the result is null.
+	# The wrapper extends RefCounted (no tree mutation), so the snippet gets the
+	# context it needs via parameters rather than `self`:
+	#   * `node` — the resolved target node
+	#   * `tree` — the SceneTree (so `tree.get_node_count()`, `tree.root` work)
+	# Autoloads are reachable by their global names. Node methods must be called
+	# on `node` (e.g. `node.get_node(...)`), not bare. `return <value>` to send a
+	# result back; with no return the result is null.
 	var indented := ""
 	for line in code.split("\n"):
 		indented += "\t" + line + "\n"
 	if indented.strip_edges() == "":
 		indented = "\treturn null\n"
-	var src := "extends RefCounted\nfunc _run(node):\n" + indented
+	var src := "extends RefCounted\nfunc _run(node, tree):\n" + indented
 
 	var script := GDScript.new()
 	script.source_code = src
@@ -403,7 +408,7 @@ func _execute_script_compiled(code: String, target: Object) -> Dictionary:
 		return {
 			"status": "error",
 			"error_type": "parse",
-			"message": "GDScript compile failed (error %d). Check syntax/indentation." % reload_err,
+			"message": "GDScript compile failed (error %d). Note: call node methods on `node`/`tree`, not bare. Check syntax/indentation." % reload_err,
 			"source": src,
 		}
 	var instance = script.new()
@@ -412,7 +417,8 @@ func _execute_script_compiled(code: String, target: Object) -> Dictionary:
 	# Runtime errors inside the snippet cannot be caught in GDScript; they push
 	# an error to the debug log (read it back with read_debug_log) and return
 	# null. The return value is surfaced here either way.
-	var result = instance.call("_run", target)
+	var scene_tree = host.get_tree() if host else null
+	var result = instance.call("_run", target, scene_tree)
 	return {"status": "ok", "result": _serialize(result), "multiline": true}
 
 

--- a/40k/addons/godot_mcp/handlers/testing_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/testing_handlers.gd
@@ -345,9 +345,17 @@ func _serialize(value):
 # --- Script execution ---------------------------------------------------
 
 func execute_script(params: Dictionary) -> Dictionary:
-	# Parse a one-line GDScript expression and evaluate it against an optional
-	# target node. Useful for poking at game state from the bridge without
-	# adding a dedicated tool.
+	# Evaluate GDScript against an optional target node.
+	#
+	# Two modes:
+	#   * Single-line expression (default) — uses Godot's Expression, fast and
+	#     sandboxed; the target node is visible as `self`. Back-compat path.
+	#   * Multi-line / statement mode — when the code spans multiple lines, or
+	#     the caller passes `multiline: true`, the snippet is compiled into a
+	#     throwaway GDScript so full statements work: `var`, `if`, `for`,
+	#     `return`, calling methods, and reaching autoloads (GameState,
+	#     PhaseManager, …) by their global names. The resolved node is the
+	#     `node` parameter; `return <value>` to send a result back.
 	var code: String = params.get("code", "")
 	if code == "":
 		return {"status": "error", "message": "Missing 'code'"}
@@ -360,16 +368,396 @@ func execute_script(params: Dictionary) -> Dictionary:
 	if target == null:
 		return {"status": "error", "message": "Node not found: %s" % node_path}
 
+	var multiline: bool = params.get("multiline", code.find("\n") != -1)
+	if multiline:
+		return _execute_script_compiled(code, target)
+
+	# --- Expression path (single-line, back-compat) ---
 	var input_names: Array = params.get("input_names", [])
 	var input_values: Array = params.get("input_values", [])
 	var expression := Expression.new()
 	var parse_err := expression.parse(code, PackedStringArray(input_names))
 	if parse_err != OK:
-		return {"status": "error", "message": expression.get_error_text()}
+		return {"status": "error", "error_type": "parse", "message": expression.get_error_text()}
 	var result = expression.execute(input_values, target, true)
 	if expression.has_execute_failed():
-		return {"status": "error", "message": "Execution failed: %s" % expression.get_error_text()}
+		return {"status": "error", "error_type": "runtime", "message": "Execution failed: %s" % expression.get_error_text()}
 	return {"status": "ok", "result": _serialize(result)}
+
+
+func _execute_script_compiled(code: String, target: Object) -> Dictionary:
+	# Wrap the user code in a function body so multi-line statements compile.
+	# `node` is the resolved target; autoloads are reachable by their global
+	# names. The body may `return <value>`; with no return the result is null.
+	var indented := ""
+	for line in code.split("\n"):
+		indented += "\t" + line + "\n"
+	if indented.strip_edges() == "":
+		indented = "\treturn null\n"
+	var src := "extends RefCounted\nfunc _run(node):\n" + indented
+
+	var script := GDScript.new()
+	script.source_code = src
+	var reload_err := script.reload()
+	if reload_err != OK:
+		return {
+			"status": "error",
+			"error_type": "parse",
+			"message": "GDScript compile failed (error %d). Check syntax/indentation." % reload_err,
+			"source": src,
+		}
+	var instance = script.new()
+	if instance == null or not instance.has_method("_run"):
+		return {"status": "error", "error_type": "parse", "message": "Failed to instantiate compiled snippet"}
+	# Runtime errors inside the snippet cannot be caught in GDScript; they push
+	# an error to the debug log (read it back with read_debug_log) and return
+	# null. The return value is surfaced here either way.
+	var result = instance.call("_run", target)
+	return {"status": "ok", "result": _serialize(result), "multiline": true}
+
+
+# --- Debug log inspection -----------------------------------------------
+
+func read_debug_log(params: Dictionary) -> Dictionary:
+	# Return the latest debug log bucketed into errors / warnings / info / debug
+	# so callers can assert "no errors fired" without grepping raw text.
+	#   path         absolute or user:// path (default: newest user://logs/debug_*.log)
+	#   tail         only keep the last N non-empty lines (default 200; 0 = all)
+	#   since_marker keep only lines after this marker's LAST occurrence
+	#   levels       filter returned `lines` to these levels (e.g. ["ERROR"])
+	#   include_lines  include the (possibly filtered) raw lines (default true)
+	#
+	# Flushes DebugLogger's in-memory buffer first so the freshest output is on
+	# disk before reading.
+	if host and host.get_tree():
+		var dl := host.get_tree().root.get_node_or_null("DebugLogger")
+		if dl and dl.has_method("_flush_buffer"):
+			dl._flush_buffer()
+
+	var path: String = params.get("path", "")
+	if path == "":
+		path = latest_log_path()
+	if path == "":
+		return {"status": "error", "message": "No debug log found under user://logs/"}
+
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return {"status": "error", "message": "Cannot open log: %s" % path}
+	var text := f.get_as_text()
+	f.close()
+
+	var lines: Array = []
+	for l in text.split("\n"):
+		lines.append(l)
+
+	var since_marker: String = params.get("since_marker", "")
+	if since_marker != "":
+		var last_idx := -1
+		for i in range(lines.size()):
+			if String(lines[i]).find(since_marker) != -1:
+				last_idx = i
+		if last_idx >= 0:
+			lines = lines.slice(last_idx + 1)
+
+	var tail: int = int(params.get("tail", 200))
+	if tail > 0 and lines.size() > tail:
+		lines = lines.slice(lines.size() - tail)
+
+	var summary := categorize_log_lines(lines)
+	var result := {
+		"status": "ok",
+		"log_path": ProjectSettings.globalize_path(path),
+		"lines_scanned": lines.size(),
+		"counts": summary["counts"],
+		"errors": summary["errors"],
+		"warnings": summary["warnings"],
+		"has_errors": int(summary["counts"]["error"]) > 0,
+	}
+
+	var include_lines: bool = params.get("include_lines", true)
+	if include_lines:
+		var level_filter: Array = params.get("levels", [])
+		if level_filter.is_empty():
+			var raw_lines: Array = []
+			for entry in summary["classified"]:
+				raw_lines.append(entry["line"])
+			result["lines"] = raw_lines
+		else:
+			var upper: Array = []
+			for lv in level_filter:
+				upper.append(String(lv).to_upper())
+			var filtered: Array = []
+			for entry in summary["classified"]:
+				if upper.has(entry["level"]):
+					filtered.append(entry["line"])
+			result["lines"] = filtered
+	return result
+
+
+static func latest_log_path() -> String:
+	# Newest non-archived debug log. Names are debug_YYYYMMDD_HHMMSS.log so a
+	# lexicographic max equals the most recent session.
+	var dir := DirAccess.open("user://logs")
+	if dir == null:
+		return ""
+	var best := ""
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		if not dir.current_is_dir() and entry.begins_with("debug_") \
+				and entry.ends_with(".log") and not entry.ends_with("_archived.log"):
+			if entry > best:
+				best = entry
+		entry = dir.get_next()
+	dir.list_dir_end()
+	if best == "":
+		return ""
+	return "user://logs/" + best
+
+
+static func categorize_log_lines(lines: Array) -> Dictionary:
+	# Bucket log lines by level. Understands the DebugLogger format
+	# "[timestamp] [LEVEL ] message" and falls back to raw engine markers
+	# (ERROR:, SCRIPT ERROR, WARNING:).
+	var counts := {"error": 0, "warning": 0, "info": 0, "debug": 0, "other": 0}
+	var errors: Array = []
+	var warnings: Array = []
+	var classified: Array = []
+	for raw in lines:
+		var line := String(raw)
+		if line.strip_edges() == "":
+			continue
+		var level := _classify_log_line(line)
+		match level:
+			"ERROR":
+				counts["error"] += 1
+				errors.append(line)
+			"WARNING":
+				counts["warning"] += 1
+				warnings.append(line)
+			"INFO":
+				counts["info"] += 1
+			"DEBUG":
+				counts["debug"] += 1
+			_:
+				counts["other"] += 1
+		classified.append({"level": level, "line": line})
+	return {"counts": counts, "errors": errors, "warnings": warnings, "classified": classified}
+
+
+static func _classify_log_line(line: String) -> String:
+	# Prefer the DebugLogger level token (the SECOND bracketed group).
+	var first := line.find("] [")
+	if first != -1:
+		var start := first + 3
+		var end := line.find("]", start)
+		if end != -1:
+			var token := line.substr(start, end - start).strip_edges().to_upper()
+			if token.begins_with("ERROR"):
+				return "ERROR"
+			if token.begins_with("WARN"):
+				return "WARNING"
+			if token.begins_with("INFO"):
+				return "INFO"
+			if token.begins_with("DEBUG"):
+				return "DEBUG"
+	# Fall back to raw engine output markers.
+	var upper := line.strip_edges().to_upper()
+	if upper.begins_with("ERROR:") or upper.find("SCRIPT ERROR") != -1:
+		return "ERROR"
+	if upper.begins_with("WARNING:") or upper.begins_with("WARN:"):
+		return "WARNING"
+	return "OTHER"
+
+
+# --- Scene snapshots / diffing ------------------------------------------
+
+func scene_snapshot(params: Dictionary) -> Dictionary:
+	# Capture a compact, diff-friendly index of the scene tree (path -> type,
+	# position, visibility, size, script properties) and persist it to
+	# user://mcp_snapshots/<label>.json so a later diff_snapshot can reference
+	# it by label. Use before/after a change to prove only the intended nodes
+	# moved.
+	var label: String = params.get("label", "snapshot_%d" % Time.get_ticks_msec())
+	var max_depth: int = int(params.get("max_depth", 12))
+	var index = _capture_index(params.get("root", ""), max_depth)
+	if index == null:
+		return {"status": "error", "message": "No scene tree (or root not found)"}
+
+	var snapshot := {"label": label, "captured_ms": Time.get_ticks_msec(), "index": index}
+	DirAccess.make_dir_recursive_absolute("user://mcp_snapshots")
+	var path := "user://mcp_snapshots/%s.json" % label
+	var f := FileAccess.open(path, FileAccess.WRITE)
+	if f:
+		f.store_string(JSON.stringify(snapshot))
+		f.close()
+	return {
+		"status": "ok",
+		"label": label,
+		"node_count": index.size(),
+		"path": ProjectSettings.globalize_path(path),
+	}
+
+
+func diff_snapshot(params: Dictionary) -> Dictionary:
+	# Compare two snapshots and report added / removed / changed nodes.
+	#   before  required snapshot label (loaded from disk)
+	#   after   snapshot label, OR omit / "__live__" to diff against the live tree
+	var before = _load_snapshot_index(params.get("before", ""))
+	if before == null:
+		return {"status": "error", "message": "Could not load 'before' snapshot (pass a label captured via scene_snapshot)"}
+	var after_arg: String = params.get("after", "")
+	var after
+	if after_arg == "" or after_arg == "__live__":
+		after = _capture_index(params.get("root", ""), int(params.get("max_depth", 12)))
+	else:
+		after = _load_snapshot_index(after_arg)
+	if after == null:
+		return {"status": "error", "message": "Could not load 'after' snapshot / capture live tree"}
+
+	var added: Array = []
+	var removed: Array = []
+	var changed: Array = []
+	for p in after.keys():
+		if not before.has(p):
+			added.append(p)
+	for p in before.keys():
+		if not after.has(p):
+			removed.append(p)
+		else:
+			var d := _diff_entry(before[p], after[p])
+			if not d.is_empty():
+				changed.append({"path": p, "changes": d})
+	return {
+		"status": "ok",
+		"added": added,
+		"removed": removed,
+		"changed": changed,
+		"summary": {"added": added.size(), "removed": removed.size(), "changed": changed.size()},
+	}
+
+
+func _capture_index(root_path: String, max_depth: int):
+	if host == null or host.get_tree() == null:
+		return null
+	var root_node: Node
+	if root_path == "":
+		root_node = host.get_tree().current_scene
+		if root_node == null:
+			root_node = host.get_tree().root
+	else:
+		root_node = host.get_node_or_null(NodePath(root_path))
+		if root_node == null:
+			return null
+	var index := {}
+	_index_node(root_node, 0, max_depth, index)
+	return index
+
+
+func _index_node(node: Node, depth: int, max_depth: int, index: Dictionary) -> void:
+	var entry := {"type": node.get_class()}
+	if node is Node2D:
+		entry["position"] = [snappedf(node.global_position.x, 0.01), snappedf(node.global_position.y, 0.01)]
+		entry["visible"] = node.visible
+		entry["rotation"] = snappedf(node.rotation, 0.0001)
+	elif node is Control:
+		entry["position"] = [snappedf(node.global_position.x, 0.01), snappedf(node.global_position.y, 0.01)]
+		entry["size"] = [snappedf(node.size.x, 0.01), snappedf(node.size.y, 0.01)]
+		entry["visible"] = node.visible
+	elif node is CanvasItem:
+		entry["visible"] = node.visible
+	var props := {}
+	for prop in node.get_property_list():
+		var usage: int = int(prop.get("usage", 0))
+		if not (usage & PROPERTY_USAGE_SCRIPT_VARIABLE):
+			continue
+		var pname: String = prop.get("name", "")
+		if pname == "" or pname.begins_with("_"):
+			continue
+		props[pname] = _serialize(node.get(pname))
+	if not props.is_empty():
+		entry["props"] = props
+	index[String(node.get_path())] = entry
+	if depth < max_depth:
+		for child in node.get_children():
+			_index_node(child, depth + 1, max_depth, index)
+
+
+func _load_snapshot_index(label: String):
+	if label == "":
+		return null
+	var path := "user://mcp_snapshots/%s.json" % label
+	if not FileAccess.file_exists(path):
+		# Allow passing an absolute/user path too.
+		path = label
+		if not FileAccess.file_exists(path):
+			return null
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return null
+	var parsed = JSON.parse_string(f.get_as_text())
+	f.close()
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return null
+	return parsed.get("index", null)
+
+
+func _diff_entry(before: Dictionary, after: Dictionary) -> Dictionary:
+	# Field-level diff of two snapshot entries (type/position/visible/size/
+	# rotation and each script property). Returns {field: [old, new]}.
+	var changes := {}
+	for key in ["type", "position", "visible", "size", "rotation"]:
+		if before.get(key, null) != after.get(key, null):
+			if before.has(key) or after.has(key):
+				changes[key] = [before.get(key, null), after.get(key, null)]
+	var bp: Dictionary = before.get("props", {})
+	var ap: Dictionary = after.get("props", {})
+	var prop_changes := {}
+	for k in bp.keys():
+		if bp[k] != ap.get(k, null):
+			prop_changes[k] = [bp[k], ap.get(k, null)]
+	for k in ap.keys():
+		if not bp.has(k):
+			prop_changes[k] = [null, ap[k]]
+	if not prop_changes.is_empty():
+		changes["props"] = prop_changes
+	return changes
+
+
+# --- Adversarial self-check ---------------------------------------------
+
+func chain_verify(params: Dictionary) -> Dictionary:
+	# Anti-overconfidence gate (mirrors the project's "pin tests aren't
+	# validation" rule). Given a `claim` describing what you believe you
+	# delivered, return challenge questions plus automated evidence (live log
+	# error counts) the agent must reconcile before closing the task.
+	var claim: String = params.get("claim", "")
+	if claim == "":
+		return {"status": "error", "message": "Missing 'claim' describing what you think you delivered"}
+
+	var questions := [
+		"Did you DRIVE the feature live (dispatch_action / simulate_click / panel toggle), or only assert that code text is present?",
+		"Did you capture a screenshot showing the feature's EFFECT (not the default game screen)?",
+		"Did any ERROR or SCRIPT ERROR appear in the debug log while exercising '%s'?" % claim,
+		"If '%s' has a UI affordance, can a player actually reach it, or only the engine?" % claim,
+		"What is the strongest reason a reviewer would say '%s' is NOT done — and have you ruled it out with evidence?" % claim,
+	]
+
+	var evidence := {}
+	var log_res := read_debug_log({"tail": 300})
+	if log_res.get("status", "") == "ok":
+		evidence["log_error_count"] = log_res["counts"]["error"]
+		evidence["log_warning_count"] = log_res["counts"]["warning"]
+		var errs: Array = log_res.get("errors", [])
+		evidence["recent_errors"] = errs.slice(maxi(0, errs.size() - 5))
+
+	return {
+		"status": "ok",
+		"claim": claim,
+		"questions": questions,
+		"evidence": evidence,
+		"verdict_hint": "Answer every question with concrete evidence before declaring '%s' verified." % claim,
+	}
 
 
 # --- Frame / time waits --------------------------------------------------

--- a/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
+++ b/40k/addons/godot_mcp/handlers/wh40k_handlers.gd
@@ -10,6 +10,103 @@ extends RefCounted
 
 var host: Node = null
 
+const TestingHandlers := preload("res://addons/godot_mcp/handlers/testing_handlers.gd")
+
+
+# --- Delivery verification (end-to-end gate) --------------------------
+
+func verify_delivery(params: Dictionary) -> Dictionary:
+	# One-call gate-check mirroring the project rule that a feature is not
+	# verified until it has been driven end-to-end. Four dimensions:
+	#   1. scene-tree integrity   (current scene present)
+	#   2. game-state health      (GameState + required autoloads present)
+	#   3. debug-log cleanliness  (no ERROR lines, optionally since a marker)
+	#   4. caller assertions      (GDScript expressions over live state)
+	# Returns passed=false if ANY required check fails.
+	var checks: Array = []
+	var passed := true
+
+	# --- 1. Scene tree integrity ---
+	var scene_ok: bool = host != null and host.get_tree() != null and host.get_tree().current_scene != null
+	checks.append({"name": "scene_tree.current_scene_present", "passed": scene_ok})
+	if not scene_ok:
+		passed = false
+
+	# --- 2. Game-state health ---
+	var gs := _autoload("GameState")
+	var gs_ok: bool = gs != null and typeof(gs.state) == TYPE_DICTIONARY and gs.state.has("units")
+	checks.append({"name": "game_state.present", "passed": gs_ok})
+	if not gs_ok:
+		passed = false
+
+	var required: Array = params.get("required_autoloads", ["GameState", "PhaseManager", "TurnManager"])
+	for al in required:
+		var present: bool = _autoload(String(al)) != null
+		checks.append({"name": "autoload.%s" % al, "passed": present})
+		if not present:
+			passed = false
+
+	if params.has("expected_phase") and gs_ok:
+		var want := String(params["expected_phase"]).to_upper()
+		var have := _phase_name(gs.state.get("meta", {}).get("phase", -1))
+		var ph_ok: bool = have == want
+		checks.append({"name": "phase.is_%s" % want, "passed": ph_ok, "actual": have})
+		if not ph_ok:
+			passed = false
+
+	# --- 3. Debug-log cleanliness + 4. caller assertions (share one helper) ---
+	var th = TestingHandlers.new()
+	th.host = host
+
+	var log_summary := {}
+	var fail_on_error: bool = params.get("fail_on_log_error", true)
+	var log_params := {"tail": int(params.get("log_tail", 500)), "include_lines": false}
+	if params.get("since_marker", "") != "":
+		log_params["since_marker"] = params["since_marker"]
+	var log_res = th.read_debug_log(log_params)
+	if log_res.get("status", "") == "ok":
+		log_summary = log_res.get("counts", {})
+		var err_count := int(log_res.get("counts", {}).get("error", 0))
+		var errs: Array = log_res.get("errors", [])
+		if errs.size() > 0:
+			log_summary["sample_errors"] = errs.slice(maxi(0, errs.size() - 5))
+		if fail_on_error:
+			checks.append({"name": "log.no_errors", "passed": err_count == 0, "error_count": err_count})
+			if err_count != 0:
+				passed = false
+
+	var assertions: Array = params.get("assertions", [])
+	for a in assertions:
+		if typeof(a) != TYPE_DICTIONARY:
+			continue
+		var expr_src: String = a.get("expr", "")
+		var desc: String = a.get("description", expr_src if expr_src != "" else "assertion")
+		var a_passed := false
+		var value = null
+		if expr_src != "":
+			# Auto-wrap a bare single-line expression so it returns a value.
+			var code := expr_src
+			if expr_src.find("\n") == -1 and expr_src.find("return") == -1:
+				code = "return (%s)" % expr_src
+			var res = th.execute_script({"code": code, "multiline": true, "node_path": a.get("node_path", "/root")})
+			if res.get("status", "") == "ok":
+				value = res.get("result", null)
+				if a.has("expect"):
+					a_passed = value == a["expect"]
+				else:
+					a_passed = bool(value)
+		checks.append({"name": "assertion.%s" % desc, "passed": a_passed, "value": value})
+		if not a_passed:
+			passed = false
+
+	return {
+		"status": "ok",
+		"passed": passed,
+		"verdict": "PASS" if passed else "FAIL",
+		"checks": checks,
+		"log_summary": log_summary,
+	}
+
 
 # --- Board / overall state --------------------------------------------
 

--- a/40k/tests/TESTING_METHODOLOGY.md
+++ b/40k/tests/TESTING_METHODOLOGY.md
@@ -56,6 +56,8 @@ get_viewport().get_texture().get_image().save_png(absolute_path)
 
 This is more reliable than the addons/godot_mcp `capture_screenshot` tool, which awaits `RenderingServer.frame_post_draw` and times out (30s default) when the engine isn't drawing.
 
+**Verified 2026-05-30:** when the game is actually running and drawing, `capture_screenshot` works fine and returns a full-res PNG plus an inline image — including in a **headless Linux/remote container** under the `godot` shim's auto-`xvfb` + Mesa llvmpipe software renderer. The "times out" caveat above applies to the backgrounded-window / not-drawing case, not to a normally-running game. See "Running the game in a remote / headless container" below and `CLAUDE.md`.
+
 **macOS gotcha (verified):** when the Godot window is backgrounded, macOS suspends rendering for that window. `viewport.get_texture()` then returns the last-rendered frame, which can be **md5-identical to a frame from minutes earlier**. Before any screenshot:
 
 ```bash
@@ -83,6 +85,38 @@ get_tree().get_root().get_node("Main/BoardRoot/TokenLayer").get_child(N).set("mo
 To find a specific unit's token, iterate `TokenLayer.get_children()` and match `get_meta("unit_id")` against the unit_id you're looking for.
 
 ---
+
+## Running the game in a remote / headless container (you CAN do this)
+
+Do not assume the game can only be run on the local Mac. In the remote
+container the `godot` shim on `$HOME/bin` auto-wraps the binary with `xvfb-run`
+(1920×1080) and the GL-compatibility renderer over Mesa **llvmpipe** software
+rendering — no GPU needed. Verified 2026-05-30: the full MainMenu rendered, the
+MCP bridge came up, and live `capture_screenshot` / `scene_snapshot` /
+`diff_snapshot` / `verify_delivery` all worked end-to-end.
+
+```bash
+export PATH="$HOME/bin:$PATH"
+godot --headless --import                                   # once per fresh clone: builds global-class cache
+godot --path . --rendering-method gl_compatibility > /tmp/game.log 2>&1 &
+until grep -q "GodotMCP] Listening" /tmp/game.log; do sleep 0.5; done   # bridge on :9080
+```
+
+Then drive `127.0.0.1:9080` from an MCP host (`godot-mcp/build/runtime_bridge.js`)
+or a small NDJSON-over-TCP client: send `{"id":N,"command":"...","params":{}}\n`,
+read one JSON line per response. If you try this and it genuinely fails, **say so
+explicitly to the user and show what you tried** — never silently fall back to
+headless-only and call a UI feature "verified."
+
+### Updated MCP commands for live validation
+
+- `verify_delivery` — gate: scene-tree integrity + autoloads + `log.no_errors`
+  (optionally `since_marker`) + GDScript `assertions`; returns `verdict: PASS|FAIL`.
+- `read_debug_log` — newest `debug_*.log` bucketed into error/warning/info/debug.
+- `scene_snapshot` / `diff_snapshot` — capture and diff node state before/after.
+- `chain_verify` — adversarial challenge questions + live log evidence for a `claim`.
+- `execute_script` (multi-line) — `multiline:true`; target is `node`, tree is
+  `tree`, autoloads by global name; `return` a value.
 
 ## Headless GDScript regression tests
 

--- a/40k/tests/test_mcp_enhancements.gd
+++ b/40k/tests/test_mcp_enhancements.gd
@@ -1,0 +1,108 @@
+extends SceneTree
+
+# Headless unit coverage for the godot-mcp addon enhancements:
+#   * testing_handlers.categorize_log_lines / _classify_log_line
+#   * testing_handlers _diff_entry (snapshot diffing)
+#   * execute_script compiled multi-line path (return value)
+#
+# These are pure / tree-light helpers, so they are validated headless-only per
+# the project gate (no UI affordance). The live bridge commands (read_debug_log,
+# scene_snapshot, diff_snapshot, verify_delivery, chain_verify) wrap these and
+# require a running game to exercise end-to-end.
+#
+# Run via: godot --headless --path 40k --script tests/test_mcp_enhancements.gd
+
+const TestingHandlers := preload("res://addons/godot_mcp/handlers/testing_handlers.gd")
+
+var _passed := 0
+var _failed := 0
+
+
+func _initialize():
+	# One frame so the SceneTree root is fully attached (node paths resolve).
+	await process_frame
+	print("\n=== godot-mcp enhancements: headless helper tests ===\n")
+	_test_log_categorization()
+	_test_log_marker_format_fallback()
+	_test_diff_entry()
+	_test_compiled_execute()
+	print("\n--- %d passed, %d failed ---" % [_passed, _failed])
+	quit(1 if _failed > 0 else 0)
+
+
+func _check(label: String, cond: bool) -> void:
+	if cond:
+		_passed += 1
+		print("[PASS] %s" % label)
+	else:
+		_failed += 1
+		print("[FAIL] %s" % label)
+
+
+func _test_log_categorization() -> void:
+	var lines := [
+		"[2026-05-29 12:00:00] [INFO   ] DebugLogger initialized",
+		"[2026-05-29 12:00:01] [WARNING] low ammo",
+		"[2026-05-29 12:00:02] [ERROR  ] unit not found",
+		"[2026-05-29 12:00:03] [DEBUG  ] tick",
+		"",
+		"plain unclassified line",
+	]
+	var summary := TestingHandlers.categorize_log_lines(lines)
+	var counts: Dictionary = summary["counts"]
+	_check("categorize: 1 error", counts["error"] == 1)
+	_check("categorize: 1 warning", counts["warning"] == 1)
+	_check("categorize: 1 info", counts["info"] == 1)
+	_check("categorize: 1 debug", counts["debug"] == 1)
+	_check("categorize: 1 other (blank skipped)", counts["other"] == 1)
+	_check("categorize: error line captured", summary["errors"].size() == 1)
+	_check("categorize: warning line captured", summary["warnings"].size() == 1)
+
+
+func _test_log_marker_format_fallback() -> void:
+	# Raw engine output (no DebugLogger brackets) should still classify.
+	var lines := [
+		"ERROR: Cannot open file 'x'.",
+		"SCRIPT ERROR: Parse Error: boom",
+		"WARNING: deprecated call",
+		"random noise",
+	]
+	var summary := TestingHandlers.categorize_log_lines(lines)
+	_check("fallback: 2 errors (ERROR: + SCRIPT ERROR)", summary["counts"]["error"] == 2)
+	_check("fallback: 1 warning", summary["counts"]["warning"] == 1)
+	_check("fallback: 1 other", summary["counts"]["other"] == 1)
+
+
+func _test_diff_entry() -> void:
+	var th = TestingHandlers.new()
+	var before := {"type": "Node2D", "position": [10.0, 20.0], "visible": true,
+		"props": {"hp": 5, "name": "a"}}
+	var after := {"type": "Node2D", "position": [30.0, 20.0], "visible": false,
+		"props": {"hp": 3, "name": "a"}}
+	var d: Dictionary = th._diff_entry(before, after)
+	_check("diff: position change detected", d.has("position"))
+	_check("diff: visible change detected", d.has("visible"))
+	_check("diff: type unchanged not reported", not d.has("type"))
+	_check("diff: hp prop change detected", d.has("props") and d["props"].has("hp"))
+	_check("diff: unchanged prop 'name' not reported", d.has("props") and not d["props"].has("name"))
+
+	var same: Dictionary = th._diff_entry(before, before.duplicate(true))
+	_check("diff: identical entries produce empty diff", same.is_empty())
+
+
+func _test_compiled_execute() -> void:
+	# Multi-line compiled snippet returns a value; node arg is the target.
+	var th = TestingHandlers.new()
+	var host_node := Node.new()
+	root.add_child(host_node)  # host must live in the tree so get_node_or_null works
+	th.host = host_node
+	var res = th.execute_script({
+		"code": "var total = 0\nfor i in range(5):\n\ttotal += i\nreturn total",
+		"multiline": true,
+		"node_path": "/root",
+	})
+	_check("compiled execute: status ok", res.get("status", "") == "ok")
+	_check("compiled execute: sum(0..4) == 10", res.get("result", null) == 10)
+
+	var bad = th.execute_script({"code": "this is not valid gdscript ::", "multiline": true})
+	_check("compiled execute: parse error surfaced", bad.get("status", "") == "error" and bad.get("error_type", "") == "parse")

--- a/40k/tests/test_mcp_enhancements.gd
+++ b/40k/tests/test_mcp_enhancements.gd
@@ -104,5 +104,12 @@ func _test_compiled_execute() -> void:
 	_check("compiled execute: status ok", res.get("status", "") == "ok")
 	_check("compiled execute: sum(0..4) == 10", res.get("result", null) == 10)
 
+	# `tree` binding: node/tree methods resolve through the params, not bare.
+	var tree_res = th.execute_script({
+		"code": "return tree.get_node_count() > 0",
+		"multiline": true, "node_path": "/root",
+	})
+	_check("compiled execute: tree param usable", tree_res.get("status", "") == "ok" and tree_res.get("result", false) == true)
+
 	var bad = th.execute_script({"code": "this is not valid gdscript ::", "multiline": true})
 	_check("compiled execute: parse error surfaced", bad.get("status", "") == "error" and bad.get("error_type", "") == "parse")

--- a/40k/tests/test_mcp_enhancements.gd.uid
+++ b/40k/tests/test_mcp_enhancements.gd.uid
@@ -1,0 +1,1 @@
+uid://cfaro3c7c1656

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,75 @@ Do not remove debugging logs unless specifically asked to do so.
 
 If godot is not running in the command line run export PATH="$HOME/bin:$PATH" and try again.
 
-The debug output of godot is being piped to files in the format /Users/.../Library/Application Support/Godot/app_userdata/40k/logs/debug_YYYYMMDD_HHMMSS.log
-As the godot output is not always reachable, ensure that all logging is also saved to this file.
+The debug output of godot is being piped to files in the format `<godot-userdata>/40k/logs/debug_YYYYMMDD_HHMMSS.log`.
+The userdata dir is platform-specific:
+- macOS (local): `~/Library/Application Support/Godot/app_userdata/40k/`
+- Linux / remote container: `~/.local/share/godot/app_userdata/40k/`
+
+Never hardcode either path — resolve it at runtime with `ProjectSettings.globalize_path("user://logs/")`, or just call the MCP `get_log_path` / `read_debug_log` commands, which return the absolute path for the current machine. As the godot stdout is not always reachable, ensure all logging is also saved to this file.
+
+## You CAN run the game AND screenshot the UI — even in a headless / remote container
+
+This is the single most important operational fact, and past sessions
+(including 2026-05-30) wrongly assumed the opposite and "fell back" to
+headless-only validation. **Do not repeat that mistake.** The `godot` shim on
+`$HOME/bin` auto-wraps the binary with `xvfb-run` (1920×1080) and the GL
+compatibility renderer backed by Mesa **llvmpipe** software rendering — no GPU
+required. The full UI renders and the in-game MCP bridge comes up.
+
+First run in a fresh clone/container — build the import + global-class cache once:
+
+```bash
+export PATH="$HOME/bin:$PATH"
+godot --headless --import          # imports resources, writes .godot/global_script_class_cache.cfg
+```
+
+Then launch the real game windowed (the shim provides the virtual display):
+
+```bash
+godot --path 40k --rendering-method gl_compatibility > /tmp/game.log 2>&1 &
+# Wait for the bridge, do NOT sleep-guess:
+until grep -q "GodotMCP] Listening" /tmp/game.log; do sleep 0.5; done
+```
+
+The bridge then listens on `127.0.0.1:9080` (runtime) and `9081` (editor). Drive
+it from an MCP host (`godot-mcp/build/runtime_bridge.js`) or, when no host is
+wired up, a tiny NDJSON-over-TCP client: send `{"id":N,"command":"...","params":{}}\n`,
+read one JSON line back per request. `capture_screenshot` writes a full-res PNG
+under `user://test_screenshots/` and returns an inline image you can view.
+
+If — after actually trying the above — you genuinely cannot run the game or
+capture a screenshot, you MUST **flag it explicitly to the user and explain
+what you tried and how it failed.** Never silently downgrade to headless-only
+and never claim a feature is verified without the evidence the gate requires.
+
+## Updated MCP bridge command set (addons/godot_mcp)
+
+Beyond the originals (`get_board_state`, `dispatch_action`, `move_unit_to`,
+`get_legal_actions`, `select_unit`, `transition_to_phase`, `get_scene_state`,
+`get_node_info`, `simulate_click`, `capture_screenshot`, …) the bridge now also
+exposes — prefer these for validation:
+
+- `verify_delivery` — **the one-call gate.** Checks scene-tree integrity,
+  required autoloads, that the debug log has no `ERROR` lines (optionally
+  `since_marker`), and any GDScript `assertions` you pass over live state.
+  Returns `verdict: PASS|FAIL`. Run it after driving a feature.
+- `read_debug_log` — newest `debug_*.log` bucketed into error/warning/info/debug
+  counts. Use it to assert "no errors fired" instead of grepping. Supports
+  `tail`, `since_marker`, `levels`.
+- `scene_snapshot` + `diff_snapshot` — capture a path→state index, then diff
+  before/after (or vs. the live tree) to prove only the intended nodes moved
+  (reports field-level changes, e.g. `visible: [true, false]`).
+- `chain_verify` — pass your `claim`; returns adversarial challenge questions +
+  live log evidence. Answer them honestly before closing a task.
+- `execute_script` — now supports **multi-line** mode (`multiline: true` or any
+  newline): full statements, `return`, autoloads by global name. The target node
+  is bound as `node` and the scene tree as `tree` — call methods on those
+  (`tree.get_node_count()`), not bare. Single-line still uses the Expression path.
+- `write_script` — refuses to overwrite an existing file without `overwrite: true`,
+  and honours the `GODOT_MCP_ALLOWED_WRITE_PATHS` allow-list when set.
+
+Reference: `40k/addons/godot_mcp/README.md`.
 
 ## Feature validation rule (project gate)
 
@@ -34,19 +101,29 @@ evidence.
 
 **To claim an audit task is validated, you must:**
 
+0. Run the game (see "You CAN run the game…" above) — this is possible in the
+   remote container, not just locally. `scene_snapshot` the relevant subtree
+   first if you want a before/after diff.
 1. Drive the feature path live via the MCP bridge:
    - `dispatch_action({type: "X", ...})` and assert `success: true`
-   - or `execute_script` calling the new helper and read the return
-   - or `simulate_key_press` / panel toggle to open the new UI
-2. Inspect the resulting state via `execute_script` reading the diff /
-   updated flags / spawned dialog / tween-in-progress
+   - or `execute_script` (now multi-line) calling the new helper and read the return
+   - or `simulate_click` / `simulate_key_press` / panel toggle to open the new UI
+2. Inspect the resulting state:
+   - `diff_snapshot` against your before-snapshot to see exactly which nodes
+     changed, and/or `execute_script` reading the updated flags / spawned dialog
+   - `read_debug_log` (or `verify_delivery`'s `log.no_errors` check) to confirm
+     **no ERROR / SCRIPT ERROR fired** while exercising the path
 3. Capture a screenshot showing the **feature's effect** — the dialog
    rendered, the token at the new position, the panel listing real rows.
    The default game screen does not count.
+4. Run `verify_delivery` with the relevant `expected_phase` / `assertions` as a
+   final gate; it should return `verdict: PASS`. Optionally run `chain_verify`
+   and answer its questions before declaring done.
 
 If the feature has no UI affordance (pure-math helper), step 3 is the
 return value of step 1/2 captured in the conversation transcript; an
 explicit screenshot is optional. Everything with a UI surface needs the
-in-game effect captured.
+in-game effect captured. If you could not produce the screenshot/MCP
+evidence, say so explicitly and why — do not fail silently.
 
 **Reference**: `~/.claude/projects/-Users-robertocallaghan-Documents-claude-godotv2/memory/feedback_pin_tests_arent_live_validation.md`

--- a/SESSION_PLAYBOOK.md
+++ b/SESSION_PLAYBOOK.md
@@ -157,6 +157,29 @@ uploaded as artifacts even on failure.
 | `40k/tests/scenarios/_schema.md` | Scenario format spec. |
 | `.llm/scaled-testing-plan.md` | Living design doc — read first if you're new to this. |
 
+## Validating via the MCP bridge (updated set)
+
+Windowed validation works in the **remote container too**, not just locally:
+the `godot` shim auto-wraps with `xvfb-run` + Mesa llvmpipe, so the UI renders
+and `addons/godot_mcp` comes up on `127.0.0.1:9080`. Run `godot --headless
+--import` once per fresh clone first (builds the global-class cache). If you
+genuinely can't run the game after trying, **flag it to the user** — don't
+quietly drop to headless-only. See `CLAUDE.md` for the launch recipe.
+
+When driving the bridge directly (live validation, ad-hoc repro), prefer:
+
+| Command | Purpose |
+|---|---|
+| `verify_delivery` | One-call gate: scene-tree integrity + autoloads + `log.no_errors` + your GDScript `assertions`. Returns `verdict: PASS\|FAIL`. Run after driving a feature. |
+| `read_debug_log` | Newest `debug_*.log` bucketed into error/warning/info/debug. Assert "no errors fired" with `since_marker` to scope to your action. |
+| `scene_snapshot` / `diff_snapshot` | Before/after node-state diff; proves only the intended nodes changed (field-level, e.g. `visible:[true,false]`). |
+| `chain_verify` | Pass your `claim`; returns adversarial questions + live log evidence. Answer before closing. |
+| `execute_script` (multi-line) | `multiline:true` for full statements; target is `node`, scene tree is `tree`, autoloads by global name. |
+
+These complement — they do **not** replace — the scenario runner. A
+player-facing change still needs a passing `run_scenario.sh` scenario; the
+bridge commands above are for live inspection and the `verify_delivery` gate.
+
 ## File locations
 
 - Scenarios: `40k/tests/scenarios/sp/*.json` and `40k/tests/scenarios/mp/*.json`

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -235,7 +235,7 @@ const TOOLS: ToolDef[] = [
   {
     name: 'execute_script',
     description:
-      'Evaluate GDScript against an optional target node. Single-line code uses an Expression (the node is visible as `self`). Multi-line code — or any code with `multiline:true` — is compiled into a throwaway script so full statements work: `var`, `if`, `for`, `return`, method calls, and autoloads (GameState, PhaseManager, …) by their global names. In compiled mode the resolved node is the `node` parameter; `return <value>` to send a result back. Runtime errors inside compiled code are not catchable — read them back with read_debug_log.',
+      'Evaluate GDScript against an optional target node. Single-line code uses an Expression (the node is visible as `self`). Multi-line code — or any code with `multiline:true` — is compiled into a throwaway script so full statements work: `var`, `if`, `for`, `return`, and autoloads (GameState, PhaseManager, …) by their global names. In compiled mode the resolved node is the `node` parameter and the scene tree is the `tree` parameter — call node/tree methods on those (e.g. `tree.get_node_count()`), not bare. `return <value>` to send a result back. Runtime errors inside compiled code are not catchable — read them back with read_debug_log.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/godot-mcp/src/runtime_bridge.ts
+++ b/godot-mcp/src/runtime_bridge.ts
@@ -235,16 +235,73 @@ const TOOLS: ToolDef[] = [
   {
     name: 'execute_script',
     description:
-      'Parse and evaluate a one-line GDScript expression against an optional target node. The expression sees the node as `self`.',
+      'Evaluate GDScript against an optional target node. Single-line code uses an Expression (the node is visible as `self`). Multi-line code — or any code with `multiline:true` — is compiled into a throwaway script so full statements work: `var`, `if`, `for`, `return`, method calls, and autoloads (GameState, PhaseManager, …) by their global names. In compiled mode the resolved node is the `node` parameter; `return <value>` to send a result back. Runtime errors inside compiled code are not catchable — read them back with read_debug_log.',
     inputSchema: {
       type: 'object',
       properties: {
         code: { type: 'string' },
         node_path: { type: 'string', default: '/root' },
-        input_names: { type: 'array', items: { type: 'string' } },
-        input_values: { type: 'array' },
+        multiline: {
+          type: 'boolean',
+          description: 'Force compiled multi-line mode. Auto-enabled when code contains a newline.',
+        },
+        input_names: { type: 'array', items: { type: 'string' }, description: 'Single-line Expression mode only.' },
+        input_values: { type: 'array', description: 'Single-line Expression mode only.' },
       },
       required: ['code'],
+    },
+  },
+  {
+    name: 'read_debug_log',
+    description:
+      'Read the running game\'s debug log bucketed into errors/warnings/info/debug. Use this to assert "no errors fired" after driving a feature instead of grepping raw text. Reads the newest user://logs/debug_*.log by default; `since_marker` keeps only lines after a marker\'s last occurrence (log a unique marker before your action to scope the read).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: { type: 'string', description: 'Absolute or user:// path. Default: newest debug log.' },
+        tail: { type: 'number', default: 200, description: 'Keep only the last N non-empty lines (0 = all).' },
+        since_marker: { type: 'string', description: "Keep only lines after this marker's last occurrence." },
+        levels: { type: 'array', items: { type: 'string' }, description: 'Filter returned lines, e.g. ["ERROR"].' },
+        include_lines: { type: 'boolean', default: true },
+      },
+    },
+  },
+  {
+    name: 'scene_snapshot',
+    description:
+      'Capture a compact, diff-friendly index of the live scene tree (path -> type/position/visibility/size/script-properties) and persist it under user://mcp_snapshots/<label>.json. Take one before and one after a change, then diff_snapshot to prove only the intended nodes moved.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: { type: 'string' },
+        root: { type: 'string', description: 'Subtree root path. Default: current scene.' },
+        max_depth: { type: 'number', default: 12 },
+      },
+    },
+  },
+  {
+    name: 'diff_snapshot',
+    description:
+      'Diff two scene snapshots and report added / removed / changed nodes (with field-level changes). `before` is a label captured via scene_snapshot; `after` is another label, or omit / "__live__" to diff against the current live tree.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        before: { type: 'string' },
+        after: { type: 'string', description: 'Label, or "__live__" / omitted to diff the live tree.' },
+        root: { type: 'string' },
+        max_depth: { type: 'number', default: 12 },
+      },
+      required: ['before'],
+    },
+  },
+  {
+    name: 'chain_verify',
+    description:
+      "Anti-overconfidence gate. Given a `claim` describing what you believe you delivered, returns 5 adversarial challenge questions plus automated evidence (live log error/warning counts) you must reconcile before closing the task. Mirrors the project rule that pin tests / markers are not validation.",
+    inputSchema: {
+      type: 'object',
+      properties: { claim: { type: 'string' } },
+      required: ['claim'],
     },
   },
   {
@@ -372,10 +429,15 @@ const TOOLS: ToolDef[] = [
   },
   {
     name: 'write_script',
-    description: 'Write text to a res:// path. Refuses paths outside res://.',
+    description:
+      'Write text to a res:// path. Refuses paths outside res:// (and outside GODOT_MCP_ALLOWED_WRITE_PATHS when that env is set). Refuses to overwrite an existing file unless `overwrite:true` is passed.',
     inputSchema: {
       type: 'object',
-      properties: { path: { type: 'string' }, content: { type: 'string' } },
+      properties: {
+        path: { type: 'string' },
+        content: { type: 'string' },
+        overwrite: { type: 'boolean', default: false, description: 'Required to clobber an existing file.' },
+      },
       required: ['path', 'content'],
     },
   },
@@ -505,6 +567,30 @@ const TOOLS: ToolDef[] = [
         model_id: { type: 'string' },
       },
       required: ['unit_id', 'dest_x', 'dest_y'],
+    },
+  },
+  {
+    name: 'verify_delivery',
+    description:
+      'WH40K [GATE]: one-call end-to-end verification mirroring the rule that a feature is not done until driven live. Checks (1) scene-tree integrity, (2) GameState + required autoloads present, (3) debug log has no ERROR lines (optionally since a marker), and (4) caller `assertions` — GDScript expressions evaluated over live state (autoloads reachable by name). Returns passed=false if any required check fails.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        required_autoloads: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Default ["GameState","PhaseManager","TurnManager"].',
+        },
+        expected_phase: { type: 'string', description: 'e.g. "MOVEMENT" — fails if the current phase differs.' },
+        fail_on_log_error: { type: 'boolean', default: true },
+        since_marker: { type: 'string', description: 'Only scan log lines after this marker.' },
+        log_tail: { type: 'number', default: 500 },
+        assertions: {
+          type: 'array',
+          description: 'Each: { expr, description?, node_path?, expect? }. expr is GDScript; bare expressions are auto-returned. Passes if expr == expect (when given) else truthy.',
+          items: { type: 'object' },
+        },
+      },
     },
   },
 ];


### PR DESCRIPTION
## Summary

Cherry-picks the highest-value ideas from `wgt19861219/godot-mcp-enhanced` into our in-engine `addons/godot_mcp` bridge **without** replacing our WH40K domain tooling. Six new/enhanced capabilities, all validated live against the running game.

## New bridge commands
- **`verify_delivery`** (WH40K) — one-call end-to-end gate: scene-tree integrity + required autoloads + debug-log cleanliness (`log.no_errors`, optional `since_marker`) + caller GDScript `assertions` over live state. Returns `verdict: PASS|FAIL`.
- **`read_debug_log`** — newest `user://logs/debug_*.log` bucketed into error/warning/info/debug counts. Supports `tail`, `since_marker`, `levels`. Lets scenarios assert "no errors fired" without grepping.
- **`scene_snapshot` / `diff_snapshot`** — capture a compact path→state index and diff two snapshots (or one vs. the live tree). Reports added/removed/changed nodes with field-level diffs.
- **`chain_verify`** — anti-overconfidence gate: given a `claim`, returns adversarial challenge questions + live log evidence.

## Enhanced existing commands
- **`execute_script` → multi-line mode** — `multiline:true` (or any newline) compiles a snippet so full statements work (`var`/`if`/`for`/`return`, autoloads by global name). Target node bound as `node`, scene tree as `tree`. Single-line stays on the fast `Expression` path (backward compatible).
- **`write_script` hardening** — `GODOT_MCP_ALLOWED_WRITE_PATHS` allow-list + `overwrite:true` confirmation before clobbering an existing file.

## Supporting changes
- Registered the new commands in `command_router.gd`; mirrored as MCP tools in `runtime_bridge.ts`.
- Updated `addons/godot_mcp/README.md` incl. a Security model section (explains why upstream's stdout tamper-proof markers don't apply to our id-correlated TCP transport).
- Docs: `CLAUDE.md`, `SESSION_PLAYBOOK.md`, `TESTING_METHODOLOGY.md` — record the new commands and that the game **can** be run and screenshotted in the headless/remote container (shim auto-xvfb + Mesa llvmpipe), with an explicit "flag failures, don't fail silently" rule.

## Validation
- Headless: `40k/tests/test_mcp_enhancements.gd` — **20/20** (log categorization incl. raw-engine fallback, snapshot field diff, compiled multi-line execute incl. `tree` binding + parse-error surfacing).
- Live (running MainMenu, bridge on `:9080`): multi-line `execute_script`, `scene_snapshot`, `diff_snapshot` (caught `StartButton visible:[true,false]`), `verify_delivery` (PASS, 8 checks), `chain_verify`, and `capture_screenshot` before/after.
- TS bridge builds clean (`npm run build`).

## Scope notes
Does **not** pull in upstream's 130+ generic tools or change the transport — our WH40K domain commands (`dispatch_action`, `get_board_state`, …) remain primary. Only behavior change to an existing tool is `write_script` now requiring `overwrite:true` to overwrite (intended hardening).

https://claude.ai/code/session_01DN8u9pZgkmKr4bdDfUhGQP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DN8u9pZgkmKr4bdDfUhGQP)_