### PR TITLE
Game log & shooting resolution log: render all dice rolls as icons

### DIFF
--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -692,12 +692,12 @@ func _resolve_charge_roll(unit_id: String) -> Dictionary:
 			target_name_list.append(get_unit(tid).get("meta", {}).get("name", tid))
 		if roll_sufficient:
 			charge_event_log.add_player_entry(charge_owner,
-				"%s charge roll: 2D6 = %d (%d + %d) vs %.1f\" needed - SUCCESS" % [
-					unit_name, total_distance, rolls[0], rolls[1], min_distance])
+				"%s charge roll: [%d, %d] = %d\" vs %.1f\" needed - SUCCESS" % [
+					unit_name, rolls[0], rolls[1], total_distance, min_distance])
 		else:
 			charge_event_log.add_player_entry(charge_owner,
-				"%s charge roll: 2D6 = %d (%d + %d) vs %.1f\" needed - FAILED" % [
-					unit_name, total_distance, rolls[0], rolls[1], min_distance])
+				"%s charge roll: [%d, %d] = %d\" vs %.1f\" needed - FAILED" % [
+					unit_name, rolls[0], rolls[1], total_distance, min_distance])
 
 	if not roll_sufficient:
 		# Charge roll failed — record structured failure, clean up state, broadcast
