### PR TITLE
Fix wound allocation freeze when target unit is wiped before all wounds resolve

### DIFF
--- a/40k/scripts/WoundAllocationOverlay.gd
+++ b/40k/scripts/WoundAllocationOverlay.gd
@@ -511,6 +511,22 @@ func setup(p_save_data: Dictionary, p_defender_player: int) -> void:
 
 func _start_wound_allocation() -> void:
 	"""Begin allocation for current_wound_index"""
+
+	# BUGFIX: When the target unit is wiped out before all wounds are
+	# allocated (i.e. there are more wounds to save than the unit has models),
+	# there are no valid models left to select. Excess wounds are simply lost
+	# per 10e — wounds do not spill over to other units. Without this guard the
+	# manual-selection path would highlight nothing, keep awaiting a click that
+	# can never come, and the overlay would appear frozen while still showing
+	# "Wound X of Y — click a model". Detect the wiped-out case and finish the
+	# allocation instead of soliciting an impossible selection. (The
+	# auto-allocate path already short-circuits via _auto_allocate_current_wound;
+	# this covers the manual path too.)
+	if _auto_pick_model_id() == "":
+		print("WoundAllocationOverlay: No allocatable models remain (unit wiped) — completing allocation early")
+		_complete_allocation()
+		return
+
 	awaiting_selection = true
 
 	# Update UI labels

--- a/40k/tests/scenarios/sp/wound_alloc_overkill_skips_when_wiped.json
+++ b/40k/tests/scenarios/sp/wound_alloc_overkill_skips_when_wiped.json
@@ -1,0 +1,49 @@
+{
+  "id": "wound_alloc_overkill_skips_when_wiped",
+  "covers": [
+    "scripts.WoundAllocationOverlay._start_wound_allocation",
+    "scripts.WoundAllocationOverlay.overkill_completes_when_unit_wiped"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Overkill bug regression: when an attack inflicts more wounds than the target unit has models, the WoundAllocationOverlay used to freeze after the last model died — it kept calling _start_wound_allocation for the remaining wounds, highlighted no models, and waited forever for a board click that could never come. This scenario drives the MANUAL allocation path (auto-allocate OFF) with a 3-wound, AP-4 attack against U_STRIKE_FORCE_A (a single 1-wound model, 3+ save -> auto-fail at 7+). The defender allocates the one model (it dies), leaving 2 wounds and zero models. With the fix, _start_wound_allocation detects no allocatable model remains, completes the allocation, and the overlay closes. Without the fix the overlay would stay alive (frozen) forever. We assert the unit is wiped AND the overlay closed itself.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_auto_allocate_wounds(false)" },
+    { "act": "execute_script",
+      "script": "SettingsService.auto_allocate_wounds",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_STRIKE_FORCE_A\"))",
+      "equals": 1 },
+    { "act": "screenshot", "label": "01_before_overkill" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(3, \"U_STRIKE_FORCE_A\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Overkill Test Gun\", \"ap\": -4, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "is_instance_valid(main.get_node(\"ShootingController\").active_allocation_overlay)",
+      "equals": true },
+    { "act": "screenshot", "label": "02_overlay_awaiting_manual_allocation" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").active_allocation_overlay._on_model_clicked(main.get_node(\"ShootingController\").active_allocation_overlay._auto_pick_model_id())" },
+
+    { "act": "wait_seconds", "seconds": 7.0 },
+
+    { "act": "execute_script",
+      "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_STRIKE_FORCE_A\"))",
+      "equals": 0 },
+    { "act": "execute_script",
+      "script": "is_instance_valid(main.get_node(\"ShootingController\").active_allocation_overlay)",
+      "equals": false },
+    { "act": "screenshot", "label": "03_unit_wiped_overlay_closed_no_freeze" }
+  ]
+}


### PR DESCRIPTION
## Problem

When a unit shooting or fighting another unit inflicts **more wounds than the target has models** (overkill), the wound-allocation overlay froze. After the last model died, the overlay kept asking the player to select a model that no longer existed — the game appeared stuck, requesting model selections when there were none.

## Root cause

`WoundAllocationOverlay._continue_to_next_wound()` decided completion **only** by `current_wound_index >= total_wounds`; it never checked whether the target unit still had living models. So once the unit was wiped, `_start_wound_allocation()` was called again for the leftover wounds, highlighted nothing on the board, and waited forever for a click that could never come. The auto-allocate path already handled this case (`_auto_pick_model_id() == ""` → complete); the **manual** selection path did not.

## Fix

Added a guard at the top of `_start_wound_allocation()` (`40k/scripts/WoundAllocationOverlay.gd`): if no allocatable model remains (unit wiped), it completes the allocation and closes the overlay instead of soliciting an impossible selection. Excess wounds are simply lost per 10e rules — they do not spill over to other units. Because this overlay is shared by `ShootingController` and `FightController`, the fix covers **both shooting and melee**.

## Validation

Added windowed regression scenario `40k/tests/scenarios/sp/wound_alloc_overkill_skips_when_wiped.json`: a manual (auto-allocate OFF) 3-wound, AP-4 attack against a single 1-model unit drives the real `ShootingController._on_saves_required` entry point, allocates the one model (it dies), then asserts the unit is wiped **and the overlay closed itself**.

- **With the fix:** 16/16 steps pass — overlay closes cleanly.
- **Reverted the fix and re-ran:** step 14 fails (`is_instance_valid(...overlay) == true`) — the overlay stays alive/frozen, reproducing the exact reported freeze. This confirms the scenario genuinely catches the bug.

https://claude.ai/code/session_01Sh3shX2gFPbH36ep5dKzVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sh3shX2gFPbH36ep5dKzVD)_