### PR TITLE
Test: prove advance reach circle via fully-live flow; add "validate, don't assume" guardrails

### DIFF
--- a/40k/tests/TESTING_METHODOLOGY.md
+++ b/40k/tests/TESTING_METHODOLOGY.md
@@ -303,6 +303,17 @@ error paths. Run before changing the diff implementation.
   thing that actually controls the pixel.
 - Subjective adjectives in Tier A (`readable`, `smooth`, `performant`).
 - Lowering `_baseline.json.count` to make a failing task green.
+- **Declaring a harness/bridge limitation without proving it.** If a scenario
+  step behaves unexpectedly (e.g. `dispatch_action` returns `success:true` but
+  the state you expected is empty), that is a lead — read the phase handler and
+  find the real cause (a reroll/overwatch pause needing a follow-up DECLINE
+  action, a different storage key, etc.). Do NOT write "the harness can't drive
+  this" until you have the failing output and the root cause. The scenario
+  runner can drive multi-step interrupt flows (e.g. `BEGIN_ADVANCE` →
+  `DECLINE_COMMAND_REROLL`) — chain the steps.
+- **Manual-setup masquerading as a live test.** Setting a value by hand
+  (`controller.set("move_cap_inches", 10)`) validates the *draw math*, not the
+  *real flow*. If you stub, label it as partial and then drive the real path.
 
 The playbook
 (`docs/design_guidelines_implementation_plan.md`) is the canonical reference.