@@ -3174,7 +3174,7 @@ func _resolve_piston_driven_brutality_after_charge(unit_id: String, changes: Arr
 	if game_event_log:
 		var owner = int(unit.get("owner", 0))
 		game_event_log.add_player_entry(owner,
-			"Piston-driven Brutality: %s rolled %d — %d mortal wound(s) to %s (%d casualt(y/ies))" % [
+			"Piston-driven Brutality: %s rolled [%d] — %d mortal wound(s) to %s (%d casualt(y/ies))" % [
 				unit_name, result.get("roll", 0), result.get("mortal_wounds", 0),
 				target_name, result.get("casualties", 0)
 			])

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -991,21 +991,21 @@ func _resolve_battle_shock_test(unit_id: String, die1: int, die2: int) -> Dictio
 		if test_passed:
 			if battle_shock_bonus > 0:
 				game_event_log.add_player_entry(owner,
-					"%s passed Battle-shock test: 2D6 = %d (%d + %d) + Waaagh! Effigy +%d = %d vs Ld %d" % [
-						unit_name, roll_total, die1, die2, battle_shock_bonus, effective_roll, leadership])
+					"%s passed Battle-shock test: [%d, %d] = %d + Waaagh! Effigy +%d = %d vs Ld %d" % [
+						unit_name, die1, die2, roll_total, battle_shock_bonus, effective_roll, leadership])
 			else:
 				game_event_log.add_player_entry(owner,
-					"%s passed Battle-shock test: 2D6 = %d (%d + %d) vs Ld %d" % [
-						unit_name, roll_total, die1, die2, leadership])
+					"%s passed Battle-shock test: [%d, %d] = %d vs Ld %d" % [
+						unit_name, die1, die2, roll_total, leadership])
 		else:
 			if battle_shock_bonus > 0:
 				game_event_log.add_player_entry(owner,
-					"%s FAILED Battle-shock test: 2D6 = %d (%d + %d) + Waaagh! Effigy +%d = %d vs Ld %d — now Battle-shocked!" % [
-						unit_name, roll_total, die1, die2, battle_shock_bonus, effective_roll, leadership])
+					"%s FAILED Battle-shock test: [%d, %d] = %d + Waaagh! Effigy +%d = %d vs Ld %d — now Battle-shocked!" % [
+						unit_name, die1, die2, roll_total, battle_shock_bonus, effective_roll, leadership])
 			else:
 				game_event_log.add_player_entry(owner,
-					"%s FAILED Battle-shock test: 2D6 = %d (%d + %d) vs Ld %d — now Battle-shocked!" % [
-						unit_name, roll_total, die1, die2, leadership])
+					"%s FAILED Battle-shock test: [%d, %d] = %d vs Ld %d — now Battle-shocked!" % [
+						unit_name, die1, die2, roll_total, leadership])
 
 	return result
 

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -1572,7 +1572,7 @@ func _resolve_advance_roll(unit_id: String, advance_roll: int) -> Dictionary:
 	if game_event_log:
 		var owner = int(unit.get("owner", 0))
 		game_event_log.add_player_entry(owner,
-			"%s advances: D6 = %d, total move = %d\" (M %d\" + %d\")" % [
+			"%s advances: rolled [%d] — total move = %d\" (M %d\" + %d\")" % [
 				unit_name, advance_roll, total_move, int(move_inches), advance_roll])
 
 	return create_result(true, [
@@ -5978,7 +5978,7 @@ func _process_begin_surge_move(action: Dictionary) -> Dictionary:
 	if game_event_log:
 		var owner = int(unit.get("owner", 0))
 		game_event_log.add_player_entry(owner,
-			"%s makes a surge move: D6 = %d, move up to %d\"" % [unit_name, surge_distance, surge_distance])
+			"%s makes a surge move: rolled [%d] — move up to %d\"" % [unit_name, surge_distance, surge_distance])
 
 	return create_result(true, [
 		{

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -5285,7 +5285,7 @@ func _process_use_shooty_power_trip(action: Dictionary) -> Dictionary:
 		if game_event_log:
 			var owner = int(get_unit(unit_id).get("owner", 0))
 			game_event_log.add_player_entry(owner,
-				"Shooty Power Trip: %s rolled %d — suffers %d mortal wounds (%d casualties)" % [unit_name, d6_roll, mortal_wounds, casualties])
+				"Shooty Power Trip: %s rolled [%d] — suffers %d mortal wounds (%d casualties)" % [unit_name, d6_roll, mortal_wounds, casualties])
 
 		emit_signal("shooty_power_trip_result", unit_id, d6_roll, "self_damage")
 
@@ -5321,7 +5321,7 @@ func _process_use_shooty_power_trip(action: Dictionary) -> Dictionary:
 		if game_event_log:
 			var owner = int(get_unit(unit_id).get("owner", 0))
 			game_event_log.add_player_entry(owner,
-				"Shooty Power Trip: %s rolled %d — ranged weapons gain [+1 STRENGTH]" % [unit_name, d6_roll])
+				"Shooty Power Trip: %s rolled [%d] — ranged weapons gain [+1 STRENGTH]" % [unit_name, d6_roll])
 
 		emit_signal("shooty_power_trip_result", unit_id, d6_roll, "plus_one_strength")
 
@@ -5344,7 +5344,7 @@ func _process_use_shooty_power_trip(action: Dictionary) -> Dictionary:
 		if game_event_log:
 			var owner = int(get_unit(unit_id).get("owner", 0))
 			game_event_log.add_player_entry(owner,
-				"Shooty Power Trip: %s rolled %d — ranged weapons gain [+1 ATTACKS]" % [unit_name, d6_roll])
+				"Shooty Power Trip: %s rolled [%d] — ranged weapons gain [+1 ATTACKS]" % [unit_name, d6_roll])
 
 		emit_signal("shooty_power_trip_result", unit_id, d6_roll, "plus_one_attacks")
 

--- a/40k/scripts/DiceFaceIcons.gd
+++ b/40k/scripts/DiceFaceIcons.gd
@@ -1,0 +1,116 @@
+extends RefCounted
+class_name DiceFaceIcons
+
+# DiceFaceIcons - generates small d6 face textures (rounded square + pips) for
+# embedding inline in RichTextLabels via add_image(). Mirrors the look of
+# DiceRowVisual (the Control-drawn dice in the game log) so dice appear
+# consistent across the UI. Textures are cached per (value, background color).
+
+const TEX_SIZE := 36          # rendered at 2x for crispness; embed at ~18px
+const CORNER := 6.0
+const PIP_RADIUS := 3.6
+const BORDER := 2
+
+# Default palette (matches DiceRowVisual / pass-fail semantics)
+const COLOR_CRITICAL := Color(1.0, 0.84, 0.0)   # natural 6 / crit
+const COLOR_FUMBLE := Color(0.9, 0.15, 0.15)    # natural 1
+const COLOR_SUCCESS := Color(0.2, 0.75, 0.2)    # passed threshold
+const COLOR_FAIL := Color(0.5, 0.18, 0.18)      # failed threshold
+const COLOR_NEUTRAL := Color(0.25, 0.45, 0.7)   # no threshold context
+
+static var _cache: Dictionary = {}
+
+static func get_face(value: int, bg: Color) -> ImageTexture:
+	var key := "%d_%s" % [value, bg.to_html(true)]
+	if _cache.has(key):
+		return _cache[key]
+	var tex := _make_face(value, bg)
+	_cache[key] = tex
+	return tex
+
+static func color_for(value: int, threshold: int, use_threshold: bool = true, crit_threshold: int = 6) -> Color:
+	# Standard d6 coloring shared with the game log: crit (gold), fumble (red),
+	# else pass/fail by threshold, else neutral.
+	if value >= crit_threshold:
+		return COLOR_CRITICAL
+	if value == 1:
+		return COLOR_FUMBLE
+	if use_threshold and threshold > 0:
+		if value >= threshold:
+			return COLOR_SUCCESS
+		return COLOR_FAIL
+	return COLOR_NEUTRAL
+
+static func _make_face(value: int, bg: Color) -> ImageTexture:
+	var img := Image.create(TEX_SIZE, TEX_SIZE, false, Image.FORMAT_RGBA8)
+	img.fill(Color(0, 0, 0, 0))
+
+	var border_col := Color(0.0, 0.0, 0.0, 0.6)
+	# Pips are dark on light faces (gold), white otherwise.
+	var pip_col := Color(0.1, 0.1, 0.1) if bg.get_luminance() > 0.6 else Color(1, 1, 1)
+
+	# Body: rounded square with a 1px-ish dark border.
+	for y in range(TEX_SIZE):
+		for x in range(TEX_SIZE):
+			if not _in_rounded_rect(x, y, TEX_SIZE, CORNER):
+				continue
+			if _in_rounded_rect(x, y, TEX_SIZE, CORNER, BORDER):
+				img.set_pixel(x, y, bg)
+			else:
+				img.set_pixel(x, y, border_col)
+
+	# Pips
+	var c := TEX_SIZE * 0.5
+	var off := TEX_SIZE * 0.27
+	var pip_positions := _pip_positions(value, c, off)
+	for p in pip_positions:
+		_draw_disc(img, p.x, p.y, PIP_RADIUS, pip_col)
+
+	return ImageTexture.create_from_image(img)
+
+static func _pip_positions(value: int, c: float, off: float) -> Array:
+	var pts := []
+	if value == 1 or value == 3 or value == 5:
+		pts.append(Vector2(c, c))
+	if value >= 2:
+		pts.append(Vector2(c - off, c - off))
+		pts.append(Vector2(c + off, c + off))
+	if value >= 4:
+		pts.append(Vector2(c + off, c - off))
+		pts.append(Vector2(c - off, c + off))
+	if value == 6:
+		pts.append(Vector2(c - off, c))
+		pts.append(Vector2(c + off, c))
+	return pts
+
+static func _in_rounded_rect(x: int, y: int, size: int, corner: float, inset: int = 0) -> bool:
+	var lo := float(inset)
+	var hi := float(size - 1 - inset)
+	var fx := float(x)
+	var fy := float(y)
+	if fx < lo or fx > hi or fy < lo or fy > hi:
+		return false
+	var r := corner - float(inset)
+	if r <= 0.0:
+		return true
+	# Check the four corner quadrants against the corner radius.
+	var cx := clampf(fx, lo + r, hi - r)
+	var cy := clampf(fy, lo + r, hi - r)
+	var dx := fx - cx
+	var dy := fy - cy
+	return dx * dx + dy * dy <= r * r
+
+static func _draw_disc(img: Image, cx: float, cy: float, radius: float, col: Color) -> void:
+	var r2 := radius * radius
+	var x0 := int(floor(cx - radius))
+	var x1 := int(ceil(cx + radius))
+	var y0 := int(floor(cy - radius))
+	var y1 := int(ceil(cy + radius))
+	for y in range(y0, y1 + 1):
+		for x in range(x0, x1 + 1):
+			if x < 0 or y < 0 or x >= img.get_width() or y >= img.get_height():
+				continue
+			var dx := float(x) + 0.5 - cx
+			var dy := float(y) + 0.5 - cy
+			if dx * dx + dy * dy <= r2:
+				img.set_pixel(x, y, col)

--- a/40k/scripts/DiceFaceIcons.gd.uid
+++ b/40k/scripts/DiceFaceIcons.gd.uid
@@ -1,0 +1,1 @@
+uid://b7qs3fqdyw1ie

--- a/40k/scripts/DiceRowVisual.gd
+++ b/40k/scripts/DiceRowVisual.gd
@@ -56,14 +56,27 @@ func _get_font() -> Font:
 	return ThemeDB.fallback_font
 
 func _count_text(count: int) -> String:
+	# A count of 1 is implied by the lone die icon, so no "xN" label is drawn.
+	if count <= 1:
+		return ""
 	return "x%d" % count
 
 func _measure_count(count: int) -> float:
+	var text := _count_text(count)
+	if text == "":
+		return 0.0
 	var font := _get_font()
 	if font == null:
 		# Fallback estimate if no font is available (shouldn't happen at runtime)
-		return float(_count_text(count).length()) * 6.0
-	return font.get_string_size(_count_text(count), HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE).x
+		return float(text.length()) * 6.0
+	return font.get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE).x
+
+func _group_width(count: int) -> float:
+	# Width of one value-group cell: die icon, plus gap + count label when shown.
+	var cw := _measure_count(count)
+	if cw <= 0.0:
+		return DIE_SIZE
+	return DIE_SIZE + COUNT_GAP + cw
 
 func get_value_groups() -> Array:
 	# Returns an Array of [value, count] pairs for the distinct values present,
@@ -86,7 +99,7 @@ func _update_min_size() -> void:
 		var groups := get_value_groups()
 		var total_w := 0.0
 		for i in range(groups.size()):
-			total_w += DIE_SIZE + COUNT_GAP + _measure_count(groups[i][1])
+			total_w += _group_width(groups[i][1])
 			if i < groups.size() - 1:
 				total_w += GROUP_SPACING
 		custom_minimum_size = Vector2(total_w, DIE_SIZE)
@@ -126,16 +139,17 @@ func _draw_grouped() -> void:
 		var count: int = g[1]
 		_draw_die(x, 0.0, value)
 
-		# "xN" count label, vertically centred against the die.
+		# "xN" count label, vertically centred against the die. A count of 1
+		# yields an empty label (the lone die already implies a single roll).
 		var count_str := _count_text(count)
-		var tx := x + DIE_SIZE + COUNT_GAP
-		if font != null:
+		if count_str != "" and font != null:
+			var tx := x + DIE_SIZE + COUNT_GAP
 			var text_h := font.get_height(COUNT_FONT_SIZE)
 			var ascent := font.get_ascent(COUNT_FONT_SIZE)
 			var ty := (DIE_SIZE - text_h) * 0.5 + ascent
 			draw_string(font, Vector2(tx, ty), count_str, HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE, COLOR_COUNT_TEXT)
 
-		x += DIE_SIZE + COUNT_GAP + _measure_count(count) + GROUP_SPACING
+		x += _group_width(count) + GROUP_SPACING
 
 func _draw_ungrouped() -> void:
 	for i in range(_rolls.size()):

--- a/40k/scripts/DiceRowVisual.gd
+++ b/40k/scripts/DiceRowVisual.gd
@@ -4,12 +4,24 @@ class_name DiceRowVisual
 # DiceRowVisual - Static inline dice row for embedding inside the game log.
 # Mirrors the color-coding of DiceRollVisual (gold=6, red=1, green=success,
 # gray=fail) but renders a single static frame: no animation, no fade, no sound.
+#
+# Grouped mode (default): instead of drawing every die individually, identical
+# values are grouped. Each distinct face value (1..6) is drawn ONCE as a die
+# icon followed by a "xN" count of how many of that value were rolled. So a
+# roll of [1, 1, 2, 6] renders as: [die-1] x2  [die-2] x1  [die-6] x1.
+# Ungrouped mode draws every die individually (legacy behaviour, used by callers
+# that pass grouped = false).
 
 const DIE_SIZE := 18.0
 const DIE_MARGIN := 3.0
 const DIE_CORNER_RADIUS := 3.0
 const ROW_SPACING := 3.0
 const MAX_DICE_PER_ROW := 10
+
+# Grouped-mode layout
+const COUNT_FONT_SIZE := 11
+const COUNT_GAP := 3.0      # gap between a die icon and its "xN" count
+const GROUP_SPACING := 9.0  # gap between adjacent value-groups
 
 const COLOR_CRITICAL := Color(1.0, 0.84, 0.0)
 const COLOR_FUMBLE := Color(0.9, 0.15, 0.15)
@@ -18,26 +30,66 @@ const COLOR_FAIL := Color(0.35, 0.35, 0.4)
 const COLOR_DIE_TEXT := Color(1.0, 1.0, 1.0)
 const COLOR_DIE_TEXT_DARK := Color(0.1, 0.1, 0.1)
 const COLOR_DIE_NEUTRAL := Color(0.25, 0.45, 0.7)
+const COLOR_COUNT_TEXT := Color(0.85, 0.88, 0.92)
 
 var _rolls: Array = []
 var _threshold: int = 0
 var _use_threshold_colors: bool = true
+var _grouped: bool = true
 
 func _ready() -> void:
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
-func set_dice(rolls: Array, threshold: int = 0, use_threshold_colors: bool = true) -> void:
+func set_dice(rolls: Array, threshold: int = 0, use_threshold_colors: bool = true, grouped: bool = true) -> void:
 	_rolls.clear()
 	for r in rolls:
 		_rolls.append(int(r))
 	_threshold = threshold
 	_use_threshold_colors = use_threshold_colors
+	_grouped = grouped
 	_update_min_size()
 	queue_redraw()
+
+func _get_font() -> Font:
+	# ThemeDB.fallback_font is always available even when the control is not yet
+	# in the tree, which keeps sizing deterministic for headless tests.
+	return ThemeDB.fallback_font
+
+func _count_text(count: int) -> String:
+	return "x%d" % count
+
+func _measure_count(count: int) -> float:
+	var font := _get_font()
+	if font == null:
+		# Fallback estimate if no font is available (shouldn't happen at runtime)
+		return float(_count_text(count).length()) * 6.0
+	return font.get_string_size(_count_text(count), HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE).x
+
+func get_value_groups() -> Array:
+	# Returns an Array of [value, count] pairs for the distinct values present,
+	# sorted ascending by value (1..6). Public so tests can assert grouping.
+	var counts := {}
+	for v in _rolls:
+		counts[v] = int(counts.get(v, 0)) + 1
+	var values := counts.keys()
+	values.sort()
+	var groups := []
+	for v in values:
+		groups.append([int(v), int(counts[v])])
+	return groups
 
 func _update_min_size() -> void:
 	if _rolls.is_empty():
 		custom_minimum_size = Vector2(0, 0)
+		return
+	if _grouped:
+		var groups := get_value_groups()
+		var total_w := 0.0
+		for i in range(groups.size()):
+			total_w += DIE_SIZE + COUNT_GAP + _measure_count(groups[i][1])
+			if i < groups.size() - 1:
+				total_w += GROUP_SPACING
+		custom_minimum_size = Vector2(total_w, DIE_SIZE)
 		return
 	var n: int = _rolls.size()
 	var cols: int = mini(n, MAX_DICE_PER_ROW)
@@ -60,48 +112,76 @@ func _get_die_color(value: int) -> Color:
 func _draw() -> void:
 	if _rolls.is_empty():
 		return
+	if _grouped:
+		_draw_grouped()
+	else:
+		_draw_ungrouped()
 
+func _draw_grouped() -> void:
+	var groups := get_value_groups()
+	var font := _get_font()
+	var x := 0.0
+	for g in groups:
+		var value: int = g[0]
+		var count: int = g[1]
+		_draw_die(x, 0.0, value)
+
+		# "xN" count label, vertically centred against the die.
+		var count_str := _count_text(count)
+		var tx := x + DIE_SIZE + COUNT_GAP
+		if font != null:
+			var text_h := font.get_height(COUNT_FONT_SIZE)
+			var ascent := font.get_ascent(COUNT_FONT_SIZE)
+			var ty := (DIE_SIZE - text_h) * 0.5 + ascent
+			draw_string(font, Vector2(tx, ty), count_str, HORIZONTAL_ALIGNMENT_LEFT, -1, COUNT_FONT_SIZE, COLOR_COUNT_TEXT)
+
+		x += DIE_SIZE + COUNT_GAP + _measure_count(count) + GROUP_SPACING
+
+func _draw_ungrouped() -> void:
 	for i in range(_rolls.size()):
 		var value: int = _rolls[i]
 		var col: int = i % MAX_DICE_PER_ROW
 		var row: int = i / MAX_DICE_PER_ROW
 		var x: float = col * (DIE_SIZE + DIE_MARGIN)
 		var y: float = row * (DIE_SIZE + ROW_SPACING)
-		var rect := Rect2(x, y, DIE_SIZE, DIE_SIZE)
-		var bg := _get_die_color(value)
+		_draw_die(x, y, value)
 
-		# Drop shadow
-		var shadow_rect := Rect2(x + 1, y + 1, DIE_SIZE, DIE_SIZE)
-		var shadow_style := StyleBoxFlat.new()
-		shadow_style.bg_color = Color(0.0, 0.0, 0.0, 0.3)
-		shadow_style.set_corner_radius_all(DIE_CORNER_RADIUS)
-		draw_style_box(shadow_style, shadow_rect)
+func _draw_die(x: float, y: float, value: int) -> void:
+	var rect := Rect2(x, y, DIE_SIZE, DIE_SIZE)
+	var bg := _get_die_color(value)
 
-		# Subtle glow for natural 6s
-		if value == 6:
-			var glow_rect := Rect2(x - 2, y - 2, DIE_SIZE + 4, DIE_SIZE + 4)
-			var glow_style := StyleBoxFlat.new()
-			glow_style.bg_color = Color(1.0, 0.84, 0.0, 0.25)
-			glow_style.set_corner_radius_all(DIE_CORNER_RADIUS + 2)
-			draw_style_box(glow_style, glow_rect)
+	# Drop shadow
+	var shadow_rect := Rect2(x + 1, y + 1, DIE_SIZE, DIE_SIZE)
+	var shadow_style := StyleBoxFlat.new()
+	shadow_style.bg_color = Color(0.0, 0.0, 0.0, 0.3)
+	shadow_style.set_corner_radius_all(DIE_CORNER_RADIUS)
+	draw_style_box(shadow_style, shadow_rect)
 
-		# Die face
-		var style := StyleBoxFlat.new()
-		style.bg_color = bg
-		style.set_corner_radius_all(DIE_CORNER_RADIUS)
-		style.set_border_width_all(1)
-		style.border_color = Color(0.0, 0.0, 0.0, 0.6)
-		draw_style_box(style, rect)
+	# Subtle glow for natural 6s
+	if value == 6:
+		var glow_rect := Rect2(x - 2, y - 2, DIE_SIZE + 4, DIE_SIZE + 4)
+		var glow_style := StyleBoxFlat.new()
+		glow_style.bg_color = Color(1.0, 0.84, 0.0, 0.25)
+		glow_style.set_corner_radius_all(DIE_CORNER_RADIUS + 2)
+		draw_style_box(glow_style, glow_rect)
 
-		# Pips
-		var pip_color: Color = COLOR_DIE_TEXT_DARK if value == 6 else COLOR_DIE_TEXT
-		_draw_pips(x, y, value, pip_color)
+	# Die face
+	var style := StyleBoxFlat.new()
+	style.bg_color = bg
+	style.set_corner_radius_all(DIE_CORNER_RADIUS)
+	style.set_border_width_all(1)
+	style.border_color = Color(0.0, 0.0, 0.0, 0.6)
+	draw_style_box(style, rect)
 
-		# Strike-through X for natural 1s
-		if value == 1:
-			var line_color := Color(1.0, 1.0, 1.0, 0.35)
-			draw_line(Vector2(x + 3, y + 3), Vector2(x + DIE_SIZE - 3, y + DIE_SIZE - 3), line_color, 1.0)
-			draw_line(Vector2(x + DIE_SIZE - 3, y + 3), Vector2(x + 3, y + DIE_SIZE - 3), line_color, 1.0)
+	# Pips
+	var pip_color: Color = COLOR_DIE_TEXT_DARK if value == 6 else COLOR_DIE_TEXT
+	_draw_pips(x, y, value, pip_color)
+
+	# Strike-through X for natural 1s
+	if value == 1:
+		var line_color := Color(1.0, 1.0, 1.0, 0.35)
+		draw_line(Vector2(x + 3, y + 3), Vector2(x + DIE_SIZE - 3, y + DIE_SIZE - 3), line_color, 1.0)
+		draw_line(Vector2(x + DIE_SIZE - 3, y + 3), Vector2(x + 3, y + DIE_SIZE - 3), line_color, 1.0)
 
 func _draw_pips(x: float, y: float, value: int, color: Color) -> void:
 	var pip_radius: float = 2.0

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -88,7 +88,7 @@ func _ready() -> void:
 	_dice_regex = RegEx.new()
 	_dice_regex.compile("\\[([0-9, ]+)\\]")
 	_threshold_regex = RegEx.new()
-	_threshold_regex.compile("(?:needed |Save |Pain )(\\d+)\\+")
+	_threshold_regex.compile("(?:needed |Save |Pain |vs )(\\d+)\\+")
 
 func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 105.0, offset_bottom: float = 0.0) -> void:
 	name = "GameLogPanel"
