### PR TITLE
Commit staged scout moves when ending the phase (real scout persistence fix)

### DIFF
--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -8532,7 +8532,14 @@ func _on_phase_action_pressed() -> void:
 		GameStateData.Phase.REDEPLOYMENT:
 			action = {"type": "END_REDEPLOYMENT_PHASE", "player": active_player}
 		GameStateData.Phase.SCOUT:
-			# Skip all remaining pending scout moves before ending the phase
+			# Resolve all remaining pending scout moves before ending the phase.
+			# A unit the player dragged but never explicitly confirmed still has
+			# staged_positions in the phase's active_scout_moves. Committing those
+			# on phase-end (instead of blindly skipping) is what the player
+			# expects — otherwise the model snaps back to its deployed spot once
+			# the game starts (the reported scout bug). Units with no staged move
+			# are skipped as before; an invalid staged config falls back to skip
+			# with a toast so the phase can still advance.
 			var scout_phase = PhaseManager.get_current_phase_instance()
 			if scout_phase:
 				var scout_pending = scout_phase.get("scout_units_pending")
@@ -8542,6 +8549,24 @@ func _on_phase_action_pressed() -> void:
 					for p in scout_pending:
 						all_pending.append_array(scout_pending[p].duplicate())
 					for pending_uid in all_pending:
+						# Confirming the last pending unit can auto-complete the
+						# phase; stop issuing actions once we've left SCOUT.
+						if GameState.get_current_phase() != GameStateData.Phase.SCOUT:
+							break
+						var active_moves = scout_phase.get("active_scout_moves")
+						var has_staged: bool = active_moves != null \
+							and active_moves.has(pending_uid) \
+							and not active_moves[pending_uid].get("staged_positions", {}).is_empty()
+						if has_staged:
+							var confirm_action = {"type": "CONFIRM_SCOUT_MOVE", "unit_id": pending_uid, "player": active_player}
+							var confirm_result = NetworkIntegration.route_action(confirm_action)
+							if confirm_result.get("success", false):
+								continue
+							# Staged move was invalid (coherency/overlap/etc.) —
+							# discard it, tell the player, then skip the unit.
+							if has_node("/root/ToastManager"):
+								var unit_name = GameState.get_unit(pending_uid).get("meta", {}).get("name", pending_uid)
+								get_node("/root/ToastManager").show_toast("Scout move for %s was invalid and discarded" % unit_name, "error")
 						var skip_action = {"type": "SKIP_SCOUT_MOVE", "unit_id": pending_uid, "player": active_player}
 						NetworkIntegration.route_action(skip_action)
 			_scout_cleanup_after_move()

--- a/40k/tests/scenarios/sp/scout_drag_then_end_phase_persists.json
+++ b/40k/tests/scenarios/sp/scout_drag_then_end_phase_persists.json
@@ -1,0 +1,79 @@
+{
+  "id": "scout_drag_then_end_phase_persists",
+  "covers": [
+    "phases.ScoutPhase.e2e.drag_then_end_phase_commits_staged_move"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Reproduces the user's actual flow: deploy a unit, enter scout, drag every model to a valid coherent spot (SET succeeds, visual moves), then END the scout phase via the phase-action button WITHOUT clicking 'Confirm Move'. The player expects the move to stick. Before the fix, the end handler SKIPs the still-pending unit and discards the staged positions, so GameState reverts to the deployed coordinates (the bug: scout looks moved, then snaps back to the deployed spot once the game starts). After the fix, ending the phase commits valid staged moves. Asserts GameState holds the moved y=400 after ending the phase and entering movement.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_WITCHSEEKERS_C')" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(840, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(900, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(960, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.confirm()" },
+    { "act": "wait_frames", "frames": 10 },
+    { "act": "expect_state", "path": "units.U_WITCHSEEKERS_C.status", "equals": 2 },
+    { "act": "screenshot", "label": "01_deployed_y240" },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script", "script": "Main._on_unit_stats_panel_unit_selected('U_WITCHSEEKERS_C', false)" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main._scout_active_unit_id", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm1')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(840, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(840, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(840, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm2')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(900, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(900, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(900, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm3')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(960, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(960, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(960, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "int(PhaseManager.get_current_phase_instance().active_scout_moves['U_WITCHSEEKERS_C']['staged_positions'].size())",
+      "equals": 3 },
+    { "act": "screenshot", "label": "02_dragged_to_y400_not_confirmed" },
+
+    { "act": "execute_script", "script": "Main._on_phase_action_pressed()" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "screenshot", "label": "03_after_end_scout_phase" },
+
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y))", "equals": 400 },
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[1].position.y))", "equals": 400 },
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[2].position.y))", "equals": 400 },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(7)" },
+    { "act": "wait_seconds", "seconds": 3.5 },
+    { "act": "expect_phase", "equals": 7 },
+    { "act": "screenshot", "label": "04_movement_phase_tokens_at_moved_pos" },
+
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y))", "equals": 400 },
+    { "act": "execute_script", "script": "round(float(get_node('/root/Main/BoardRoot/TokenLayer/Token_U_WITCHSEEKERS_C_0').position.y))", "equals": 400 }
+  ]
+}

