### PR TITLE
Regression tests: only-reserve-scout Scout-phase behavior (edition-gated)

### DIFF
--- a/40k/tests/scenarios/sp/iss067_scout_only_reserve_e10_gated.json
+++ b/40k/tests/scenarios/sp/iss067_scout_only_reserve_e10_gated.json
@@ -1,0 +1,46 @@
+{
+  "id": "iss067_scout_only_reserve_e10_gated",
+  "covers": [
+    "phases.ScoutPhase.reserve_scout_gated_off_at_e10"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 10,
+  "disable_ai": true,
+  "description": "Confirms that at EDITION 10, a player with only a reserve scout (no on-table) gets the Scout phase SKIPPED to Command (the 24.31 reserve-scout option is 11e-only). This matches the reported screenshot and indicates the user is on edition 10, not 11.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})"
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_WITCHSEEKERS_C\"].merge({\"status\": 7, \"reserve_type\": \"strategic_reserves\"}, true)"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(GameState.get_scout_reserve_units_for_player(1))",
+      "equals": "[]"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(GameState.get_scout_units_for_player(1).size() + GameState.get_scout_units_for_player(2).size())",
+      "equals": "0"
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "expect_phase",
+      "equals": 6
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss067_scout_only_reserve_no_skip.json
+++ b/40k/tests/scenarios/sp/iss067_scout_only_reserve_no_skip.json
@@ -1,0 +1,39 @@
+{
+  "id": "iss067_scout_only_reserve_no_skip",
+  "covers": [
+    "phases.ScoutPhase.no_skip_when_only_reserve_scouts"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "description": "Reported bug: 'When I only have scouts in reserve I never get a scout step — it goes from the first-turn roll-off straight to the Command phase.' This is the case where a player has ONLY a reserve scout and NO on-table scout. ScoutPhase._on_phase_enter skips (call_deferred _complete_phase) when total_scouts == 0; total_scouts must include reserve scouts at e11 or the phase is skipped and the player never gets the set-up option. This scenario gives U_WITCHSEEKERS_C the Scout ability and puts it in strategic reserves, with NO on-table scout for either player, transitions to SCOUT, and asserts the phase does NOT auto-skip to COMMAND and the reserve scout is offered.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({'name': 'Scouts 6\"', 'type': 'Core', 'parameter': '6\"'})" },
+    { "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_WITCHSEEKERS_C\"].merge({\"status\": 7, \"reserve_type\": \"strategic_reserves\"}, true)" },
+
+    { "act": "execute_script",
+      "script": "str(GameState.get_scout_reserve_units_for_player(1))",
+      "equals": "[\"U_WITCHSEEKERS_C\"]" },
+    { "act": "execute_script",
+      "script": "str(GameState.get_scout_units_for_player(1).size() + GameState.get_scout_units_for_player(2).size())",
+      "equals": "0" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(4)" },
+    { "act": "wait_seconds", "seconds": 1.5 },
+
+    { "act": "expect_phase", "equals": 4 },
+
+    { "act": "execute_script",
+      "script": "str(PhaseManager.get_current_phase_instance().scout_reserve_units_pending.get(1, []).has(\"U_WITCHSEEKERS_C\"))",
+      "equals": "true" },
+    { "act": "execute_script", "script": "get_node('/root/Main').refresh_unit_list()" },
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').unit_list.get_item_metadata(0)",
+      "equals": "U_WITCHSEEKERS_C" },
+    { "act": "screenshot", "label": "only_reserve_scout_phase_runs" }
+  ]
+}


### PR DESCRIPTION
## Summary

Diagnoses and locks in the behavior behind the report *"When I only have scouts in reserve I never get a scout step — it goes from the first-turn roll-off straight to the Command phase."*

`ScoutPhase._on_phase_enter` skips the phase when `total_scouts == 0`, and the reserve-scout count is only added at edition ≥ 11. So a player with **only** a reserve scout (no on-table scout):
- **Edition 11:** phase runs and offers the reserve scout (24.31). ✅
- **Edition 10:** phase skips to Command. ✅ Correct — 24.31 is an 11e-only rule; at 10e strategic-reserves units arrive later via reinforcements instead.

Both `GameConstants.edition` and `SettingsService.rules_edition` default to **10**, so a player who hasn't selected "11th Edition (beta)" in the menu sees the skip — which is what the reporter's screenshot showed. **No game-code change** — this is working as designed. The scenarios pin the edition-gated behavior so it can't silently regress in either direction.

## Tests

- `iss067_scout_only_reserve_no_skip` (12/0): edition 11, only a reserve scout → Scout phase does **not** skip and lists the reserve scout.
- `iss067_scout_only_reserve_e10_gated` (8/0): edition 10, only a reserve scout → Scout phase skips to Command and the reserve detector returns `[]`.

## Deployment note

The GitHub → itch.io pipeline (`deploy-web.yml` → butler → `oisinrob/warhammer40k-simulator:html5`) was verified healthy — the `deploy-itch` job succeeded on the latest `main` merges, so the itch.io build is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrkiVQh7fgsQyvJqgkKC8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrkiVQh7fgsQyvJqgkKC8X)_