@@ -268,6 +268,23 @@ func combat_detail_row_has_visual(row_index: int) -> bool:
 			return true
 	return false
 
+func _node_has_dice_visual(node: Node) -> bool:
+	# Recursively search a node subtree for a DiceRowVisual instance.
+	if node is DiceRowVisualScript:
+		return true
+	for c in node.get_children():
+		if _node_has_dice_visual(c):
+			return true
+	return false
+
+func last_simple_card_has_dice_visual() -> bool:
+	# Test introspection helper: true if the most recently added card in the main
+	# card container renders dice icons (e.g. an advance/charge roll line).
+	if _card_container == null or _card_container.get_child_count() == 0:
+		return false
+	var last = _card_container.get_child(_card_container.get_child_count() - 1)
+	return _node_has_dice_visual(last)
+
 func _build_realtime_dice_row(data: Dictionary, context: String) -> Control:
 	"""Build an HBox row containing prefix label + graphical dice + suffix label."""
 	var rolls_raw = data.get("rolls_raw", [])
@@ -342,7 +359,7 @@ func _build_realtime_dice_row(data: Dictionary, context: String) -> Control:
 		_:
 			return null
 
-func _make_dice_row(prefix_bbcode: String, rolls: Array, threshold: int, use_threshold_colors: bool, suffix_bbcode: String) -> Control:
+func _make_dice_row(prefix_bbcode: String, rolls: Array, threshold: int, use_threshold_colors: bool, suffix_bbcode: String, normal_size: int = 10, bold_size: int = 11) -> Control:
 	"""Build a single HBox row: [prefix RichTextLabel] [DiceRowVisual] [suffix RichTextLabel]."""
 	var hbox := HBoxContainer.new()
 	hbox.add_theme_constant_override("separation", 4)