--- a/40k/tests/scenarios/sp/scout_real_drag_confirm_persists_e2e.json
+++ b/40k/tests/scenarios/sp/scout_real_drag_confirm_persists_e2e.json
@@ -1,0 +1,83 @@
+{
+  "id": "scout_real_drag_confirm_persists_e2e",
+  "covers": [
+    "phases.ScoutPhase.e2e.real_drag_confirm_persists_to_state_through_movement"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "End-to-end faithful reproduction of the user's report: deploy a unit interactively (real nested tokens), enter scout, drive the REAL scout drag handlers (motion+release -> SET_SCOUT_MODEL_DEST) for every model to a coherent cluster, click the REAL Confirm Move button, then advance to the movement phase. Asserts the moved positions persist into GameState AND the on-board token sits at the moved position once movement starts (not back at the deployed spot). Screenshots at each stage.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_WITCHSEEKERS_C')" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(840, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(900, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.try_place_at(Vector2(960, 240))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "Main.deployment_controller.confirm()" },
+    { "act": "wait_frames", "frames": 10 },
+    { "act": "expect_state", "path": "units.U_WITCHSEEKERS_C.status", "equals": 2 },
+    { "act": "execute_script", "script": "float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y)", "equals": 240.0 },
+    { "act": "screenshot", "label": "01_deployed_y240" },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script", "script": "Main._on_unit_stats_panel_unit_selected('U_WITCHSEEKERS_C', false)" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main._scout_active_unit_id", "equals": "U_WITCHSEEKERS_C" },
+    { "act": "screenshot", "label": "02_scout_unit_selected" },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm1')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(840, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(840, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(840, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm2')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(900, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(900, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(900, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script", "script": "Main.set('_scout_dragging_model', true)" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_model_id', 'm3')" },
+    { "act": "execute_script", "script": "Main.set('_scout_drag_start_pos', Vector2(960, 240))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_motion(get_node('/root/Main/BoardRoot').transform * Vector2(960, 400))" },
+    { "act": "execute_script", "script": "Main._scout_handle_mouse_release(get_node('/root/Main/BoardRoot').transform * Vector2(960, 400))" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "int(PhaseManager.get_current_phase_instance().active_scout_moves['U_WITCHSEEKERS_C']['staged_positions'].size())",
+      "equals": 3 },
+    { "act": "execute_script",
+      "script": "round(float(PhaseManager.get_current_phase_instance().active_scout_moves['U_WITCHSEEKERS_C']['staged_positions']['m1']['y']))",
+      "equals": 400 },
+    { "act": "screenshot", "label": "03_dragged_to_y400" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton" },
+    { "act": "wait_frames", "frames": 10 },
+    { "act": "screenshot", "label": "04_after_confirm_click" },
+
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y))", "equals": 400 },
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[1].position.y))", "equals": 400 },
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[2].position.y))", "equals": 400 },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(7)" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_phase", "equals": 7 },
+    { "act": "screenshot", "label": "05_movement_phase" },
+
+    { "act": "execute_script", "script": "round(float(GameState.state.units.U_WITCHSEEKERS_C.models[0].position.y))", "equals": 400 }
+  ]
+}


### PR DESCRIPTION
## Summary

This is the **actual root-cause fix** for the recurring "scout looks moved but is back at the deployed spot once the game starts" bug.

The real flow: a player drags a scout unit's models to a valid spot (the tokens move and `SET_SCOUT_MODEL_DEST` stages the positions), then ends the scout phase with the phase-action button (`Enter` / "End Scout Moves") **without** clicking the separate "Confirm Move" button. The end handler `SKIP`ped every still-pending unit — and a dragged-but-unconfirmed unit is still pending — so its staged positions were discarded and `GameState` kept the deployed coordinates.

Earlier fixes in this area (active-unit-id recovery #440/#442, the lost MOVEMENT `elif`, nested-token snap-back #457) fixed real adjacent issues but never this one: staged moves were only committed by the explicit Confirm button, and every other exit path threw them away.

## Fix

In the `SCOUT` branch of `_on_phase_action_pressed` (`Main.gd`), before skipping a pending unit, check the phase's `active_scout_moves` for non-empty `staged_positions` and dispatch `CONFIRM_SCOUT_MOVE` to commit them. If the staged config is invalid (coherency/overlap/range), fall back to `SKIP_SCOUT_MOVE` and show a toast so the player knows it was discarded. A guard stops issuing actions once confirming the last unit auto-advances the phase.

## Before / after (movement phase, same scenario)

Drag 3 scouts down, then "End Scout Moves" without clicking Confirm:
- **Before:** scouts revert to the deployed position (`GameState` y and on-board token both = 240).
- **After:** scouts stay at the scouted position (y = 400) through the movement phase.

## Test coverage

Two new windowed scenarios that deploy a unit interactively (producing real nested tokens) and drive the **actual scout drag handlers**:
- `scout_real_drag_confirm_persists_e2e.json` — drag + click Confirm + advance to movement → positions persist (already worked; guards the happy path).
- `scout_drag_then_end_phase_persists.json` — drag + **End phase without Confirm** + advance to movement → positions now persist. Verified it **fails on the pre-fix code** (state and on-board token revert to the deployed y) and passes after.

All 9 scout scenarios pass.

https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq

---
_Generated by [Claude Code](https://claude.ai/code/session_01ArDEkgDbu9fzeD82Sp3ZGq)_