--- a/40k/tests/scenarios/sp/move_range_advance_live.json
+++ b/40k/tests/scenarios/sp/move_range_advance_live.json
@@ -1,0 +1,54 @@
+{
+  "id": "move_range_advance_live",
+  "covers": [
+    "movement.advance_distance_circle",
+    "phases.MovementPhase.BEGIN_ADVANCE",
+    "phases.MovementPhase.DECLINE_COMMAND_REROLL"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 7,
+  "description": "FULLY LIVE advance flow (no manual cap): dispatch the real BEGIN_ADVANCE (which pauses awaiting a Command Re-roll decision because the player has CP), then dispatch the real DECLINE_COMMAND_REROLL which calls _resolve_advance_roll, populating active_moves with the engine-rolled move cap (M + D6) and emitting unit_move_begun -> the MovementController's _on_unit_move_begun sets its move_cap_inches. Finally call the real pickup draw fn _show_model_range_overlay and assert the per-model circle radius equals the engine's advanced cap (NOT base Move 6).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "dispatch_action", "action": { "type": "BEGIN_ADVANCE", "actor_unit_id": "U_BLADE_CHAMPION_A" }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance()._awaiting_reroll_decision",
+      "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "DECLINE_COMMAND_REROLL" }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "float(PhaseManager.get_current_phase_instance().active_moves[\"U_BLADE_CHAMPION_A\"][\"move_cap_inches\"])",
+      "expect_min": 7.0 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\").active_mode",
+      "equals": "ADVANCE" },
+    { "act": "execute_script",
+      "script": "abs(main.get_node(\"MovementController\").move_cap_inches - float(PhaseManager.get_current_phase_instance().active_moves[\"U_BLADE_CHAMPION_A\"][\"move_cap_inches\"]))",
+      "expect_max": 0.01 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"MovementController\")._show_model_range_overlay(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], Vector2(0, 0))" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/MoveRangeVisual\").get_child_count()",
+      "expect_min": 9 },
+    { "act": "execute_script",
+      "script": "abs(main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(0).points[0].distance_to(Vector2(0,0)) - Measurement.inches_to_px(float(PhaseManager.get_current_phase_instance().active_moves[\"U_BLADE_CHAMPION_A\"][\"move_cap_inches\"])))",
+      "expect_max": 1.5 },
+    { "act": "execute_script",
+      "script": "(main.get_node(\"BoardRoot/MoveRangeVisual\").get_child(0).points[0].distance_to(Vector2(0,0)) / Measurement.PX_PER_INCH) > 6.5",
+      "equals": true },
+    { "act": "screenshot", "label": "advance_circle_live" }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,36 @@ explicit screenshot is optional. Everything with a UI surface needs the
 in-game effect captured.
 
 **Reference**: `~/.claude/projects/-Users-robertocallaghan-Documents-claude-godotv2/memory/feedback_pin_tests_arent_live_validation.md`
+
+## Anti-pattern: do NOT assume — validate, and never claim a limitation you haven't proven (2026-05-30 lesson)
+
+Stating something as fact without running it is the single most frustrating
+failure mode in this project. It has happened repeatedly. STOP.
+
+**Rules — these are non-negotiable:**
+
+1. **Never report a tool/harness/engine limitation you have not reproduced and
+   root-caused.** "The MCP bridge can't drive X", "the test harness can't do
+   Y", "this isn't reachable headless" are CLAIMS, not facts, until you have
+   the failing output AND the reason. If a call returns an unexpected result
+   (e.g. `success:true` but empty state), that is a lead to investigate, not a
+   conclusion — read the handler source and find out *why* before reporting.
+   (Real example: `BEGIN_ADVANCE` returned `success:true` with empty
+   `active_moves`; the real cause was a `_awaiting_reroll_decision` pause that
+   needed a follow-up `DECLINE_COMMAND_REROLL` — the harness was fully capable.)
+
+2. **Trace the code path before declaring how something behaves.** If you find
+   yourself writing "should", "probably", "I believe", or "likely" about
+   behaviour you could just run, you are guessing. Run it.
+
+3. **When you simplify or stub to make a test pass** (e.g. setting a value
+   manually instead of driving the real flow), say so explicitly AND treat it
+   as incomplete validation. Then go drive the real flow. Do not present a
+   manual-setup test as proof the real path works.
+
+4. **If you genuinely cannot validate something, say "I have not validated
+   this" plainly** — do not dress an assumption up as a finding. An honest
+   "unverified" is acceptable; a confident wrong claim is not.
+
+Before writing "X can't be done" or "X works", ask: *did I actually run it and
+read the result?* If not, do that first.


### PR DESCRIPTION
## Summary

Follow-up to #458 / #461. Adds a **fully-live** end-to-end validation of the Advance reach circle (no manual cap setting), and adds project guardrails against assuming behaviour instead of validating it.

### Live advance test

`tests/scenarios/sp/move_range_advance_live.json` (18/18) drives the real path:
1. `dispatch BEGIN_ADVANCE` → `success:true`
2. assert `_awaiting_reroll_decision == true` — `BEGIN_ADVANCE` pauses for a Command Re-roll decision because the player has CP (this is why an earlier probe saw `active_moves` empty)
3. `dispatch DECLINE_COMMAND_REROLL` → engine rolls D6=1 → cap = M6 + 1 = **7"**
4. assert the `MovementController` picked up `move_cap_inches = 7.0` via the real `unit_move_begun` signal
5. the actual pickup draw function renders the circle at 7" (> 6.5", i.e. the advance distance, not base Move)

Screenshot confirms the live state: header *"Blade Champion advance roll 1 (Move 7)"* with the reach circle drawn at the advanced range.

This corrects an earlier incorrect claim that the harness could not drive `BEGIN_ADVANCE` — the empty `active_moves` was a reroll pause needing the follow-up `DECLINE_COMMAND_REROLL`, not a harness limitation.

### Guardrails

- **`CLAUDE.md`** — new section: never report a tool/harness/engine limitation without reproducing and root-causing it; trace the code path instead of guessing; label stubbed/manual setup as partial validation; say "I have not validated this" plainly rather than dressing an assumption as a finding.
- **`40k/tests/TESTING_METHODOLOGY.md`** — same two items added to the banned anti-patterns list, with the concrete `BEGIN_ADVANCE → DECLINE_COMMAND_REROLL` example.

## Validation

All three movement reach-circle scenarios pass: `move_range_per_model_circle` (24), `move_range_advance_grows` (19), `move_range_advance_live` (18).

https://claude.ai/code/session_01KG9o3TPrZXUUMfSCn97eEE

---
_Generated by [Claude Code](https://claude.ai/code/session_01KG9o3TPrZXUUMfSCn97eEE)_