@@ -352,8 +369,13 @@ func _make_dice_row(prefix_bbcode: String, rolls: Array, threshold: int, use_thr
 	prefix.bbcode_enabled = true
 	prefix.fit_content = true
 	prefix.scroll_active = false
-	prefix.add_theme_font_size_override("normal_font_size", 10)
-	prefix.add_theme_font_size_override("bold_font_size", 11)
+	# The prefix is non-expanding, so leaving autowrap on lets it collapse to a
+	# 1px-wide column and grow absurdly tall. Disable autowrap so it sizes to its
+	# natural single-line width.
+	prefix.autowrap_mode = TextServer.AUTOWRAP_OFF
+	prefix.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	prefix.add_theme_font_size_override("normal_font_size", normal_size)
+	prefix.add_theme_font_size_override("bold_font_size", bold_size)
 	prefix.append_text(prefix_bbcode)
 	hbox.add_child(prefix)
 
@@ -368,8 +390,8 @@ func _make_dice_row(prefix_bbcode: String, rolls: Array, threshold: int, use_thr
 	suffix.fit_content = true
 	suffix.scroll_active = false
 	suffix.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	suffix.add_theme_font_size_override("normal_font_size", 10)
-	suffix.add_theme_font_size_override("bold_font_size", 11)
+	suffix.add_theme_font_size_override("normal_font_size", normal_size)
+	suffix.add_theme_font_size_override("bold_font_size", bold_size)
 	suffix.append_text(suffix_bbcode)
 	hbox.add_child(suffix)
 
@@ -512,17 +534,28 @@ func _build_combat_detail_line(text: String) -> Control:
 	"""Build a Control for one combat-detail line. If the line contains a dice
 	array (e.g. 'rolled [1, 1, 2, 6]'), render the array as a grouped DiceRowVisual
 	(one die icon per value + xN count); otherwise render styled text."""
+	return _build_dice_aware_line(text, "#B0B8C0", 10, 11)
+
+func line_has_dice_array(text: String) -> bool:
+	"""True if a log line contains a [n, n, ...] dice array that should render as
+	dice icons. Used to route simple cards through the dice-aware builder."""
+	return _dice_regex.search(text) != null
+
+func _build_dice_aware_line(text: String, color_hex: String, normal_size: int, bold_size: int) -> Control:
+	"""Generic builder shared by combat details and simple cards. A line with a
+	dice array renders as [prefix label][grouped DiceRowVisual][suffix label];
+	otherwise it renders as a single styled label. Keyword highlighting and the
+	supplied text color/font size are applied to the surrounding text either way."""
 	var dice_match = _dice_regex.search(text)
 	if dice_match == null:
-		# No dice — single styled label.
 		var label := RichTextLabel.new()
 		label.bbcode_enabled = true
 		label.fit_content = true
 		label.scroll_active = false
 		label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-		label.add_theme_font_size_override("normal_font_size", 10)
-		label.add_theme_font_size_override("bold_font_size", 11)
-		label.append_text("[color=#B0B8C0]%s[/color]" % _highlight_keywords(text))
+		label.add_theme_font_size_override("normal_font_size", normal_size)
+		label.add_theme_font_size_override("bold_font_size", bold_size)
+		label.append_text("[color=%s]%s[/color]" % [color_hex, _highlight_keywords(text)])
 		return label
 
 	# Split the line around the dice array: [prefix] [dice icons] [suffix]
@@ -536,9 +569,9 @@ func _build_combat_detail_line(text: String) -> Control:
 		if dval != "":
 			rolls.append(int(dval))
 
-	var prefix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(prefix_text) if prefix_text != "" else ""
-	var suffix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(suffix_text) if suffix_text != "" else ""
-	return _make_dice_row(prefix_bbcode, rolls, threshold, threshold > 0, suffix_bbcode)
+	var prefix_bbcode := "[color=%s]%s[/color]" % [color_hex, _highlight_keywords(prefix_text)] if prefix_text != "" else ""
+	var suffix_bbcode := "[color=%s]%s[/color]" % [color_hex, _highlight_keywords(suffix_text)] if suffix_text != "" else ""
+	return _make_dice_row(prefix_bbcode, rolls, threshold, threshold > 0, suffix_bbcode, normal_size, bold_size)
 
 func _finalize_combat_card(text: String, animate: bool) -> void:
 	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_summary_label:
@@ -701,6 +734,14 @@ func _make_simple_entry_card(text: String, entry_type: String, category: int) ->
 	var icon = _create_icon(category)
 	hbox.add_child(icon)
 
+	# Dice-bearing lines (e.g. advance/charge/overwatch rolls) render their
+	# dice array as grouped icons instead of plain numbers — same treatment as
+	# combat details, but tinted to the entry's color.
+	if line_has_dice_array(text):
+		var dice_content = _build_dice_aware_line(text, _entry_text_color(entry_type), 11, 12)
+		hbox.add_child(dice_content)
+		return card
+
 	# Text label — truncate long entries with expand on click
 	var display_text = text
 	var is_truncated = false
@@ -808,6 +849,23 @@ func _animate_card_in(card: Control) -> void:
 # ==========================================================================
 # Text formatting
 # ==========================================================================
+
+func _entry_text_color(entry_type: String) -> String:
+	"""Base text color (hex with leading #) used for a simple-card entry type.
+	Mirrors the colors in _format_entry_text so dice-aware lines stay on-palette."""
+	match entry_type:
+		"phase_header":
+			return "#D49761"
+		"p1_action":
+			return "#6699CC"
+		"p2_action":
+			return "#CC6666"
+		"ai_thinking":
+			return "#8899AA"
+		"overwatch":
+			return "#FF6600"
+		_:
+			return "#B0B8C0"
 
 func _format_entry_text(text: String, entry_type: String) -> String:
 	match entry_type:

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -252,6 +252,22 @@ func dice_row_has_visual(row_index: int) -> bool:
 			return true
 	return false
 
+func combat_detail_row_has_visual(row_index: int) -> bool:
+	# Test introspection helper: returns true if the collapsible details row at
+	# `row_index` contains a DiceRowVisual child (i.e. the dice array was rendered
+	# as grouped icons instead of inline number badges).
+	if not _current_combat_details_container or not is_instance_valid(_current_combat_details_container):
+		return false
+	if row_index < 0 or row_index >= _current_combat_details_container.get_child_count():
+		return false
+	var row = _current_combat_details_container.get_child(row_index)
+	if row is DiceRowVisualScript:
+		return true
+	for c in row.get_children():
+		if c is DiceRowVisualScript:
+			return true
+	return false
+
 func _build_realtime_dice_row(data: Dictionary, context: String) -> Control:
 	"""Build an HBox row containing prefix label + graphical dice + suffix label."""
 	var rolls_raw = data.get("rolls_raw", [])
@@ -452,20 +468,13 @@ func _start_combat_card(header_text: String, animate: bool) -> void:
 	var toggle_btn = _current_combat_toggle_button
 	card_vbox.add_child(toggle_btn)
 
-	# Collapsible details container
+	# Collapsible details container — holds one row Control per detail line
+	# (text-only or a grouped DiceRowVisual row). Populated by _append_combat_detail.
 	_current_combat_details_container = VBoxContainer.new()
+	_current_combat_details_container.add_theme_constant_override("separation", 2)
 	_current_combat_details_container.visible = false
 	card_vbox.add_child(_current_combat_details_container)
-
-	# Details RichTextLabel
-	_current_combat_details_label = RichTextLabel.new()
-	_current_combat_details_label.bbcode_enabled = true
-	_current_combat_details_label.fit_content = true
-	_current_combat_details_label.scroll_active = false
-	_current_combat_details_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_current_combat_details_label.add_theme_font_size_override("normal_font_size", 10)
-	_current_combat_details_label.add_theme_font_size_override("bold_font_size", 11)
-	_current_combat_details_container.add_child(_current_combat_details_label)
+	_current_combat_details_label = null  # legacy single-label model retired; rows added directly
 
 	# Wire up toggle — capture references for the closure
 	var details_cont = _current_combat_details_container
@@ -485,13 +494,12 @@ func _start_combat_card(header_text: String, animate: bool) -> void:
 		_animate_card_in(card)
 
 func _append_combat_detail(text: String, animate: bool) -> void:
-	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_details_label:
-		# Append to current combat card's collapsible section
-		if _current_combat_details_text != "":
-			_current_combat_details_text += "\n"
-		_current_combat_details_text += _style_combat_detail(text.strip_edges())
-		_current_combat_details_label.text = ""
-		_current_combat_details_label.append_text("[color=#B0B8C0]%s[/color]" % _current_combat_details_text)
+	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_details_container and is_instance_valid(_current_combat_details_container):
+		# Append a per-line row to the current combat card's collapsible section.
+		# Lines containing a dice array [..] render the dice as grouped icons via
+		# DiceRowVisual; other lines render as styled text.
+		var row := _build_combat_detail_line(text.strip_edges())
+		_current_combat_details_container.add_child(row)
 	else:
 		# Orphaned detail — create standalone card
 		var card = _make_simple_entry_card(text, "combat_detail", EntryCategory.COMBAT)
@@ -499,6 +507,38 @@ func _append_combat_detail(text: String, animate: bool) -> void:
 		_card_count += 1
 		if animate:
 			_animate_card_in(card)
+
+func _build_combat_detail_line(text: String) -> Control:
+	"""Build a Control for one combat-detail line. If the line contains a dice
+	array (e.g. 'rolled [1, 1, 2, 6]'), render the array as a grouped DiceRowVisual
+	(one die icon per value + xN count); otherwise render styled text."""
+	var dice_match = _dice_regex.search(text)
+	if dice_match == null:
+		# No dice — single styled label.
+		var label := RichTextLabel.new()
+		label.bbcode_enabled = true
+		label.fit_content = true
+		label.scroll_active = false
+		label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		label.add_theme_font_size_override("normal_font_size", 10)
+		label.add_theme_font_size_override("bold_font_size", 11)
+		label.append_text("[color=#B0B8C0]%s[/color]" % _highlight_keywords(text))
+		return label
+
+	# Split the line around the dice array: [prefix] [dice icons] [suffix]
+	var threshold := _extract_threshold(text)
+	var prefix_text := text.substr(0, dice_match.get_start()).strip_edges()
+	var suffix_text := text.substr(dice_match.get_end()).strip_edges()
+
+	var rolls := []
+	for d in dice_match.get_string(1).split(","):
+		var dval := d.strip_edges()
+		if dval != "":
+			rolls.append(int(dval))
+
+	var prefix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(prefix_text) if prefix_text != "" else ""
+	var suffix_bbcode := "[color=#B0B8C0]%s[/color]" % _highlight_keywords(suffix_text) if suffix_text != "" else ""
+	return _make_dice_row(prefix_bbcode, rolls, threshold, threshold > 0, suffix_bbcode)
 
 func _finalize_combat_card(text: String, animate: bool) -> void:
 	if _current_combat_card and is_instance_valid(_current_combat_card) and _current_combat_summary_label:
@@ -855,10 +895,7 @@ func _style_combat_detail(text: String) -> String:
 	var styled = text
 
 	# Extract threshold from line context (e.g. "needed 3+", "Save 4+", "Pain 5+")
-	var threshold := 0
-	var threshold_match = _threshold_regex.search(text)
-	if threshold_match:
-		threshold = int(threshold_match.get_string(1))
+	var threshold := _extract_threshold(text)
 
 	# Replace dice roll arrays [1, 3, 5, 6] with colored dice badges
 	var dice_results = _dice_regex.search_all(styled)
@@ -874,7 +911,18 @@ func _style_combat_detail(text: String) -> String:
 		var replacement = " ".join(dice_badges)
 		styled = styled.substr(0, m.get_start()) + replacement + styled.substr(m.get_end())
 
-	# Highlight keywords
+	return _highlight_keywords(styled)
+
+func _extract_threshold(text: String) -> int:
+	"""Pull the success threshold out of a detail line (e.g. 'needed 3+' -> 3)."""
+	var threshold_match = _threshold_regex.search(text)
+	if threshold_match:
+		return int(threshold_match.get_string(1))
+	return 0
+
+func _highlight_keywords(text: String) -> String:
+	"""Apply BBCode color highlights to combat keywords (no dice substitution)."""
+	var styled = text
 	styled = styled.replace("DEVASTATING WOUNDS", "[color=#FF4444]DEVASTATING WOUNDS[/color]")
 	styled = styled.replace("DEVASTATING", "[color=#FF4444]DEVASTATING[/color]")
 	styled = styled.replace("Lethal Hits", "[color=#FF8844]Lethal Hits[/color]")
@@ -883,7 +931,6 @@ func _style_combat_detail(text: String) -> String:
 	styled = styled.replace("Invulnerable Save", "[color=#BB88FF]Invulnerable Save[/color]")
 	styled = styled.replace("Re-rolls:", "[color=#88BBFF]Re-rolls:[/color]")
 	styled = styled.replace("Torrent", "[color=#FF8844]Torrent[/color]")
-
 	return styled
 
 func _make_die_badge(value: int, threshold: int) -> String:

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -2120,6 +2120,42 @@ func _on_shooting_resolved(shooter_id: String, target_id: String, result: Dictio
 	# Update grenade button (unit may have shot, reducing eligible units)
 	_update_grenade_button_visibility()
 
+func _dice_icon_bg(raw: int, mod: int, threshold_num: int, context: String, crit_threshold: int) -> Color:
+	# Color for a die face in the resolution log: crit (gold) for to-hit 6s,
+	# else pass (green) / fail (red) by threshold, else neutral.
+	if context == "to_hit" and raw >= crit_threshold:
+		return DiceFaceIcons.COLOR_CRITICAL
+	if threshold_num > 0:
+		return DiceFaceIcons.COLOR_SUCCESS if mod >= threshold_num else DiceFaceIcons.COLOR_FAIL
+	return DiceFaceIcons.COLOR_NEUTRAL
+
+func _append_dice_icons(rolls: Array, threshold_num: int, context: String, crit_threshold: int = 6, modified: Array = []) -> void:
+	# Render `rolls` as grouped inline d6 icons in the resolution log: one icon
+	# per distinct value, with an "xN" count when more than one was rolled.
+	if not dice_log_display:
+		return
+	if rolls.is_empty():
+		dice_log_display.append_text("—")
+		return
+	var counts := {}
+	var mod_for := {}
+	for i in range(rolls.size()):
+		var v := int(rolls[i])
+		counts[v] = int(counts.get(v, 0)) + 1
+		if not mod_for.has(v):
+			mod_for[v] = int(modified[i]) if i < modified.size() else v
+	var values := counts.keys()
+	values.sort()
+	for idx in range(values.size()):
+		var v := int(values[idx])
+		var count := int(counts[v])
+		var bg := _dice_icon_bg(v, int(mod_for[v]), threshold_num, context, crit_threshold)
+		dice_log_display.add_image(DiceFaceIcons.get_face(v, bg), 18, 18, Color.WHITE, INLINE_ALIGNMENT_CENTER)
+		if count > 1:
+			dice_log_display.append_text(" [color=#cfd6dd]x%d[/color]" % count)
+		if idx < values.size() - 1:
+			dice_log_display.append_text("  ")
+
 func _on_dice_rolled(dice_data: Dictionary) -> void:
 	# P3-117: Record roll in centralized dice history
 	if DiceHistoryPanel:
@@ -2159,16 +2195,13 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 		var log_text = "[b][color=cyan]Feel No Pain %d+[/color][/b]" % fnp_val
 		if not target_name.is_empty():
 			log_text += " (%s)" % target_name
-		log_text += "\n"
+		log_text += "\n  Rolls: "
 
-		# Show individual dice
-		var dice_str = "  Rolls: "
-		for fnp_roll in fnp_rolls:
-			if fnp_roll >= fnp_val:
-				dice_str += "[color=green]%d[/color] " % fnp_roll
-			else:
-				dice_str += "[color=red]%d[/color] " % fnp_roll
-		log_text += dice_str + "\n"
+		# Flush header, then render FNP dice as inline icons.
+		dice_log_display.append_text(log_text)
+		_append_dice_icons(fnp_rolls, fnp_val, "feel_no_pain", 7)
+		dice_log_display.append_text("\n")
+		log_text = ""
 
 		# Show summary
 		if prevented > 0:
@@ -2188,12 +2221,13 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 		var notation = dice_data.get("notation", "")
 		var total_dmg = dice_data.get("total_damage", 0)
 		var dmg_rolls = dice_data.get("rolls", [])
-		var log_text = "[b][color=yellow]Variable Damage (%s)[/color][/b]\n" % notation
-		var roll_values = []
-		for r in dmg_rolls:
-			roll_values.append(str(r.get("value", 0)))
-		log_text += "  Rolled: [%s] = %d total damage\n" % [", ".join(roll_values), total_dmg]
+		var log_text = "[b][color=yellow]Variable Damage (%s)[/color][/b]\n  Rolled: " % notation
 		dice_log_display.append_text(log_text)
+		var dmg_values := []
+		for r in dmg_rolls:
+			dmg_values.append(int(r.get("value", 0)))
+		_append_dice_icons(dmg_values, 0, "damage", 7)
+		dice_log_display.append_text(" = %d total damage\n" % total_dmg)
 		return
 
 	# TORRENT (PRP-014): Handle auto_hit context for Torrent weapons
@@ -2262,10 +2296,15 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 		var attacks_notation = dice_data.get("attacks_notation", "")
 		var attacks_rolls = dice_data.get("attacks_rolls", [])
 		var base_attacks = dice_data.get("base_attacks", 0)
-		var roll_values = []
+		# Flush text so far, then render the attack dice as inline icons.
+		log_text += "  [color=yellow][VARIABLE ATTACKS] %s per model → rolled [/color]" % attacks_notation
+		dice_log_display.append_text(log_text)
+		log_text = ""
+		var attack_values := []
 		for r in attacks_rolls:
-			roll_values.append(str(r.get("value", 0)))
-		log_text += "  [color=yellow][VARIABLE ATTACKS] %s per model → rolled [%s] = %d attacks[/color]\n" % [attacks_notation, ", ".join(roll_values), base_attacks]
+			attack_values.append(int(r.get("value", 0)))
+		_append_dice_icons(attack_values, 0, "attacks", 7)
+		dice_log_display.append_text("[color=yellow] = %d attacks[/color]\n" % base_attacks)
 
 	# Show Rapid Fire bonus if applied
 	var rapid_fire_bonus = dice_data.get("rapid_fire_bonus", 0)
@@ -2337,21 +2376,16 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 	var critical_hit_threshold = dice_data.get("critical_hit_threshold", 6)
 
 	if threshold_num > 0 and not show_rolls.is_empty():
-		log_text += "  Rolls: ["
-		for i in range(show_rolls.size()):
-			var raw_val = show_rolls[i]
-			var mod_val = check_rolls[i] if i < check_rolls.size() else raw_val
-			if context == "to_hit" and raw_val >= critical_hit_threshold:
-				log_text += "[color=magenta][b]%d[/b][/color]" % raw_val
-			elif mod_val >= threshold_num:
-				log_text += "[color=green]%d[/color]" % raw_val
-			else:
-				log_text += "[color=red]%d[/color]" % raw_val
-			if i < show_rolls.size() - 1:
-				log_text += ", "
-		log_text += "]"
+		# Flush text accumulated so far, then render the dice as inline icons.
+		log_text += "  Rolls: "
+		dice_log_display.append_text(log_text)
+		log_text = ""
+		_append_dice_icons(show_rolls, threshold_num, context, critical_hit_threshold, check_rolls)
 	else:
-		log_text += "  Rolls: %s" % str(show_rolls)
+		log_text += "  Rolls: "
+		dice_log_display.append_text(log_text)
+		log_text = ""
+		_append_dice_icons(show_rolls, 0, context, critical_hit_threshold)
 
 	# CRITICAL HIT TRACKING (PRP-031): Show critical hits for to_hit rolls
 	var critical_hits = dice_data.get("critical_hits", 0)

--- a/40k/tests/scenarios/sp/dice_grouped_log_render.json
+++ b/40k/tests/scenarios/sp/dice_grouped_log_render.json
@@ -1,0 +1,62 @@
+{
+  "id": "dice_grouped_log_render",
+  "covers": ["ui.log.inline_dice_graphics", "ui.log.grouped_dice_icons"],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Verify dice rolls in the GameLogPanel render as GROUPED die icons (one icon per distinct value plus an 'xN' count) instead of a flat array of numbers. Drives both the real-time roll path (DiceHistoryPanel.roll_recorded -> _current_combat_dice_container) and the combat-detail text path (a 'rolled [1, 1, 2, 6]' line -> _current_combat_details_container). Asserts each path mounts a DiceRowVisual whose get_value_groups() collapses duplicate values, then reveals the details and captures a screenshot of the grouped icons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Test Shooter shoots Test Target', 'combat_header', false)" },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_dice_container != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "DiceHistoryPanel.roll_recorded.emit({'data': {'context': 'to_hit', 'rolls_raw': [1, 1, 2, 6], 'threshold': '3+', 'successes': 1}})" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_dice_container.get_child_count()",
+      "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.dice_row_has_visual(0)",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('  To Hit: needed 3+ — rolled [1, 1, 2, 6] — 1/4 hit', 'combat_detail', false)" },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('    Modifiers: +1 to hit', 'combat_detail', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_details_container.get_child_count()",
+      "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.combat_detail_row_has_visual(0)",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.combat_detail_row_has_visual(1)",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._current_combat_details_container.set_visible(true)" },
+
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "grouped_dice_icons_in_log" }
+  ]
+}

