### PR TITLE
Movement: grow the reach circle in place when an Advance roll resolves

### DIFF
--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -2901,6 +2901,23 @@ func _update_movement_display_with_advance(dice_result: int) -> void:
 		inches_left_label.text = "Left: %.1f\"" % total_movement
 		inches_left_label.modulate = Color.WHITE
 
+	# T-094 (revised): an Advance roll raises the move cap, so any reach circle
+	# already on screen must grow to the new distance rather than show the stale,
+	# smaller value. (A circle picked up after this point already reads the new
+	# cap via _start_model_drag, so this only matters for a circle drawn before
+	# the roll resolved.)
+	_refresh_model_range_overlay()
+
+func _refresh_model_range_overlay() -> void:
+	# Redraw the currently-displayed per-model reach circle(s) using the latest
+	# move cap. No-op when nothing is being dragged.
+	if not is_instance_valid(move_range_visual):
+		return
+	if group_dragging:
+		_show_group_range_overlay()
+	elif dragging_model and not selected_model.is_empty():
+		_show_model_range_overlay(selected_model, drag_start_pos)
+
 func _update_dice_log_display(dice_log: Array) -> void:
 	if not dice_log_display:
 		return

--- a/40k/tests/scenarios/sp/move_range_advance_grows.json
+++ b/40k/tests/scenarios/sp/move_range_advance_grows.json
@@ -1,0 +1,54 @@
+{
+  "id": "move_range_advance_grows",
+  "covers": [
+    "movement.advance_distance_circle",
+    "phases.MovementPhase.UI.advance_refreshes_range_overlay"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "T-094 (revised): when an Advance roll raises the move cap while a per-model reach circle is already displayed, the circle must grow to the new distance in place (not stay at the stale base-Move size). Sets up an in-progress drag with move_cap=6 (circle drawn at 6\"), then calls _update_movement_display_with_advance(4) (base 6 + advance 4 = 10) and asserts the SAME overlay redrew to a 10\" radius with a '10\"' label, with no re-pickup.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").set(\"active_unit_id\", \"U_BLADE_CHAMPION_A\")" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").set(\"move_cap_inches\", 6.0)" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").set(\"drag_start_pos\", Vector2(0, 0))" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").set(\"selected_model\", GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0])" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").set(\"dragging_model\", true)" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\")._refresh_model_range_overlay()" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script",
+      "script": "(main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(0).points[0].distance_to(Vector2(0,0)) / Measurement.PX_PER_INCH)",
+      "expect_max": 6.3 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(8).text",
+      "equals": "6\"" },
+    { "act": "screenshot", "label": "01_circle_before_advance_6in" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\")._update_movement_display_with_advance(4)" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").move_cap_inches",
+      "equals": 10.0 },
+    { "act": "execute_script",
+      "script": "(main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(0).points[0].distance_to(Vector2(0,0)) / Measurement.PX_PER_INCH)",
+      "expect_min": 9.7 },
+    { "act": "execute_script",
+      "script": "(main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(0).points[0].distance_to(Vector2(0,0)) / Measurement.PX_PER_INCH)",
+      "expect_max": 10.3 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(8).text",
+      "equals": "10\"" },
+    { "act": "screenshot", "label": "02_circle_after_advance_10in" }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #458. When a model **Advances**, the move cap rises to M + D6, but a per-model reach circle that was already on screen kept its stale, smaller base-Move radius. This makes the visible circle grow to the Advance distance the moment the roll is applied.

### Detail

- `_update_movement_display_with_advance()` raised `move_cap_inches` and updated the labels, but never redrew the overlay.
- Picking up a model *after* the roll already drew the correct larger circle (the drag start re-syncs the cap from the phase), so the gap was only a circle that was already visible when the roll resolved.
- Added `_refresh_model_range_overlay()`, called right after the advanced cap is applied. It redraws the active single-drag or group-drag reach circle using the new cap, so the **same circle grows in place** to the Advance distance (preferred behaviour requested by the user).

## Validation

- New windowed scenario `tests/scenarios/sp/move_range_advance_grows.json` passes **19/19**: a 6" circle redraws in place to 10" (base 6 + advance 4) when `_update_movement_display_with_advance(4)` is applied, with `move_cap_inches=10` and the label relabelled to `10"`. Screenshots confirm the larger circle renders.
- The original per-model regression scenario `move_range_per_model_circle.json` still passes 24/24.

https://claude.ai/code/session_01KG9o3TPrZXUUMfSCn97eEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KG9o3TPrZXUUMfSCn97eEE)_