### PR TITLE
Show deployment zones during the Scout phase (reserve-scout set-up reference)

### DIFF
--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2266,6 +2266,11 @@ func _begin_scout_reserves_placement(unit_id: String) -> void:
 
 	status_label.text = "Scout reserves: set up %s wholly within your deployment zone (24.31)" % unit_name
 
+	# Make sure the active player's deployment zone is shown/highlighted while
+	# placing — reserve Scouts must be set up wholly within it (24.31). This also
+	# corrects the highlight after a scout-phase hand-off to the other player.
+	update_deployment_zone_visibility()
+
 	# Wire the unit-card buttons for scout-reserves placement. Disconnect any
 	# scout-move handlers so Confirm/Reset/Undo route to the deployment controller
 	# (via the SCOUT cases of _on_confirm_pressed / _on_reset_pressed / _on_undo_pressed).
@@ -8961,9 +8966,11 @@ func update_ui_for_phase() -> void:
 				phase_action_button.disabled = false
 
 		GameStateData.Phase.SCOUT:
-			# Hide deployment zones during scout phase
-			p1_zone.visible = false
-			p2_zone.visible = false
+			# Show deployment zones so the player can see where reserve Scouts
+			# (24.31) may be set up — wholly within their own deployment zone.
+			# Highlights the active player's zone and dims the opponent's; also
+			# useful reference for on-table scout moves.
+			update_deployment_zone_visibility()
 			# Hide movement action buttons
 			_show_movement_action_buttons(false)
 			# Show unit list for scout unit selection, show unit card for details

--- a/40k/tests/scenarios/sp/iss067_scout_reserve_discoverability.json
+++ b/40k/tests/scenarios/sp/iss067_scout_reserve_discoverability.json
@@ -31,6 +31,13 @@
     { "act": "execute_script",
       "script": "('Reserves -> DZ' in get_node('/root/Main').status_label.text)",
       "equals": true },
+
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').p1_zone.visible",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "get_node('/root/Main').p2_zone.visible",
+      "equals": true },
     { "act": "screenshot", "label": "scout_entry_with_reserve_prompt" }
   ]
 }


### PR DESCRIPTION
## Summary

Setting up a reserve Scout (11e 24.31) requires placing it wholly within your own deployment zone, but the Scout phase was **hiding** the deployment zones — so there was no on-board indication of where models could go. This keeps the zones shown during the Scout step.

## Changes

- `update_ui_for_phase`'s `SCOUT` case now calls `update_deployment_zone_visibility()` instead of hiding the zones: both zones render, the **active player's zone is highlighted** (bright) and the opponent's is dimmed. Also handy reference for on-table scout moves.
- `_begin_scout_reserves_placement()` refreshes the zone highlight when placement starts, so it reflects the correct player after a scout-phase hand-off.

## Validation

- **Live (edition 11):** reached the Scout phase with a reserve scout — P1's blue deployment zone now renders on the board (screenshot), alongside the reserve-scout status prompt and the `[Reserves → DZ]` list row.
- `iss067_scout_reserve_discoverability` (13/0) extended to assert both zones are visible on Scout-phase entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrkiVQh7fgsQyvJqgkKC8X

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrkiVQh7fgsQyvJqgkKC8X)_