--- a/40k/tests/scenarios/sp/dice_icons_simple_cards.json
+++ b/40k/tests/scenarios/sp/dice_icons_simple_cards.json
@@ -1,0 +1,55 @@
+{
+  "id": "dice_icons_simple_cards",
+  "covers": ["ui.log.inline_dice_graphics", "ui.log.grouped_dice_icons", "ui.log.simple_card_dice"],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Verify that non-combat log lines (advance / charge / battle-shock style rolls logged as p1_action/p2_action) render their [n, ...] dice arrays as grouped die icons in their simple cards, not as plain number arrays. A single-die roll (advance) shows just the icon with no 'x1' label. Drives real player-action log entries through _create_card and asserts last_simple_card_has_dice_visual(), then captures a screenshot of the icons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Intercessors advances: rolled [4] - total move = 10 inches', 'p1_action', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.last_simple_card_has_dice_visual()",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Boyz charge roll: [5, 3] = 8 inches vs 6.0 inches needed - SUCCESS', 'p2_action', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.last_simple_card_has_dice_visual()",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Warboss passed Battle-shock test: [6, 2] = 8 vs Ld 7', 'p1_action', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.last_simple_card_has_dice_visual()",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel._create_card('Intercessors holds position on the objective', 'p1_action', false)" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.game_log_panel.last_simple_card_has_dice_visual()",
+      "equals": false },
+
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "simple_card_dice_icons" }
+  ]
+}

