### PR TITLE
Actually default auto-allocate wounds ON; fix settings-UI validation

### DIFF
--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -47,7 +47,9 @@ var show_unit_labels: bool = true
 # Per 10e rules the *defending* player makes this choice; until a proper
 # defender-driven flow exists, this lets the player delegate the choice to the
 # computer so the attacker isn't forced to pick the opponent's casualties.
-var auto_allocate_wounds: bool = false
+# Defaults ON: per 10e the *defending* player picks casualties, so by default
+# we let the computer pick rather than forcing the attacker to choose them.
+var auto_allocate_wounds: bool = true
 
 # Board texture style: "grass", "mud", "desert", "stone", "felt", "tilepack", "none"
 var board_style: String = "grass"

--- a/40k/tests/scenarios/sp/auto_allocate_wounds_settings_ui.json
+++ b/40k/tests/scenarios/sp/auto_allocate_wounds_settings_ui.json
@@ -8,7 +8,7 @@
   "fixture": "audit_386_deadly_demise",
   "rng_seed": 42,
   "transition_to_phase": 8,
-  "description": "Settings UI: the in-game Escape settings menu exposes a Gameplay tab with the 'Computer allocates wounds' toggle, and the setting defaults ON. Asserts the default (no settings.cfg present), opens the real Escape menu via a simulated ESC key, switches to the Gameplay tab, and verifies the checkbox exists, is visible, and is checked by default.",
+  "description": "Settings UI: the in-game Escape settings menu exposes a Gameplay tab with the 'Computer allocates wounds' toggle, and the setting defaults ON. Asserts the default (no settings.cfg present), opens the real menu via the exact method the ESC key calls (Main._open_settings_menu), switches to the Gameplay tab, and verifies the checkbox exists, is visible, and is checked by default.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
 
@@ -16,33 +16,36 @@
       "script": "SettingsService.auto_allocate_wounds",
       "equals": true },
 
-    { "act": "simulate_key", "key": "ESCAPE" },
-    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main._open_settings_menu()" },
+    { "act": "wait_seconds", "seconds": 0.6 },
 
     { "act": "expect_node_visible",
-      "node": "/root/Main/SettingsMenu",
+      "node": "/root/SettingsMenu",
       "timeout_s": 2.0 },
 
     { "act": "execute_script",
-      "script": "main.get_node(\"SettingsMenu\")._tab_buttons.size()",
+      "script": "get_node(\"/root/SettingsMenu\")._tab_buttons.size()",
       "equals": 4 },
     { "act": "execute_script",
-      "script": "main.get_node(\"SettingsMenu\")._tab_buttons[2].text",
+      "script": "get_node(\"/root/SettingsMenu\")._tab_buttons[2].text",
       "equals": "Gameplay" },
 
     { "act": "execute_script",
-      "script": "main.get_node(\"SettingsMenu\")._on_tab_pressed(2)" },
-    { "act": "wait_seconds", "seconds": 0.3 },
+      "script": "get_node(\"/root/SettingsMenu\")._on_tab_pressed(2)" },
+    { "act": "wait_seconds", "seconds": 0.4 },
 
     { "act": "execute_script",
-      "script": "is_instance_valid(main.get_node(\"SettingsMenu\")._auto_allocate_checkbox)",
+      "script": "is_instance_valid(get_node(\"/root/SettingsMenu\")._auto_allocate_checkbox)",
       "equals": true },
     { "act": "execute_script",
-      "script": "main.get_node(\"SettingsMenu\")._auto_allocate_checkbox.is_visible_in_tree()",
+      "script": "get_node(\"/root/SettingsMenu\")._auto_allocate_checkbox.is_visible_in_tree()",
       "equals": true },
     { "act": "execute_script",
-      "script": "main.get_node(\"SettingsMenu\")._auto_allocate_checkbox.button_pressed",
+      "script": "get_node(\"/root/SettingsMenu\")._auto_allocate_checkbox.button_pressed",
       "equals": true },
+    { "act": "execute_script",
+      "script": "get_node(\"/root/SettingsMenu\")._auto_allocate_checkbox.text",
+      "equals": "Computer allocates wounds (auto-remove models)" },
     { "act": "screenshot", "label": "01_gameplay_tab_with_auto_allocate_toggle" }
   ]
 }


### PR DESCRIPTION
## Summary

Corrects two real bugs from the prior change (#463) that I caught while re-validating the request to default the toggle ON and confirm it's in the Escape menu.

### Bug 1 — the setting was NOT actually defaulting ON
The variable default for `auto_allocate_wounds` was still `false`. The earlier edit only flipped the config-load *fallback*, but `_load_settings()` early-returns when no `settings.cfg` exists — so a fresh install got `false` and auto-allocation was off by default. Fixed by setting the variable default to `true`.

### Bug 2 — the settings-UI scenario never actually opened the menu
The previous scenario reported a pass count that masked failures: it used the wrong `simulate_key` field (`key` vs `keycode`), the wrong node path (`/root/Main/SettingsMenu`), and `simulate_key` ESC doesn't reach `Main._input` in headless anyway. Rewrote it to drive the **exact method the ESC key calls** — `Main._open_settings_menu()` — and assert against the real path `/root/SettingsMenu`.

## What the toggle looks like

The Escape → Settings → **Gameplay** tab now shows **"Computer allocates wounds (auto-remove models)"**, checked ON by default. (Screenshot shared in the session.)

## Validation (all green, settings.cfg cleared between runs)

- `auto_allocate_wounds` — 15/15 (ON: overlay resolves 4 wounds with zero clicks, 4 Boyz die)
- `auto_allocate_wounds_off` — 12/12 (OFF: overlay waits for the player, no casualties)
- `auto_allocate_wounds_settings_ui` — 13/13 (menu opens via the ESC method; Gameplay tab's checkbox is `is_visible_in_tree() == true`, label matches exactly, and `button_pressed == true` by default)

https://claude.ai/code/session_01EReRkdedU76mExwvyNCRuJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EReRkdedU76mExwvyNCRuJ)_