--- a/40k/tests/scenarios/sp/resolution_log_dice_icons.json
+++ b/40k/tests/scenarios/sp/resolution_log_dice_icons.json
@@ -1,0 +1,55 @@
+{
+  "id": "resolution_log_dice_icons",
+  "covers": ["ui.shooting.resolution_log_dice_icons", "ui.log.grouped_dice_icons"],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Verify the shooting phase sequential-resolution log (ShootingController.dice_log_display) renders dice rolls as inline grouped d6 icons via DiceFaceIcons/add_image, not as [2, 5, 6, 6] number arrays. Drives _on_dice_rolled with real to_hit / to_wound / feel_no_pain dice blocks and asserts the RichTextLabel now contains inline images (get_parsed_text drops the [n,...] arrays). Captures a screenshot of the icon-rendered log.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display != null",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display.clear()" },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display.append_text('Resolution Log:\nStarting sequential weapon resolution...\n>>> Resolving weapon 1 of 1 <<<\n')" },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller._on_dice_rolled({'context': 'to_hit', 'rolls_raw': [2, 5, 6, 6], 'rolls_modified': [2, 5, 6, 6], 'threshold': '2+', 'successes': 4, 'weapon_name': 'Bolt Rifle', 'critical_hit_threshold': 6})" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller._on_dice_rolled({'context': 'to_wound', 'rolls_raw': [1, 2, 3, 6], 'rolls_modified': [1, 2, 3, 6], 'threshold': '2+', 'successes': 4})" },
+
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller._on_dice_rolled({'context': 'feel_no_pain', 'fnp_value': 5, 'rolls_raw': [5, 2, 6, 1], 'wounds_prevented': 2, 'wounds_remaining': 2, 'total_wounds': 4, 'target_unit_name': 'Boyz'})" },
+
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "'[2, 5, 6, 6]' in main.shooting_controller.dice_log_display.get_parsed_text()",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display.get_parsed_text().contains('successes')",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display.get_parent().get_parent().ensure_control_visible(main.shooting_controller.dice_log_display)" },
+
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "resolution_log_dice_icons" }
+  ]
+}

--- a/40k/tests/test_dice_face_icons.gd
+++ b/40k/tests/test_dice_face_icons.gd
@@ -1,0 +1,47 @@
+extends SceneTree
+
+# Headless test for DiceFaceIcons — the d6 face texture factory used to embed
+# dice icons inline in RichTextLabel resolution logs.
+
+const DiceFaceIconsScript := preload("res://scripts/DiceFaceIcons.gd")
+
+var _passed := 0
+var _failed := 0
+
+func _initialize() -> void:
+	print("=== DiceFaceIcons Test ===")
+	_test_face_generation()
+	_test_cache_reuse()
+	_test_color_for()
+	print("\n=== Result: %d passed / %d failed ===" % [_passed, _failed])
+	quit(0 if _failed == 0 else 1)
+
+func _check(name: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		_passed += 1
+		print("  PASS  %s" % name)
+	else:
+		_failed += 1
+		print("  FAIL  %s — %s" % [name, detail])
+
+func _test_face_generation() -> void:
+	for v in range(1, 7):
+		var tex = DiceFaceIconsScript.get_face(v, DiceFaceIconsScript.COLOR_NEUTRAL)
+		_check("face %d produces a texture" % v, tex != null and tex is ImageTexture)
+		_check("face %d is TEX_SIZE square" % v,
+			tex.get_width() == DiceFaceIconsScript.TEX_SIZE and tex.get_height() == DiceFaceIconsScript.TEX_SIZE,
+			"got %dx%d" % [tex.get_width(), tex.get_height()])
+
+func _test_cache_reuse() -> void:
+	var a = DiceFaceIconsScript.get_face(6, DiceFaceIconsScript.COLOR_CRITICAL)
+	var b = DiceFaceIconsScript.get_face(6, DiceFaceIconsScript.COLOR_CRITICAL)
+	_check("identical (value,color) returns cached instance", a == b)
+	var c = DiceFaceIconsScript.get_face(6, DiceFaceIconsScript.COLOR_SUCCESS)
+	_check("different color returns a different texture", a != c)
+
+func _test_color_for() -> void:
+	_check("6 -> critical gold", DiceFaceIconsScript.color_for(6, 3) == DiceFaceIconsScript.COLOR_CRITICAL)
+	_check("1 -> fumble red", DiceFaceIconsScript.color_for(1, 3) == DiceFaceIconsScript.COLOR_FUMBLE)
+	_check("4 vs 3+ -> success", DiceFaceIconsScript.color_for(4, 3) == DiceFaceIconsScript.COLOR_SUCCESS)
+	_check("2 vs 3+ -> fail", DiceFaceIconsScript.color_for(2, 3) == DiceFaceIconsScript.COLOR_FAIL)
+	_check("3 no threshold -> neutral", DiceFaceIconsScript.color_for(3, 0, false) == DiceFaceIconsScript.COLOR_NEUTRAL)

--- a/40k/tests/test_dice_face_icons.gd.uid
+++ b/40k/tests/test_dice_face_icons.gd.uid
@@ -1,0 +1,1 @@
+uid://bnfi3rk8bpkva

--- a/40k/tests/test_inline_dice_log.gd
+++ b/40k/tests/test_inline_dice_log.gd
@@ -23,9 +23,11 @@ func _initialize() -> void:
 	_test_dice_row_visual_threshold_colors()
 	_test_dice_row_visual_grouping()
 	_test_dice_row_visual_grouped_single_row()
+	_test_dice_row_visual_single_die_no_count()
 	_test_dice_row_visual_ungrouped_wrap_size()
 	_test_game_log_panel_records_dice_row()
 	_test_game_log_panel_detail_dice_row()
+	_test_game_log_panel_simple_card_dice_icons()
 	_test_game_log_panel_skips_when_no_combat()
 
 	print("\n=== Result: %d passed / %d failed ===" % [_passed, _failed])
@@ -87,6 +89,28 @@ func _test_dice_row_visual_grouped_single_row() -> void:
 	_check("grouped row is one die tall", d.custom_minimum_size.y == DiceRowVisualScript.DIE_SIZE,
 		"got y=%s expected %s" % [str(d.custom_minimum_size.y), str(DiceRowVisualScript.DIE_SIZE)])
 	d.free()
+
+func _test_dice_row_visual_single_die_no_count() -> void:
+	# A single die (e.g. an Advance roll) shows just the icon, no "x1" label.
+	var single = DiceRowVisualScript.new()
+	single.set_dice([4], 0, false)
+	_check("single die width == DIE_SIZE (no x1 label)",
+		single.custom_minimum_size.x == DiceRowVisualScript.DIE_SIZE,
+		"got x=%s expected %s" % [str(single.custom_minimum_size.x), str(DiceRowVisualScript.DIE_SIZE)])
+	single.free()
+
+	# Count-of-1 groups inside a multi-die roll also drop the "x1" label, so the
+	# row is narrower than if every group carried a count.
+	var mixed = DiceRowVisualScript.new()
+	mixed.set_dice([1, 1, 2, 6], 3, true)
+	# Groups: (1 x2 -> labelled), (2 -> bare), (6 -> bare). Width = labelled cell
+	# + 2 bare die cells + 2 group gaps.
+	var labelled_w = DiceRowVisualScript.DIE_SIZE + DiceRowVisualScript.COUNT_GAP + mixed._measure_count(2)
+	var expected_w = labelled_w + DiceRowVisualScript.DIE_SIZE + DiceRowVisualScript.DIE_SIZE \
+		+ 2 * DiceRowVisualScript.GROUP_SPACING
+	_check("singleton groups omit x1 in width", mixed.custom_minimum_size.x == expected_w,
+		"got x=%s expected %s" % [str(mixed.custom_minimum_size.x), str(expected_w)])
+	mixed.free()
 
 func _test_dice_row_visual_ungrouped_wrap_size() -> void:
 	# Legacy ungrouped mode still wraps 25 dice to 3 rows (MAX_DICE_PER_ROW=10).
@@ -167,6 +191,35 @@ func _test_game_log_panel_detail_dice_row() -> void:
 		"got %d" % panel._current_combat_details_container.get_child_count())
 	_check("dice detail line rendered as grouped DiceRowVisual", panel.combat_detail_row_has_visual(0))
 	_check("text-only detail line has no DiceRowVisual", not panel.combat_detail_row_has_visual(1))
+
+	panel.queue_free()
+
+func _test_game_log_panel_simple_card_dice_icons() -> void:
+	# Non-combat log lines (advance/charge/overwatch) that contain a [n, ...]
+	# dice array must render the array as dice icons in their simple card.
+	var panel = GameLogPanelScript.new()
+	get_root().add_child(panel)
+	panel._ready()
+	# setup() builds the card container as part of the full UI; for this unit
+	# test we just need the container the simple cards are appended to.
+	panel._card_container = VBoxContainer.new()
+	panel.add_child(panel._card_container)
+
+	# Advance line — single die, no count label.
+	panel._create_card("Intercessors advances: rolled [4] — total move = 10\"", "p1_action", false)
+	_check("advance simple card renders dice icon", panel.last_simple_card_has_dice_visual())
+
+	# Charge line — two dice.
+	panel._create_card("Boyz charge roll: [5, 3] = 8\" vs 6.0\" needed - SUCCESS", "p2_action", false)
+	_check("charge simple card renders dice icons", panel.last_simple_card_has_dice_visual())
+
+	# Plain line — no dice array -> no DiceRowVisual.
+	panel._create_card("Intercessors holds position", "p1_action", false)
+	_check("plain simple card has no dice icon", not panel.last_simple_card_has_dice_visual())
+
+	# line_has_dice_array helper sanity.
+	_check("line_has_dice_array true for [4]", panel.line_has_dice_array("rolled [4]"))
+	_check("line_has_dice_array false for [+1 STRENGTH]", not panel.line_has_dice_array("gain [+1 STRENGTH]"))
 
 	panel.queue_free()
 

--- a/40k/tests/test_inline_dice_log.gd
+++ b/40k/tests/test_inline_dice_log.gd
@@ -21,8 +21,11 @@ func _initialize() -> void:
 	_test_dice_row_visual_basic()
 	_test_dice_row_visual_empty()
 	_test_dice_row_visual_threshold_colors()
-	_test_dice_row_visual_wrap_size()
+	_test_dice_row_visual_grouping()
+	_test_dice_row_visual_grouped_single_row()
+	_test_dice_row_visual_ungrouped_wrap_size()
 	_test_game_log_panel_records_dice_row()
+	_test_game_log_panel_detail_dice_row()
 	_test_game_log_panel_skips_when_no_combat()
 
 	print("\n=== Result: %d passed / %d failed ===" % [_passed, _failed])
@@ -60,16 +63,41 @@ func _test_dice_row_visual_threshold_colors() -> void:
 	_check("die value 2 (<threshold 3) -> FAIL gray", d._get_die_color(2) == DiceRowVisualScript.COLOR_FAIL)
 	d.free()
 
-func _test_dice_row_visual_wrap_size() -> void:
+func _test_dice_row_visual_grouping() -> void:
+	# [1, 1, 2, 6] -> three groups: (1 x2), (2 x1), (6 x1), sorted ascending.
 	var d = DiceRowVisualScript.new()
-	# 25 dice should wrap to 3 rows (MAX_DICE_PER_ROW=10)
+	d.set_dice([1, 1, 2, 6], 3, true)
+	var groups = d.get_value_groups()
+	_check("grouping yields 3 distinct values", groups.size() == 3,
+		"got %s" % str(groups))
+	_check("group order/values/counts correct",
+		groups == [[1, 2], [2, 1], [6, 1]],
+		"got %s" % str(groups))
+	d.free()
+
+func _test_dice_row_visual_grouped_single_row() -> void:
+	# 25 identical dice collapse to one group -> a single-row (DIE_SIZE tall) icon.
+	var d = DiceRowVisualScript.new()
 	var rolls := []
 	for i in range(25):
 		rolls.append(4)
 	d.set_dice(rolls, 3, true)
+	_check("25 identical dice -> 1 group", d.get_value_groups() == [[4, 25]],
+		"got %s" % str(d.get_value_groups()))
+	_check("grouped row is one die tall", d.custom_minimum_size.y == DiceRowVisualScript.DIE_SIZE,
+		"got y=%s expected %s" % [str(d.custom_minimum_size.y), str(DiceRowVisualScript.DIE_SIZE)])
+	d.free()
+
+func _test_dice_row_visual_ungrouped_wrap_size() -> void:
+	# Legacy ungrouped mode still wraps 25 dice to 3 rows (MAX_DICE_PER_ROW=10).
+	var d = DiceRowVisualScript.new()
+	var rolls := []
+	for i in range(25):
+		rolls.append(4)
+	d.set_dice(rolls, 3, true, false)
 	var expected_rows := 3
 	var expected_h := expected_rows * DiceRowVisualScript.DIE_SIZE + (expected_rows - 1) * DiceRowVisualScript.ROW_SPACING
-	_check("25 dice -> 3-row min height", d.custom_minimum_size.y == expected_h,
+	_check("ungrouped 25 dice -> 3-row min height", d.custom_minimum_size.y == expected_h,
 		"got y=%s expected %s" % [str(d.custom_minimum_size.y), str(expected_h)])
 	d.free()
 
@@ -112,6 +140,33 @@ func _test_game_log_panel_records_dice_row() -> void:
 			has_dice_visual = true
 			break
 	_check("appended row contains a DiceRowVisual", has_dice_visual)
+
+	panel.queue_free()
+
+func _test_game_log_panel_detail_dice_row() -> void:
+	# A combat-detail line containing a dice array must render the array as a
+	# grouped DiceRowVisual row in the collapsible details container — NOT as a
+	# plain "[1, 1, 2, 6]" number array.
+	var panel = GameLogPanelScript.new()
+	get_root().add_child(panel)
+	panel._ready()
+	panel._create_card("Test shooter shoots Target", "combat_header", false)
+
+	if panel._current_combat_details_container == null:
+		_check("combat card creates details container", false, "container is null")
+		panel.queue_free()
+		return
+	_check("combat card creates details container", true)
+
+	# A dice-bearing detail line -> grouped DiceRowVisual row.
+	panel._create_card("  To Hit: needed 3+ — rolled [1, 1, 2, 6] — 2/4 hit", "combat_detail", false)
+	# A text-only detail line -> plain label (no DiceRowVisual).
+	panel._create_card("    Modifiers: +1 to hit", "combat_detail", false)
+
+	_check("two detail rows added", panel._current_combat_details_container.get_child_count() == 2,
+		"got %d" % panel._current_combat_details_container.get_child_count())
+	_check("dice detail line rendered as grouped DiceRowVisual", panel.combat_detail_row_has_visual(0))
+	_check("text-only detail line has no DiceRowVisual", not panel.combat_detail_row_has_visual(1))
 
 	panel.queue_free()
 


### PR DESCRIPTION
## Summary

Two related improvements to how dice rolls appear in the game log and shooting resolution log.

### 1. All dice rolls in the left game log use icons; drop redundant "x1"
- Single-die rolls (advance, etc.) now show just the die icon with **no "x1"** label; any value rolled once omits the count.
- Simple log cards (advance / charge / battle-shock / surge / Shooty Power Trip / overwatch) render their `[n, ...]` dice arrays as grouped icons via a shared dice-aware line builder, tinted to the entry's color.
- Source log strings updated to emit dice values in `[..]` form (e.g. advance `"D6 = 4"` → `"rolled [4]"`).
- Threshold regex also recognizes `"vs N+"` so overwatch hit/wound/save dice get success/fail coloring.
- Fixed a layout bug where a non-expanding prefix `RichTextLabel` collapsed to 1px wide and grew ~650px tall; autowrap is now disabled on it.

### 2. Shooting sequential-resolution log uses inline dice icons
- New `DiceFaceIcons` factory generates cached d6 face textures (rounded square + pips) for embedding in `RichTextLabel`s via `add_image()`, matching the game log's dice look.
- `ShootingController._on_dice_rolled` renders To Hit / To Wound / Save / Feel No Pain / variable damage / variable attacks as grouped icons with "xN" counts, colored by pass/fail (gold for to-hit crits), instead of `Rolls: [2, 5, 6, 6]` arrays.

## Validation
- Headless: `test_inline_dice_log.gd` (26 checks) and `test_dice_face_icons.gd` (19 checks) — all pass.
- Windowed (per the project's feature-validation gate): `dice_icons_simple_cards.json` and `resolution_log_dice_icons.json` drive the real UI paths and are screenshot-verified; existing `dice_grouped_log_render` and `inline_dice_log_render` scenarios still pass.

https://claude.ai/code/session_01FV82ccuMANj6XMB6PjyrUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01FV82ccuMANj6XMB6PjyrUM)_