### PR TITLE
11e GDM 2026 mission system: Force Dispositions, secondary deck, web-sourced card mechanics

### DIFF
--- a/40k/armies/orks.json
+++ b/40k/armies/orks.json
@@ -1276,7 +1276,8 @@
           "BATTLEWAGON",
           "ORKS",
           "TRANSPORT",
-          "VEHICLE"
+          "VEHICLE",
+          "FRAME"
         ],
         "stats": {
           "move": 10,

--- a/40k/autoloads/ArmyListManager.gd
+++ b/40k/autoloads/ArmyListManager.gd
@@ -1327,6 +1327,79 @@ func validate_army_structure(army_data: Dictionary) -> Dictionary:
 # Standard game sizes per 10th Edition Muster Rules
 const STANDARD_GAME_SIZES: Array = [500, 1000, 1500, 2000, 3000]
 
+## 11e army construction rules (sourced 2026-07-03; see the missions doc
+## appendix): Warlord must share the army's Faction keyword; enhancement
+## count capped at 2 per 1000 pts (2 @ 1000 / 4 @ 2000); Upgrade-tagged
+## enhancements may sit on up to three non-CHARACTER units while counting
+## as one choice; Detachment Points pool is 3 at 2000 pts (only checked
+## when the army data declares detachment DP costs — current army JSONs
+## carry a single detachment with no cost, which passes trivially).
+func validate_army_construction_11e(army_data: Dictionary) -> Dictionary:
+	var result = {"valid": true, "errors": [], "warnings": []}
+	if not army_data.get("faction", null) is Dictionary:
+		result.valid = false
+		result.errors.append("Missing 'faction' field")
+		return result
+	var faction = army_data.faction
+	var faction_keyword = str(faction.get("name", "")).to_upper()
+	var points_limit = int(faction.get("points", 2000))
+	var units = army_data.get("units", {})
+
+	# --- Warlord must match the army faction ---
+	var warlord_found = false
+	for unit_id in units:
+		var meta = units[unit_id].get("meta", {})
+		if not meta.get("is_warlord", false):
+			continue
+		warlord_found = true
+		var keywords = []
+		for kw in meta.get("keywords", []):
+			keywords.append(str(kw).to_upper())
+		if faction_keyword != "" and not faction_keyword in keywords:
+			result.warnings.append("11e: Warlord %s lacks the army Faction keyword %s" % [unit_id, faction_keyword])
+	if not warlord_found:
+		result.warnings.append("11e: no Warlord designated")
+
+	# --- Enhancement cap: 2 per 1000 points; Upgrade-tag counts once ---
+	var enhancement_choices = {}
+	for unit_id in units:
+		var meta = units[unit_id].get("meta", {})
+		var upper_kw = []
+		for k in meta.get("keywords", []):
+			upper_kw.append(str(k).to_upper())
+		var is_character = "CHARACTER" in upper_kw
+		for enh in meta.get("enhancements", []):
+			var name = str(enh) if enh is String else str(enh.get("name", ""))
+			var is_upgrade = enh is Dictionary and enh.get("upgrade", false)
+			if is_upgrade:
+				if is_character:
+					result.warnings.append("11e: Upgrade enhancement '%s' on CHARACTER unit %s (Upgrades are non-CHARACTER only)" % [name, unit_id])
+				var entry = enhancement_choices.get(name, {"count": 0, "upgrade": true})
+				entry["count"] = int(entry.get("count", 0)) + 1
+				enhancement_choices[name] = entry
+				if entry["count"] > 3:
+					result.warnings.append("11e: Upgrade enhancement '%s' on more than three units" % name)
+			else:
+				enhancement_choices["%s@%s" % [name, unit_id]] = {"count": 1, "upgrade": false}
+	var max_enhancements = int(floor(points_limit / 1000.0)) * 2
+	if enhancement_choices.size() > max_enhancements and max_enhancements > 0:
+		result.warnings.append("11e: %d enhancement choices exceed the cap of %d at %d pts" % [
+			enhancement_choices.size(), max_enhancements, points_limit])
+
+	# --- Detachment Points: pool of 3 at 2000 pts ---
+	var detachments = army_data.get("detachments", [])
+	if detachments is Array and detachments.size() > 0:
+		var dp_total = 0
+		for det in detachments:
+			if det is Dictionary:
+				dp_total += int(det.get("dp_cost", 1))
+		var dp_pool = 3 if points_limit >= 2000 else maxi(1, int(floor(points_limit / 2000.0 * 3)))
+		if dp_total > dp_pool:
+			result.warnings.append("11e: detachments cost %d DP, pool is %d at %d pts" % [dp_total, dp_pool, points_limit])
+
+	result.valid = result.errors.is_empty()
+	return result
+
 func validate_army_construction_points(army_data: Dictionary) -> Dictionary:
 	"""Validate army construction points and detachment rules.
 	Returns a dictionary with 'valid' (bool), 'errors' (Array), and 'warnings' (Array).

--- a/40k/autoloads/MissionManager.gd
+++ b/40k/autoloads/MissionManager.gd
@@ -82,6 +82,21 @@ var _control_at_turn_start: Dictionary = {}
 var _eog_primary_scored: bool = false
 # Action-type components we've already warned about (log once per game)
 var _warned_unimplemented_actions: Dictionary = {}
+# Per-player marker/action state for the GDM card mechanics (see the
+# missions doc appendix). Auto-resolved: the real cards let the player pick
+# targets; we pick deterministically and flag the cards approximate.
+# player_key -> { triangulated: [obj_id], consecrated: [obj_id],
+#   decoyed: [obj_id], decoyed_ever: [obj_id], trapped: [terrain_id],
+#   operation_markers: int, intel_tokens: [obj_id],
+#   intel_placed_this_turn: int, condemned: [unit_id],
+#   condemned_left_this_turn: bool, sensor_swept_this_turn: bool }
+var _primary_state_11e: Dictionary = {}
+# Shared relic/operation markers for the Extract Relic / Locate and Deny
+# pairing: terrain feature ids still carrying a marker
+var _relic_markers_11e: Array = []
+# player_key (turn owner) -> {unit_id: true} units on the battlefield at
+# the start of that player's turn (for left-battlefield / destroyed checks)
+var _alive_at_turn_start_11e: Dictionary = {}
 
 func _ready() -> void:
 	print("MissionManager: Initializing mission system")
@@ -203,9 +218,46 @@ func _setup_objectives_for_deployment(deployment_type: String) -> void:
 	for obj in objectives:
 		objective_control_state[obj.id] = 0  # 0 = contested/uncontrolled
 
+	# 11e GDM: Chapter Approved objective designations — Home (one per
+	# deployment zone), Central (nearest the board centre), Expansion (the
+	# remaining NML objectives). Assigned for all editions; only 11e reads it.
+	_assign_objective_designations(objectives)
+
 	print("MissionManager: Set up %d objectives for %s deployment" % [objectives.size(), deployment_type])
 	for obj in objectives:
-		print("  - %s at position %s (zone: %s)" % [obj.id, obj.position, obj.get("zone", "unknown")])
+		print("  - %s at position %s (zone: %s, designation: %s)" % [obj.id, obj.position, obj.get("zone", "unknown"), obj.get("designation", "?")])
+
+func _assign_objective_designations(objectives: Array) -> void:
+	var board_size = GameState.state.get("board", {}).get("size", {})
+	var center = Vector2(
+		Measurement.inches_to_px(float(board_size.get("width", 44)) / 2.0),
+		Measurement.inches_to_px(float(board_size.get("height", 60)) / 2.0))
+	var central_id = ""
+	var best_dist = INF
+	for obj in objectives:
+		if obj.get("zone", "") != "no_mans_land":
+			obj["designation"] = "home"
+			continue
+		var pos = obj.get("position")
+		if pos is Dictionary:
+			pos = Vector2(pos.x, pos.y)
+		var d = pos.distance_to(center)
+		if d < best_dist:
+			best_dist = d
+			central_id = obj.get("id", "")
+	for obj in objectives:
+		if obj.get("zone", "") == "no_mans_land":
+			obj["designation"] = "central" if obj.get("id", "") == central_id else "expansion"
+
+func get_objective_designation(obj_id: String) -> String:
+	return _get_objective_by_id(obj_id).get("designation", "")
+
+func get_objective_ids_by_designation(designation: String) -> Array:
+	var out = []
+	for obj in GameState.state.board.get("objectives", []):
+		if obj.get("designation", "") == designation:
+			out.append(obj.get("id", ""))
+	return out
 
 # ============================================================
 # OBJECTIVE CONTROL (shared by all missions)
@@ -1037,6 +1089,9 @@ func initialize_dispositions_11e(p1_disposition: String, p2_disposition: String)
 	_control_at_turn_start = {}
 	_eog_primary_scored = false
 	_warned_unimplemented_actions = {}
+	_primary_state_11e = {"1": _blank_primary_state_11e(), "2": _blank_primary_state_11e()}
+	_alive_at_turn_start_11e = {}
+	_setup_relic_markers_11e()
 
 	GameState.state.meta["dispositions_11e"] = player_dispositions.duplicate(true)
 	for pk in ["1", "2"]:
@@ -1046,6 +1101,46 @@ func initialize_dispositions_11e(p1_disposition: String, p2_disposition: String)
 			card.get("name", "?"),
 			" (approximate)" if card.get("approximate", false) else ""])
 
+func _blank_primary_state_11e() -> Dictionary:
+	return {
+		"triangulated": [], "consecrated": [], "decoyed": [], "decoyed_ever": [],
+		"trapped": [], "operation_markers": 0, "intel_tokens": [],
+		"intel_placed_this_turn": 0, "condemned": [],
+		"condemned_left_this_turn": false, "sensor_swept_this_turn": false,
+	}
+
+## Extract Relic / Locate and Deny pairing: the Disruption player marks five
+## terrain areas outside their deployment zone at the start of the mission.
+## Auto-picked: the five terrain features farthest from the Disruption
+## player's home objective (deterministic; flagged approximate).
+func _setup_relic_markers_11e() -> void:
+	_relic_markers_11e = []
+	var ids = [player_primary_missions.get("1", {}).get("id", ""),
+		player_primary_missions.get("2", {}).get("id", "")]
+	if not ("extract_relic" in ids or "locate_and_deny" in ids):
+		return
+	var di_player = 1 if player_dispositions.get("1", "") == "disruption" else 2
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null or tm.terrain_features.is_empty():
+		print("MissionManager: 11e relic markers — no terrain features available")
+		return
+	var di_home_pos = null
+	for obj in GameState.state.board.get("objectives", []):
+		if obj.get("zone", "") == "player%d" % di_player:
+			di_home_pos = obj.get("position")
+			if di_home_pos is Dictionary:
+				di_home_pos = Vector2(di_home_pos.x, di_home_pos.y)
+			break
+	var candidates = []
+	for feature in tm.terrain_features:
+		var fpos = feature.get("position", Vector2.ZERO)
+		var dist = fpos.distance_to(di_home_pos) if di_home_pos != null else 0.0
+		candidates.append({"id": feature.get("id", ""), "dist": dist})
+	candidates.sort_custom(func(a, b): return a["dist"] > b["dist"])
+	for i in range(min(5, candidates.size())):
+		_relic_markers_11e.append(candidates[i]["id"])
+	print("MissionManager: 11e relic markers placed on %s" % str(_relic_markers_11e))
+
 ## Called at Command phase entry (after check_all_objectives) — opens the
 ## active player's per-turn VP window and snapshots start-of-turn control.
 func on_turn_start_11e(player: int) -> void:
@@ -1054,17 +1149,188 @@ func on_turn_start_11e(player: int) -> void:
 	var pk = str(player)
 	_primary_vp_this_turn[pk] = 0
 	_control_at_turn_start[pk] = _get_controlled_objectives(player)
+	# Snapshot who is on the battlefield for left-battlefield / kill checks
+	var alive = {}
+	for unit_id in GameState.state.get("units", {}):
+		if _unit_on_battlefield_11e(unit_id):
+			alive[unit_id] = true
+	_alive_at_turn_start_11e[pk] = alive
+	# Per-turn marker-state resets (both players — the windows are per turn)
+	for spk in _primary_state_11e:
+		var st = _primary_state_11e[spk]
+		st["intel_placed_this_turn"] = 0
+		st["sensor_swept_this_turn"] = false
+		st["condemned_left_this_turn"] = false
+	# Punishment: auto-Condemn up to 3 enemy units in range of an objective
+	# (real card: player's choice, incl. units that killed friendlies)
+	if player_primary_missions.get(pk, {}).get("id", "") == "punishment":
+		_auto_condemn_11e(player)
 	print("MissionManager: 11e turn start P%s — controls %s" % [pk, str(_control_at_turn_start[pk])])
 
-## End-of-turn primary scoring: EOT conditions always, plus Command
-## conditions in Round 5 (GDM: "C ... switches to end of turn in Round 5").
+func _unit_on_battlefield_11e(unit_id: String) -> bool:
+	var unit = GameState.state.get("units", {}).get(unit_id, {})
+	var emb = unit.get("embarked_in", null)
+	if emb != null and str(emb) != "":
+		return false
+	for model in unit.get("models", []):
+		if model.get("alive", true) and model.get("position") != null:
+			return true
+	return false
+
+func _auto_condemn_11e(player: int) -> void:
+	var pk = str(player)
+	var st = _primary_state_11e.get(pk, {})
+	var opponent = 3 - player
+	var control_radius = Measurement.inches_to_px(3.78740157)
+	var condemned = []
+	for unit_id in GameState.state.get("units", {}):
+		if condemned.size() >= 3:
+			break
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != opponent or not _unit_on_battlefield_11e(unit_id):
+			continue
+		if _unit_within_of_any_objective_11e(unit_id, control_radius):
+			condemned.append(unit_id)
+	st["condemned"] = condemned
+	if condemned.size() > 0:
+		print("MissionManager: 11e Punishment — P%s condemns %s" % [pk, str(condemned)])
+
+func _unit_within_of_any_objective_11e(unit_id: String, radius_px: float) -> bool:
+	var unit = GameState.state.get("units", {}).get(unit_id, {})
+	for obj in GameState.state.board.get("objectives", []):
+		var obj_pos = obj.get("position")
+		if obj_pos is Dictionary:
+			obj_pos = Vector2(obj_pos.x, obj_pos.y)
+		for model in unit.get("models", []):
+			if not model.get("alive", true) or model.get("position") == null:
+				continue
+			if Measurement.model_edge_to_point_distance_px(model, obj_pos) <= radius_px:
+				return true
+	return false
+
+## End-of-turn primary scoring: auto-resolve card actions first, then EOT
+## conditions, plus Command conditions in Round 5 (GDM: "C ... switches to
+## end of turn in Round 5"). "End of ANY turn" conditions (eot_any) are also
+## evaluated for the non-active player.
 func score_primary_eot_11e(player: int) -> void:
 	if GameConstants.edition < 11 or player_primary_missions.is_empty():
 		return
 	var battle_round = GameState.get_battle_round()
+	_run_primary_auto_actions_11e(player, battle_round)
 	_score_primary_11e(player, battle_round, "eot")
+	_score_primary_11e(player, battle_round, "eot_any")
 	if battle_round >= 5:
 		_score_primary_11e(player, battle_round, "command")
+	# Opponent's end-of-ANY-turn conditions (e.g. Punishment's Condemned check)
+	var opponent = 3 - player
+	_update_condemned_left_11e(opponent, player)
+	_score_primary_11e(opponent, battle_round, "eot_any")
+
+## Auto-resolve the active player's card action for this turn. The real
+## cards let the player pick targets; we pick deterministically (flagged
+## approximate on the cards). Also scrubs decoy markers enemies reached.
+func _run_primary_auto_actions_11e(player: int, battle_round: int) -> void:
+	var pk = str(player)
+	var st = _primary_state_11e.get(pk, {})
+	if st.is_empty():
+		return
+	var card_id = player_primary_missions.get(pk, {}).get("id", "")
+	var control_radius = Measurement.inches_to_px(3.78740157)
+
+	# Decoy scrub (both players): a decoy is removed once an enemy unit is
+	# within range of the objective (approximates "ends a move within range")
+	for spk in _primary_state_11e:
+		var owner = int(spk)
+		var sst = _primary_state_11e[spk]
+		var kept = []
+		for obj_id in sst.get("decoyed", []):
+			if not _enemy_unit_in_range_of_objective_11e(owner, obj_id, control_radius):
+				kept.append(obj_id)
+			else:
+				print("MissionManager: 11e decoy on %s scrubbed (enemy in range)" % obj_id)
+		sst["decoyed"] = kept
+
+	match card_id:
+		"triangulation":
+			# Triangulate: once per turn, an objective you control at EOT
+			for obj_id in _get_controlled_objectives(player):
+				if not obj_id in st["triangulated"]:
+					st["triangulated"].append(obj_id)
+					print("MissionManager: 11e Triangulated %s (P%s)" % [obj_id, pk])
+					break
+		"consecrate":
+			# Killer unit becomes a Consecration unit; approximated as: a kill
+			# this turn lets one friendly unit in range consecrate an eligible
+			# (non-home, unconsecrated) objective at EOT.
+			if _kills_this_turn_11e(player) >= 1:
+				for obj_id in _get_controlled_objectives(player):
+					if _is_home_objective_11e(obj_id, player) or obj_id in st["consecrated"]:
+						continue
+					st["consecrated"].append(obj_id)
+					print("MissionManager: 11e Consecrated %s (P%s)" % [obj_id, pk])
+					break
+		"smoke_and_mirrors":
+			# Decoy action: unlimited uses at end of turn on controlled non-home
+			for obj_id in _get_controlled_objectives(player):
+				if _is_home_objective_11e(obj_id, player) or obj_id in st["decoyed"]:
+					continue
+				st["decoyed"].append(obj_id)
+				if not obj_id in st["decoyed_ever"]:
+					st["decoyed_ever"].append(obj_id)
+				print("MissionManager: 11e Decoyed %s (P%s)" % [obj_id, pk])
+		"vital_link":
+			var central = _get_central_objective_id_11e()
+			if central != "" and objective_control_state.get(central, 0) == player:
+				st["operation_markers"] = int(st.get("operation_markers", 0)) + 1
+				print("MissionManager: 11e Vital Link operation marker %d placed (P%s)" % [st["operation_markers"], pk])
+		"death_trap":
+			# Booby Trap: once per turn, an untrapped terrain area containing
+			# one of your models (eligibility simplified)
+			var tm = get_node_or_null("/root/TerrainManager")
+			if tm != null:
+				for feature in tm.terrain_features:
+					var fid = feature.get("id", "")
+					if fid == "" or fid in st["trapped"]:
+						continue
+					if _player_model_in_terrain_11e(player, feature):
+						st["trapped"].append(fid)
+						print("MissionManager: 11e Booby Trapped %s (P%s)" % [fid, pk])
+						break
+		"gather_intel":
+			if battle_round >= 2:
+				for obj in GameState.state.board.get("objectives", []):
+					var obj_id = obj.get("id", "")
+					if obj.get("zone", "") != "no_mans_land" or obj_id in st["intel_tokens"]:
+						continue
+					if _friendly_unit_in_range_of_objective_11e(player, obj_id, control_radius):
+						st["intel_tokens"].append(obj_id)
+						st["intel_placed_this_turn"] = int(st.get("intel_placed_this_turn", 0)) + 1
+						print("MissionManager: 11e intel token on %s (P%s)" % [obj_id, pk])
+		"extract_relic", "locate_and_deny":
+			# Sensor Sweep: once per turn while >1 marker remains, needs a unit
+			# in range of a controlled Central objective
+			if _relic_markers_11e.size() > 1:
+				var central2 = _get_central_objective_id_11e()
+				if central2 != "" and objective_control_state.get(central2, 0) == player \
+						and _friendly_unit_in_range_of_objective_11e(player, central2, control_radius):
+					var removed = _relic_markers_11e.pop_back()
+					st["sensor_swept_this_turn"] = true
+					print("MissionManager: 11e Sensor Sweep removed marker %s (P%s, %d left)" % [str(removed), pk, _relic_markers_11e.size()])
+
+	# The active player's own Condemned check also runs at their EOT
+	_update_condemned_left_11e(player, player)
+
+func _update_condemned_left_11e(card_owner: int, turn_owner: int) -> void:
+	var pk = str(card_owner)
+	var st = _primary_state_11e.get(pk, {})
+	if st.is_empty() or st.get("condemned", []).is_empty():
+		return
+	var turn_snapshot = _alive_at_turn_start_11e.get(str(turn_owner), {})
+	for unit_id in st["condemned"]:
+		if turn_snapshot.has(unit_id) and not _unit_on_battlefield_11e(unit_id):
+			st["condemned_left_this_turn"] = true
+			print("MissionManager: 11e Condemned unit %s left the battlefield" % unit_id)
+			return
 
 ## End-of-game primary scoring for both players (idempotent).
 func score_primary_eog_11e() -> void:
@@ -1159,6 +1425,74 @@ func _evaluate_primary_rule_11e(player: int, rule: Dictionary, battle_round: int
 				return 0
 			var params = {"count": int(rule.get("min", 3)), "min_distance_from_center": 6.0}
 			return rule.get("vp", 0) if secondary_mgr._check_table_quarter_presence(player, params) else 0
+		"triangulated_count":
+			var n = _primary_state_11e.get(str(player), {}).get("triangulated", []).size()
+			return 10 if n >= 3 else (6 if n == 2 else (3 if n == 1 else 0))
+		"consecrated_count":
+			var n2 = _primary_state_11e.get(str(player), {}).get("consecrated", []).size()
+			return 6 if n2 >= 3 else (3 if n2 >= 1 else 0)
+		"consecrated_enemy_home":
+			var enemy_home = _get_home_objective_id_11e(3 - player)
+			var consecrated = _primary_state_11e.get(str(player), {}).get("consecrated", [])
+			return rule.get("vp", 0) if enemy_home != "" and enemy_home in consecrated else 0
+		"condemned_left":
+			return rule.get("vp", 0) if _primary_state_11e.get(str(player), {}).get("condemned_left_this_turn", false) else 0
+		"sabotage_per_objective":
+			# Auto-completed Sabotage on each controlled non-home objective
+			var total = 0
+			for obj_id in _get_controlled_objectives(player):
+				if _is_home_objective_11e(obj_id, player):
+					continue
+				total += int(rule.get("vp_per", 3))
+				if _objective_in_enemy_territory_11e(obj_id, player):
+					total += int(rule.get("enemy_territory_bonus", 2))
+			return total
+		"central_operation_markers":
+			var central3 = _get_central_objective_id_11e()
+			if central3 == "" or objective_control_state.get(central3, 0) != player:
+				return 0
+			var markers = int(_primary_state_11e.get(str(player), {}).get("operation_markers", 0))
+			return int(rule.get("vp", 2)) + markers * int(rule.get("vp_per_marker", 1))
+		"destroyed_near_central":
+			var central4 = _get_central_objective_id_11e()
+			if central4 == "":
+				return 0
+			return rule.get("vp", 0) if _destroyed_enemy_near_objective_11e(player, central4) else 0
+		"vanguard_terrain_area":
+			return rule.get("vp", 0) if _vanguard_area_held_11e(player) else 0
+		"sensor_sweep_vp":
+			return rule.get("vp", 0) if _primary_state_11e.get(str(player), {}).get("sensor_swept_this_turn", false) else 0
+		"relic_final_marker":
+			return rule.get("vp", 0) if _final_relic_marker_held_11e(player) else 0
+		"decoyed_score":
+			var total2 = 0
+			for obj_id in _primary_state_11e.get(str(player), {}).get("decoyed", []):
+				total2 += int(rule.get("vp_per", 2))
+				if _objective_in_enemy_territory_11e(obj_id, player):
+					total2 += int(rule.get("enemy_territory_bonus", 2))
+			return total2
+		"decoyed_total_eog":
+			var ever = _primary_state_11e.get(str(player), {}).get("decoyed_ever", []).size()
+			return rule.get("vp", 0) if ever >= int(rule.get("min", 4)) else 0
+		"no_enemy_markers":
+			var opp_st = _primary_state_11e.get(str(3 - player), {})
+			return rule.get("vp", 0) if opp_st.get("decoyed", []).is_empty() else 0
+		"intel_tokens_placed":
+			return int(_primary_state_11e.get(str(player), {}).get("intel_placed_this_turn", 0)) * int(rule.get("vp_per", 7))
+		"trapped_score":
+			var tm2 = get_node_or_null("/root/TerrainManager")
+			var total3 = 0
+			for fid in _primary_state_11e.get(str(player), {}).get("trapped", []):
+				total3 += int(rule.get("vp_per", 2))
+				if tm2 != null and _terrain_contains_objective_11e(tm2, fid):
+					total3 += int(rule.get("objective_bonus", 3))
+			return total3
+		"destroyed_started_on_objective":
+			return rule.get("vp", 0) if _destroyed_enemy_near_any_objective_11e(player) else 0
+		"destroyed_in_terrain_area":
+			return rule.get("vp", 0) if _destroyed_enemy_in_terrain_11e(player) else 0
+		"no_enemy_wholly_in_my_dz":
+			return rule.get("vp", 0) if not _enemy_wholly_in_my_dz_11e(player) else 0
 		"action":
 			var action_name = rule.get("action_name", "?")
 			if not _warned_unimplemented_actions.has(action_name):
@@ -1201,7 +1535,11 @@ func _controls_enemy_home_11e(player: int) -> bool:
 	return false
 
 func _get_central_objective_id_11e() -> String:
-	# The objective nearest the board centre (NML preferred by geometry anyway).
+	# Prefer the Chapter Approved "central" designation; fall back to the
+	# objective nearest the board centre.
+	var centrals = get_objective_ids_by_designation("central")
+	if centrals.size() > 0:
+		return centrals[0]
 	var board_size = GameState.state.get("board", {}).get("size", {})
 	var center = Vector2(
 		Measurement.inches_to_px(float(board_size.get("width", 44)) / 2.0),
@@ -1219,6 +1557,180 @@ func _get_central_objective_id_11e() -> String:
 			best_dist = d
 			best_id = obj.get("id", "")
 	return best_id
+
+func _get_home_objective_id_11e(player: int) -> String:
+	for obj in GameState.state.board.get("objectives", []):
+		if obj.get("zone", "") == "player%d" % player:
+			return obj.get("id", "")
+	return ""
+
+## "In the opponent's territory" — the objective sits in the enemy
+## deployment zone, or is the Central objective (per the Sabotage card
+## text: the central objective counts).
+func _objective_in_enemy_territory_11e(obj_id: String, player: int) -> bool:
+	var obj = _get_objective_by_id(obj_id)
+	if obj.get("zone", "") == "player%d" % (3 - player):
+		return true
+	return obj.get("designation", "") == "central"
+
+func _friendly_unit_in_range_of_objective_11e(player: int, obj_id: String, radius_px: float) -> bool:
+	return _any_unit_in_range_of_objective_11e(player, obj_id, radius_px)
+
+func _enemy_unit_in_range_of_objective_11e(player: int, obj_id: String, radius_px: float) -> bool:
+	return _any_unit_in_range_of_objective_11e(3 - player, obj_id, radius_px)
+
+func _any_unit_in_range_of_objective_11e(owner: int, obj_id: String, radius_px: float) -> bool:
+	var obj = _get_objective_by_id(obj_id)
+	var obj_pos = obj.get("position")
+	if obj_pos == null:
+		return false
+	if obj_pos is Dictionary:
+		obj_pos = Vector2(obj_pos.x, obj_pos.y)
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != owner:
+			continue
+		for model in unit.get("models", []):
+			if not model.get("alive", true) or model.get("position") == null:
+				continue
+			if Measurement.model_edge_to_point_distance_px(model, obj_pos) <= radius_px:
+				return true
+	return false
+
+func _player_model_in_terrain_11e(player: int, feature: Dictionary) -> bool:
+	var polygon = feature.get("polygon", PackedVector2Array())
+	if polygon.is_empty():
+		return false
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		for model in unit.get("models", []):
+			if not model.get("alive", true) or model.get("position") == null:
+				continue
+			var pos = model.get("position")
+			if pos is Dictionary:
+				pos = Vector2(pos.x, pos.y)
+			if Geometry2D.is_point_in_polygon(pos, polygon):
+				return true
+	return false
+
+## Enemy units destroyed this turn (on the battlefield at the active
+## player's turn start, fully dead now). Dead models keep their positions,
+## which the location-conditioned kill checks below rely on.
+func _destroyed_enemy_units_this_turn_11e(player: int) -> Array:
+	var out = []
+	var snapshot = _alive_at_turn_start_11e.get(str(GameState.get_active_player()), {})
+	for unit_id in snapshot:
+		var unit = GameState.state.get("units", {}).get(unit_id, {})
+		if unit.is_empty() or int(unit.get("owner", 0)) != 3 - player:
+			continue
+		var any_alive = false
+		for model in unit.get("models", []):
+			if model.get("alive", true):
+				any_alive = true
+				break
+		if not any_alive:
+			out.append(unit_id)
+	return out
+
+func _destroyed_enemy_near_objective_11e(player: int, obj_id: String) -> bool:
+	var control_radius = Measurement.inches_to_px(3.78740157)
+	var obj = _get_objective_by_id(obj_id)
+	var obj_pos = obj.get("position")
+	if obj_pos == null:
+		return false
+	if obj_pos is Dictionary:
+		obj_pos = Vector2(obj_pos.x, obj_pos.y)
+	for unit_id in _destroyed_enemy_units_this_turn_11e(player):
+		var unit = GameState.state.units[unit_id]
+		for model in unit.get("models", []):
+			if model.get("position") == null:
+				continue
+			if Measurement.model_edge_to_point_distance_px(model, obj_pos) <= control_radius:
+				return true
+	return false
+
+func _destroyed_enemy_near_any_objective_11e(player: int) -> bool:
+	for obj in GameState.state.board.get("objectives", []):
+		if _destroyed_enemy_near_objective_11e(player, obj.get("id", "")):
+			return true
+	return false
+
+func _destroyed_enemy_in_terrain_11e(player: int) -> bool:
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null:
+		return false
+	for unit_id in _destroyed_enemy_units_this_turn_11e(player):
+		var unit = GameState.state.units[unit_id]
+		for model in unit.get("models", []):
+			var pos = model.get("position")
+			if pos == null:
+				continue
+			if pos is Dictionary:
+				pos = Vector2(pos.x, pos.y)
+			if not tm.get_terrain_at_position(pos).is_empty():
+				return true
+	return false
+
+## Vanguard Operation: a friendly unit is inside a terrain area located in
+## enemy territory (feature position inside the enemy deployment zone —
+## approximation) with no enemy units in that area.
+func _vanguard_area_held_11e(player: int) -> bool:
+	var tm = get_node_or_null("/root/TerrainManager")
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if tm == null or secondary_mgr == null:
+		return false
+	var enemy_zone = secondary_mgr._get_deployment_zone_polygon(3 - player)
+	if enemy_zone.is_empty():
+		return false
+	for feature in tm.terrain_features:
+		var fpos = feature.get("position", Vector2.ZERO)
+		if not Geometry2D.is_point_in_polygon(fpos, enemy_zone):
+			continue
+		if _player_model_in_terrain_11e(player, feature) and not _player_model_in_terrain_11e(3 - player, feature):
+			return true
+	return false
+
+func _final_relic_marker_held_11e(player: int) -> bool:
+	if _relic_markers_11e.size() != 1:
+		return false
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null:
+		return false
+	for feature in tm.terrain_features:
+		if feature.get("id", "") != _relic_markers_11e[0]:
+			continue
+		return _player_model_in_terrain_11e(player, feature) and not _player_model_in_terrain_11e(3 - player, feature)
+	return false
+
+func _terrain_contains_objective_11e(tm, feature_id: String) -> bool:
+	for feature in tm.terrain_features:
+		if feature.get("id", "") != feature_id:
+			continue
+		var polygon = feature.get("polygon", PackedVector2Array())
+		for obj in GameState.state.board.get("objectives", []):
+			var pos = obj.get("position")
+			if pos is Dictionary:
+				pos = Vector2(pos.x, pos.y)
+			if not polygon.is_empty() and Geometry2D.is_point_in_polygon(pos, polygon):
+				return true
+	return false
+
+func _enemy_wholly_in_my_dz_11e(player: int) -> bool:
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr == null:
+		return false
+	var my_zone = secondary_mgr._get_deployment_zone_polygon(player)
+	if my_zone.is_empty():
+		return false
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != 3 - player or not _unit_on_battlefield_11e(unit_id):
+			continue
+		if secondary_mgr._is_unit_wholly_in_zone(unit, my_zone):
+			return true
+	return false
 
 func _kills_this_turn_11e(player: int) -> int:
 	# Best available proxy: kills recorded for this player this battle round
@@ -1523,7 +2035,10 @@ func get_state_for_save() -> Dictionary:
 		"player_primary_missions": player_primary_missions.duplicate(true),
 		"primary_vp_this_turn": _primary_vp_this_turn.duplicate(true),
 		"control_at_turn_start": _control_at_turn_start.duplicate(true),
-		"eog_primary_scored": _eog_primary_scored
+		"eog_primary_scored": _eog_primary_scored,
+		"primary_state_11e": _primary_state_11e.duplicate(true),
+		"relic_markers_11e": _relic_markers_11e.duplicate(true),
+		"alive_at_turn_start_11e": _alive_at_turn_start_11e.duplicate(true)
 	}
 
 func load_state(data: Dictionary) -> void:
@@ -1551,6 +2066,9 @@ func load_state(data: Dictionary) -> void:
 	_primary_vp_this_turn = data.get("primary_vp_this_turn", {"1": 0, "2": 0})
 	_control_at_turn_start = data.get("control_at_turn_start", {})
 	_eog_primary_scored = data.get("eog_primary_scored", false)
+	_primary_state_11e = data.get("primary_state_11e", {})
+	_relic_markers_11e = data.get("relic_markers_11e", [])
+	_alive_at_turn_start_11e = data.get("alive_at_turn_start_11e", {})
 	print("MissionManager: Loaded state — %d sticky, %d burned, %d ritual" % [
 		_sticky_objectives.size(), burned_objectives.size(), _ritual_objectives.size()
 	])

--- a/40k/autoloads/MissionManager.gd
+++ b/40k/autoloads/MissionManager.gd
@@ -67,6 +67,22 @@ var kills_per_round: Dictionary = {}
 # Tracks which objectives have been claimed by a character: objective_id -> { "player": int, "claimed_round": int }
 var character_claimed_objectives: Dictionary = {}
 
+# --- 11e GDM 2026 Force Disposition primary missions ---
+# player_key ("1"/"2") -> disposition id ("take_and_hold" | "purge_the_foe" |
+# "reconnaissance" | "priority_assets" | "disruption")
+var player_dispositions: Dictionary = {}
+# player_key -> resolved primary mission card (own deck vs opponent disposition)
+var player_primary_missions: Dictionary = {}
+# player_key -> primary VP scored in the current turn window (15/turn cap)
+var _primary_vp_this_turn: Dictionary = {"1": 0, "2": 0}
+# player_key -> Array of objective ids controlled at the start of their turn
+# (for "hold an objective you didn't start your turn with" conditions)
+var _control_at_turn_start: Dictionary = {}
+# One-shot guard so end-of-game conditions only score once
+var _eog_primary_scored: bool = false
+# Action-type components we've already warned about (log once per game)
+var _warned_unimplemented_actions: Dictionary = {}
+
 func _ready() -> void:
 	print("MissionManager: Initializing mission system")
 	initialize_default_mission()
@@ -161,6 +177,16 @@ func initialize_mission(mission_id: String) -> void:
 
 	# Store mission type in GameState meta for reference
 	GameState.state.meta["mission_type"] = mission_id
+
+	# 11e GDM 2026: primary missions come from the Force Disposition pairing
+	# table instead of the shared 10e mission card. The 10e current_mission is
+	# still initialized above (objectives, control tracking, UI compatibility);
+	# only the SCORING dispatch is replaced at e11.
+	if GameConstants.edition >= 11:
+		var config = GameState.state.get("meta", {}).get("game_config", {})
+		initialize_dispositions_11e(
+			str(config.get("player1_disposition", "take_and_hold")),
+			str(config.get("player2_disposition", "take_and_hold")))
 
 	print("MissionManager: Initialized '%s' mission (scoring_type: %s)" % [current_mission.name, current_mission.scoring_type])
 
@@ -525,6 +551,18 @@ func find_nearest_controlled_objective(unit_id: String) -> String:
 func score_primary_objectives() -> void:
 	var battle_round = GameState.get_battle_round()
 	var active_player = GameState.get_active_player()
+
+	# 11e GDM 2026: score the active player's own disposition-paired card.
+	# Command-phase conditions switch to end-of-turn scoring in Round 5, so
+	# the Command-phase trigger is a no-op there (score_primary_eot_11e picks
+	# them up instead).
+	if GameConstants.edition >= 11 and not player_primary_missions.is_empty():
+		if battle_round >= 5:
+			print("MissionManager: 11e R5 — Command-phase primary scoring deferred to end of turn")
+			return
+		_score_primary_11e(active_player, battle_round, "command")
+		return
+
 	var start_round = current_mission.get("start_round", current_mission.get("scoring_rules", {}).get("start_round", 2))
 
 	print("MissionManager: Checking primary scoring for Player %d in battle round %d (mission: %s)" % [active_player, battle_round, current_mission.name])
@@ -974,6 +1012,257 @@ func _score_terraform(active_player: int, _battle_round: int) -> void:
 	_apply_primary_vp(active_player, vp_earned, "Terraform: held %d objectives, %d terraformed" % [controlled_count, terraform_bonus])
 
 # ============================================================
+# 11e GDM 2026 — FORCE DISPOSITION PRIMARY MISSIONS
+# ============================================================
+# Each player scores their OWN card: their deck (disposition) paired against
+# the opponent's disposition. Caps: 45 primary total, 15 per turn. Command
+# conditions score at the end of your Command phase in R1-4 and switch to end
+# of turn in R5. EOT conditions score every end of turn; EOG conditions score
+# once when the game ends.
+
+func initialize_dispositions_11e(p1_disposition: String, p2_disposition: String) -> void:
+	if not PrimaryMissionData11e.is_valid_disposition(p1_disposition):
+		print("MissionManager: 11e unknown disposition '%s' for P1, using take_and_hold" % p1_disposition)
+		p1_disposition = "take_and_hold"
+	if not PrimaryMissionData11e.is_valid_disposition(p2_disposition):
+		print("MissionManager: 11e unknown disposition '%s' for P2, using take_and_hold" % p2_disposition)
+		p2_disposition = "take_and_hold"
+
+	player_dispositions = {"1": p1_disposition, "2": p2_disposition}
+	player_primary_missions = {
+		"1": PrimaryMissionData11e.get_card(p1_disposition, p2_disposition),
+		"2": PrimaryMissionData11e.get_card(p2_disposition, p1_disposition),
+	}
+	_primary_vp_this_turn = {"1": 0, "2": 0}
+	_control_at_turn_start = {}
+	_eog_primary_scored = false
+	_warned_unimplemented_actions = {}
+
+	GameState.state.meta["dispositions_11e"] = player_dispositions.duplicate(true)
+	for pk in ["1", "2"]:
+		var card = player_primary_missions[pk]
+		print("MissionManager: 11e P%s disposition %s vs %s -> primary mission '%s'%s" % [
+			pk, player_dispositions[pk], player_dispositions["2" if pk == "1" else "1"],
+			card.get("name", "?"),
+			" (approximate)" if card.get("approximate", false) else ""])
+
+## Called at Command phase entry (after check_all_objectives) — opens the
+## active player's per-turn VP window and snapshots start-of-turn control.
+func on_turn_start_11e(player: int) -> void:
+	if GameConstants.edition < 11:
+		return
+	var pk = str(player)
+	_primary_vp_this_turn[pk] = 0
+	_control_at_turn_start[pk] = _get_controlled_objectives(player)
+	print("MissionManager: 11e turn start P%s — controls %s" % [pk, str(_control_at_turn_start[pk])])
+
+## End-of-turn primary scoring: EOT conditions always, plus Command
+## conditions in Round 5 (GDM: "C ... switches to end of turn in Round 5").
+func score_primary_eot_11e(player: int) -> void:
+	if GameConstants.edition < 11 or player_primary_missions.is_empty():
+		return
+	var battle_round = GameState.get_battle_round()
+	_score_primary_11e(player, battle_round, "eot")
+	if battle_round >= 5:
+		_score_primary_11e(player, battle_round, "command")
+
+## End-of-game primary scoring for both players (idempotent).
+func score_primary_eog_11e() -> void:
+	if GameConstants.edition < 11 or player_primary_missions.is_empty():
+		return
+	if _eog_primary_scored:
+		return
+	_eog_primary_scored = true
+	var battle_round = GameState.get_battle_round()
+	for player in [1, 2]:
+		_score_primary_11e(player, battle_round, "eog")
+
+func _score_primary_11e(player: int, battle_round: int, timing: String) -> void:
+	var pk = str(player)
+	var card = player_primary_missions.get(pk, {})
+	if card.is_empty():
+		print("MissionManager: 11e — no primary mission card for P%s" % pk)
+		return
+
+	var vp_total = 0
+	var reasons = []
+	for rule in card.get("rules", []):
+		if rule.get("when", "command") != timing:
+			continue
+		var window = rule.get("rounds", [])
+		if window.size() == 2 and (battle_round < int(window[0]) or battle_round > int(window[1])):
+			continue
+		var vp = _evaluate_primary_rule_11e(player, rule, battle_round)
+		if vp > 0:
+			vp_total += vp
+			reasons.append("%s +%d" % [rule.get("type", "?"), vp])
+
+	var reason = "%s (%s): %s" % [card.get("name", "?"), timing,
+		"; ".join(reasons) if reasons.size() > 0 else "no conditions met"]
+	print("MissionManager: 11e primary P%s R%d — %s" % [pk, battle_round, reason])
+	_award_primary_vp_11e(player, vp_total, reason, timing)
+
+func _evaluate_primary_rule_11e(player: int, rule: Dictionary, battle_round: int) -> int:
+	var opponent = 3 - player
+	match rule.get("type", ""):
+		"hold_min":
+			var count = _count_controlled_filtered_11e(player, rule)
+			return rule.get("vp", 0) if count >= int(rule.get("min", 1)) else 0
+		"per_objective":
+			var count = _count_controlled_filtered_11e(player, rule)
+			var vp_per = int(rule.get("vp_per", 0))
+			var by_round = rule.get("vp_by_round", {})
+			if not by_round.is_empty():
+				vp_per = int(by_round.get(battle_round, by_round.get(str(battle_round), 0)))
+			return count * vp_per
+		"hold_more":
+			var mine = _get_controlled_objectives(player).size()
+			var theirs = _get_controlled_objectives(opponent).size()
+			return rule.get("vp", 0) if mine > theirs else 0
+		"hold_enemy_home":
+			return rule.get("vp", 0) if _controls_enemy_home_11e(player) else 0
+		"hold_central":
+			var central = _get_central_objective_id_11e()
+			return rule.get("vp", 0) if central != "" and objective_control_state.get(central, 0) == player else 0
+		"hold_central_plus_nml":
+			var central2 = _get_central_objective_id_11e()
+			if central2 == "" or objective_control_state.get(central2, 0) != player:
+				return 0
+			var other_nml = 0
+			for obj_id in _get_controlled_nml_objectives(player):
+				if obj_id != central2:
+					other_nml += 1
+			return rule.get("vp", 0) if other_nml >= 1 else 0
+		"hold_new":
+			var start_set = _control_at_turn_start.get(str(player), [])
+			for obj_id in _get_controlled_objectives(player):
+				if obj_id in start_set:
+					continue
+				if rule.get("exclude_home", false) and _is_home_objective_11e(obj_id, player):
+					continue
+				return rule.get("vp", 0)
+			return 0
+		"destroyed_min":
+			return rule.get("vp", 0) if _kills_this_turn_11e(player) >= int(rule.get("min", 1)) else 0
+		"destroyed_per_unit":
+			return _kills_this_turn_11e(player) * int(rule.get("vp_per", 0))
+		"killed_more_than_opponent_last_turn":
+			var my_kills = _kills_this_turn_11e(player)
+			# Opponent's most recent turn: same round if they already went this
+			# round (player 2 scoring), otherwise the previous round.
+			var opp_round = battle_round if player == 2 else battle_round - 1
+			var opp_kills = int(kills_per_round.get(str(opp_round), {}).get(str(opponent), 0))
+			return rule.get("vp", 0) if my_kills > opp_kills else 0
+		"quarters":
+			var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+			if secondary_mgr == null:
+				return 0
+			var params = {"count": int(rule.get("min", 3)), "min_distance_from_center": 6.0}
+			return rule.get("vp", 0) if secondary_mgr._check_table_quarter_presence(player, params) else 0
+		"action":
+			var action_name = rule.get("action_name", "?")
+			if not _warned_unimplemented_actions.has(action_name):
+				_warned_unimplemented_actions[action_name] = true
+				print("MissionManager: 11e primary action '%s' is not implemented yet — scores 0 (GDM source approximate)" % action_name)
+			return 0
+		_:
+			print("MissionManager: 11e unknown primary rule type '%s'" % rule.get("type", ""))
+			return 0
+
+func _count_controlled_filtered_11e(player: int, rule: Dictionary) -> int:
+	var exclude_home = rule.get("exclude_home", false)
+	var zone_filter = rule.get("zone", "any")
+	var opponent = 3 - player
+	var count = 0
+	for obj_id in _get_controlled_objectives(player):
+		if exclude_home and _is_home_objective_11e(obj_id, player):
+			continue
+		if zone_filter != "any":
+			var zone = _get_objective_by_id(obj_id).get("zone", "no_mans_land")
+			var in_enemy = (zone == "player%d" % opponent)
+			if zone_filter == "enemy_territory" and not in_enemy:
+				continue
+			if zone_filter == "not_enemy_territory" and in_enemy:
+				continue
+			if zone_filter == "nml" and zone != "no_mans_land":
+				continue
+		count += 1
+	return count
+
+func _is_home_objective_11e(obj_id: String, player: int) -> bool:
+	return _get_objective_by_id(obj_id).get("zone", "") == "player%d" % player
+
+func _controls_enemy_home_11e(player: int) -> bool:
+	var opponent = 3 - player
+	for obj in GameState.state.board.get("objectives", []):
+		if obj.get("zone", "") == "player%d" % opponent \
+				and objective_control_state.get(obj.get("id", ""), 0) == player:
+			return true
+	return false
+
+func _get_central_objective_id_11e() -> String:
+	# The objective nearest the board centre (NML preferred by geometry anyway).
+	var board_size = GameState.state.get("board", {}).get("size", {})
+	var center = Vector2(
+		Measurement.inches_to_px(float(board_size.get("width", 44)) / 2.0),
+		Measurement.inches_to_px(float(board_size.get("height", 60)) / 2.0))
+	var best_id = ""
+	var best_dist = INF
+	for obj in GameState.state.board.get("objectives", []):
+		var pos = obj.get("position")
+		if pos is Dictionary:
+			pos = Vector2(pos.x, pos.y)
+		if pos == null:
+			continue
+		var d = pos.distance_to(center)
+		if d < best_dist:
+			best_dist = d
+			best_id = obj.get("id", "")
+	return best_id
+
+func _kills_this_turn_11e(player: int) -> int:
+	# Best available proxy: kills recorded for this player this battle round
+	# (count_destroyed_units_this_round refreshes it before each scoring call).
+	var battle_round = str(GameState.get_battle_round())
+	var from_rounds = int(kills_per_round.get(battle_round, {}).get(str(player), 0))
+	return max(from_rounds, int(_kills_this_round.get(str(player), 0)))
+
+func _award_primary_vp_11e(player: int, vp_earned: int, reason: String, timing: String) -> void:
+	if vp_earned <= 0:
+		return
+	var pk = str(player)
+	if not GameState.state.players.has(pk):
+		GameState.state.players[pk] = {}
+
+	# 15 VP per-turn window (EOG scoring happens outside any turn — total cap only)
+	if timing != "eog":
+		var turn_so_far = int(_primary_vp_this_turn.get(pk, 0))
+		var turn_room = PrimaryMissionData11e.MAX_PRIMARY_VP_PER_TURN_11E - turn_so_far
+		if vp_earned > turn_room:
+			print("MissionManager: 11e P%s primary clipped by 15/turn cap (%d -> %d)" % [pk, vp_earned, max(0, turn_room)])
+			vp_earned = max(0, turn_room)
+
+	# 45 VP total cap
+	var primary_vp = int(GameState.state.players[pk].get("primary_vp", 0))
+	var total_room = PrimaryMissionData11e.MAX_PRIMARY_VP_11E - primary_vp
+	if vp_earned > total_room:
+		print("MissionManager: 11e P%s primary clipped by 45 total cap (%d -> %d)" % [pk, vp_earned, max(0, total_room)])
+		vp_earned = max(0, total_room)
+	if vp_earned <= 0:
+		return
+
+	if timing != "eog":
+		_primary_vp_this_turn[pk] = int(_primary_vp_this_turn.get(pk, 0)) + vp_earned
+	GameState.state.players[pk]["primary_vp"] = primary_vp + vp_earned
+	GameState.state.players[pk]["vp"] = int(GameState.state.players[pk].get("vp", 0)) + vp_earned
+	emit_signal("victory_points_scored", player, vp_earned, reason)
+	print("MissionManager: 11e P%s scored %d primary VP (%s) — primary total %d/45" % [
+		pk, vp_earned, reason, primary_vp + vp_earned])
+
+func get_primary_mission_for_player(player: int) -> Dictionary:
+	return player_primary_missions.get(str(player), {}).duplicate(true)
+
+# ============================================================
 # HELPER METHODS
 # ============================================================
 
@@ -1229,7 +1518,12 @@ func get_state_for_save() -> Dictionary:
 		"supply_drop_resolved_round_4": supply_drop_resolved_round_4,
 		"kills_per_round": kills_per_round.duplicate(true),
 		"character_claimed_objectives": character_claimed_objectives.duplicate(true),
-		"units_alive_at_round_start": _units_alive_at_round_start.duplicate(true)
+		"units_alive_at_round_start": _units_alive_at_round_start.duplicate(true),
+		"player_dispositions": player_dispositions.duplicate(true),
+		"player_primary_missions": player_primary_missions.duplicate(true),
+		"primary_vp_this_turn": _primary_vp_this_turn.duplicate(true),
+		"control_at_turn_start": _control_at_turn_start.duplicate(true),
+		"eog_primary_scored": _eog_primary_scored
 	}
 
 func load_state(data: Dictionary) -> void:
@@ -1252,6 +1546,11 @@ func load_state(data: Dictionary) -> void:
 	kills_per_round = data.get("kills_per_round", {})
 	character_claimed_objectives = data.get("character_claimed_objectives", {})
 	_units_alive_at_round_start = data.get("units_alive_at_round_start", {})
+	player_dispositions = data.get("player_dispositions", {})
+	player_primary_missions = data.get("player_primary_missions", {})
+	_primary_vp_this_turn = data.get("primary_vp_this_turn", {"1": 0, "2": 0})
+	_control_at_turn_start = data.get("control_at_turn_start", {})
+	_eog_primary_scored = data.get("eog_primary_scored", false)
 	print("MissionManager: Loaded state — %d sticky, %d burned, %d ritual" % [
 		_sticky_objectives.size(), burned_objectives.size(), _ritual_objectives.size()
 	])

--- a/40k/autoloads/PhaseManager.gd
+++ b/40k/autoloads/PhaseManager.gd
@@ -347,6 +347,10 @@ func _handle_game_end() -> void:
 	# but trigger again here for paths that reach _handle_game_end without it.
 	if MissionManager:
 		MissionManager.score_end_of_game_burn_bonus()
+		# 11e GDM primary missions: end-of-game conditions (idempotent guard
+		# inside — ScoringPhase._handle_game_end_turn usually fires first).
+		if GameConstants.edition >= 11:
+			MissionManager.score_primary_eog_11e()
 
 	game_ended = true
 

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6535,6 +6535,58 @@ static func get_surge_move_inches(unit: Dictionary) -> float:
 				return float(digits.to_int())
 	return 0.0
 
+## 11e core ability "Heal X" (sourced 2026-07-03; see the missions doc
+## appendix): parses X from a "Heal X" ability name. 0 = no heal rule.
+static func get_heal_amount(unit: Dictionary) -> int:
+	for ab in unit.get("meta", {}).get("abilities", []):
+		var nm := ""
+		if ab is String:
+			nm = ab
+		elif ab is Dictionary:
+			nm = str(ab.get("name", ""))
+		if nm.to_lower().begins_with("heal"):
+			var digits := ""
+			for c in nm:
+				if c >= "0" and c <= "9":
+					digits += c
+				elif digits != "":
+					break
+			if digits != "":
+				return digits.to_int()
+	return 0
+
+## 11e Heal X resolution: X times — restore one lost wound to a wounded
+## model; if no wounded models exist, return one destroyed model with 1
+## wound. A unit at full strength/wounds wastes the remaining heals.
+## Mutates the unit dict in place; returns {"healed": n, "revived": n}.
+static func apply_heal_11e(unit: Dictionary, amount: int) -> Dictionary:
+	var healed := 0
+	var revived := 0
+	for _i in range(amount):
+		var wounded = null
+		for model in unit.get("models", []):
+			if not model.get("alive", true):
+				continue
+			if int(model.get("current_wounds", model.get("wounds", 1))) < int(model.get("wounds", 1)):
+				wounded = model
+				break
+		if wounded != null:
+			wounded["current_wounds"] = int(wounded.get("current_wounds", 0)) + 1
+			healed += 1
+			continue
+		var dead = null
+		for model in unit.get("models", []):
+			if not model.get("alive", true):
+				dead = model
+				break
+		if dead != null:
+			dead["alive"] = true
+			dead["current_wounds"] = 1
+			revived += 1
+			continue
+		break  # everything alive at full wounds — excess heals are wasted
+	return {"healed": healed, "revived": revived}
+
 ## ISS-069 (11e 24.24): "Lone Operative X\"" gates targeting at X" (visibility
 ## AND [INDIRECT FIRE]); the default form is 12". Parses the first number in
 ## any ability whose name contains "lone operative". Edition-agnostic — the

--- a/40k/autoloads/SecondaryMissionManager.gd
+++ b/40k/autoloads/SecondaryMissionManager.gd
@@ -20,6 +20,11 @@ signal missions_drawn_for_review(player: int, drawn_missions: Array)
 const MAX_SECONDARY_VP = 40
 const MAX_COMBINED_VP = 90  # primary + secondary + challenger combined
 const MAX_ACTIVE_MISSIONS = 2
+# 11e (GDM 2026): 45 VP secondary total, 15 VP per turn, no hand limit
+# (source: docs/rules/11th_edition_missions_gdm2026.md).
+const MAX_SECONDARY_VP_11E = 45
+const MAX_SECONDARY_VP_PER_TURN_11E = 15
+const CARDS_DRAWN_PER_TURN_11E = 2
 const MAX_FIXED_MISSION_VP = 20  # Max VP per individual fixed mission card
 
 # Per-player secondary mission state
@@ -57,6 +62,7 @@ static func _create_default_player_state() -> Dictionary:
 		"active": [],        # Array of active mission dicts (max 2)
 		"discard": [],       # Array of discarded mission IDs
 		"secondary_vp": 0,   # Total secondary VP scored
+		"secondary_vp_this_turn": 0,  # 11e: 15/turn cap window
 		"initialized": false,
 	}
 
@@ -81,8 +87,9 @@ func setup_tactical_deck(player: int) -> void:
 	var player_key = str(player)
 	var state = _player_state[player_key]
 
-	# Get standard 18-card tactical deck
-	var deck_ids = SecondaryMissionData.get_mission_ids_for_deck(false)
+	# Get the edition's 18-card tactical deck (11e: GDM 2026 deck)
+	var deck_ids = SecondaryMissionData.get_mission_ids_for_deck_11e() \
+		if GameConstants.edition >= 11 else SecondaryMissionData.get_mission_ids_for_deck(false)
 
 	# T16-1: For AI players, filter out missions the army literally cannot score
 	# This prevents the AI from wasting CP and turns cycling through impossible missions
@@ -108,6 +115,14 @@ func setup_fixed_missions(player: int, mission_ids: Array) -> Dictionary:
 	"""Set up fixed secondary missions for a player. Fixed missions stay active
 	the entire game and can be scored multiple times (up to 20VP per mission).
 	mission_ids: Array of exactly 2 mission ID strings."""
+	# 11e (GDM 2026): only the four fixed-eligible cards may be taken as
+	# Fixed — Assassination, A Grievous Blow, Bring it Down, Engage on
+	# All Fronts.
+	if GameConstants.edition >= 11:
+		var eligible = SecondaryMissionData.get_fixed_eligible_11e()
+		for mid in mission_ids:
+			if not str(mid) in eligible:
+				return {"success": false, "error": "%s is not fixed-eligible in 11e (choose from %s)" % [str(mid), str(eligible)]}
 	if mission_ids.size() != 2:
 		return {"success": false, "error": "Must select exactly 2 fixed missions (got %d)" % mission_ids.size()}
 
@@ -179,7 +194,12 @@ func draw_missions_to_hand(player: int) -> Array:
 		return []
 
 	var drawn = []
-	while state["active"].size() < MAX_ACTIVE_MISSIONS and state["deck"].size() > 0:
+	# 11e (GDM 2026): draw TWO cards each turn with NO hand limit;
+	# 10e: fill the hand up to MAX_ACTIVE_MISSIONS.
+	var draws_remaining_11e := CARDS_DRAWN_PER_TURN_11E
+	while ((GameConstants.edition >= 11 and draws_remaining_11e > 0)
+			or (GameConstants.edition < 11 and state["active"].size() < MAX_ACTIVE_MISSIONS)) \
+			and state["deck"].size() > 0:
 		var mission_id = state["deck"].pop_front()
 		var mission_data = SecondaryMissionData.get_mission_by_id(mission_id)
 
@@ -216,12 +236,14 @@ func draw_missions_to_hand(player: int) -> Array:
 			emit_signal("when_drawn_requires_interaction", player, mission_id,
 				active_mission["interaction_type"], active_mission["interaction_details"])
 			print("SecondaryMissionManager: Player %d drew %s (requires interaction)" % [player, mission_data["name"]])
+			draws_remaining_11e -= 1
 			continue
 
 		# Normal draw - add to active missions
 		var active_mission = _create_active_mission(mission_data)
 		state["active"].append(active_mission)
 		drawn.append(active_mission)
+		draws_remaining_11e -= 1
 		emit_signal("mission_drawn", player, mission_id)
 		print("SecondaryMissionManager: Player %d drew %s" % [player, mission_data["name"]])
 
@@ -629,9 +651,19 @@ func _check_condition(player: int, check: String, params: Dictionary, mission: D
 		"objectives_cleansed":
 			return _check_objectives_cleansed(player, params)
 		"teleport_homer_deployed_not_in_opponent_zone":
-			return _check_teleport_homer(player, false)
+			return _check_teleport_homer(player, false, params)
 		"teleport_homer_deployed_in_opponent_zone":
-			return _check_teleport_homer(player, true)
+			return _check_teleport_homer(player, true, params)
+
+		# 11e (GDM 2026) deck checks
+		"high_value_unit_destroyed_this_turn":
+			return _check_high_value_unit_destroyed(player, params)
+		"holds_enemy_home_objective":
+			return _check_enemy_home_objective(player)
+		"objectives_held_since_turn_start":
+			return _check_objectives_held_since_turn_start(player, params)
+		"units_near_board_edges":
+			return _check_units_near_board_edges(player, params)
 		"units_recovered_assets":
 			return _check_recovered_assets(player, params)
 
@@ -971,18 +1003,21 @@ func _check_locus_opponent_zone(player: int) -> bool:
 	return false
 
 func _check_objectives_cleansed(player: int, params: Dictionary) -> bool:
-	"""Check if objectives were cleansed this turn."""
+	"""Check if objectives were cleansed/looted this turn. The 11e Plunder
+	card reuses this check with its own action name."""
 	var required = params.get("count", 1)
+	var wanted_action = str(params.get("action_name", "Cleanse"))
 	var count = 0
 	for action in _active_actions[str(player)]:
-		if action.get("action_name", "") == "Cleanse" and action.get("completed", false):
+		if action.get("action_name", "") == wanted_action and action.get("completed", false):
 			count += 1
 	return count >= required
 
-func _check_teleport_homer(player: int, in_opponent_zone: bool) -> bool:
-	"""Check if a teleport homer was deployed."""
+func _check_teleport_homer(player: int, in_opponent_zone: bool, params: Dictionary = {}) -> bool:
+	"""Check if a teleport homer (or 11e Beacon) was deployed."""
+	var wanted_homer = str(params.get("action_name", "Deploy Teleport Homer"))
 	for action in _active_actions[str(player)]:
-		if action.get("action_name", "") == "Deploy Teleport Homer" and action.get("completed", false):
+		if action.get("action_name", "") == wanted_homer and action.get("completed", false):
 			if in_opponent_zone:
 				return action.get("location", "") == "opponent_zone"
 			else:
@@ -1008,13 +1043,22 @@ func _award_secondary_vp(player: int, vp: int, mission_id: String) -> int:
 	var state = _player_state[player_key]
 	var current_secondary = state["secondary_vp"]
 
-	# Cap at MAX_SECONDARY_VP
-	var available = MAX_SECONDARY_VP - current_secondary
+	# Cap at the edition's secondary total (11e GDM 2026: 45; 10e: 40)
+	var vp_cap := MAX_SECONDARY_VP_11E if GameConstants.edition >= 11 else MAX_SECONDARY_VP
+	var available = vp_cap - current_secondary
 	var actual_vp = mini(vp, available)
 
 	if actual_vp <= 0:
-		print("SecondaryMissionManager: Player %d at secondary VP cap (%d)" % [player, MAX_SECONDARY_VP])
+		print("SecondaryMissionManager: Player %d at secondary VP cap (%d)" % [player, vp_cap])
 		return 0
+
+	# 11e: additionally capped at 15 secondary VP per turn
+	if GameConstants.edition >= 11:
+		var turn_available = MAX_SECONDARY_VP_PER_TURN_11E - int(state.get("secondary_vp_this_turn", 0))
+		actual_vp = mini(actual_vp, turn_available)
+		if actual_vp <= 0:
+			print("SecondaryMissionManager: Player %d at per-turn secondary VP cap (%d)" % [player, MAX_SECONDARY_VP_PER_TURN_11E])
+			return 0
 
 	# Also check combined cap
 	var primary_vp = GameState.state.get("players", {}).get(player_key, {}).get("primary_vp", 0)
@@ -1027,6 +1071,7 @@ func _award_secondary_vp(player: int, vp: int, mission_id: String) -> int:
 
 	# Award VP
 	state["secondary_vp"] += actual_vp
+	state["secondary_vp_this_turn"] = int(state.get("secondary_vp_this_turn", 0)) + actual_vp
 
 	# Update GameState total VP
 	var total_vp = GameState.state.get("players", {}).get(player_key, {}).get("vp", 0)
@@ -1073,12 +1118,91 @@ func _discard_achieved_missions(player: int) -> void:
 	state["active"] = remaining
 
 # ============================================================================
+# CONDITION CHECKERS — 11e (GDM 2026) deck
+# ============================================================================
+
+## A Grievous Blow (approx.): an enemy unit worth min_points+ points, or
+## containing a model with min_wounds+ starting wounds, was destroyed this turn.
+func _check_high_value_unit_destroyed(player: int, params: Dictionary) -> bool:
+	var min_points = int(params.get("min_points", 100))
+	var min_wounds = int(params.get("min_wounds", 10))
+	for destroyed in _units_destroyed_this_turn:
+		if int(destroyed.get("owner", 0)) == player:
+			continue
+		if int(destroyed.get("points", 0)) >= min_points:
+			return true
+		if int(destroyed.get("max_model_wounds", 0)) >= min_wounds:
+			return true
+	return false
+
+## Forward Position: the player controls the objective in the OPPONENT's
+## deployment zone (their home objective).
+func _check_enemy_home_objective(player: int) -> bool:
+	var opponent = 3 - player
+	var opponent_zone = "player%d" % opponent
+	for obj in GameState.state.get("board", {}).get("objectives", []):
+		if obj.get("zone", "") == opponent_zone:
+			if MissionManager.objective_control_state.get(obj["id"], 0) == player:
+				return true
+	return false
+
+## Burden of Trust (approx.): count objectives the player controlled at the
+## START of the turn and still controls now.
+func _check_objectives_held_since_turn_start(player: int, params: Dictionary) -> bool:
+	var required = int(params.get("count", 1))
+	var count = 0
+	for obj_id in _objective_control_at_turn_start:
+		if _objective_control_at_turn_start[obj_id] == player \
+				and MissionManager.objective_control_state.get(obj_id, 0) == player:
+			count += 1
+	return count >= required
+
+## Outflank (approx.): units with every alive model within edge_inches of a
+## battlefield edge, outside the player's own deployment zone.
+func _check_units_near_board_edges(player: int, params: Dictionary) -> bool:
+	var required = int(params.get("count", 1))
+	var edge_in = float(params.get("edge_inches", 6.0))
+	var exclude = params.get("exclude", [])
+	var board_w_px = Measurement.inches_to_px(float(GameState.state.get("board", {}).get("size", {}).get("width", 44)))
+	var board_h_px = Measurement.inches_to_px(float(GameState.state.get("board", {}).get("size", {}).get("height", 60)))
+	var edge_px = Measurement.inches_to_px(edge_in)
+	var own_zone = GameState.get_deployment_zone_for_player(player) if GameState.has_method("get_deployment_zone_for_player") else {}
+	var count = 0
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if "Battle-shocked" in exclude and unit.get("flags", {}).get("battle_shocked", false):
+			continue
+		var any_alive = false
+		var all_near_edge = true
+		for m in unit.get("models", []):
+			if not m.get("alive", true) or m.get("position") == null:
+				continue
+			any_alive = true
+			var pos = m["position"]
+			var px = float(pos.x) if not (pos is Dictionary) else float(pos.get("x", 0))
+			var py = float(pos.y) if not (pos is Dictionary) else float(pos.get("y", 0))
+			var near = px <= edge_px or py <= edge_px \
+				or px >= board_w_px - edge_px or py >= board_h_px - edge_px
+			if not near:
+				all_near_edge = false
+				break
+		if any_alive and all_near_edge:
+			count += 1
+	return count >= required
+
+# ============================================================================
 # EVENT HOOKS - Called by other systems to track game events
 # ============================================================================
 
 func on_turn_start(player: int) -> void:
 	"""Called at the start of a player's turn. Snapshot objective control."""
 	_units_destroyed_this_turn.clear()
+	# 11e: the 15 VP/turn secondary window resets for both players (either
+	# player can score at either turn's end).
+	for pk in _player_state:
+		_player_state[pk]["secondary_vp_this_turn"] = 0
 	_while_active_vp_this_window.clear()
 	_objective_control_at_turn_start = MissionManager.objective_control_state.duplicate()
 	# Clear completed actions from previous turn
@@ -1198,11 +1322,16 @@ func check_and_report_unit_destroyed(unit_id: String) -> void:
 			if label not in model_type_labels:
 				model_type_labels.append(label)
 
+	var max_model_wounds := 0
+	for m in models:
+		max_model_wounds = maxi(max_model_wounds, int(m.get("wounds", 1)))
 	var destroyed_dict = {
 		"unit_id": unit_id,
 		"unit_name": unit_name,
 		"owner": owner,
 		"keywords": keywords,
+		"points": int(unit.get("meta", {}).get("points", 0)),
+		"max_model_wounds": max_model_wounds,
 		"starting_strength": starting_strength,
 		"is_character": "CHARACTER" in upper_keywords,
 		"is_infantry": "INFANTRY" in upper_keywords,

--- a/40k/autoloads/SecondaryMissionManager.gd
+++ b/40k/autoloads/SecondaryMissionManager.gd
@@ -24,6 +24,7 @@ const MAX_ACTIVE_MISSIONS = 2
 # (source: docs/rules/11th_edition_missions_gdm2026.md).
 const MAX_SECONDARY_VP_11E = 45
 const MAX_SECONDARY_VP_PER_TURN_11E = 15
+const MAX_VP_PER_FIXED_CARD_11E = 20  # GDM sourced: 20 VP max from each fixed card per game
 const CARDS_DRAWN_PER_TURN_11E = 2
 const MAX_FIXED_MISSION_VP = 20  # Max VP per individual fixed mission card
 
@@ -63,6 +64,7 @@ static func _create_default_player_state() -> Dictionary:
 		"discard": [],       # Array of discarded mission IDs
 		"secondary_vp": 0,   # Total secondary VP scored
 		"secondary_vp_this_turn": 0,  # 11e: 15/turn cap window
+		"vp_by_mission": {},  # 11e fixed mode: 20 VP cap per fixed card
 		"initialized": false,
 	}
 
@@ -664,6 +666,8 @@ func _check_condition(player: int, check: String, params: Dictionary, mission: D
 			return _check_objectives_held_since_turn_start(player, params)
 		"units_near_board_edges":
 			return _check_units_near_board_edges(player, params)
+		"unit_outside_own_dz":
+			return _check_unit_outside_own_dz(player, params)
 		"units_recovered_assets":
 			return _check_recovered_assets(player, params)
 
@@ -1060,6 +1064,16 @@ func _award_secondary_vp(player: int, vp: int, mission_id: String) -> int:
 			print("SecondaryMissionManager: Player %d at per-turn secondary VP cap (%d)" % [player, MAX_SECONDARY_VP_PER_TURN_11E])
 			return 0
 
+	# 11e Fixed mode (GDM sourced): each fixed card can score at most 20 VP
+	# over the game
+	if GameConstants.edition >= 11 and state.get("mode", "tactical") == "fixed":
+		var by_mission = state.get("vp_by_mission", {})
+		var card_available = MAX_VP_PER_FIXED_CARD_11E - int(by_mission.get(mission_id, 0))
+		actual_vp = mini(actual_vp, card_available)
+		if actual_vp <= 0:
+			print("SecondaryMissionManager: Player %d fixed card %s at its 20 VP cap" % [player, mission_id])
+			return 0
+
 	# Also check combined cap
 	var primary_vp = GameState.state.get("players", {}).get(player_key, {}).get("primary_vp", 0)
 	var combined_available = MAX_COMBINED_VP - primary_vp - current_secondary
@@ -1072,6 +1086,9 @@ func _award_secondary_vp(player: int, vp: int, mission_id: String) -> int:
 	# Award VP
 	state["secondary_vp"] += actual_vp
 	state["secondary_vp_this_turn"] = int(state.get("secondary_vp_this_turn", 0)) + actual_vp
+	if not state.has("vp_by_mission"):
+		state["vp_by_mission"] = {}
+	state["vp_by_mission"][mission_id] = int(state["vp_by_mission"].get(mission_id, 0)) + actual_vp
 
 	# Update GameState total VP
 	var total_vp = GameState.state.get("players", {}).get(player_key, {}).get("vp", 0)
@@ -1124,25 +1141,42 @@ func _discard_achieved_missions(player: int) -> void:
 ## A Grievous Blow (approx.): an enemy unit worth min_points+ points, or
 ## containing a model with min_wounds+ starting wounds, was destroyed this turn.
 func _check_high_value_unit_destroyed(player: int, params: Dictionary) -> bool:
-	var min_points = int(params.get("min_points", 100))
-	var min_wounds = int(params.get("min_wounds", 10))
+	# GDM sourced text: A Grievous Blow targets units with a Starting
+	# Strength of 13+ models (min_models). The points/wounds params remain
+	# for any card that wants a value-based threshold.
+	var min_models = int(params.get("min_models", 0))
+	var min_points = int(params.get("min_points", 0))
+	var min_wounds = int(params.get("min_wounds", 0))
 	for destroyed in _units_destroyed_this_turn:
 		if int(destroyed.get("owner", 0)) == player:
 			continue
-		if int(destroyed.get("points", 0)) >= min_points:
+		if min_models > 0 and int(destroyed.get("starting_strength", 0)) >= min_models:
 			return true
-		if int(destroyed.get("max_model_wounds", 0)) >= min_wounds:
+		if min_points > 0 and int(destroyed.get("points", 0)) >= min_points:
+			return true
+		if min_wounds > 0 and int(destroyed.get("max_model_wounds", 0)) >= min_wounds:
 			return true
 	return false
 
 ## Forward Position: the player controls the objective in the OPPONENT's
-## deployment zone (their home objective).
+## deployment zone (their home objective), OR — per the card's alternative —
+## BOTH Expansion objectives.
 func _check_enemy_home_objective(player: int) -> bool:
 	var opponent = 3 - player
 	var opponent_zone = "player%d" % opponent
 	for obj in GameState.state.get("board", {}).get("objectives", []):
 		if obj.get("zone", "") == opponent_zone:
 			if MissionManager.objective_control_state.get(obj["id"], 0) == player:
+				return true
+	if MissionManager.has_method("get_objective_ids_by_designation"):
+		var expansions = MissionManager.get_objective_ids_by_designation("expansion")
+		if expansions.size() >= 2:
+			var all_mine = true
+			for obj_id in expansions:
+				if MissionManager.objective_control_state.get(obj_id, 0) != player:
+					all_mine = false
+					break
+			if all_mine:
 				return true
 	return false
 
@@ -1157,17 +1191,21 @@ func _check_objectives_held_since_turn_start(player: int, params: Dictionary) ->
 			count += 1
 	return count >= required
 
-## Outflank (approx.): units with every alive model within edge_inches of a
+## Outflank: units with every alive model within edge_inches of a
 ## battlefield edge, outside the player's own deployment zone.
+## params.count — require N qualifying units (legacy); params.min_edges —
+## require qualifying units on N DISTINCT battlefield edges (sourced card
+## text: 3 VP for one edge, 5 VP for two).
 func _check_units_near_board_edges(player: int, params: Dictionary) -> bool:
 	var required = int(params.get("count", 1))
+	var min_edges = int(params.get("min_edges", 0))
 	var edge_in = float(params.get("edge_inches", 6.0))
 	var exclude = params.get("exclude", [])
 	var board_w_px = Measurement.inches_to_px(float(GameState.state.get("board", {}).get("size", {}).get("width", 44)))
 	var board_h_px = Measurement.inches_to_px(float(GameState.state.get("board", {}).get("size", {}).get("height", 60)))
 	var edge_px = Measurement.inches_to_px(edge_in)
-	var own_zone = GameState.get_deployment_zone_for_player(player) if GameState.has_method("get_deployment_zone_for_player") else {}
 	var count = 0
+	var edges_hit = {}
 	for unit_id in GameState.state.get("units", {}):
 		var unit = GameState.state.units[unit_id]
 		if int(unit.get("owner", 0)) != player:
@@ -1176,6 +1214,7 @@ func _check_units_near_board_edges(player: int, params: Dictionary) -> bool:
 			continue
 		var any_alive = false
 		var all_near_edge = true
+		var unit_edges = {}
 		for m in unit.get("models", []):
 			if not m.get("alive", true) or m.get("position") == null:
 				continue
@@ -1183,14 +1222,56 @@ func _check_units_near_board_edges(player: int, params: Dictionary) -> bool:
 			var pos = m["position"]
 			var px = float(pos.x) if not (pos is Dictionary) else float(pos.get("x", 0))
 			var py = float(pos.y) if not (pos is Dictionary) else float(pos.get("y", 0))
-			var near = px <= edge_px or py <= edge_px \
-				or px >= board_w_px - edge_px or py >= board_h_px - edge_px
-			if not near:
+			var model_edges = {}
+			if px <= edge_px:
+				model_edges["left"] = true
+			if py <= edge_px:
+				model_edges["top"] = true
+			if px >= board_w_px - edge_px:
+				model_edges["right"] = true
+			if py >= board_h_px - edge_px:
+				model_edges["bottom"] = true
+			if model_edges.is_empty():
 				all_near_edge = false
 				break
+			for e in model_edges:
+				unit_edges[e] = true
 		if any_alive and all_near_edge:
 			count += 1
+			for e in unit_edges:
+				edges_hit[e] = true
+	if min_edges > 0:
+		return edges_hit.size() >= min_edges
 	return count >= required
+
+## Beacon (sourced, pick auto-resolved): a friendly unit is alive on the
+## battlefield with every model outside the player's own deployment zone.
+func _check_unit_outside_own_dz(player: int, params: Dictionary) -> bool:
+	var exclude = params.get("exclude", [])
+	var own_zone = _get_deployment_zone_polygon(player)
+	if own_zone.is_empty():
+		return false
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if "Battle-shocked" in exclude and unit.get("flags", {}).get("battle_shocked", false):
+			continue
+		var any_alive = false
+		var any_inside = false
+		for m in unit.get("models", []):
+			if not m.get("alive", true) or m.get("position") == null:
+				continue
+			any_alive = true
+			var pos = m["position"]
+			if pos is Dictionary:
+				pos = Vector2(float(pos.get("x", 0)), float(pos.get("y", 0)))
+			if Geometry2D.is_point_in_polygon(pos, own_zone):
+				any_inside = true
+				break
+		if any_alive and not any_inside:
+			return true
+	return false
 
 # ============================================================================
 # EVENT HOOKS - Called by other systems to track game events

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -106,6 +106,9 @@ func _on_phase_enter() -> void:
 		MissionManager.check_all_objectives()
 		# Snapshot alive units for kill detection (used by Purge the Foe)
 		MissionManager.snapshot_alive_units()
+		# 11e GDM: open the active player's 15-VP-per-turn primary window and
+		# snapshot start-of-turn control for "hold new objective" conditions.
+		MissionManager.on_turn_start_11e(current_player)
 
 	# Step 6: Draw secondary mission cards (tactical mode only — fixed mode skips drawing)
 	_newly_drawn_missions = []

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -371,6 +371,12 @@ func _handle_end_turn() -> Dictionary:
 	# diffs are built.
 	PhaseManager.run_turn_ending_hooks(current_player)
 
+	# 11e GDM primary missions: EOT conditions score at the end of every turn,
+	# and Command-phase conditions switch to end of turn in Round 5.
+	if MissionManager and GameConstants.edition >= 11:
+		MissionManager.count_destroyed_units_this_round()
+		MissionManager.score_primary_eot_11e(current_player)
+
 	# P3-128: Record VP snapshot at end of each player's turn for the timeline chart
 	if MissionManager:
 		var battle_round = GameState.get_battle_round()
@@ -484,6 +490,11 @@ func _handle_game_end_turn() -> Dictionary:
 	# so the bonus VP counts toward the result.
 	if MissionManager and MissionManager.has_method("score_end_of_game_burn_bonus"):
 		MissionManager.score_end_of_game_burn_bonus()
+
+	# 11e GDM primary missions: end-of-game conditions (e.g. "5VP enemy home
+	# EOG") score before the winner is determined. Idempotent.
+	if MissionManager and GameConstants.edition >= 11:
+		MissionManager.score_primary_eog_11e()
 
 	var winner := _determine_winner()
 

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -28,6 +28,10 @@ var p1_select_fixed_button: Button = null
 var p2_select_fixed_button: Button = null
 var _p1_fixed_mission_ids: Array = []
 var _p2_fixed_mission_ids: Array = []
+# 11e GDM 2026: Force Disposition selection (drives the primary mission pairing)
+var disposition_container: VBoxContainer = null
+var p1_disposition_dropdown: OptionButton = null
+var p2_disposition_dropdown: OptionButton = null
 @onready var start_button: Button = $ScrollContainer/MenuContainer/ButtonSection/StartButton
 @onready var multiplayer_button: Button = $ScrollContainer/MenuContainer/ButtonSection/MultiplayerButton
 @onready var load_button: Button = $ScrollContainer/MenuContainer/ButtonSection/LoadButton
@@ -223,6 +227,9 @@ func _setup_dropdowns() -> void:
 
 	# P2-85: Create secondary mission mode selection
 	_create_secondary_mission_mode_ui()
+
+	# 11e GDM 2026: Force Disposition selection (primary mission pairing)
+	_create_disposition_ui()
 
 	# 11e go-live: rules edition selector
 	_create_edition_dropdown()
@@ -469,6 +476,52 @@ func _create_secondary_mission_mode_ui() -> void:
 	p2_row.add_child(p2_select_fixed_button)
 
 	print("MainMenu: P2-85 Secondary mission mode UI created")
+
+func _create_disposition_ui() -> void:
+	"""11e GDM 2026: per-player Force Disposition selection. The primary
+	mission each player scores is their disposition paired against the
+	opponent's (25-card table in PrimaryMissionData11e). Ignored at 10e."""
+	var mission_section = $ScrollContainer/MenuContainer/MissionSection
+
+	disposition_container = VBoxContainer.new()
+	disposition_container.name = "DispositionContainer"
+	disposition_container.add_theme_constant_override("separation", 6)
+	mission_section.add_child(disposition_container)
+
+	var section_label = Label.new()
+	section_label.text = "Force Disposition (11th Edition):"
+	section_label.custom_minimum_size = Vector2(150, 0)
+	disposition_container.add_child(section_label)
+
+	for player in [1, 2]:
+		var row = HBoxContainer.new()
+		row.add_theme_constant_override("separation", 8)
+		disposition_container.add_child(row)
+
+		var label = Label.new()
+		label.text = "Player %d:" % player
+		label.custom_minimum_size = Vector2(80, 0)
+		row.add_child(label)
+
+		var dropdown = OptionButton.new()
+		dropdown.name = "P%dDispositionDropdown" % player
+		dropdown.custom_minimum_size = Vector2(180, 0)
+		for disp_id in PrimaryMissionData11e.DISPOSITIONS:
+			dropdown.add_item(PrimaryMissionData11e.get_disposition_name(disp_id))
+		dropdown.selected = 0
+		row.add_child(dropdown)
+
+		if player == 1:
+			p1_disposition_dropdown = dropdown
+		else:
+			p2_disposition_dropdown = dropdown
+
+	print("MainMenu: 11e Force Disposition UI created")
+
+func _get_selected_disposition(dropdown: OptionButton) -> String:
+	if dropdown == null or dropdown.selected < 0 or dropdown.selected >= PrimaryMissionData11e.DISPOSITIONS.size():
+		return "take_and_hold"
+	return PrimaryMissionData11e.DISPOSITIONS[dropdown.selected]
 
 func _on_p1_secondary_mode_changed(index: int) -> void:
 	"""P2-85: Show/hide fixed mission select button for Player 1."""
@@ -850,6 +903,8 @@ func _on_start_button_pressed() -> void:
 		"player2_secondary_mode": p2_secondary_mode,
 		"player1_fixed_missions": _p1_fixed_mission_ids.duplicate() if p1_secondary_mode == "fixed" else [],
 		"player2_fixed_missions": _p2_fixed_mission_ids.duplicate() if p2_secondary_mode == "fixed" else [],
+		"player1_disposition": _get_selected_disposition(p1_disposition_dropdown),
+		"player2_disposition": _get_selected_disposition(p2_disposition_dropdown),
 	}
 
 	print("MainMenu: Starting game with config: ", config)
@@ -914,7 +969,12 @@ func _initialize_game_with_config(config: Dictionary) -> void:
 
 	# Initialize base game state with selected deployment type
 	GameState.initialize_default_state(config.deployment)
-	
+
+	# Store configuration in game state BEFORE mission init — the 11e path in
+	# MissionManager.initialize_mission reads the Force Dispositions from
+	# meta.game_config (also re-stored below after army loading for clarity).
+	GameState.state.meta["game_config"] = config
+
 	# Apply terrain configuration
 	if TerrainManager:
 		TerrainManager.current_layout = config.terrain

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -315,13 +315,29 @@ func _build_objective_control_section(panel: VBoxContainer, _current_player: int
 		summary_hbox.add_child(cont_sum)
 	panel.add_child(summary_hbox)
 
-	# Mission info
-	var mission_name = MissionManager.get_current_mission_name()
-	var mission_info = Label.new()
-	mission_info.text = "Mission: %s" % mission_name
-	mission_info.add_theme_font_size_override("font_size", 11)
-	mission_info.add_theme_color_override("font_color", Color(0.55, 0.52, 0.45))
-	panel.add_child(mission_info)
+	# Mission info — at e11 (GDM 2026) each player scores their OWN
+	# disposition-paired primary card, so show both instead of the shared
+	# 10e mission name. "~" marks cards built from approximate source rows.
+	if GameConstants.edition >= 11 and not MissionManager.player_primary_missions.is_empty():
+		for p in [1, 2]:
+			var card = MissionManager.get_primary_mission_for_player(p)
+			var disp = MissionManager.player_dispositions.get(str(p), "")
+			var card_label = Label.new()
+			card_label.name = "P%dPrimaryMissionLabel" % p
+			card_label.text = "P%d Primary: %s%s (%s)" % [
+				p, card.get("name", "?"),
+				" ~" if card.get("approximate", false) else "",
+				PrimaryMissionData11e.get_disposition_name(disp)]
+			card_label.add_theme_font_size_override("font_size", 11)
+			card_label.add_theme_color_override("font_color", Color(0.55, 0.52, 0.45))
+			panel.add_child(card_label)
+	else:
+		var mission_name = MissionManager.get_current_mission_name()
+		var mission_info = Label.new()
+		mission_info.text = "Mission: %s" % mission_name
+		mission_info.add_theme_font_size_override("font_size", 11)
+		mission_info.add_theme_color_override("font_color", Color(0.55, 0.52, 0.45))
+		panel.add_child(mission_info)
 
 func _add_gold_separator(parent: VBoxContainer) -> void:
 	var sep = ColorRect.new()

--- a/40k/scripts/data/PrimaryMissionData11e.gd
+++ b/40k/scripts/data/PrimaryMissionData11e.gd
@@ -13,16 +13,25 @@ class_name PrimaryMissionData11e
 #   when: "command" — scored at the end of your Command phase (GDM: switches
 #                     to end of turn in battle round 5)
 #         "eot"     — scored at the end of your turn
+#         "eot_any" — scored at the end of EVERY turn (yours and opponent's)
 #         "eog"     — scored once at the end of the game
 #   type: hold_min | per_objective | hold_more | hold_enemy_home |
 #         hold_central | hold_central_plus_nml | hold_new | destroyed_min |
-#         destroyed_per_unit | killed_more_than_opponent_last_turn |
-#         quarters | action
+#         destroyed_per_unit | killed_more_than_opponent_last_turn | quarters
+#         — plus the marker/action mechanics (auto-resolved by
+#         MissionManager._run_primary_auto_actions_11e; the real cards let
+#         the player choose targets — see the missions doc appendix):
+#         triangulated_count | consecrated_count | consecrated_enemy_home |
+#         condemned_left | sabotage_per_objective | central_operation_markers |
+#         destroyed_near_central | vanguard_terrain_area | sensor_sweep_vp |
+#         relic_final_marker | decoyed_score | decoyed_total_eog |
+#         no_enemy_markers | intel_tokens_placed | trapped_score |
+#         destroyed_started_on_objective | destroyed_in_terrain_area |
+#         no_enemy_wholly_in_my_dz | action (unimplemented placeholder)
 #   vp / vp_per / vp_by_round: victory points awarded
 #   rounds: [from, to] inclusive battle-round window (default all rounds)
-#   approximate: the GDM source row had no exact card text for this component
-#   type "action" components are NOT implemented yet (bespoke marker/action
-#   mechanics) — they score nothing and are logged once per game.
+#   approximate: numbers/mechanics reconstructed from review text or the
+#   GDM summary table rather than exact card text.
 #
 # VP caps (GDM 2026): 45 primary total, 15 per turn.
 
@@ -67,10 +76,10 @@ static func _load_cards() -> void:
 	_add({
 		"id": "immovable_object", "name": "Immovable Object",
 		"deck": "take_and_hold", "played_vs": "purge_the_foe",
-		"approximate": true,
+		"approximate": true,  # review text; summary-table row differed in shape
 		"rules": [
-			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": false, "vp": 4, "approximate": true},
-			{"when": "command", "type": "hold_min", "min": 2, "exclude_home": false, "vp": 4, "approximate": true},
+			{"when": "eot", "type": "per_objective", "vp_per": 5, "exclude_home": true},
+			{"when": "eot", "type": "hold_central", "vp": 3},
 		],
 	})
 	_add({
@@ -80,7 +89,7 @@ static func _load_cards() -> void:
 		"rules": [
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 			{"when": "command", "type": "hold_more", "vp": 4},
-			{"when": "command", "type": "action", "action_name": "Kill on objectives / capture new"},
+			{"when": "eot", "type": "destroyed_started_on_objective", "vp": 2, "approximate": true},
 		],
 	})
 	_add({
@@ -112,7 +121,7 @@ static func _load_cards() -> void:
 		"rules": [
 			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
-			{"when": "command", "type": "hold_new", "vp": 3, "exclude_home": true, "approximate": true},
+			{"when": "eot", "type": "hold_new", "vp": 3, "exclude_home": true},
 			{"when": "eog", "type": "hold_central", "vp": 5},
 		],
 	})
@@ -129,9 +138,9 @@ static func _load_cards() -> void:
 	_add({
 		"id": "punishment", "name": "Punishment",
 		"deck": "purge_the_foe", "played_vs": "disruption",
-		"approximate": true,
+		"approximate": true,  # condemn auto-picked; 5 VP per review (table said 3)
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Condemn"},
+			{"when": "eot_any", "type": "condemned_left", "vp": 5},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 			{"when": "command", "type": "hold_more", "vp": 5},
 			{"when": "eog", "type": "hold_enemy_home", "vp": 8},
@@ -140,11 +149,11 @@ static func _load_cards() -> void:
 	_add({
 		"id": "consecrate", "name": "Consecrate",
 		"deck": "purge_the_foe", "played_vs": "reconnaissance",
-		"approximate": true,
+		"approximate": true,  # auto-resolved marker placement
 		"rules": [
-			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
-			{"when": "command", "type": "hold_more", "vp": 4},
-			{"when": "command", "type": "action", "action_name": "Consecrate"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "rounds": [2, 5]},
+			{"when": "eot", "type": "consecrated_count"},
+			{"when": "eog", "type": "consecrated_enemy_home", "vp": 5},
 		],
 	})
 	_add({
@@ -172,18 +181,18 @@ static func _load_cards() -> void:
 	_add({
 		"id": "triangulation", "name": "Triangulation",
 		"deck": "reconnaissance", "played_vs": "purge_the_foe",
-		"approximate": true,
+		"approximate": true,  # Triangulate target auto-picked
 		"rules": [
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
-			{"when": "eot", "type": "action", "action_name": "Triangulate"},
+			{"when": "eot", "type": "triangulated_count"},
 		],
 	})
 	_add({
 		"id": "gather_intel", "name": "Gather Intel",
 		"deck": "reconnaissance", "played_vs": "reconnaissance",
-		"approximate": true,
+		"approximate": true,  # extract auto-completed for units in range
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Extract Intelligence"},
+			{"when": "eot", "type": "intel_tokens_placed", "vp_per": 7, "rounds": [2, 5]},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
 		],
 	})
@@ -192,16 +201,18 @@ static func _load_cards() -> void:
 		"deck": "reconnaissance", "played_vs": "priority_assets",
 		"approximate": true,
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Sweep operation markers"},
-			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
+			{"when": "command", "type": "hold_central", "vp": 3},
+			{"when": "eot", "type": "destroyed_in_terrain_area", "vp": 2, "approximate": true},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eog", "type": "no_enemy_wholly_in_my_dz", "vp": 5},
 		],
 	})
 	_add({
 		"id": "surveil_the_foe", "name": "Surveil the Foe",
 		"deck": "reconnaissance", "played_vs": "disruption",
-		"approximate": true,
+		"approximate": true,  # Surveil-tag VP not published; decoy-scrub side modelled
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Surveil / scrub decoys"},
+			{"when": "eot", "type": "no_enemy_markers", "vp": 5},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
 		],
 	})
@@ -210,9 +221,10 @@ static func _load_cards() -> void:
 	_add({
 		"id": "secure_asset", "name": "Secure Asset",
 		"deck": "priority_assets", "played_vs": "take_and_hold",
-		"approximate": true,
+		"approximate": true,  # Secure Asset auto-completes on controlled non-home
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Secure Asset"},
+			{"when": "eot", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eot", "type": "destroyed_near_central", "vp": 2},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 			{"when": "command", "type": "hold_min", "min": 3, "exclude_home": true, "vp": 4},
 		],
@@ -220,9 +232,9 @@ static func _load_cards() -> void:
 	_add({
 		"id": "vital_link", "name": "Vital Link",
 		"deck": "priority_assets", "played_vs": "purge_the_foe",
-		"approximate": true,
+		"approximate": true,  # marker action auto-completes while central is held
 		"rules": [
-			{"when": "command", "type": "hold_central", "vp": 2, "approximate": true},
+			{"when": "eot", "type": "central_operation_markers", "vp": 2, "vp_per_marker": 1},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 			{"when": "command", "type": "hold_central", "vp": 4},
 			{"when": "eog", "type": "hold_enemy_home", "vp": 10},
@@ -231,9 +243,9 @@ static func _load_cards() -> void:
 	_add({
 		"id": "vanguard_operation", "name": "Vanguard Operation",
 		"deck": "priority_assets", "played_vs": "reconnaissance",
-		"approximate": true,
+		"approximate": true,  # enemy territory approximated by deployment zone
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Vanguard Op"},
+			{"when": "eot", "type": "vanguard_terrain_area", "vp": 4},
 			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 2},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 			{"when": "eog", "type": "hold_enemy_home", "vp": 10},
@@ -242,19 +254,21 @@ static func _load_cards() -> void:
 	_add({
 		"id": "sabotage", "name": "Sabotage",
 		"deck": "priority_assets", "played_vs": "priority_assets",
-		"approximate": true,
+		"approximate": true,  # Sabotage auto-completes on controlled non-home
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Sabotage"},
+			{"when": "eot", "type": "sabotage_per_objective", "vp_per": 3, "enemy_territory_bonus": 2},
 			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 		],
 	})
 	_add({
 		"id": "extract_relic", "name": "Extract Relic",
 		"deck": "priority_assets", "played_vs": "disruption",
-		"approximate": true,
+		"approximate": true,  # marker placement + sweeps auto-resolved
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Sensor Sweep"},
-			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3, "approximate": true},
+			{"when": "eot", "type": "sensor_sweep_vp", "vp": 4},
+			{"when": "eot", "type": "relic_final_marker", "vp": 4},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eog", "type": "relic_final_marker", "vp": 5},
 		],
 	})
 
@@ -262,9 +276,9 @@ static func _load_cards() -> void:
 	_add({
 		"id": "death_trap", "name": "Death Trap",
 		"deck": "disruption", "played_vs": "take_and_hold",
-		"approximate": true,
+		"approximate": true,  # trap eligibility/auto-pick simplified
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Booby Trap"},
+			{"when": "eot", "type": "trapped_score", "vp_per": 2, "objective_bonus": 3},
 		],
 	})
 	_add({
@@ -288,17 +302,21 @@ static func _load_cards() -> void:
 	_add({
 		"id": "smoke_and_mirrors", "name": "Smoke and Mirrors",
 		"deck": "disruption", "played_vs": "reconnaissance",
-		"approximate": true,
+		"approximate": true,  # decoy placement/removal auto-resolved
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Decoy markers"},
+			{"when": "eot", "type": "decoyed_score", "vp_per": 2, "enemy_territory_bonus": 2},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "rounds": [2, 5]},
+			{"when": "eog", "type": "decoyed_total_eog", "min": 4, "vp": 10},
 		],
 	})
 	_add({
 		"id": "locate_and_deny", "name": "Locate and Deny",
 		"deck": "disruption", "played_vs": "priority_assets",
-		"approximate": true,
+		"approximate": true,  # shares the relic markers with Extract Relic
 		"rules": [
-			{"when": "command", "type": "action", "action_name": "Locate and Deny"},
+			{"when": "eot", "type": "destroyed_started_on_objective", "vp": 4},
+			{"when": "eot", "type": "relic_final_marker", "vp": 4},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
 		],
 	})
 

--- a/40k/scripts/data/PrimaryMissionData11e.gd
+++ b/40k/scripts/data/PrimaryMissionData11e.gd
@@ -1,0 +1,336 @@
+extends RefCounted
+class_name PrimaryMissionData11e
+
+# 11th-edition (GDM 2026) primary missions — Force Disposition pairing system.
+# Source: docs/rules/11th_edition_missions_gdm2026.md (provided by the project
+# owner; card images at gdmissions.app/11th).
+#
+# Each player picks a Force Disposition before the game. The primary mission
+# card each player scores is determined by THEIR deck paired against the
+# OPPONENT's disposition — so the two players usually play different cards.
+#
+# Rule dict schema (consumed by MissionManager._score_primary_11e):
+#   when: "command" — scored at the end of your Command phase (GDM: switches
+#                     to end of turn in battle round 5)
+#         "eot"     — scored at the end of your turn
+#         "eog"     — scored once at the end of the game
+#   type: hold_min | per_objective | hold_more | hold_enemy_home |
+#         hold_central | hold_central_plus_nml | hold_new | destroyed_min |
+#         destroyed_per_unit | killed_more_than_opponent_last_turn |
+#         quarters | action
+#   vp / vp_per / vp_by_round: victory points awarded
+#   rounds: [from, to] inclusive battle-round window (default all rounds)
+#   approximate: the GDM source row had no exact card text for this component
+#   type "action" components are NOT implemented yet (bespoke marker/action
+#   mechanics) — they score nothing and are logged once per game.
+#
+# VP caps (GDM 2026): 45 primary total, 15 per turn.
+
+const MAX_PRIMARY_VP_11E: int = 45
+const MAX_PRIMARY_VP_PER_TURN_11E: int = 15
+
+const DISPOSITIONS := [
+	"take_and_hold",
+	"purge_the_foe",
+	"reconnaissance",
+	"priority_assets",
+	"disruption",
+]
+
+const DISPOSITION_NAMES := {
+	"take_and_hold": "Take and Hold",
+	"purge_the_foe": "Purge the Foe",
+	"reconnaissance": "Reconnaissance",
+	"priority_assets": "Priority Assets",
+	"disruption": "Disruption",
+}
+
+static var _cards: Dictionary = {}
+
+static func _ensure_loaded() -> void:
+	if _cards.is_empty():
+		_load_cards()
+
+static func _add(card: Dictionary) -> void:
+	_cards["%s|%s" % [card["deck"], card["played_vs"]]] = card
+
+static func _load_cards() -> void:
+	# ---- Take and Hold deck ----
+	_add({
+		"id": "battlefield_dominance", "name": "Battlefield Dominance",
+		"deck": "take_and_hold", "played_vs": "take_and_hold",
+		"rules": [
+			{"when": "command", "type": "hold_more", "vp": 2, "rounds": [1, 2]},
+			{"when": "command", "type": "per_objective", "vp_per": 3, "exclude_home": false, "rounds": [2, 5]},
+		],
+	})
+	_add({
+		"id": "immovable_object", "name": "Immovable Object",
+		"deck": "take_and_hold", "played_vs": "purge_the_foe",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": false, "vp": 4, "approximate": true},
+			{"when": "command", "type": "hold_min", "min": 2, "exclude_home": false, "vp": 4, "approximate": true},
+		],
+	})
+	_add({
+		"id": "purge_and_secure", "name": "Purge and Secure",
+		"deck": "take_and_hold", "played_vs": "reconnaissance",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_more", "vp": 4},
+			{"when": "command", "type": "action", "action_name": "Kill on objectives / capture new"},
+		],
+	})
+	_add({
+		"id": "inescapable_dominion", "name": "Inescapable Dominion",
+		"deck": "take_and_hold", "played_vs": "priority_assets",
+		"approximate": true,  # card assumes 6-objective maps; ours have 5
+		"rules": [
+			{"when": "eot", "type": "hold_min", "min": 3, "exclude_home": false, "vp": 4},
+			{"when": "command", "type": "hold_min", "min": 2, "exclude_home": false, "vp": 5},
+			{"when": "command", "type": "hold_more", "vp": 4},
+			{"when": "eog", "type": "hold_enemy_home", "vp": 5},
+		],
+	})
+	_add({
+		"id": "determined_acquisition", "name": "Determined Acquisition",
+		"deck": "take_and_hold", "played_vs": "disruption",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_new", "vp": 2, "exclude_home": true, "approximate": true},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "zone": "not_enemy_territory", "vp": 3},
+			{"when": "command", "type": "hold_min", "min": 1, "zone": "enemy_territory", "vp": 6},
+		],
+	})
+
+	# ---- Purge the Foe deck ----
+	_add({
+		"id": "unstoppable_force", "name": "Unstoppable Force",
+		"deck": "purge_the_foe", "played_vs": "take_and_hold",
+		"rules": [
+			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_new", "vp": 3, "exclude_home": true, "approximate": true},
+			{"when": "eog", "type": "hold_central", "vp": 5},
+		],
+	})
+	_add({
+		"id": "meatgrinder", "name": "Meatgrinder",
+		"deck": "purge_the_foe", "played_vs": "purge_the_foe",
+		"rules": [
+			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eot", "type": "killed_more_than_opponent_last_turn", "vp": 4},
+			{"when": "eog", "type": "hold_enemy_home", "vp": 5, "approximate": true},
+		],
+	})
+	_add({
+		"id": "punishment", "name": "Punishment",
+		"deck": "purge_the_foe", "played_vs": "disruption",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Condemn"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_more", "vp": 5},
+			{"when": "eog", "type": "hold_enemy_home", "vp": 8},
+		],
+	})
+	_add({
+		"id": "consecrate", "name": "Consecrate",
+		"deck": "purge_the_foe", "played_vs": "reconnaissance",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_more", "vp": 4},
+			{"when": "command", "type": "action", "action_name": "Consecrate"},
+		],
+	})
+	_add({
+		"id": "destroyers_wrath", "name": "Destroyer's Wrath",
+		"deck": "purge_the_foe", "played_vs": "priority_assets",
+		"rules": [
+			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_more", "vp": 4},
+			{"when": "eot", "type": "killed_more_than_opponent_last_turn", "vp": 5},
+		],
+	})
+
+	# ---- Reconnaissance deck ----
+	_add({
+		"id": "reconnaissance_sweep", "name": "Reconnaissance Sweep",
+		"deck": "reconnaissance", "played_vs": "take_and_hold",
+		"approximate": true,
+		"rules": [
+			{"when": "eot", "type": "quarters", "min": 3, "vp": 6, "approximate": true},
+			{"when": "eot", "type": "destroyed_per_unit", "vp_per": 1},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
+		],
+	})
+	_add({
+		"id": "triangulation", "name": "Triangulation",
+		"deck": "reconnaissance", "played_vs": "purge_the_foe",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eot", "type": "action", "action_name": "Triangulate"},
+		],
+	})
+	_add({
+		"id": "gather_intel", "name": "Gather Intel",
+		"deck": "reconnaissance", "played_vs": "reconnaissance",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Extract Intelligence"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
+		],
+	})
+	_add({
+		"id": "search_and_scour", "name": "Search and Scour",
+		"deck": "reconnaissance", "played_vs": "priority_assets",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Sweep operation markers"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
+		],
+	})
+	_add({
+		"id": "surveil_the_foe", "name": "Surveil the Foe",
+		"deck": "reconnaissance", "played_vs": "disruption",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Surveil / scrub decoys"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4, "approximate": true},
+		],
+	})
+
+	# ---- Priority Assets deck ----
+	_add({
+		"id": "secure_asset", "name": "Secure Asset",
+		"deck": "priority_assets", "played_vs": "take_and_hold",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Secure Asset"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_min", "min": 3, "exclude_home": true, "vp": 4},
+		],
+	})
+	_add({
+		"id": "vital_link", "name": "Vital Link",
+		"deck": "priority_assets", "played_vs": "purge_the_foe",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "hold_central", "vp": 2, "approximate": true},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_central", "vp": 4},
+			{"when": "eog", "type": "hold_enemy_home", "vp": 10},
+		],
+	})
+	_add({
+		"id": "vanguard_operation", "name": "Vanguard Operation",
+		"deck": "priority_assets", "played_vs": "reconnaissance",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Vanguard Op"},
+			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 2},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "eog", "type": "hold_enemy_home", "vp": 10},
+		],
+	})
+	_add({
+		"id": "sabotage", "name": "Sabotage",
+		"deck": "priority_assets", "played_vs": "priority_assets",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Sabotage"},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+		],
+	})
+	_add({
+		"id": "extract_relic", "name": "Extract Relic",
+		"deck": "priority_assets", "played_vs": "disruption",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Sensor Sweep"},
+			{"when": "eot", "type": "destroyed_min", "min": 1, "vp": 3, "approximate": true},
+		],
+	})
+
+	# ---- Disruption deck ----
+	_add({
+		"id": "death_trap", "name": "Death Trap",
+		"deck": "disruption", "played_vs": "take_and_hold",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Booby Trap"},
+		],
+	})
+	_add({
+		"id": "delaying_action", "name": "Delaying Action",
+		"deck": "disruption", "played_vs": "purge_the_foe",
+		"rules": [
+			{"when": "eot", "type": "destroyed_per_unit", "vp_per": 2},
+			{"when": "command", "type": "hold_min", "min": 1, "exclude_home": true, "vp": 4},
+			{"when": "command", "type": "hold_central_plus_nml", "vp": 3},
+		],
+	})
+	_add({
+		"id": "outmanoeuvre", "name": "Outmanoeuvre",
+		"deck": "disruption", "played_vs": "disruption",
+		"rules": [
+			{"when": "command", "type": "hold_enemy_home", "vp": 10},
+			{"when": "command", "type": "per_objective", "exclude_home": true,
+				"vp_by_round": {1: 4, 2: 5, 3: 5, 4: 6, 5: 6}},
+		],
+	})
+	_add({
+		"id": "smoke_and_mirrors", "name": "Smoke and Mirrors",
+		"deck": "disruption", "played_vs": "reconnaissance",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Decoy markers"},
+		],
+	})
+	_add({
+		"id": "locate_and_deny", "name": "Locate and Deny",
+		"deck": "disruption", "played_vs": "priority_assets",
+		"approximate": true,
+		"rules": [
+			{"when": "command", "type": "action", "action_name": "Locate and Deny"},
+		],
+	})
+
+# ============================================================================
+# PUBLIC API
+# ============================================================================
+
+## The primary mission card a player plays: their own deck paired against the
+## opponent's disposition. Returns {} for unknown dispositions.
+static func get_card(own_disposition: String, opponent_disposition: String) -> Dictionary:
+	_ensure_loaded()
+	var key := "%s|%s" % [own_disposition, opponent_disposition]
+	if not _cards.has(key):
+		return {}
+	return _cards[key].duplicate(true)
+
+static func get_card_by_id(card_id: String) -> Dictionary:
+	_ensure_loaded()
+	for key in _cards:
+		if _cards[key].get("id", "") == card_id:
+			return _cards[key].duplicate(true)
+	return {}
+
+static func get_all_cards() -> Array:
+	_ensure_loaded()
+	var out := []
+	for key in _cards:
+		out.append(_cards[key].duplicate(true))
+	return out
+
+static func is_valid_disposition(disposition: String) -> bool:
+	return disposition in DISPOSITIONS
+
+static func get_disposition_name(disposition: String) -> String:
+	return DISPOSITION_NAMES.get(disposition, disposition)

--- a/40k/scripts/data/PrimaryMissionData11e.gd.uid
+++ b/40k/scripts/data/PrimaryMissionData11e.gd.uid
@@ -1,0 +1,1 @@
+uid://dg8nkodfogqaq

--- a/40k/scripts/data/SecondaryMissionData.gd
+++ b/40k/scripts/data/SecondaryMissionData.gd
@@ -395,11 +395,11 @@ static func _load_missions() -> void:
 		"category": "Purge the Enemy",
 		"edition": 11,
 		"approximate": true,
-		"description": "Destroy a high-value enemy unit (approx.: 100+ points, or any 10+ wound model).",
+		"description": "Destroy an enemy unit with a Starting Strength of 13+ models (replaces Cull the Horde; VP value approximate).",
 		"scoring": {
 			"when": TIMING_END_OF_EITHER_TURN,
 			"conditions": [
-				{"check": "high_value_unit_destroyed_this_turn", "params": {"min_points": 100, "min_wounds": 10}, "vp": 5},
+				{"check": "high_value_unit_destroyed_this_turn", "params": {"min_models": 13}, "vp": 5},
 			],
 		},
 		"requires_action": false,
@@ -414,7 +414,7 @@ static func _load_missions() -> void:
 		"category": "Battlefield Supremacy",
 		"edition": 11,
 		"approximate": true,
-		"description": "Control your opponent's home objective (the both-Expansion-objectives alternative awaits Home/Expansion designations).",
+		"description": "Control your opponent's home objective, or both Expansion objectives.",
 		"scoring": {
 			"when": TIMING_END_OF_YOUR_TURN,
 			"conditions": [
@@ -473,16 +473,15 @@ static func _load_missions() -> void:
 		"category": "Shadow Operations",
 		"edition": 11,
 		"approximate": true,
-		"description": "Plant a beacon in enemy territory (approx.: Deploy-Teleport-Homer-style action).",
+		"description": "Your Beacon unit survives to the end of your opponent's turn outside your deployment zone (Beacon pick auto-resolved: any qualifying unit).",
 		"scoring": {
-			"when": TIMING_END_OF_YOUR_TURN,
+			"when": TIMING_END_OF_OPPONENT_TURN,
 			"conditions": [
-				{"check": "teleport_homer_deployed_in_opponent_zone", "params": {"action_name": "Plant Beacon"}, "vp": 5},
-				{"check": "teleport_homer_deployed_not_in_opponent_zone", "params": {"action_name": "Plant Beacon"}, "vp": 3},
+				{"check": "unit_outside_own_dz", "params": {"exclude": ["Battle-shocked"]}, "vp": 5},
 			],
 		},
-		"requires_action": true,
-		"action": {"name": "Plant Beacon", "phase": "shooting"},
+		"requires_action": false,
+		"action": {},
 		"when_drawn": {},
 	}
 
@@ -493,12 +492,12 @@ static func _load_missions() -> void:
 		"category": "Battlefield Supremacy",
 		"edition": 11,
 		"approximate": true,
-		"description": "Have units on the flanks (approx.: wholly within 6\" of a battlefield edge, outside your deployment zone).",
+		"description": "Units within 6\" of a battlefield edge outside your deployment zone: 3 VP for one edge, 5 VP for two.",
 		"scoring": {
 			"when": TIMING_END_OF_YOUR_TURN,
 			"conditions": [
-				{"check": "units_near_board_edges", "params": {"count": 2, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 5},
-				{"check": "units_near_board_edges", "params": {"count": 1, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 2},
+				{"check": "units_near_board_edges", "params": {"min_edges": 2, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 5},
+				{"check": "units_near_board_edges", "params": {"min_edges": 1, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 3},
 			],
 		},
 		"requires_action": false,

--- a/40k/scripts/data/SecondaryMissionData.gd
+++ b/40k/scripts/data/SecondaryMissionData.gd
@@ -380,6 +380,152 @@ static func _load_missions() -> void:
 		"when_drawn": {},
 	}
 
+	# ====================================================================
+	# 11e (GDM 2026) DECK ADDITIONS — source:
+	# docs/rules/11th_edition_missions_gdm2026.md. Cards whose full text
+	# was not published carry "approximate": true; their scoring is a
+	# minimal defensible reading of the summary line, to be replaced when
+	# the card text lands.
+	# ====================================================================
+
+	_missions["a_grievous_blow"] = {
+		"id": "a_grievous_blow",
+		"name": "A Grievous Blow",
+		"number": 19,
+		"category": "Purge the Enemy",
+		"edition": 11,
+		"approximate": true,
+		"description": "Destroy a high-value enemy unit (approx.: 100+ points, or any 10+ wound model).",
+		"scoring": {
+			"when": TIMING_END_OF_EITHER_TURN,
+			"conditions": [
+				{"check": "high_value_unit_destroyed_this_turn", "params": {"min_points": 100, "min_wounds": 10}, "vp": 5},
+			],
+		},
+		"requires_action": false,
+		"action": {},
+		"when_drawn": {},
+	}
+
+	_missions["forward_position"] = {
+		"id": "forward_position",
+		"name": "Forward Position",
+		"number": 20,
+		"category": "Battlefield Supremacy",
+		"edition": 11,
+		"approximate": true,
+		"description": "Control your opponent's home objective (the both-Expansion-objectives alternative awaits Home/Expansion designations).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "holds_enemy_home_objective", "params": {}, "vp": 5},
+			],
+		},
+		"requires_action": false,
+		"action": {},
+		"when_drawn": {"condition": "first_battle_round", "effect": EFFECT_SHUFFLE_BACK},
+	}
+
+	_missions["burden_of_trust"] = {
+		"id": "burden_of_trust",
+		"name": "Burden of Trust",
+		"number": 21,
+		"category": "Battlefield Supremacy",
+		"edition": 11,
+		"approximate": true,
+		"description": "Guard your objectives (approx.: hold 2+ objectives you already held at the start of the turn).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "objectives_held_since_turn_start", "params": {"count": 2}, "vp": 5},
+				{"check": "objectives_held_since_turn_start", "params": {"count": 1}, "vp": 2},
+			],
+		},
+		"requires_action": false,
+		"action": {},
+		"when_drawn": {},
+	}
+
+	_missions["centre_ground"] = {
+		"id": "centre_ground",
+		"name": "Centre Ground",
+		"number": 22,
+		"category": "Battlefield Supremacy",
+		"edition": 11,
+		"approximate": true,
+		"description": "Control the centre of the battlefield (replaces Area Denial).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "units_within_center_no_enemies_within", "params": {"friendly_range": 6.0, "enemy_range": 6.0, "exclude": ["Battle-shocked"]}, "vp": 5},
+				{"check": "units_within_center_no_enemies_within", "params": {"friendly_range": 6.0, "enemy_range": 3.0, "exclude": ["Battle-shocked"]}, "vp": 3},
+			],
+		},
+		"requires_action": false,
+		"action": {},
+		"when_drawn": {},
+	}
+
+	_missions["beacon"] = {
+		"id": "beacon",
+		"name": "Beacon",
+		"number": 23,
+		"category": "Shadow Operations",
+		"edition": 11,
+		"approximate": true,
+		"description": "Plant a beacon in enemy territory (approx.: Deploy-Teleport-Homer-style action).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "teleport_homer_deployed_in_opponent_zone", "params": {"action_name": "Plant Beacon"}, "vp": 5},
+				{"check": "teleport_homer_deployed_not_in_opponent_zone", "params": {"action_name": "Plant Beacon"}, "vp": 3},
+			],
+		},
+		"requires_action": true,
+		"action": {"name": "Plant Beacon", "phase": "shooting"},
+		"when_drawn": {},
+	}
+
+	_missions["outflank"] = {
+		"id": "outflank",
+		"name": "Outflank",
+		"number": 24,
+		"category": "Battlefield Supremacy",
+		"edition": 11,
+		"approximate": true,
+		"description": "Have units on the flanks (approx.: wholly within 6\" of a battlefield edge, outside your deployment zone).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "units_near_board_edges", "params": {"count": 2, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 5},
+				{"check": "units_near_board_edges", "params": {"count": 1, "edge_inches": 6.0, "exclude": ["Battle-shocked"]}, "vp": 2},
+			],
+		},
+		"requires_action": false,
+		"action": {},
+		"when_drawn": {},
+	}
+
+	_missions["plunder"] = {
+		"id": "plunder",
+		"name": "Plunder",
+		"number": 25,
+		"category": "Shadow Operations",
+		"edition": 11,
+		"approximate": true,
+		"description": "Loot objective markers by completing actions (approx.: Cleanse-style).",
+		"scoring": {
+			"when": TIMING_END_OF_YOUR_TURN,
+			"conditions": [
+				{"check": "objectives_cleansed", "params": {"count": 2, "action_name": "Plunder"}, "vp": 5},
+				{"check": "objectives_cleansed", "params": {"count": 1, "action_name": "Plunder"}, "vp": 2},
+			],
+		},
+		"requires_action": true,
+		"action": {"name": "Plunder", "phase": "shooting"},
+		"when_drawn": {},
+	}
+
 # ============================================================================
 # PUBLIC API
 # ============================================================================
@@ -388,6 +534,22 @@ static func get_mission_by_id(mission_id: String) -> Dictionary:
 	"""Get a single mission definition by ID. Returns empty dict if not found."""
 	_ensure_loaded()
 	return _missions.get(mission_id, {})
+
+## 11e (GDM 2026) 18-card tactical deck — the four returning-with-tweaks
+## cards keep their existing implementations; new cards are authored above.
+static func get_mission_ids_for_deck_11e() -> Array:
+	_ensure_loaded()
+	return [
+		"assassination", "a_grievous_blow", "bring_it_down", "engage_on_all_fronts",
+		"behind_enemy_lines", "no_prisoners", "cleanse", "defend_stronghold",
+		"overwhelming_force", "forward_position", "burden_of_trust", "centre_ground",
+		"a_tempting_target", "secure_no_mans_land", "beacon", "display_of_might",
+		"outflank", "plunder",
+	]
+
+## 11e Fixed mode: exactly these four cards are fixed-eligible.
+static func get_fixed_eligible_11e() -> Array:
+	return ["assassination", "a_grievous_blow", "bring_it_down", "engage_on_all_fronts"]
 
 static func get_mission_ids_for_deck(include_challenger: bool = false) -> Array:
 	"""Get the list of all mission IDs for building a tactical deck (18 cards)."""

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1933,6 +1933,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "autoloads.SecondaryMissionManager.deck_11e",
+      "description": "Tier-1 #2 (GDM 2026): the 18-card 11e tactical secondary deck (7 new cards authored from docs/rules/11th_edition_missions_gdm2026.md, retired 10e cards absent), built on first Command phase at e11.",
+      "scenarios": [
+        "iss063b_secondary_deck_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "rules.secondaries.gdm2026_draw_rules",
+      "description": "11e secondary rules: draw 2/turn with NO hand limit (10e cap preserved), Fixed restricted to the four fixed-eligible cards, 45 VP total + 15 VP/turn caps, discard-for-1CP intact from a grown hand.",
+      "scenarios": [
+        "iss063b_secondary_deck_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1969,6 +1969,15 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "ui.ScoringPanel.primary_missions_11e",
+      "description": "Tier-1 #1 UI surface: the Scoring-phase right panel shows each player's own disposition-paired 11e primary card (name + disposition, ~ for approximate source rows) instead of the shared 10e mission line.",
+      "scenarios": [
+        "iss064c_primary_mission_panel_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1,6 +1,6 @@
 {
   "$schema_version": 1,
-  "description": "Machine-readable coverage matrix for the windowed-scenario gate. Source of truth for what is verified — append-only AUDIT_REPORT.md is a generated narrative view. See SESSION_PLAYBOOK.md for the rules of the road.",
+  "description": "Machine-readable coverage matrix for the windowed-scenario gate. Source of truth for what is verified \u2014 append-only AUDIT_REPORT.md is a generated narrative view. See SESSION_PLAYBOOK.md for the rules of the road.",
   "$rules": [
     "A 'covered' tile must reference at least one scenario file under tests/scenarios/.",
     "Each tile's scenarios[] entries must exist as files; check_coverage.py enforces this.",
@@ -10,7 +10,7 @@
   "tiles": [
     {
       "id": "autoloads.EffectPrimitives.PLUS_CHARGE",
-      "description": "EffectPrimitives PLUS_CHARGE effect — sets effect_plus_charge flag on a unit",
+      "description": "EffectPrimitives PLUS_CHARGE effect \u2014 sets effect_plus_charge flag on a unit",
       "scenarios": [
         "372_ere_we_go_charge_modifier"
       ],
@@ -92,7 +92,7 @@
     },
     {
       "id": "autoloads.RulesEngine.validate_shoot",
-      "description": "RulesEngine: validates a SHOOT action against the current shooter state — eligibility, target legality, weapon assignments. Validated by '370_bgnt_vehicle_shoots_in_engagement (Big Guns Never Tire seam).",
+      "description": "RulesEngine: validates a SHOOT action against the current shooter state \u2014 eligibility, target legality, weapon assignments. Validated by '370_bgnt_vehicle_shoots_in_engagement (Big Guns Never Tire seam).",
       "scenarios": [
         "370_bgnt_vehicle_shoots_in_engagement"
       ],
@@ -137,7 +137,7 @@
     },
     {
       "id": "charge.modifier_primitive",
-      "description": "Charge-roll modifier flag (effect_plus_charge) honoured by DECLARE_CHARGE — 'ERE WE GO stratagem path",
+      "description": "Charge-roll modifier flag (effect_plus_charge) honoured by DECLARE_CHARGE \u2014 'ERE WE GO stratagem path",
       "scenarios": [
         "372_ere_we_go_charge_modifier"
       ],
@@ -264,7 +264,7 @@
     },
     {
       "id": "deployment.predeploy_roll_off",
-      "description": "Pre-deployment roll-off (issue #85): both players roll a D6. The winner chooses to be Attacker or Defender — Defender deploys first and takes the second turn, Attacker deploys second and takes the first turn.",
+      "description": "Pre-deployment roll-off (issue #85): both players roll a D6. The winner chooses to be Attacker or Defender \u2014 Defender deploys first and takes the second turn, Attacker deploys second and takes the first turn.",
       "scenarios": [
         "85_predeploy_rolloff"
       ],
@@ -318,7 +318,7 @@
     },
     {
       "id": "fight.self_targeting_fix",
-      "description": "Fight-phase AI does not select own units as melee targets — observational scenario captures before/after screenshots of AI fight decisions",
+      "description": "Fight-phase AI does not select own units as melee targets \u2014 observational scenario captures before/after screenshots of AI fight decisions",
       "scenarios": [
         "fight_self_targeting"
       ],
@@ -336,7 +336,7 @@
     },
     {
       "id": "fight.subphase_transition",
-      "description": "FIGHT phase: subphases (fights-first → normal → fights-last) transition correctly when no eligible fighters remain in the current subphase. Validated by 'fights_last_select_fighter.",
+      "description": "FIGHT phase: subphases (fights-first \u2192 normal \u2192 fights-last) transition correctly when no eligible fighters remain in the current subphase. Validated by 'fights_last_select_fighter.",
       "scenarios": [
         "fights_last_select_fighter"
       ],
@@ -363,7 +363,7 @@
     },
     {
       "id": "movement.da_jump_placement_bounds",
-      "description": "MOVEMENT phase: Da Jump teleports a unit to within 9\" of the warlord and ≥9\" from enemies. Bounds check rejects invalid placements. Validated by '376_da_jump_bounds.",
+      "description": "MOVEMENT phase: Da Jump teleports a unit to within 9\" of the warlord and \u22659\" from enemies. Bounds check rejects invalid placements. Validated by '376_da_jump_bounds.",
       "scenarios": [
         "376_da_jump_bounds"
       ],
@@ -408,7 +408,7 @@
     },
     {
       "id": "movement.terrain.infantry_ruin_traversal",
-      "description": "Regression guard: MovementPhase rejects ANY model drop whose base overlaps a wall segment at the final position — no unit may end its movement on top of a wall. Infantry may still pass through walls mid-move (path-traversal honors unit keywords); this guard covers only the endpoint rule. Reverses prior #431 interpretation that let INFANTRY end movement overlapping walls (observed broken in-game: Witchseekers sitting on the north wall of Grey Ruins). Validated by 'infantry_enters_ruin_wall.",
+      "description": "Regression guard: MovementPhase rejects ANY model drop whose base overlaps a wall segment at the final position \u2014 no unit may end its movement on top of a wall. Infantry may still pass through walls mid-move (path-traversal honors unit keywords); this guard covers only the endpoint rule. Reverses prior #431 interpretation that let INFANTRY end movement overlapping walls (observed broken in-game: Witchseekers sitting on the north wall of Grey Ruins). Validated by 'infantry_enters_ruin_wall.",
       "scenarios": [
         "infantry_enters_ruin_wall"
       ],
@@ -417,7 +417,7 @@
     },
     {
       "id": "multiplayer.deployment.host_to_client_sync",
-      "description": "Multi-peer deployment sync — host deploys, client mirrors positions and coherency state",
+      "description": "Multi-peer deployment sync \u2014 host deploys, client mirrors positions and coherency state",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_deployment.gd"
       ],
@@ -426,7 +426,7 @@
     },
     {
       "id": "multiplayer.dice.broadcast_sync",
-      "description": "Multi-peer dice broadcast — defender re-emits result.dice on remote (T5-MP5)",
+      "description": "Multi-peer dice broadcast \u2014 defender re-emits result.dice on remote (T5-MP5)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_dice_log_sync.gd"
       ],
@@ -435,7 +435,7 @@
     },
     {
       "id": "multiplayer.network.session",
-      "description": "Multi-peer network session lifecycle — host/join/disconnect, peer registration",
+      "description": "Multi-peer network session lifecycle \u2014 host/join/disconnect, peer registration",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_network.gd"
       ],
@@ -444,7 +444,7 @@
     },
     {
       "id": "multiplayer.save.broadcast_reliability",
-      "description": "Multi-peer save broadcast — broadcast_id + retry budget + dedupe (T5-MP4-RELIABILITY)",
+      "description": "Multi-peer save broadcast \u2014 broadcast_id + retry budget + dedupe (T5-MP4-RELIABILITY)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_save_dialog_retry.gd"
       ],
@@ -453,7 +453,7 @@
     },
     {
       "id": "multiplayer.shooting.visual_broadcast",
-      "description": "Multi-peer shooting visual broadcast — SELECT_SHOOTER/ASSIGN_TARGET/CONFIRM/COMPLETE (T5-MP3)",
+      "description": "Multi-peer shooting visual broadcast \u2014 SELECT_SHOOTER/ASSIGN_TARGET/CONFIRM/COMPLETE (T5-MP3)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_shooting_visuals.gd"
       ],
@@ -575,7 +575,7 @@
     },
     {
       "id": "phases.ScoutPhase.SET_SCOUT_MODEL_DEST.overlap_rejected",
-      "description": "Regression guard (#425): ScoutPhase._validate_set_scout_model_dest rejects a destination that overlaps a sibling model — either a sibling's already-staged scout-move position or an unmoved sibling's original position. A clearly non-overlapping destination still succeeds. Validated by 'scout_no_overlap.",
+      "description": "Regression guard (#425): ScoutPhase._validate_set_scout_model_dest rejects a destination that overlaps a sibling model \u2014 either a sibling's already-staged scout-move position or an unmoved sibling's original position. A clearly non-overlapping destination still succeeds. Validated by 'scout_no_overlap.",
       "scenarios": [
         "scout_no_overlap"
       ],
@@ -602,7 +602,7 @@
     },
     {
       "id": "rules.abilities.stealth_t2",
-      "description": "T2-1 — STEALTH ability: -1 to hit on ranged attacks vs Stealth target",
+      "description": "T2-1 \u2014 STEALTH ability: -1 to hit on ranged attacks vs Stealth target",
       "scenarios": [
         "mp:tests/test_stealth_keyword_pipeline.gd"
       ],
@@ -611,7 +611,7 @@
     },
     {
       "id": "rules.command.cp_gain_336",
-      "description": "Issue #336 — no CP on R1 first command phase; otherwise active player only",
+      "description": "Issue #336 \u2014 no CP on R1 first command phase; otherwise active player only",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -620,7 +620,7 @@
     },
     {
       "id": "rules.keywords.melta_x_t1",
-      "description": "T1-1 — MELTA X auto-resolves damage bonus at half range",
+      "description": "T1-1 \u2014 MELTA X auto-resolves damage bonus at half range",
       "scenarios": [
         "mp:tests/test_melta_keyword_pipeline.gd"
       ],
@@ -629,7 +629,7 @@
     },
     {
       "id": "rules.keywords.twin_linked_t1",
-      "description": "T1-2 — TWIN-LINKED re-rolls all failed wound rolls",
+      "description": "T1-2 \u2014 TWIN-LINKED re-rolls all failed wound rolls",
       "scenarios": [
         "mp:tests/test_twin_linked_pipeline.gd"
       ],
@@ -638,7 +638,7 @@
     },
     {
       "id": "rules.movement.base_touching_m6",
-      "description": "T2-M6 — base-touching regression (#321/#327)",
+      "description": "T2-M6 \u2014 base-touching regression (#321/#327)",
       "scenarios": [
         "mp:tests/test_m6_base_touching_regression.gd"
       ],
@@ -647,7 +647,7 @@
     },
     {
       "id": "rules.rng.determinism_329",
-      "description": "Issue #329 — RNGService.test_mode_seed produces identical dice across runs; new helpers (randi/randi_range/randf) honor it; TransportManager + MissionManager + Mathhammer plumbed",
+      "description": "Issue #329 \u2014 RNGService.test_mode_seed produces identical dice across runs; new helpers (randi/randi_range/randf) honor it; TransportManager + MissionManager + Mathhammer plumbed",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd",
         "mp:tests/test_rng_determinism_extended.gd"
@@ -657,7 +657,7 @@
     },
     {
       "id": "rules.save_load.autoload_state_338",
-      "description": "Issue #338 — FactionAbilityManager + StratagemManager state round-trips through save/load",
+      "description": "Issue #338 \u2014 FactionAbilityManager + StratagemManager state round-trips through save/load",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -666,7 +666,7 @@
     },
     {
       "id": "rules.shooting.cover_save_cap_s7",
-      "description": "T2-S7 — Cover save bonus capped: Sv3+ vs AP0 in cover stays 3+ (was 2+)",
+      "description": "T2-S7 \u2014 Cover save bonus capped: Sv3+ vs AP0 in cover stays 3+ (was 2+)",
       "scenarios": [
         "mp:tests/test_s7_cover_save_bonus.gd"
       ],
@@ -675,7 +675,7 @@
     },
     {
       "id": "rules.shooting.fall_back_and_shoot_override_356",
-      "description": "Issue #356 — Multipotentiality stratagem: effect_fall_back_and_shoot overrides cannot_shoot gate in ShootingPhase + RulesEngine.validate_shoot",
+      "description": "Issue #356 \u2014 Multipotentiality stratagem: effect_fall_back_and_shoot overrides cannot_shoot gate in ShootingPhase + RulesEngine.validate_shoot",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -684,7 +684,7 @@
     },
     {
       "id": "rules.shooting.keyword_pipeline",
-      "description": "T2-S4..S6 — SUSTAINED HITS / LETHAL HITS / DEVASTATING WOUNDS keyword pipelines",
+      "description": "T2-S4..S6 \u2014 SUSTAINED HITS / LETHAL HITS / DEVASTATING WOUNDS keyword pipelines",
       "scenarios": [
         "mp:tests/test_keyword_pipeline.gd"
       ],
@@ -693,7 +693,7 @@
     },
     {
       "id": "rules.stratagem.excluding_keyword_parser_359",
-      "description": "Issue #359 — FactionStratagemLoader._map_target correctly handles 'excluding X' as not_keyword:X (was incorrectly mapping to keyword:X). Affects 'ARD AS NAILS, UNWAVERING SENTINELS, ARCHEOTECH MUNITIONS",
+      "description": "Issue #359 \u2014 FactionStratagemLoader._map_target correctly handles 'excluding X' as not_keyword:X (was incorrectly mapping to keyword:X). Affects 'ARD AS NAILS, UNWAVERING SENTINELS, ARCHEOTECH MUNITIONS",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -1711,7 +1711,7 @@
     },
     {
       "id": "autoloads.CharacterAttachmentManager.attachment_role",
-      "description": "attachment_role derives 'support' from the datasheet Support ability (ISS-059), 'leader' otherwise — driven live via the shipped orks.json Bannernob.",
+      "description": "attachment_role derives 'support' from the datasheet Support ability (ISS-059), 'leader' otherwise \u2014 driven live via the shipped orks.json Bannernob.",
       "scenarios": [
         "iss059b_support_attach_11e"
       ],
@@ -1792,7 +1792,7 @@
     },
     {
       "id": "phases.ScoutPhase.UI.reserve_scout_list_select_place_confirm",
-      "description": "ISS-067 UI: reserve scout appears in the Scout-phase unit list; select → place → confirm flow works through the real panel.",
+      "description": "ISS-067 UI: reserve scout appears in the Scout-phase unit list; select \u2192 place \u2192 confirm flow works through the real panel.",
       "scenarios": [
         "iss067_scout_reserves_deploy_11e"
       ],
@@ -1801,7 +1801,7 @@
     },
     {
       "id": "autoloads.TerrainManager.detection_range_inches_for",
-      "description": "Audit Tier-1 #4: per-observer effective detection range for hidden models — datasheet base, Gone to Ground −3\", 9\" floor — consumed by hidden_model_visible_to in the live targeting path.",
+      "description": "Audit Tier-1 #4: per-observer effective detection range for hidden models \u2014 datasheet base, Gone to Ground \u22123\", 9\" floor \u2014 consumed by hidden_model_visible_to in the live targeting path.",
       "scenarios": [
         "iss052b_gone_to_ground_11e"
       ],
@@ -1882,7 +1882,7 @@
     },
     {
       "id": "ui.ShootingController.ability_choice_dialog",
-      "description": "Audit #17: assigning a [DEVASTATING WOUNDS] weapon at e11 pops the AbilityChoiceDialog — DW mortal-wound conversion (default on) and, when combined, LETHAL HITS auto-wound (default off, preserving the Devastating trigger).",
+      "description": "Audit #17: assigning a [DEVASTATING WOUNDS] weapon at e11 pops the AbilityChoiceDialog \u2014 DW mortal-wound conversion (default on) and, when combined, LETHAL HITS auto-wound (default off, preserving the Devastating trigger).",
       "scenarios": [
         "iss047c_ability_choice_prompts_11e"
       ],
@@ -1918,7 +1918,7 @@
     },
     {
       "id": "phases.MovementPhase.surge_move_21_02",
-      "description": "Audit #8: BEGIN_SURGE_MOVE at e11 routes through the SurgeMove template — stated distance (payload.max_inches or the 'Surge X\"' datasheet ability, no D6), closest enemy recorded as the surge target, template eligibility gates; 10e D6 semantics untouched.",
+      "description": "Audit #8: BEGIN_SURGE_MOVE at e11 routes through the SurgeMove template \u2014 stated distance (payload.max_inches or the 'Surge X\"' datasheet ability, no D6), closest enemy recorded as the surge target, template eligibility gates; 10e D6 semantics untouched.",
       "scenarios": [
         "iss040b_surge_move_11e"
       ],
@@ -1948,6 +1948,24 @@
       "description": "11e secondary rules: draw 2/turn with NO hand limit (10e cap preserved), Fixed restricted to the four fixed-eligible cards, 45 VP total + 15 VP/turn caps, discard-for-1CP intact from a grown hand.",
       "scenarios": [
         "iss063b_secondary_deck_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "missions.primary_11e.disposition_pairing",
+      "description": "Tier-1 #1 (GDM 2026): Force Disposition selection resolves each player's primary mission card from the 25-entry pairing table (own deck vs opponent disposition) via meta.game_config in MissionManager.initialize_mission at e11.",
+      "scenarios": [
+        "iss064b_primary_disposition_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "missions.primary_11e.command_scoring",
+      "description": "Tier-1 #1 (GDM 2026): 11e primary command-phase scoring \u2014 END_COMMAND live-scores the active player's own card conditions (hold non-home, hold-new) with the 15/turn window; caps 45 total. R5 EOT switch + EOG conditions covered headless (test_primary_missions_11e.gd).",
+      "scenarios": [
+        "iss064b_primary_disposition_11e"
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -108,6 +108,7 @@ TESTS=(
     "tests/test_iss059_attached_units_11e.gd"
     "tests/test_secondary_deck_11e.gd"
     "tests/test_primary_missions_11e.gd"
+    "tests/test_gdm_sourced_11e.gd"
     "tests/test_iss029_golden_replay.gd"
     "tests/test_iss064_fallback_no_double_hazard.gd"
     "tests/test_iss065_at_half_battleshock.gd"

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -106,6 +106,7 @@ TESTS=(
     "tests/test_iss048_shooting_types_11e.gd"
     "tests/test_iss050_fight_phase_11e.gd"
     "tests/test_iss059_attached_units_11e.gd"
+    "tests/test_secondary_deck_11e.gd"
     "tests/test_iss029_golden_replay.gd"
     "tests/test_iss064_fallback_no_double_hazard.gd"
     "tests/test_iss065_at_half_battleshock.gd"

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -107,6 +107,7 @@ TESTS=(
     "tests/test_iss050_fight_phase_11e.gd"
     "tests/test_iss059_attached_units_11e.gd"
     "tests/test_secondary_deck_11e.gd"
+    "tests/test_primary_missions_11e.gd"
     "tests/test_iss029_golden_replay.gd"
     "tests/test_iss064_fallback_no_double_hazard.gd"
     "tests/test_iss065_at_half_battleshock.gd"

--- a/40k/tests/scenarios/sp/iss063b_secondary_deck_11e.json
+++ b/40k/tests/scenarios/sp/iss063b_secondary_deck_11e.json
@@ -1,0 +1,76 @@
+{
+  "id": "iss063b_secondary_deck_11e",
+  "covers": [
+    "autoloads.SecondaryMissionManager.deck_11e",
+    "rules.secondaries.gdm2026_draw_rules"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "description": "Tier-1 #2 (GDM 2026 secondaries): entering the Command phase at e11 builds the 18-card GDM tactical deck and draws 2; re-entering draws 2 MORE (no hand limit — 10e capped the hand at 2). The deck contains the new GDM cards and none of the retired 10e cards; the discard-for-1CP flow still works from the grown hand.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 6
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"deck\"].size() + SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size()",
+      "equals": 18
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size()",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"deck\"]) .contains(\"plunder\") or str(SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"]).contains(\"plunder\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"deck\"]).contains(\"area_denial\")",
+      "equals": false
+    },
+    {
+      "act": "screenshot",
+      "label": "01_first_command_draw_two"
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager.draw_missions_to_hand(GameState.get_active_player()).size()",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size()",
+      "equals": 4
+    },
+    {
+      "act": "screenshot",
+      "label": "02_no_hand_limit_hand_of_four"
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager.voluntary_discard(GameState.get_active_player(), 0)[\"success\"]",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size()",
+      "equals": 3
+    },
+    {
+      "act": "screenshot",
+      "label": "03_discard_for_cp_from_grown_hand"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss064b_primary_disposition_11e.json
+++ b/40k/tests/scenarios/sp/iss064b_primary_disposition_11e.json
@@ -1,0 +1,55 @@
+{
+  "id": "iss064b_primary_disposition_11e",
+  "covers": [
+    "missions.primary_11e.disposition_pairing",
+    "missions.primary_11e.command_scoring"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "description": "Audit Tier-1 #1 (GDM 2026 Force Dispositions): each player's primary mission is their own deck paired against the opponent's disposition. P1 Take and Hold vs P2 Purge the Foe resolves to Immovable Object (P1) and Unstoppable Force (P2) via the meta.game_config path in initialize_mission. Turn-start control is snapshotted while P2 only holds obj_nml_2; then the P1 centre garrison (Caladius OC4 + Contemptor OC3) withdraws and Boyz K capture obj_center. END_COMMAND live-scores P2's Unstoppable Force command conditions: 4VP (hold 1+ non-home) + 3VP (obj_center was not held at turn start) = 7 primary VP, while P1 scores nothing.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "GameState.state[\"meta\"].merge({\"game_config\": {\"deployment\": \"search_and_destroy\", \"player1_disposition\": \"take_and_hold\", \"player2_disposition\": \"purge_the_foe\"}}, true)" },
+    { "act": "execute_script", "script": "MissionManager.initialize_mission(\"take_and_hold\")" },
+    { "act": "execute_script",
+      "script": "MissionManager.get_primary_mission_for_player(2)[\"id\"]",
+      "equals": "unstoppable_force" },
+    { "act": "execute_script",
+      "script": "MissionManager.get_primary_mission_for_player(1)[\"id\"]",
+      "equals": "immovable_object" },
+
+    { "act": "execute_script", "script": "MissionManager.check_all_objectives()" },
+    { "act": "execute_script", "script": "MissionManager.on_turn_start_11e(2)" },
+    { "act": "execute_script",
+      "script": "\"obj_center\" in MissionManager._control_at_turn_start[\"2\"]",
+      "equals": false },
+
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_CALADIUS_GRAV-TANK_E\")[\"models\"][0].merge({\"position\": {\"x\": 200.0, \"y\": 300.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\")[\"models\"][0].merge({\"position\": {\"x\": 320.0, \"y\": 300.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BOYZ_K\")[\"models\"][0].merge({\"position\": {\"x\": 900.0, \"y\": 1180.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BOYZ_K\")[\"models\"][1].merge({\"position\": {\"x\": 860.0, \"y\": 1220.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BOYZ_K\")[\"models\"][2].merge({\"position\": {\"x\": 910.0, \"y\": 1230.0}}, true)" },
+    { "act": "execute_script", "script": "MissionManager.check_all_objectives()" },
+    { "act": "execute_script",
+      "script": "MissionManager.objective_control_state[\"obj_center\"]",
+      "equals": 2 },
+    { "act": "screenshot", "label": "01_boyz_on_centre_objective" },
+
+    { "act": "dispatch_action", "action": { "type": "END_COMMAND" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "expect_state", "path": "players.2.primary_vp", "equals": 7 },
+    { "act": "expect_state", "path": "players.1.primary_vp", "equals": 0 },
+    { "act": "execute_script",
+      "script": "int(MissionManager._primary_vp_this_turn[\"2\"])",
+      "equals": 7 },
+    { "act": "screenshot", "label": "02_unstoppable_force_scored_7vp" }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss064b_primary_disposition_11e.json
+++ b/40k/tests/scenarios/sp/iss064b_primary_disposition_11e.json
@@ -9,7 +9,7 @@
   "rng_seed": 42,
   "transition_to_phase": 6,
   "disable_ai": true,
-  "description": "Audit Tier-1 #1 (GDM 2026 Force Dispositions): each player's primary mission is their own deck paired against the opponent's disposition. P1 Take and Hold vs P2 Purge the Foe resolves to Immovable Object (P1) and Unstoppable Force (P2) via the meta.game_config path in initialize_mission. Turn-start control is snapshotted while P2 only holds obj_nml_2; then the P1 centre garrison (Caladius OC4 + Contemptor OC3) withdraws and Boyz K capture obj_center. END_COMMAND live-scores P2's Unstoppable Force command conditions: 4VP (hold 1+ non-home) + 3VP (obj_center was not held at turn start) = 7 primary VP, while P1 scores nothing.",
+  "description": "Audit Tier-1 #1 (GDM 2026 Force Dispositions): each player plays their own deck paired against the opponent disposition. P1 Take and Hold vs P2 Purge the Foe resolves to Immovable Object (P1) and Unstoppable Force (P2) via the meta.game_config path. Turn-start control snapshotted while P2 only holds obj_nml_2; the P1 centre garrison withdraws and Boyz K capture obj_center. END_COMMAND scores the command condition (4VP hold 1+ non-home); the sourced card text puts hold-new at end of turn, so the EOT pass adds 3VP for the freshly captured obj_center = 7 total, P1 scores nothing.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 6 },
@@ -45,8 +45,11 @@
     { "act": "dispatch_action", "action": { "type": "END_COMMAND" } },
     { "act": "expect_action_result", "path": "success", "equals": true },
 
-    { "act": "expect_state", "path": "players.2.primary_vp", "equals": 7 },
+    { "act": "expect_state", "path": "players.2.primary_vp", "equals": 4 },
     { "act": "expect_state", "path": "players.1.primary_vp", "equals": 0 },
+
+    { "act": "execute_script", "script": "MissionManager.score_primary_eot_11e(2)" },
+    { "act": "expect_state", "path": "players.2.primary_vp", "equals": 7 },
     { "act": "execute_script",
       "script": "int(MissionManager._primary_vp_this_turn[\"2\"])",
       "equals": 7 },

--- a/40k/tests/scenarios/sp/iss064c_primary_mission_panel_11e.json
+++ b/40k/tests/scenarios/sp/iss064c_primary_mission_panel_11e.json
@@ -1,0 +1,32 @@
+{
+  "id": "iss064c_primary_mission_panel_11e",
+  "covers": [
+    "ui.ScoringPanel.primary_missions_11e"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 11,
+  "disable_ai": true,
+  "description": "Audit Tier-1 #1 UI surface (GDM 2026): at e11 the Scoring-phase right panel shows each player's OWN disposition-paired primary card instead of the shared 10e mission name. P1 Priority Assets vs P2 Purge the Foe pairs to Vital Link (flagged ~ approximate) and Destroyer's Wrath; the panel rebuild renders both named labels with the exact card + disposition text.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 11 },
+
+    { "act": "execute_script", "script": "MissionManager.initialize_dispositions_11e(\"priority_assets\", \"purge_the_foe\")" },
+    { "act": "execute_script", "script": "main.get_node(\"ScoringController\")._rebuild_right_panel()" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryMissionLabel", "timeout_s": 2.0 },
+    { "act": "expect_node_property",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryMissionLabel",
+      "property": "text",
+      "equals": "P1 Primary: Vital Link ~ (Priority Assets)" },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryMissionLabel" },
+    { "act": "expect_node_property",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryMissionLabel",
+      "property": "text",
+      "equals": "P2 Primary: Destroyer's Wrath (Purge the Foe)" },
+    { "act": "screenshot", "label": "01_per_player_primary_cards_in_panel" }
+  ]
+}

--- a/40k/tests/test_gdm_sourced_11e.gd
+++ b/40k/tests/test_gdm_sourced_11e.gd
@@ -1,0 +1,149 @@
+extends SceneTree
+
+# Web-sourced 11e GDM mechanics (docs/rules/11th_edition_missions_gdm2026.md
+# appendix, retrieved 2026-07-03):
+#  - Heal X core ability: heal wounded model, else revive one at 1 wound.
+#  - A Grievous Blow: Starting Strength 13+ criterion.
+#  - Outflank: 3 VP one board edge / 5 VP two (min_edges).
+#  - Beacon: friendly unit alive wholly outside own deployment zone.
+#  - Forward Position: enemy home OR both Expansion objectives.
+#  - Fixed secondaries: 20 VP cap per fixed card.
+#  - 11e army construction validator (warlord faction, enhancement caps).
+#
+# Usage: godot --headless --path . -s tests/test_gdm_sourced_11e.gd
+
+var passed := 0
+var failed := 0
+var gs = null
+var re = null
+var meas = null
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _mk_unit(owner: int, models: Array, abilities: Array = []) -> Dictionary:
+	return {"id": "U_T", "owner": owner,
+		"meta": {"name": "T", "keywords": ["INFANTRY"], "abilities": abilities, "stats": {}},
+		"models": models}
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_gdm_sourced_11e ===\n")
+	gs = root.get_node_or_null("GameState")
+	var sec = root.get_node_or_null("SecondaryMissionManager")
+	var alm = root.get_node_or_null("ArmyListManager")
+	re = root.get_node_or_null("RulesEngine")
+	meas = root.get_node_or_null("Measurement")
+	_check("autoloads present", gs != null and sec != null and alm != null and re != null and meas != null)
+
+	print("-- Heal X --")
+	var hu = _mk_unit(1, [
+		{"id": "a", "alive": true, "wounds": 3, "current_wounds": 1},
+		{"id": "b", "alive": false, "wounds": 3, "current_wounds": 0},
+	], ["Heal 3"])
+	_check("Heal 3 parsed from abilities", re.get_heal_amount(hu) == 3)
+	var res = re.apply_heal_11e(hu, re.get_heal_amount(hu))
+	_check("wounded model healed before revival", int(hu["models"][0]["current_wounds"]) == 3,
+		str(hu["models"][0]))
+	_check("third heal revives the dead model at 1 wound",
+		res["healed"] == 2 and res["revived"] == 1 and hu["models"][1]["alive"] == true
+		and int(hu["models"][1]["current_wounds"]) == 1, str(res))
+	var hu2 = _mk_unit(1, [{"id": "a", "alive": true, "wounds": 2, "current_wounds": 2}], ["Heal 2"])
+	var res2 = re.apply_heal_11e(hu2, 2)
+	_check("full-strength unit wastes excess heals", res2["healed"] == 0 and res2["revived"] == 0, str(res2))
+	_check("no Heal ability parses as 0", re.get_heal_amount(_mk_unit(1, [])) == 0)
+
+	print("\n-- A Grievous Blow: Starting Strength 13+ --")
+	GameConstants.edition = 11
+	sec._units_destroyed_this_turn = [
+		{"unit_id": "U_X", "owner": 2, "points": 60, "max_model_wounds": 1, "starting_strength": 20},
+	]
+	_check("SS 20 unit qualifies at min_models 13",
+		sec._check_high_value_unit_destroyed(1, {"min_models": 13}))
+	sec._units_destroyed_this_turn = [
+		{"unit_id": "U_Y", "owner": 2, "points": 300, "max_model_wounds": 20, "starting_strength": 5},
+	]
+	_check("SS 5 unit does NOT qualify (points/wounds no longer implied)",
+		not sec._check_high_value_unit_destroyed(1, {"min_models": 13}))
+	sec._units_destroyed_this_turn.clear()
+
+	print("\n-- Outflank: distinct board edges --")
+	var w = meas.inches_to_px(float(gs.state.board.size.width))
+	gs.state["units"]["U_EDGE_L"] = _mk_unit(1, [{"id": "m", "alive": true, "wounds": 1, "current_wounds": 1,
+		"base_mm": 32, "base_type": "circular", "position": {"x": 40.0, "y": 1200.0}}])
+	gs.state["units"]["U_EDGE_R"] = _mk_unit(1, [{"id": "m", "alive": true, "wounds": 1, "current_wounds": 1,
+		"base_mm": 32, "base_type": "circular", "position": {"x": w - 40.0, "y": 1200.0}}])
+	_check("two units on opposite edges satisfy min_edges 2",
+		sec._check_units_near_board_edges(1, {"min_edges": 2, "edge_inches": 6.0}))
+	gs.state.units.erase("U_EDGE_R")
+	_check("one edge does not satisfy min_edges 2",
+		not sec._check_units_near_board_edges(1, {"min_edges": 2, "edge_inches": 6.0}))
+	_check("one edge satisfies min_edges 1",
+		sec._check_units_near_board_edges(1, {"min_edges": 1, "edge_inches": 6.0}))
+	gs.state.units.erase("U_EDGE_L")
+
+	print("\n-- Beacon: unit wholly outside own deployment zone --")
+	var center_px = Vector2(meas.inches_to_px(22), meas.inches_to_px(30))
+	gs.state["units"]["U_OUT"] = _mk_unit(1, [{"id": "m", "alive": true, "wounds": 1, "current_wounds": 1,
+		"base_mm": 32, "base_type": "circular", "position": {"x": center_px.x, "y": center_px.y}}])
+	_check("unit at board centre is outside its own DZ",
+		sec._check_unit_outside_own_dz(1, {}), "centre should be NML")
+	gs.state.units.erase("U_OUT")
+	_check("no qualifying unit -> false", not sec._check_unit_outside_own_dz(1, {}))
+
+	print("\n-- Forward Position: both Expansion objectives --")
+	var mm = root.get_node("MissionManager")
+	var expansions = mm.get_objective_ids_by_designation("expansion")
+	_check("two expansion objectives designated", expansions.size() == 2, str(expansions))
+	for obj_id in mm.objective_control_state:
+		mm.objective_control_state[obj_id] = 0
+	for obj_id in expansions:
+		mm.objective_control_state[obj_id] = 1
+	_check("both expansions controlled satisfies Forward Position",
+		sec._check_enemy_home_objective(1))
+	mm.objective_control_state[expansions[0]] = 2
+	_check("one expansion is not enough (and enemy home not held)",
+		not sec._check_enemy_home_objective(1))
+
+	print("\n-- Fixed secondaries: 20 VP per-card cap --")
+	sec.initialize_for_game()
+	sec.setup_fixed_missions(1, ["assassination", "a_grievous_blow"])
+	var st = sec._player_state["1"]
+	var a1 = sec._award_secondary_vp(1, 15, "assassination")
+	st["secondary_vp_this_turn"] = 0
+	var a2 = sec._award_secondary_vp(1, 15, "assassination")
+	_check("second 15 VP award clipped to the card's 20 total",
+		a1 == 15 and a2 == 5, "%d then %d" % [a1, a2])
+	st["secondary_vp_this_turn"] = 0
+	var a3 = sec._award_secondary_vp(1, 5, "a_grievous_blow")
+	_check("other fixed card unaffected by the first card's cap", a3 == 5, str(a3))
+
+	print("\n-- 11e army construction validator --")
+	var army = alm.load_army_list("orks", 1)
+	var v = alm.validate_army_construction_11e(army)
+	_check("orks army passes 11e construction validation", v["valid"] and v["warnings"].is_empty(),
+		str(v))
+	var bad = army.duplicate(true)
+	for uid in bad["units"]:
+		if bad["units"][uid]["meta"].get("is_warlord", false):
+			bad["units"][uid]["meta"]["keywords"] = ["CHARACTER", "TYRANIDS"]
+	var v2 = alm.validate_army_construction_11e(bad)
+	var has_warlord_warning = false
+	for wmsg in v2["warnings"]:
+		if "Faction keyword" in wmsg:
+			has_warlord_warning = true
+	_check("warlord without the army Faction keyword is flagged", has_warlord_warning, str(v2))
+
+	GameConstants.edition = 10
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_gdm_sourced_11e.gd.uid
+++ b/40k/tests/test_gdm_sourced_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://bbn7hdnr1uolm

--- a/40k/tests/test_primary_missions_11e.gd
+++ b/40k/tests/test_primary_missions_11e.gd
@@ -138,22 +138,27 @@ func _run_tests():
 		int(gs.state.players["1"]["primary_vp"]) == 4, str(gs.state.players["1"]["primary_vp"]))
 	mgr.kills_per_round.clear()
 
-	print("\n-- hold_new: Unstoppable Force --")
+	print("\n-- hold_new: Unstoppable Force (hold_new scores at EOT) --")
 	mgr.initialize_dispositions_11e("purge_the_foe", "take_and_hold")
 	gs.state.meta["battle_round"] = 2
+	gs.state.meta["active_player"] = 1
 	_reset_vp(null)
 	mgr._kills_this_round = {"1": 0, "2": 0}
+	mgr.kills_per_round.clear()
 	for obj_id in mgr.objective_control_state:
 		mgr.objective_control_state[obj_id] = 0
 	mgr._control_at_turn_start["1"] = []
 	mgr.objective_control_state[nml] = 1
 	mgr.score_primary_objectives()
-	# hold_min 1 non-home (4) + hold_new non-home (3) = 7
-	_check("newly captured NML objective: 4 (hold) + 3 (new) = 7 VP",
+	_check("command: hold 1+ non-home = 4 VP",
+		int(gs.state.players["1"]["primary_vp"]) == 4, str(gs.state.players["1"]["primary_vp"]))
+	mgr.score_primary_eot_11e(1)
+	_check("EOT adds 3 VP for the newly captured objective (total 7)",
 		int(gs.state.players["1"]["primary_vp"]) == 7, str(gs.state.players["1"]["primary_vp"]))
 	_reset_vp(null)
 	mgr._control_at_turn_start["1"] = [nml]
 	mgr.score_primary_objectives()
+	mgr.score_primary_eot_11e(1)
 	_check("already-held objective: hold only (4 VP)",
 		int(gs.state.players["1"]["primary_vp"]) == 4, str(gs.state.players["1"]["primary_vp"]))
 
@@ -187,6 +192,92 @@ func _run_tests():
 	mgr.score_primary_objectives()
 	_check("R4: escalates to 6 VP per non-home objective",
 		int(gs.state.players["1"]["primary_vp"]) == 6, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- objective designations (Home / Expansion / Central) --")
+	_check("home objectives designated", mgr.get_objective_designation(home1) == "home"
+		and mgr.get_objective_designation(home2) == "home")
+	var centrals = mgr.get_objective_ids_by_designation("central")
+	var expansions = mgr.get_objective_ids_by_designation("expansion")
+	_check("exactly one central objective", centrals.size() == 1, str(centrals))
+	_check("remaining NML objectives are expansions", expansions.size() == 2, str(expansions))
+
+	print("\n-- marker mechanics: Triangulation 3/6/10 --")
+	mgr.initialize_dispositions_11e("reconnaissance", "purge_the_foe")
+	gs.state.meta["battle_round"] = 2
+	gs.state.meta["active_player"] = 1
+	_reset_vp(null)
+	mgr._kills_this_round = {"1": 0, "2": 0}
+	mgr.kills_per_round.clear()
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[nml] = 1
+	mgr.score_primary_eot_11e(1)
+	var st1t = mgr._primary_state_11e["1"]
+	_check("Triangulate auto-marks the controlled objective",
+		st1t["triangulated"] == [nml], str(st1t["triangulated"]))
+	_check("1 triangulated objective scores 3 VP at EOT",
+		int(gs.state.players["1"]["primary_vp"]) == 3, str(gs.state.players["1"]["primary_vp"]))
+	_reset_vp(null)
+	st1t["triangulated"] = [nml, home1, home2]
+	mgr.score_primary_eot_11e(1)
+	# 3 triangulated -> 10, but a 4th mark is auto-added only for controlled
+	# non-marked objectives; nml already marked so the count stays 3 -> 10 VP
+	_check("3+ triangulated objectives score 10 VP",
+		int(gs.state.players["1"]["primary_vp"]) == 10, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- marker mechanics: Sabotage per-objective + territory bonus --")
+	mgr.initialize_dispositions_11e("priority_assets", "priority_assets")
+	_reset_vp(null)
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[nml] = 1
+	var central_id = mgr.get_objective_ids_by_designation("central")[0]
+	mgr.objective_control_state[central_id] = 1
+	mgr.score_primary_eot_11e(1)
+	# Compute the expectation over the unique controlled non-home objectives
+	var sab_ids = [nml]
+	if central_id != nml:
+		sab_ids.append(central_id)
+	var expected_sab = 0
+	for oid in sab_ids:
+		expected_sab += 3
+		if mgr._objective_in_enemy_territory_11e(oid, 1):
+			expected_sab += 2
+	_check("Sabotage: 3 VP per non-home + 2 territory/central bonus",
+		int(gs.state.players["1"]["primary_vp"]) == expected_sab,
+		"%s vs %d" % [gs.state.players["1"]["primary_vp"], expected_sab])
+
+	print("\n-- marker mechanics: Vital Link operation markers --")
+	mgr.initialize_dispositions_11e("priority_assets", "purge_the_foe")
+	_reset_vp(null)
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[central_id] = 1
+	mgr.score_primary_eot_11e(1)
+	# turn 1: marker placed (1), EOT central 2 + 1 marker = 3; command hold non-home 4
+	var vl1 = int(gs.state.players["1"]["primary_vp"])
+	mgr.score_primary_eot_11e(1)
+	var vl2 = int(gs.state.players["1"]["primary_vp"]) - vl1
+	_check("Vital Link escalates: 2nd sweep scores 1 more than the 1st",
+		vl2 == vl1 + 1, "first %d then %d" % [vl1, vl2])
+
+	print("\n-- marker mechanics: Punishment condemned-left --")
+	mgr.initialize_dispositions_11e("purge_the_foe", "disruption")
+	_reset_vp(null)
+	gs.state["units"]["U_COND"] = {"id": "U_COND", "owner": 2,
+		"meta": {"name": "Runner", "keywords": [], "stats": {"objective_control": 1}},
+		"models": [{"id": "m1", "alive": true, "wounds": 1, "current_wounds": 1,
+			"base_mm": 32, "base_type": "circular",
+			"position": {"x": gs.state.board.objectives[0].position.x, "y": gs.state.board.objectives[0].position.y}}]}
+	mgr.on_turn_start_11e(1)
+	_check("enemy unit on an objective is auto-condemned",
+		"U_COND" in mgr._primary_state_11e["1"]["condemned"],
+		str(mgr._primary_state_11e["1"]["condemned"]))
+	gs.state.units["U_COND"]["models"][0]["alive"] = false
+	mgr.score_primary_eot_11e(1)
+	_check("condemned unit leaving the battlefield scores 5 VP",
+		int(gs.state.players["1"]["primary_vp"]) >= 5, str(gs.state.players["1"]["primary_vp"]))
+	gs.state.units.erase("U_COND")
 
 	print("\n-- 10e regression: dispatch unchanged --")
 	GameConstants.edition = 10

--- a/40k/tests/test_primary_missions_11e.gd
+++ b/40k/tests/test_primary_missions_11e.gd
@@ -1,0 +1,204 @@
+extends SceneTree
+
+# 11e (GDM 2026) Force Disposition primary missions — source:
+# docs/rules/11th_edition_missions_gdm2026.md.
+#  - 5 dispositions; each player's card = own deck paired vs opponent's
+#    disposition (25-card table, PrimaryMissionData11e).
+#  - Command conditions score at end of your Command phase R1-4, switching
+#    to end of turn in R5; EOT every turn; EOG once at game end.
+#  - Caps: 45 primary total, 15 per turn.
+#
+# Usage: godot --headless --path . -s tests/test_primary_missions_11e.gd
+
+var passed := 0
+var failed := 0
+var gs = null
+var mgr = null
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _find_obj_by_zone(zone: String) -> String:
+	for obj in gs.state.board.get("objectives", []):
+		if obj.get("zone", "") == zone:
+			return obj.get("id", "")
+	return ""
+
+func _reset_vp(_m) -> void:
+	for pk in ["1", "2"]:
+		gs.state.players[pk]["vp"] = 0
+		gs.state.players[pk]["primary_vp"] = 0
+	mgr._primary_vp_this_turn = {"1": 0, "2": 0}
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_primary_missions_11e ===\n")
+	mgr = root.get_node_or_null("MissionManager")
+	gs = root.get_node_or_null("GameState")
+	_check("autoloads present", mgr != null and gs != null)
+
+	print("-- pairing table --")
+	var cards = PrimaryMissionData11e.get_all_cards()
+	_check("25 primary mission cards", cards.size() == 25, str(cards.size()))
+	var ids = {}
+	var complete = true
+	for own in PrimaryMissionData11e.DISPOSITIONS:
+		for opp in PrimaryMissionData11e.DISPOSITIONS:
+			var card = PrimaryMissionData11e.get_card(own, opp)
+			if card.is_empty():
+				complete = false
+			else:
+				ids[card["id"]] = true
+	_check("all 25 disposition pairings resolve", complete)
+	_check("all card ids unique", ids.size() == 25, str(ids.size()))
+	_check("TH vs TH is Battlefield Dominance",
+		PrimaryMissionData11e.get_card("take_and_hold", "take_and_hold").get("id", "") == "battlefield_dominance")
+	_check("DI vs PF is Delaying Action",
+		PrimaryMissionData11e.get_card("disruption", "purge_the_foe").get("id", "") == "delaying_action")
+	_check("approximate rows are flagged",
+		PrimaryMissionData11e.get_card_by_id("smoke_and_mirrors").get("approximate", false)
+		and PrimaryMissionData11e.get_card_by_id("gather_intel").get("approximate", false))
+
+	print("\n-- disposition initialization --")
+	GameConstants.edition = 11
+	mgr.initialize_dispositions_11e("take_and_hold", "disruption")
+	_check("P1 (TH vs DI) plays Determined Acquisition",
+		mgr.get_primary_mission_for_player(1).get("id", "") == "determined_acquisition")
+	_check("P2 (DI vs TH) plays Death Trap",
+		mgr.get_primary_mission_for_player(2).get("id", "") == "death_trap")
+	_check("dispositions stored in meta",
+		gs.state.meta.get("dispositions_11e", {}).get("1", "") == "take_and_hold")
+	mgr.initialize_dispositions_11e("bogus", "priority_assets")
+	_check("unknown disposition falls back to take_and_hold",
+		mgr.get_primary_mission_for_player(1).get("id", "") == "inescapable_dominion")
+
+	print("\n-- command scoring: Battlefield Dominance --")
+	mgr.initialize_dispositions_11e("take_and_hold", "take_and_hold")
+	var home1 = _find_obj_by_zone("player1")
+	var home2 = _find_obj_by_zone("player2")
+	var nml = _find_obj_by_zone("no_mans_land")
+	_check("board has home + NML objectives", home1 != "" and home2 != "" and nml != "")
+	gs.state.meta["battle_round"] = 2
+	gs.state.meta["active_player"] = 1
+	_reset_vp(null)
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[home1] = 1
+	mgr.objective_control_state[nml] = 1
+	mgr.score_primary_objectives()
+	# R2: hold_more (2VP, P1 holds 2 vs 0) + per_objective 3VP x2 = 8
+	_check("R2 command: 2 (hold more) + 3x2 objectives = 8 VP",
+		int(gs.state.players["1"]["primary_vp"]) == 8, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- caps: 15/turn and 45 total --")
+	_reset_vp(null)
+	mgr._award_primary_vp_11e(1, 12, "test", "command")
+	mgr._award_primary_vp_11e(1, 9, "test", "command")
+	_check("second award clipped to the 15/turn window",
+		int(gs.state.players["1"]["primary_vp"]) == 15, str(gs.state.players["1"]["primary_vp"]))
+	mgr.on_turn_start_11e(1)
+	_check("turn window resets on turn start", int(mgr._primary_vp_this_turn["1"]) == 0)
+	gs.state.players["1"]["primary_vp"] = 44
+	mgr._award_primary_vp_11e(1, 10, "test", "command")
+	_check("45 total cap respected", int(gs.state.players["1"]["primary_vp"]) == 45,
+		str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- Round 5: command scoring switches to end of turn --")
+	mgr.initialize_dispositions_11e("take_and_hold", "take_and_hold")
+	gs.state.meta["battle_round"] = 5
+	_reset_vp(null)
+	mgr.score_primary_objectives()
+	_check("R5 Command phase awards nothing", int(gs.state.players["1"]["primary_vp"]) == 0,
+		str(gs.state.players["1"]["primary_vp"]))
+	mgr.score_primary_eot_11e(1)
+	# R5 EOT: hold_more window is R1-2 (skipped); per_objective 3x2 = 6
+	_check("R5 EOT scores the command conditions (3x2 = 6 VP)",
+		int(gs.state.players["1"]["primary_vp"]) == 6, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- EOT kill conditions: Delaying Action --")
+	mgr.initialize_dispositions_11e("disruption", "purge_the_foe")
+	gs.state.meta["battle_round"] = 3
+	_reset_vp(null)
+	mgr.kills_per_round["3"] = {"1": 2, "2": 0}
+	mgr._kills_this_round = {"1": 0, "2": 0}
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.score_primary_eot_11e(1)
+	_check("EOT: 2 VP per destroyed unit x2 = 4 VP",
+		int(gs.state.players["1"]["primary_vp"]) == 4, str(gs.state.players["1"]["primary_vp"]))
+	mgr.kills_per_round.clear()
+
+	print("\n-- hold_new: Unstoppable Force --")
+	mgr.initialize_dispositions_11e("purge_the_foe", "take_and_hold")
+	gs.state.meta["battle_round"] = 2
+	_reset_vp(null)
+	mgr._kills_this_round = {"1": 0, "2": 0}
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr._control_at_turn_start["1"] = []
+	mgr.objective_control_state[nml] = 1
+	mgr.score_primary_objectives()
+	# hold_min 1 non-home (4) + hold_new non-home (3) = 7
+	_check("newly captured NML objective: 4 (hold) + 3 (new) = 7 VP",
+		int(gs.state.players["1"]["primary_vp"]) == 7, str(gs.state.players["1"]["primary_vp"]))
+	_reset_vp(null)
+	mgr._control_at_turn_start["1"] = [nml]
+	mgr.score_primary_objectives()
+	_check("already-held objective: hold only (4 VP)",
+		int(gs.state.players["1"]["primary_vp"]) == 4, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- EOG conditions: enemy home (Inescapable Dominion) --")
+	mgr.initialize_dispositions_11e("take_and_hold", "priority_assets")
+	gs.state.meta["battle_round"] = 5
+	_reset_vp(null)
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[home2] = 1
+	mgr.score_primary_eog_11e()
+	_check("EOG: 5 VP for holding the enemy home objective",
+		int(gs.state.players["1"]["primary_vp"]) == 5, str(gs.state.players["1"]["primary_vp"]))
+	mgr.score_primary_eog_11e()
+	_check("EOG scoring is idempotent",
+		int(gs.state.players["1"]["primary_vp"]) == 5, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- Outmanoeuvre escalation --")
+	mgr.initialize_dispositions_11e("disruption", "disruption")
+	mgr._eog_primary_scored = false
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[nml] = 1
+	gs.state.meta["battle_round"] = 1
+	_reset_vp(null)
+	mgr.score_primary_objectives()
+	_check("R1: 4 VP per non-home objective", int(gs.state.players["1"]["primary_vp"]) == 4,
+		str(gs.state.players["1"]["primary_vp"]))
+	gs.state.meta["battle_round"] = 4
+	_reset_vp(null)
+	mgr.score_primary_objectives()
+	_check("R4: escalates to 6 VP per non-home objective",
+		int(gs.state.players["1"]["primary_vp"]) == 6, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n-- 10e regression: dispatch unchanged --")
+	GameConstants.edition = 10
+	gs.state.meta["battle_round"] = 2
+	_reset_vp(null)
+	mgr.initialize_mission("take_and_hold")
+	for obj_id in mgr.objective_control_state:
+		mgr.objective_control_state[obj_id] = 0
+	mgr.objective_control_state[nml] = 1
+	mgr.score_primary_objectives()
+	_check("10e Take and Hold still scores 5 VP/objective",
+		int(gs.state.players["1"]["primary_vp"]) == 5, str(gs.state.players["1"]["primary_vp"]))
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_primary_missions_11e.gd.uid
+++ b/40k/tests/test_primary_missions_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://ds28ohdxdxbl1

--- a/40k/tests/test_secondary_deck_11e.gd
+++ b/40k/tests/test_secondary_deck_11e.gd
@@ -1,0 +1,112 @@
+extends SceneTree
+
+# 11e (GDM 2026) secondary mission deck — source:
+# docs/rules/11th_edition_missions_gdm2026.md.
+#  - 18-card deck: four returning fixed-eligible cards + returning tacticals
+#    + the new GDM cards; retired 10e cards are absent.
+#  - Tactical: draw 2/turn with NO hand limit (10e: fill to 2).
+#  - Fixed: only Assassination / A Grievous Blow / Bring it Down /
+#    Engage on All Fronts may be taken.
+#  - Caps: 45 VP secondary total, 15 VP per turn (10e: 40 total).
+#
+# Usage: godot --headless --path . -s tests/test_secondary_deck_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_secondary_deck_11e ===\n")
+	var mgr = root.get_node_or_null("SecondaryMissionManager")
+	var gs = root.get_node_or_null("GameState")
+	_check("autoloads present", mgr != null and gs != null)
+
+	print("-- deck composition --")
+	var deck = SecondaryMissionData.get_mission_ids_for_deck_11e()
+	_check("11e tactical deck has 18 cards", deck.size() == 18, str(deck))
+	for nid in ["a_grievous_blow", "forward_position", "burden_of_trust", "centre_ground", "beacon", "outflank", "plunder"]:
+		_check("new card %s present with data" % nid,
+			nid in deck and not SecondaryMissionData.get_mission_by_id(nid).is_empty())
+	for gone in ["area_denial", "extend_battle_lines", "storm_hostile_objective", "cull_the_horde", "marked_for_death", "establish_locus", "deploy_teleport_homer"]:
+		_check("retired 10e card %s absent" % gone, not gone in deck)
+	_check("approximate cards are flagged",
+		SecondaryMissionData.get_mission_by_id("beacon").get("approximate", false)
+		and SecondaryMissionData.get_mission_by_id("forward_position").get("approximate", false))
+
+	print("\n-- draw rules: 2/turn, no hand limit (11e) --")
+	GameConstants.edition = 11
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	var st = mgr._player_state["1"]
+	_check("deck built with 18 cards at e11", st["deck"].size() == 18, str(st["deck"].size()))
+	mgr.draw_missions_to_hand(1)
+	_check("first draw: 2 cards in hand", st["active"].size() == 2, str(st["active"].size()))
+	mgr.draw_missions_to_hand(1)
+	_check("second draw: hand grows to 4 (no hand limit)", st["active"].size() == 4, str(st["active"].size()))
+	GameConstants.edition = 10
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	var st10 = mgr._player_state["1"]
+	mgr.draw_missions_to_hand(1)
+	mgr.draw_missions_to_hand(1)
+	_check("10e unchanged: hand capped at 2", st10["active"].size() == 2, str(st10["active"].size()))
+
+	print("\n-- fixed eligibility (11e) --")
+	GameConstants.edition = 11
+	mgr.initialize_for_game()
+	var bad = mgr.setup_fixed_missions(1, ["no_prisoners", "assassination"])
+	_check("11e fixed: non-eligible card rejected", not bad.get("success", true), str(bad))
+	var good = mgr.setup_fixed_missions(1, ["assassination", "a_grievous_blow"])
+	_check("11e fixed: two fixed-eligible cards accepted", good.get("success", false), str(good))
+
+	print("\n-- caps: 15/turn and 45 total (11e) --")
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	var award1 = mgr._award_secondary_vp(1, 14, "test_a")
+	var award2 = mgr._award_secondary_vp(1, 5, "test_b")
+	_check("14 VP awarded freely", award1 == 14, str(award1))
+	_check("next 5 VP clipped to 1 by the 15/turn cap", award2 == 1, str(award2))
+	mgr.on_turn_start(1)
+	var s1 = mgr._player_state["1"]
+	_check("turn window resets on turn start", int(s1.get("secondary_vp_this_turn", -1)) == 0)
+	# Pump to the 45 total cap in 15-per-turn windows.
+	for _t in range(2):
+		mgr._award_secondary_vp(1, 15, "test_c")
+		mgr.on_turn_start(1)
+	# Windows so far: 15 (turn 1) + 15 + 15 = 45 — the total cap is reached.
+	var final_award = mgr._award_secondary_vp(1, 15, "test_d")
+	_check("45 total cap: nothing awarded beyond it", final_award == 0, str(final_award))
+	mgr.on_turn_start(1)
+	var over_cap = mgr._award_secondary_vp(1, 5, "test_e")
+	_check("fresh turn window does not bypass the total cap", over_cap == 0, str(over_cap))
+	_check("secondary_vp settled at exactly 45", int(s1["secondary_vp"]) == 45, str(s1["secondary_vp"]))
+
+	print("\n-- new condition checkers --")
+	gs.state["units"]["U_HV"] = {"id": "U_HV", "owner": 2,
+		"meta": {"name": "BigThing", "keywords": ["VEHICLE"], "points": 180, "stats": {}},
+		"models": [{"id": "m1", "alive": false, "wounds": 12, "current_wounds": 0,
+			"base_mm": 100, "base_type": "circular", "position": {"x": 500, "y": 500}}]}
+	mgr._units_destroyed_this_turn.clear()
+	mgr.check_and_report_unit_destroyed("U_HV")
+	_check("high-value kill detected (180 pts / 12W model)",
+		mgr._check_high_value_unit_destroyed(1, {"min_points": 100, "min_wounds": 10}))
+	_check("high-value threshold respected",
+		not mgr._check_high_value_unit_destroyed(1, {"min_points": 500, "min_wounds": 20}))
+	gs.state.units.erase("U_HV")
+
+	GameConstants.edition = 10
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_secondary_deck_11e.gd.uid
+++ b/40k/tests/test_secondary_deck_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://ceajhuphp742b

--- a/docs/rules/11th_edition_doc_change_audit.md
+++ b/docs/rules/11th_edition_doc_change_audit.md
@@ -210,17 +210,28 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
    resolves each player's own primary mission; a condition-based scorer in MissionManager evaluates
    hold/kill/enemy-home/central/quarters/hold-new/escalating-per-objective rules with the 45-total + 15-per-turn caps,
    the Round-5 Command→EOT switch, EOT conditions every turn, and EOG conditions at game end (save/load covered).
-   Windowed `iss064b_primary_disposition_11e` (24/24) + live MainMenu→start→pairing check; headless
-   `test_primary_missions_11e` 26/26. **Remaining (source-blocked):** the bespoke action/marker mechanics on ~11 cards
-   (Triangulate, Booby Trap, Sabotage, decoy/intel/relic markers, Condemn, Consecrate, Secure Asset…) have no
-   published card text — they currently score 0 and are flagged `approximate`; rows with inferred numbers are
-   flagged per-rule. Also: disposition is a menu pick, not detachment-derived, and 6-objective Inescapable Dominion
-   maps aren't modelled (5-objective layouts). *(Ref: doc Tab 10.)*
+   Windowed `iss064b_primary_disposition_11e` + live MainMenu→start→pairing check; headless
+   `test_primary_missions_11e` 37/37. **Update 2026-07-03 (web-sourced):** the bespoke action/marker mechanics were
+   recovered from gdmissions.app snippets + the Tabletop Battles disposition reviews (missions doc appendix) and are
+   now implemented AUTO-RESOLVED (deterministic target picks; the real cards let the player choose — cards stay
+   flagged `approximate`): Triangulate (3/6/10), Consecrate markers, Punishment Condemn (left-battlefield 5 VP),
+   Sabotage (3+2/objective), Vital Link operation markers (2+1/marker), Secure Asset (EOT 4 + destroyed-near-central
+   2), Vanguard Operation terrain areas, Extract Relic / Locate and Deny shared relic markers + Sensor Sweep, Smoke
+   and Mirrors decoys (2+2, EOG 10 at 4+, enemy-proximity scrub), Surveil (5 VP no-markers), Gather Intel tokens
+   (7 VP R2+), Death Trap (2+3/area). Home/Expansion/Central objective designations are assigned per layout and
+   drive the central/expansion conditions. Still open: disposition is a menu pick rather than detachment-derived;
+   6-objective Inescapable Dominion maps aren't modelled; the auto-picks should eventually become player prompts.
+   *(Ref: doc Tab 10 + appendix.)*
 2. **[data] 11e secondary mission deck.** *(Done 2026-07-02, approximations flagged:)* the GDM 2026 deck is authored
    from `docs/rules/11th_edition_missions_gdm2026.md` — 18 cards incl. the Fixed four, draw-2-per-turn with no hand
    limit, the fixed-eligibility restriction, and the 45-total/15-per-turn caps. Cards whose full text was unpublished
    (Beacon, Plunder, Burden of Trust, Outflank, A Grievous Blow scoring numbers, Forward Position's Expansion
-   alternative) are marked `approximate: true` pending card text; Attacker/Defender variants are not modelled. *(Tab 10.)*
+   alternative) are marked `approximate: true` pending card text; Attacker/Defender variants are not modelled.
+   **Update 2026-07-03 (web-sourced):** A Grievous Blow now keys on Starting Strength 13+; Outflank scores 3/5 VP by
+   distinct board edges; Beacon scores a surviving unit outside your DZ at the end of the opponent's turn; Forward
+   Position's both-Expansion-objectives alternative is live (designations); fixed cards enforce the sourced 20 VP
+   per-card cap (`test_gdm_sourced_11e` 20/20). Attacker/Defender variants exist as separate cards upstream but
+   their texts were not retrievable — still not modelled. *(Tab 10 + appendix.)*
 3. **[data] Support-role datasheets + true 11e stat lines.** *(Partially done 2026-07-02:)* the Bannernob now carries
    `Support` + `leader_data` in orks.json, FormationsPhase enforces the 11e per-role slots (one leader + one support),
    and the flow is windowed-validated (`iss059b_support_attach_11e`). Still open: tag Support characters in other
@@ -236,7 +247,11 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
 
 ### Tier 2 — army construction & terrain fidelity
 5. **[code] Army construction 11e:** Detachment Points pool (3 @ 2000), Upgrades (non-char, ×3, one enhancement pick),
-   enhancement-after-attach sequencing, and the Warlord-must-match-army-faction rule. *(Tab 1.)*
+   enhancement-after-attach sequencing, and the Warlord-must-match-army-faction rule. *(Update 2026-07-03, partial:)*
+   `ArmyListManager.validate_army_construction_11e` enforces the sourced rules as warnings — Warlord faction-keyword
+   match, enhancement caps (2 per 1000 pts), Upgrade-tag ×3-non-CHARACTER semantics, and the 3-DP pool when army data
+   declares DP costs (current army JSONs carry one detachment with no cost). Full DP-based list building UI and
+   detachment data authoring remain. *(Tab 1 + appendix.)*
 6. **[code+data] Terrain categories & areas:** author explicit Exposed/Light/Dense categories and Terrain-Area polygons
    per layout; implement the **Solid** <3"-gap rule and the Home/Expansion/Central objective designations used by
    missions. *(Tab 6.)*
@@ -246,7 +261,11 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
 
 ### Tier 3 — ability/affordance completeness (engine mostly present)
 8. **[code] Surge Moves** — *(Code done 2026-07-02:)* `BEGIN_SURGE_MOVE` is template-gated at e11 (stated distance, closest-enemy target, no D6), a `Surge X"` datasheet ability lights up the movement-list offering (`iss040b_surge_move_11e`). Remaining: author a real datasheet with the ability once 11e data is sourced (PRD §5 q.2). *(Tab 8.)*
-9. **[code] Hunter X and Heal X** core abilities. *(Tab 8 — currently absent.)*
+9. **[code] Hunter X and Heal X** core abilities. *(Update 2026-07-03:)* **Heal X** implemented from the sourced core
+   rule (restore a wound, else revive a model at 1 wound, X times; excess wasted) — `RulesEngine.get_heal_amount` /
+   `apply_heal_11e`, pinned in `test_gdm_sourced_11e`. **Hunter X**: no rule text exists in ANY available source
+   (core-rules deep dives, keyword cheat sheets, faction reviews all silent) — closed as not-in-shipped-rules; will
+   revisit if a source ever materialises. *(Tab 8.)*
 10. **[code] Combat Disembark** — *(Done 2026-07-02:)* the validator honours "set up **engaged** within 6"" for enemy units the transport is engaged with (and only those); the placement UI gets a Combat Disembark toggle, 6" ring, and matching placement rules. Windowed `iss058b_combat_disembark_engaged_11e` 26/26. *(Tab 3.)*
 11. **[code] Explosives / Crushing Impact** — *(Done 2026-07-02:)* the stratagem panel now runs a two-step target prompt (friendly unit, then eligible enemy — engaged for Crushing Impact, within-8"-and-visible for Explosives) and resolves via `use_stratagem` with the chosen enemy in context (`iss047d_crushing_impact_prompt_11e`). *(Tab 8.)*
 12. **[code] Modifier-order pipeline** — *(Verified + pinned 2026-07-02:)* halve-after-melta already holds in every
@@ -271,13 +290,18 @@ in-repo, Tier-1 #2 (secondary deck, 2026-07-02) and the core of Tier-1 #1 (Force
 table, per-player primary scoring with 45/15 caps and the R5 EOT switch, 2026-07-03) are implemented and validated
 windowed + headless, with unpublished card components flagged `approximate` and scoring 0 rather than invented.
 Earlier sweep results stand: Tier-1 #3 (Support attach) and #4 (Hidden/Gone to Ground/Detection Range)
-code-complete; Tier-3 #7, #8, #10, #11, #12, #13, #14 (Extra Attacks), #16, #17 landed; delta-audit B6 closed. What
-remains **source-blocked**: the bespoke primary-card action mechanics (#1 remainder) and secondary Attacker/Defender
-variants (#2 remainder), true 11e stat lines and Support tags for other factions (#3, PRD §5 open q.2), Hunter X /
-Heal X (#9, zero rule text in the shipped core-rules PDF), Melta "post-order" (#14 remainder, deep-dive only),
-terrain-category authoring incl. Home/Expansion/Central designations (#6, layout data decisions), the DP/Upgrades
-army-construction model (#5) — plus #15's fight-step restructure, which the audit itself parks pending a GW FAQ on
-the 3"-vs-5" Engaging consolidation.
+code-complete; Tier-3 #7, #8, #10, #11, #12, #13, #14 (Extra Attacks), #16, #17 landed; delta-audit B6 closed.
+**2026-07-03 web-source recovery:** the previously source-blocked card mechanics were recovered from
+gdmissions.app/Tabletop Battles snippets (appendix in the missions doc) and implemented — all 25 primary cards now
+score their sourced conditions with auto-resolved marker actions, the secondary corrections (Grievous Blow SS13+,
+Outflank edges, Beacon, Forward Position expansions, fixed 20-per-card cap) are in, Home/Expansion/Central
+designations exist per layout, Heal X is implemented, and army-construction rules validate as warnings. What
+remains **genuinely blocked**: Hunter X (no rule text exists anywhere — presumed not shipped), secondary
+Attacker/Defender variant texts, true 11e stat lines and Support tags for other factions (#3, PRD §5 open q.2),
+Melta "post-order" (#14 remainder, deep-dive only), terrain Exposed/Light/Dense category authoring (#6 remainder),
+DP costs per detachment + list-building UI (#5 remainder), player-choice prompts for the auto-resolved card actions
+— plus #15's fight-step restructure, which the audit itself parks pending a GW FAQ on the 3"-vs-5" Engaging
+consolidation.
 
 The **core engine** of 11th edition is in and genuinely playable at `edition == 11`: the new attack/allocation model,
 cover-as-BS, engagement 2" / coherency 9", the move-type framework incl. FLY, the select-after-roll charge, the

--- a/docs/rules/11th_edition_doc_change_audit.md
+++ b/docs/rules/11th_edition_doc_change_audit.md
@@ -196,7 +196,7 @@ Plunging Fire 3"/+1 ✅, **Hunter X** 🔴 (unimplemented, no data), **Heal X** 
 | **Asymmetric primaries** (15 pairings, e.g. Meatgrinder/Vital Link) | 🔴 | Game uses 10e-style **symmetric** primary selection (Take & Hold / Purge the Foe dropdowns). |
 | Primary caps (45 VP, 15/round, 2nd-player R5 EoT) | 🟡 | Take-and-Hold / Purge scoring exists; not the 11e pairing/caps model. |
 | Secondary **Fixed vs Tactical** | ✅ | Both modes selectable + validated Tactical draw. |
-| 11e **secondary deck** (Forward Position, Plunder, Beacon, Centre Ground, A Grievous Blow; no hand limit; 45 cap) | 🔴 | Current deck is 10e-derived; the specific 11e cards/rules not authored. |
+| 11e **secondary deck** (Forward Position, Plunder, Beacon, Centre Ground, A Grievous Blow; no hand limit; 45 cap) | 🟡 | GDM 2026 deck authored from `docs/rules/11th_edition_missions_gdm2026.md`: 18 cards (7 new), draw-2/no-hand-limit, fixed-four restriction, 45-total + 15/turn caps (`iss063b_secondary_deck_11e`; `test_secondary_deck_11e` 31/31). Cards without published text carry `approximate: true`; Attacker/Defender variants not modelled (no variant text). |
 
 ---
 
@@ -208,9 +208,11 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
 1. **[code+data] 11e mission system.** Implement Force Dispositions (5), the 15 disposition-pairing table, and
    asymmetric per-player primary missions (Meatgrinder, Vital Link, Destroyer's Wrath, …) with the 45/15 caps and
    2nd-player round-5 end-of-turn scoring. Add disposition selection to army build/new-game. *(Ref: doc Tab 10.)*
-2. **[data] 11e secondary mission deck.** Author the 11e Fixed four (Assassination, Bring it Down, A Grievous Blow,
-   Engage on All Fronts) and the 18-card Tactical deck (Forward Position, Plunder, Beacon, Centre Ground, returning
-   cards with tweaks), with no hand-size limit and the 45-VP cap. *(Tab 10.)*
+2. **[data] 11e secondary mission deck.** *(Done 2026-07-02, approximations flagged:)* the GDM 2026 deck is authored
+   from `docs/rules/11th_edition_missions_gdm2026.md` — 18 cards incl. the Fixed four, draw-2-per-turn with no hand
+   limit, the fixed-eligibility restriction, and the 45-total/15-per-turn caps. Cards whose full text was unpublished
+   (Beacon, Plunder, Burden of Trust, Outflank, A Grievous Blow scoring numbers, Forward Position's Expansion
+   alternative) are marked `approximate: true` pending card text; Attacker/Defender variants are not modelled. *(Tab 10.)*
 3. **[data] Support-role datasheets + true 11e stat lines.** *(Partially done 2026-07-02:)* the Bannernob now carries
    `Support` + `leader_data` in orks.json, FormationsPhase enforces the 11e per-role slots (one leader + one support),
    and the flow is windowed-validated (`iss059b_support_attach_11e`). Still open: tag Support characters in other

--- a/docs/rules/11th_edition_doc_change_audit.md
+++ b/docs/rules/11th_edition_doc_change_audit.md
@@ -238,7 +238,10 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
    factions, and source real 11e **Ld/OC/Invuln** values — note the invuln picture is better than first reported
    (Custodes 4+/Draxus 5+/Beastboss 5+ etc. already present in `meta.stats.invuln`); what's missing is mostly
    orks.json characters (Ghazghkull, Badrukk, Warbosses) and any true-11e deltas, which need an official source
-   (PRD §5 open q.2). *(Tab 1/7; §1, §7.)*
+   (PRD §5 open q.2). *(Update 2026-07-03:)* the Tabletop Battles Orks/Custodes faction-pack review snippets yielded
+   ability-level changes, not full stat lines — the sourced FRAME keyword was added to the Battlewagon (the only
+   FRAME unit present in orks.json); Snikrot/Kommandos ability tweaks and per-datasheet Ld/OC values were not
+   retrievable and remain open. *(Tab 1/7; §1, §7 + appendix.)*
 4. **[code] Hidden / Gone to Ground / Detection Range.** *(Done 2026-07-02, code side:)* Gone to Ground (−3" → 12"
    behind an intervening dense/Solid feature), the `Detection Range X"` datasheet parser with the 9" floor, and the
    Hidden gate all validated in the live targeting path (windowed `iss052b_gone_to_ground_11e`, 46/46; headless
@@ -252,9 +255,12 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
    match, enhancement caps (2 per 1000 pts), Upgrade-tag ×3-non-CHARACTER semantics, and the 3-DP pool when army data
    declares DP costs (current army JSONs carry one detachment with no cost). Full DP-based list building UI and
    detachment data authoring remain. *(Tab 1 + appendix.)*
-6. **[code+data] Terrain categories & areas:** author explicit Exposed/Light/Dense categories and Terrain-Area polygons
-   per layout; implement the **Solid** <3"-gap rule and the Home/Expansion/Central objective designations used by
-   missions. *(Tab 6.)*
+6. **[code+data] Terrain categories & areas:** *(Update 2026-07-03:)* the sourced category definitions (Exposed:
+   craters/razorwire/debris; Light: barricades/low walls/statues; Dense: buildings/ruins/containers/woods) MATCH the
+   existing `TerrainManager.category_of` derivation exactly — the implementation is now source-validated, and layouts
+   can already override per piece via explicit `category`. **Home/Expansion/Central objective designations are DONE**
+   (assigned per layout in MissionManager, used by the 11e mission conditions). Remaining: the **Solid** <3"-gap rule
+   (no retrievable rule text yet) and authoring multi-feature Terrain-Area boundaries (schema v2). *(Tab 6 + appendix.)*
 7. **[code] Cover per attacking model:** *(Done 2026-07-02:)* each attack's BS worsening is computed from its own
    firing model's view of the target (13.08 second condition is per-attack); attacks with no recorded firer (overrides/
    bonus attacks) fall back to the first firer. Pinned in `test_iss047_weapon_abilities_11e` E6. *(Tab 4/6.)*
@@ -273,11 +279,16 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
     sites and pinned live (`test_iss047_weapon_abilities_11e` E4). Deferred: consolidating into one shared pipeline and
     set-×/set-0 semantics, which no shipped modifier uses yet. *(Tab 1.)*
 13. **[code] Precision** — *(Done 2026-07-02:)* promotion is gated on the character being visible to an attacking model (13.09/13.10/13.11 + LoS), and the attacker chooses the promoted group (or declines) via the AllocationGroupOverlay PrecisionPicker; chosen group rides the save batch (`iss047b_precision_choice_11e`; headless E2 section). *(Tab 8.)*
-14. **[code] Melee/Extra-Attacks/Melta polish** — *(Extra Attacks done 2026-07-02:)* the 10e Balance-Dataslate "cannot modify A" suppression is edition-gated off at e11 (Waaagh/Da Biggest bonuses now apply; pinned 10e-vs-11e in `test_iss047` E5). Melta "post-order" remains — its precise semantics live in the review-doc deep-dive, which is not in the repo (needs source). *(Tab 8.)*
+14. **[code] Melee/Extra-Attacks/Melta polish** — *(Extra Attacks done 2026-07-02:)* the 10e Balance-Dataslate "cannot modify A" suppression is edition-gated off at e11 (Waaagh/Da Biggest bonuses now apply; pinned 10e-vs-11e in `test_iss047` E5). *(Melta order RESOLVED 2026-07-03 by web source:)* the 11e sequence is base damage → add Melta bonus → apply damage-reduction (halve-after-melta) — exactly what the engine already does in all six damage paths (verified + pinned 2026-07-02, `test_iss047` E4). No code change needed; closed. *(Tab 8 + missions doc appendix.)*
 
 ### Tier 4 — structural/cosmetic
 15. **[code] Fight-phase step structure** — make Pile-In and Consolidation single global both-player steps (active-first)
-    rather than per-fighter; resolve the Engaging-consolidation 3"-vs-5" once GW FAQs. *(Tab 5.)*
+    rather than per-fighter. *(Update 2026-07-03:)* the 3"-vs-5" Engaging-consolidation question the audit parked is now
+    RESOLVED by source: Engaging Consolidation is **3"** (must engage the selected targets; otherwise move toward the
+    nearest objective), and consolidation happens **after all fighting across the battlefield, both players, active
+    player first**. The per-fighter `ConsolidationMove` template already enforces the 3" engaging/objective modes, so
+    outcomes match in the common case; the remaining work is purely the sequencer restructure (global end-of-phase
+    consolidation step) — an engineering refactor, no longer rules-blocked. *(Tab 5 + appendix.)*
 16. **[code] End-of-turn coherency removal dialog** — *(Done 2026-07-02:)* END_TURN pauses for human-owned incoherent units; the CoherencyRemovalDialog lets the player pick each removed model, and the turn auto-completes once coherent (`iss042b_coherency_removal_choice_11e`). Auto-pick stays as the AI/backstop. *(Tab 3.)*
 17. **[code] `[DEVASTATING WOUNDS]` / `[LETHAL HITS]` attacker-choice prompts** — *(Done 2026-07-02:)* the AbilityChoiceDialog offers both choices when a DW weapon is assigned; choices ride the assignment into all three resolution paths, incl. the new 24.10 decline (`iss047c_ability_choice_prompts_11e`; headless E3). *(Tab 4/8.)*
 

--- a/docs/rules/11th_edition_doc_change_audit.md
+++ b/docs/rules/11th_edition_doc_change_audit.md
@@ -192,9 +192,9 @@ Plunging Fire 3"/+1 ✅, **Hunter X** 🔴 (unimplemented, no data), **Heal X** 
 
 | # | Change | Status | Note |
 |---|---|---|---|
-| **Force Dispositions** (5, pick from detachment) | 🔴 | No disposition system — "disposition" appears only as a detachment flavour string in `Stratagems.csv`. |
-| **Asymmetric primaries** (15 pairings, e.g. Meatgrinder/Vital Link) | 🔴 | Game uses 10e-style **symmetric** primary selection (Take & Hold / Purge the Foe dropdowns). |
-| Primary caps (45 VP, 15/round, 2nd-player R5 EoT) | 🟡 | Take-and-Hold / Purge scoring exists; not the 11e pairing/caps model. |
+| **Force Dispositions** (5, pick from detachment) | 🟡 | Per-player Force Disposition dropdowns in the new-game menu (`PrimaryMissionData11e.DISPOSITIONS`); pairing resolved at game init from `meta.game_config` (`iss064b_primary_disposition_11e`). Pick is menu-level, not detachment-derived. |
+| **Asymmetric primaries** (25 pairings, e.g. Meatgrinder/Vital Link) | 🟡 | Full 25-card GDM 2026 pairing table authored from `docs/rules/11th_edition_missions_gdm2026.md`; each player scores their own card (own deck × opponent disposition). Concretely-specified conditions (hold/kill/enemy-home/central/quarters/escalation) are live; bespoke marker/action mechanics (Triangulate, Booby Trap, Sabotage, decoys, intel, Condemn, Consecrate…) score 0 and are flagged `approximate` pending card text. |
+| Primary caps (45 VP, 15/round, 2nd-player R5 EoT) | 🟡 | 45-total + 15-per-turn caps enforced at e11; Command-phase scoring switches to end-of-turn in Round 5; EOT/EOG conditions hooked into ScoringPhase/game-end (`test_primary_missions_11e` 26/26). Doc says "C switches to EOT in Round 5" — applied to both players, not only the 2nd. |
 | Secondary **Fixed vs Tactical** | ✅ | Both modes selectable + validated Tactical draw. |
 | 11e **secondary deck** (Forward Position, Plunder, Beacon, Centre Ground, A Grievous Blow; no hand limit; 45 cap) | 🟡 | GDM 2026 deck authored from `docs/rules/11th_edition_missions_gdm2026.md`: 18 cards (7 new), draw-2/no-hand-limit, fixed-four restriction, 45-total + 15/turn caps (`iss063b_secondary_deck_11e`; `test_secondary_deck_11e` 31/31). Cards without published text carry `approximate: true`; Attacker/Defender variants not modelled (no variant text). |
 
@@ -205,9 +205,17 @@ Plunging Fire 3"/+1 ✅, **Hunter X** 🔴 (unimplemented, no data), **Heal X** 
 Ordered by player impact. Engine-level items marked **[code]**; content-authoring **[data]**.
 
 ### Tier 1 — whole subsystems a player cannot use today
-1. **[code+data] 11e mission system.** Implement Force Dispositions (5), the 15 disposition-pairing table, and
-   asymmetric per-player primary missions (Meatgrinder, Vital Link, Destroyer's Wrath, …) with the 45/15 caps and
-   2nd-player round-5 end-of-turn scoring. Add disposition selection to army build/new-game. *(Ref: doc Tab 10.)*
+1. **[code+data] 11e mission system.** *(Core done 2026-07-03, approximations flagged:)* Force Dispositions (5) are
+   selectable per player in the new-game menu; the full 25-card GDM 2026 pairing table (`PrimaryMissionData11e`)
+   resolves each player's own primary mission; a condition-based scorer in MissionManager evaluates
+   hold/kill/enemy-home/central/quarters/hold-new/escalating-per-objective rules with the 45-total + 15-per-turn caps,
+   the Round-5 Command→EOT switch, EOT conditions every turn, and EOG conditions at game end (save/load covered).
+   Windowed `iss064b_primary_disposition_11e` (24/24) + live MainMenu→start→pairing check; headless
+   `test_primary_missions_11e` 26/26. **Remaining (source-blocked):** the bespoke action/marker mechanics on ~11 cards
+   (Triangulate, Booby Trap, Sabotage, decoy/intel/relic markers, Condemn, Consecrate, Secure Asset…) have no
+   published card text — they currently score 0 and are flagged `approximate`; rows with inferred numbers are
+   flagged per-rule. Also: disposition is a menu pick, not detachment-derived, and 6-objective Inescapable Dominion
+   maps aren't modelled (5-objective layouts). *(Ref: doc Tab 10.)*
 2. **[data] 11e secondary mission deck.** *(Done 2026-07-02, approximations flagged:)* the GDM 2026 deck is authored
    from `docs/rules/11th_edition_missions_gdm2026.md` — 18 cards incl. the Fixed four, draw-2-per-turn with no hand
    limit, the fixed-eligibility restriction, and the 45-total/15-per-turn caps. Cards whose full text was unpublished
@@ -258,21 +266,27 @@ Ordered by player impact. Engine-level items marked **[code]**; content-authorin
 
 ## 11. Bottom line
 
-**Status 2026-07-02 (post-sweep):** every task-list item implementable from in-repo sources is done — Tier-1 #3
-(Support attach) and #4 (Hidden/Gone to Ground/Detection Range) code-complete; Tier-3 #7, #8, #10, #11, #12, #13,
-#14 (Extra Attacks), #16, #17 all landed with windowed/headless validation; delta-audit B6 closed. What remains is
-**source-blocked**: the 11e mission system (#1–2, mission-pack texts not in repo), true 11e stat lines and Support
-tags for other factions (#3, PRD §5 open q.2), Hunter X / Heal X (#9, zero rule text in the shipped core-rules PDF),
-Melta "post-order" (#14 remainder, deep-dive only), terrain-category authoring (#6, layout data decisions), the DP/
-Upgrades army-construction model (#5) — plus #15's fight-step restructure, which the audit itself parks pending a GW
-FAQ on the 3"-vs-5" Engaging consolidation.
+**Status 2026-07-03 (post-GDM-missions):** the mission system is no longer unbuilt — with the GDM 2026 document now
+in-repo, Tier-1 #2 (secondary deck, 2026-07-02) and the core of Tier-1 #1 (Force Dispositions, the 25-card pairing
+table, per-player primary scoring with 45/15 caps and the R5 EOT switch, 2026-07-03) are implemented and validated
+windowed + headless, with unpublished card components flagged `approximate` and scoring 0 rather than invented.
+Earlier sweep results stand: Tier-1 #3 (Support attach) and #4 (Hidden/Gone to Ground/Detection Range)
+code-complete; Tier-3 #7, #8, #10, #11, #12, #13, #14 (Extra Attacks), #16, #17 landed; delta-audit B6 closed. What
+remains **source-blocked**: the bespoke primary-card action mechanics (#1 remainder) and secondary Attacker/Defender
+variants (#2 remainder), true 11e stat lines and Support tags for other factions (#3, PRD §5 open q.2), Hunter X /
+Heal X (#9, zero rule text in the shipped core-rules PDF), Melta "post-order" (#14 remainder, deep-dive only),
+terrain-category authoring incl. Home/Expansion/Central designations (#6, layout data decisions), the DP/Upgrades
+army-construction model (#5) — plus #15's fight-step restructure, which the audit itself parks pending a GW FAQ on
+the 3"-vs-5" Engaging consolidation.
 
 The **core engine** of 11th edition is in and genuinely playable at `edition == 11`: the new attack/allocation model,
 cover-as-BS, engagement 2" / coherency 9", the move-type framework incl. FLY, the select-after-roll charge, the
 active-first Fight sequencer, terrain-as-objectives with per-phase control, battle-shock, disembark modes, two-slot
-attach, and the hazard/indirect/hazardous/heavy fixes all validate live or in the windowed suite. The **residual gap is
-concentrated in three places**: (1) the **11e mission system** (Force Dispositions + asymmetric primaries + the new
-secondary deck) is essentially unbuilt; (2) **Hidden/Gone-to-Ground/Detection-Range** and full **terrain-category /
-Solid** fidelity are partial; and (3) **content** — Support datasheets, true 11e stat lines, Upgrades/Detachment-Points
-army building, and the Hunter/Heal/Surge abilities that no shipped datasheet yet uses. Tiers 1–2 above are what stand
-between "the 11e rules engine runs" and "a player plays a complete, rules-accurate 11th-edition game."
+attach, and the hazard/indirect/hazardous/heavy fixes all validate live or in the windowed suite. The **11e mission
+system now runs end to end** — dispositions in the menu, the 25-card pairing table, per-player primary scoring with
+the GDM caps/timing, and the 18-card secondary deck — with the bespoke card actions the only unbuilt part (no
+published text). The **residual gap is concentrated in**: (1) those **card action mechanics** plus mission-facing
+terrain designations (Home/Expansion/Central); (2) full **terrain-category / Solid** fidelity; and (3) **content** —
+Support datasheets, true 11e stat lines, Upgrades/Detachment-Points army building, and the Hunter/Heal/Surge
+abilities that no shipped datasheet yet uses. Tiers 1–2 above are what stand between "the 11e rules engine runs" and
+"a player plays a complete, rules-accurate 11th-edition game."

--- a/docs/rules/11th_edition_missions_gdm2026.md
+++ b/docs/rules/11th_edition_missions_gdm2026.md
@@ -1,0 +1,68 @@
+# Warhammer 40,000 11th Edition — GDM 2026 Missions
+
+> Source: provided by the project owner (2026-07-02); card images at gdmissions.app/11th.
+> Rows without exact numbers (e.g. Smoke and Mirrors, Beacon, Gather Intel) had no full card
+> text published at time of writing — treat as approximate.
+
+VP caps: **45 primary total, 15/turn**. Timing key: **C** = your Command phase (switches to end of turn in Round 5), **EOT** = end of turn, **EOG** = end of game, **NML** = No Man's Land.
+
+## Primary Missions (25)
+
+Each card is played based on your Force Disposition vs your opponent's.
+
+| Mission | Deck | Played vs | Scoring |
+|---|---|---|---|
+| Battlefield Dominance | Take and Hold | Take and Hold | 2VP hold more than opponent (R1–2); 3VP/objective held incl. home (R2–5 C) |
+| Immovable Object | Take and Hold | Purge the Foe | Hold objectives incl. home each C; bonus for 2+ (pure hold, no kills) |
+| Purge and Secure | Take and Hold | Reconnaissance | 4VP hold 1+ non-home (C); +4VP hold more; VP for killing units on objectives / capturing new ones |
+| Inescapable Dominion | Take and Hold | Priority Assets | 4VP hold 3+ (EOT); 5VP hold 2+ (C); 4VP hold more (C); 5VP enemy home (EOG). 6-objective maps |
+| Determined Acquisition | Take and Hold | Disruption | 2VP hold obj you didn't start turn with (excl. home); 3VP obj outside enemy territory (C); 6VP obj in enemy territory (C) |
+| Unstoppable Force | Purge the Foe | Take and Hold | 3VP destroy 1+ units (EOT); 4VP hold 1+ non-home (C); 3VP hold new objective; 5VP central obj (EOG) |
+| Meatgrinder | Purge the Foe | Purge the Foe | 3VP destroy 1+; 4VP hold 1+ non-home (C); 4VP kill more than opponent's last turn; 5VP enemy home |
+| Punishment | Purge the Foe | Disruption | Condemn 1–3 enemy units/turn (killed you or on obj); 3VP if a condemned unit leaves the table; 4VP hold 1+ non-home; 5VP hold more; 8VP enemy home (EOG) |
+| Consecrate | Purge the Foe | Reconnaissance | 4VP hold 1+ non-home (C); +4VP hold more; consecrate objectives permanently by killing units on them for extra VP |
+| Destroyer's Wrath | Purge the Foe | Priority Assets | 3VP destroy 1+; 4VP hold 1+ non-home (C); 4VP hold more (C); 5VP kill more than opponent's last turn |
+| Reconnaissance Sweep | Reconnaissance | Take and Hold | 6VP units in table quarters (EOT); 1VP per enemy unit destroyed; C-phase VP for a non-home objective |
+| Triangulation | Reconnaissance | Purge the Foe | 4VP hold 1+ non-home (C); Triangulate action (1/turn, permanent markers): 3/6/10VP for 1/2/3+ triangulated objectives (EOT) |
+| Gather Intel | Reconnaissance | Reconnaissance | Race to complete Extract Intelligence actions placing intel tokens on objectives, plus hold-based VP |
+| Search and Scour | Reconnaissance | Priority Assets | Remove enemy operation markers by ending moves near objectives; ~5VP/round for sweeps + kill/hold VP |
+| Surveil the Foe | Reconnaissance | Disruption | Action-based "tagging": scrub enemy decoy markers off terrain (~5VP/round) + hold VP |
+| Secure Asset | Priority Assets | Take and Hold | 4VP Secure Asset action; 2VP destroy unit on central obj; 4VP hold 1+ non-home (C); 4VP hold 3+ non-home (C) |
+| Vital Link | Priority Assets | Purge the Foe | 2VP hold central +1VP per operation marker there (escalating action, ~3→7VP); 4VP hold 1+ non-home, +4 if central (C); 10VP enemy home (EOG) |
+| Vanguard Operation | Priority Assets | Reconnaissance | 4VP Vanguard Op action (terrain in enemy territory, no enemies in it at EOT); 2VP kill 1+; 4VP hold 1+ non-home (C); 10VP enemy home (EOG) |
+| Sabotage | Priority Assets | Priority Assets | Sabotage actions (multiple/turn): 3VP non-home obj your side, 5VP obj in enemy territory; 4VP hold 1+ non-home (C) |
+| Extract Relic | Priority Assets | Disruption | 4VP Sensor Sweep action (removes an operation marker); 3VP kill unit near objectives; +4VP endgame marker condition |
+| Death Trap | Disruption | Take and Hold | Booby Trap action: 2VP per terrain area trapped (+3 if it's an objective); VP for kills in trapped areas / trapping enemy territory (incl. their home, 5VP) |
+| Delaying Action | Disruption | Purge the Foe | 2VP per enemy unit destroyed; 4VP hold 1+ non-home (C); 3VP hold central + 1 other NML objective |
+| Outmanoeuvre | Disruption | Disruption | 10VP hold enemy home; 4VP/obj excl. home (R1) → 5VP (R2–3 C) → 6VP (R4–5) |
+| Smoke and Mirrors | Disruption | Reconnaissance | Place decoy/operation markers on terrain for cumulative VP; opponent can remove them |
+| Locate and Deny | Disruption | Priority Assets | Marker-denial duel vs the PA player's relic markers + hold-based VP |
+
+## Secondary Missions (18 — each has Attacker and Defender variants)
+
+| Mission | Fixed option | Scoring |
+|---|---|---|
+| Assassination | ✅ | Up to 5VP for killing characters; bonus for 4+ wound characters |
+| A Grievous Blow | ✅ | VP for destroying a high-value enemy unit |
+| Bring it Down | ✅ | VP for destroying Monsters/Vehicles |
+| Engage on All Fronts | ✅ | Units in 3–4 table quarters |
+| Behind Enemy Lines | — | Up to 5VP, units in enemy deployment zone (redrawable R1) |
+| No Prisoners | — | 2VP per unit destroyed, up to 10VP |
+| Cleanse | — | 2/5VP for cleansing 1/2+ objectives (action) |
+| Defend Stronghold | — | Hold home objective; bonus if no enemies in your DZ |
+| Overwhelming Force | — | Up to 5VP destroying units that started turn on objectives |
+| Forward Position | — | 5VP for enemy home objective or both Expansion objectives (redrawable R1) |
+| Burden of Trust | — | Pick objectives + guard units; score for keeping them guarded |
+| Centre Ground | — | Control the battlefield centre (replaces Area Denial) |
+| A Tempting Target | — | Hold a designated objective |
+| Secure No Man's Land | — | Hold 2 objectives in NML |
+| Beacon | — | New — action/position based |
+| Display of Might | — | New — kill/presence based |
+| Outflank | — | Units on flanks/board edges |
+| Plunder | — | Action on objectives to loot |
+
+## Secondary Rules Summary
+
+- Choose **Fixed** (2 from the fixed list) or **Tactical** (draw 2/turn, no hand limit)
+- Discard a secondary at end of turn for **1CP**
+- Max **15VP/turn**, **45VP total** from secondaries

--- a/docs/rules/11th_edition_missions_gdm2026.md
+++ b/docs/rules/11th_edition_missions_gdm2026.md
@@ -187,3 +187,30 @@ Introduction to Missions in 11th Edition", "Rules Deep Dive: Terrain and
 Objectives"; gdmissions.app / game-datamissions.com card pages (via search
 snippets); warhammer-community.com "Building an army in the new edition";
 frontlinegaming.org 11th-ed roundups; thrifthammer.com keywords cheat sheet.
+
+### Additional core-rules details recovered (2026-07-03, second sweep)
+- **Melta modifier order (11e)**: base damage → add the Melta bonus → apply
+  damage-reduction effects (halving is NO longer bypassed by Melta).
+- **Consolidation (11e)**: after ALL fighting across the battlefield, both
+  players make consolidation moves, active player first. Engaging
+  Consolidation is **3"** — select enemy units within 3", move up to 3"
+  under pile-in conditions and engage all selected targets; if you cannot
+  engage, move toward the nearest objective.
+- **Terrain categories (11e)**: Exposed = craters, razorwire, debris
+  (can still grant cover); Light = barricades, low walls, statues; Dense =
+  buildings, ruins, armoured containers, woods. Cover = -1 to the
+  attacker's BS for units within a terrain area or partially obscured by
+  intervening terrain. Obscuring applies to any terrain area with 1+
+  Light/Dense features — LoS cannot pass completely through it.
+- **Faction packs (Orks/Custodes snippets)**: Battlewagon, Blitza-bommer,
+  Burna-bommer, Dakkajet, Hunta Rig, Kill Rig, Stompa, Trukk gain the
+  FRAME keyword; Snikrot's Red Skull Kommandos grants +1 Sv vs ranged;
+  Kommandos' Sneaky Gitz blocks snap-shooting targeting (incl. Overwatch);
+  Custodes Ares Gunship gains FRAME, loses Move/OC as an Aircraft. Full
+  11e stat lines (Ld/OC per datasheet) were not retrievable.
+
+Additional sources: dakkadakka Melta/modifier threads, goonhammer
+Ruleshammer pile-in/consolidate, tabletopbattles "Rules Deep Dive: The
+Charge and Fight Phases" / "Ruleshammer 11th Edition: Terrain Guide" /
+faction pack reviews (Orks, Adeptus Custodes), warhammer-community terrain
+article, spruesandbrews core-rules deep dive.

--- a/docs/rules/11th_edition_missions_gdm2026.md
+++ b/docs/rules/11th_edition_missions_gdm2026.md
@@ -66,3 +66,124 @@ Each card is played based on your Force Disposition vs your opponent's.
 - Choose **Fixed** (2 from the fixed list) or **Tactical** (draw 2/turn, no hand limit)
 - Discard a secondary at end of turn for **1CP**
 - Max **15VP/turn**, **45VP total** from secondaries
+
+---
+
+## Appendix: web-sourced card texts (retrieved 2026-07-03)
+
+Retrieved via web search from gdmissions.app / game-datamissions.com search
+snippets and the Tabletop Battles Force Disposition review series
+(tabletopbattles.com: take-and-hold, purge-the-foe, reconnaissance,
+priority-assets, disruption reviews + "An Introduction to Missions in 11th
+Edition"), plus warhammer-community.com / frontlinegaming.org for core rules.
+Search-result synthesis — treat numbers as good-faith but still approximate
+where only one source stated them.
+
+### Objective designations (Chapter Approved maps)
+- **Home**: one objective in each player's deployment zone.
+- **Expansion**: two NML objectives, each closer to one player's zone.
+- **Central**: the single central objective (or two slightly-offset centrals
+  on some layouts).
+
+### Primary card details recovered
+- **Triangulation**: *Triangulate* action, once per turn, applies the
+  Triangulated descriptor to an objective you control at the end of your
+  turn. EOT score 3/6/10 VP for 1/2/3+ Triangulated objectives (control of
+  them not needed). Markers permanent.
+- **Consecrate**: destroying an enemy unit makes the killer a Consecration
+  unit; at end of your turn each Consecration unit in range of a non-home,
+  non-Consecrated objective places a marker (permanent) and stops being one.
+  EOT: 3 VP if 1–2 objectives Consecrated, 6 VP if 3+. From R2 each C (EOT in
+  final round): 4 VP for holding 1+ non-home. EOG: +5 VP if opponent's home
+  is Consecrated.
+- **Punishment (Condemn)**: at the start of each of your turns choose up to
+  3 enemy units on the battlefield in range of an objective and/or that
+  destroyed a friendly unit the previous turn — they are Condemned. At the
+  end of any turn, if 1+ Condemned units left the battlefield that turn,
+  score 5 VP (review text; the summary table above said 3).
+- **Unstoppable Force**: kill 1+ each turn (EOT); from R2, C-phase VP per
+  non-home objective; EOT +3 VP for controlling an objective you didn't
+  control at the start of your turn; EOG +5 VP for holding a Central
+  objective.
+- **Immovable Object**: EOT 5 VP per objective controlled excluding home;
+  3 VP for controlling 1+ Central objective (review text; per-objective
+  shape differs from the summary table row).
+- **Sabotage**: EOT 3 VP for each non-home objective a unit performed
+  Sabotage on (hold-the-objective action completing at end of your turn);
+  +2 VP each if in opponent's territory (the central objective counts).
+- **Vital Link**: *Operation Marker* action once per turn on a Central
+  objective, completes at EOT if you control it. EOT: 2 VP for holding 1+
+  Central, +1 VP per Operation Marker on those objectives.
+- **Secure Asset**: EOT 4 VP for performing Secure Asset on a non-home
+  objective (completes if you control it at EOT); EOT 2 VP if you destroyed
+  1+ units in range of a Central objective.
+- **Vanguard Operation**: action once per turn, started in your Shooting
+  phase by a unit within a terrain area in your opponent's territory
+  (within, not wholly within); completes at EOT if no enemy units are in
+  that area → 4 VP.
+- **Extract Relic / Locate and Deny (PA vs DI pairing)**: the Disruption
+  player marks five terrain areas outside their deployment zone at the
+  start; both players get *Sensor Sweep* (once per turn, unit in range of a
+  Central objective, completes if you control it at EOT) which removes one
+  marker until one is left. PA: 4 VP per Sensor Sweep; 4 VP if exactly one
+  marker is left with 1+ friendly units within that area and no enemy units
+  in it; 4 VP hold 1+ non-home; EOG 5 VP under the same marker condition.
+  DI (Locate and Deny): 4 VP destroy 1+ enemy units that started the turn
+  on an objective; the same one-marker-left condition for 4 VP; 4 VP hold
+  1+ non-home.
+- **Smoke and Mirrors**: *Decoy* action (end of turn, unlimited uses) puts
+  the Decoyed descriptor on a non-home objective you control. Score 2 VP
+  per Decoyed objective (+2 if in opponent's territory). Markers are
+  removed immediately if an enemy unit ends a move within range. From R2:
+  4 VP hold 1+ non-home. EOG: 10 VP if 4+ objectives were Decoyed in total.
+- **Surveil the Foe**: *Surveil* action (unlimited) tags a visible enemy
+  unit within 18" (the acting unit cannot shoot/charge). Opponent has the
+  Decoy action; EOT flat 5 VP if none of their markers remain on the board.
+- **Gather Intel**: *Extract Intelligence* action from R2, units in range
+  of an NML objective place an intel token; EOT 7 VP per friendly unit that
+  completed the action.
+- **Search and Scour (RE side)**: C 3 VP hold 1+ Central (R1–5); EOT 2 VP
+  destroy 1+ units that started the turn in a terrain area; 4 VP non-home
+  hold; EOG 5 VP if no enemy units wholly within your deployment zone.
+- **Death Trap (Booby Trap)**: action started in the Shooting phase by a
+  unit within an eligible terrain area/objective not yet Trapped; Trapped
+  is permanent. EOT 2 VP per Trapped terrain area (+3 if the area is an
+  objective).
+
+### Secondary details recovered
+- Fixed secondaries: max **20 VP from each fixed card per game** (plus the
+  15/turn, 45 total caps).
+- **A Grievous Blow**: replaces Cull the Horde — destroy enemy units with a
+  **Starting Strength of 13+ models** (VP value not stated in snippets).
+- **Beacon**: pick a unit (on the battlefield or embarked) as your Beacon;
+  if it survives to the end of your opponent's turn and is outside your
+  deployment zone, score VP.
+- **Outflank**: units within 6" of a board edge and not in your deployment
+  zone — 3 VP for one edge, 5 VP for two edges.
+- **Display of Might**: as 10e, but scores more at the end of your
+  opponent's turn in No Man's Land (numbers not stated).
+- **Plunder**: replaces the 10e Sabotage secondary; redraw if you already
+  have Cleanse (and vice versa).
+- Attacker/Defender variants exist as separate cards (e.g. "A Grievous
+  Blow — Defender"); full variant texts were not retrievable.
+
+### Core rules recovered
+- **Heal X**: when a unit is Healed, restore one lost wound to a wounded
+  model; if no wounded models exist, return one destroyed model with 1
+  wound. Repeat X times. A single-model unit wastes excess heals.
+- **Hunter X**: no rule text found in ANY available source (core-rules
+  deep dives, keyword cheat sheets, faction reviews) — presumed not in the
+  shipped core rules; cannot be implemented without fabrication.
+- **Army construction**: Detachment Points pool — 3 DP at 2000 pts,
+  detachments cost 1–3 DP, multiple detachments allowed. Enhancements: max
+  2 at 1000 pts / 4 at 2000 pts; **Upgrade**-tagged enhancements go on up
+  to three non-CHARACTER units while counting as one choice. Leader/Support
+  attachment is fixed at list-build time. The **Warlord must share the
+  army's Faction keyword**.
+
+Sources: tabletopbattles.com Force Disposition reviews (take-and-hold,
+purge-the-foe, reconnaissance, priority-assets, disruption), "An
+Introduction to Missions in 11th Edition", "Rules Deep Dive: Terrain and
+Objectives"; gdmissions.app / game-datamissions.com card pages (via search
+snippets); warhammer-community.com "Building an army in the new edition";
+frontlinegaming.org 11th-ed roundups; thrifthammer.com keywords cheat sheet.


### PR DESCRIPTION
Implements the GDM 2026 11th-edition mission system from `docs/rules/11th_edition_missions_gdm2026.md` (owner-provided) plus a web-source recovery pass that unblocked the previously source-blocked mechanics.

## Secondary missions (audit Tier-1 #2)
- 18-card 11e tactical deck (7 new cards), draw 2/turn with no hand limit, fixed-four restriction, 45-total + 15-per-turn caps, discard-for-1CP intact.
- Sourced corrections: A Grievous Blow keys on Starting Strength 13+; Outflank scores 3/5 VP by distinct board edges; Beacon scores a unit surviving outside your DZ at the end of the opponent's turn; Forward Position accepts both Expansion objectives; fixed cards enforce the sourced 20 VP per-card game cap.

## Primary missions / Force Dispositions (audit Tier-1 #1)
- `PrimaryMissionData11e`: 5 dispositions + the full 25-card pairing table — each player scores their OWN card (own deck × opponent disposition).
- Edition-gated scorer in MissionManager: hold/kill/enemy-home/central/quarters/hold-new/escalating conditions, 45-total + 15-per-turn caps, Round-5 Command→end-of-turn switch, EOT/EOG hooks, save/load.
- Web-sourced card mechanics implemented auto-resolved (cards flagged `approximate` since the real cards give the player target choices): Triangulate 3/6/10, Consecrate markers, Punishment Condemn (end-of-any-turn), Sabotage 3+2/objective, Vital Link operation markers, Secure Asset, Vanguard Operation terrain areas, Extract Relic / Locate and Deny shared relic markers + Sensor Sweep, Smoke and Mirrors decoys with enemy-proximity scrub, Surveil, Gather Intel tokens, Death Trap trapped areas.
- Home/Expansion/Central objective designations assigned per layout and used by the conditions.
- UI: Force Disposition dropdowns in the new-game menu; the Scoring-phase panel shows each player's own card at e11.

## Core rules / other closures
- **Heal X** implemented from the sourced rule (`RulesEngine.get_heal_amount` / `apply_heal_11e`).
- **Hunter X** closed as not-in-shipped-rules (no rule text exists in any source).
- **Melta order** confirmed by source to match the existing engine (base → Melta → reductions); no code change.
- **Engaging Consolidation** resolved to 3" by source — the existing template already enforces it; only the global-step sequencer refactor remains.
- Terrain Exposed/Light/Dense derivation source-validated; FRAME keyword added to the Battlewagon.
- 11e army-construction validator (Warlord faction match, enhancement caps, Upgrade-tag ×3, DP pool) as warnings.

All sourced texts are recorded with provenance in the missions doc appendix; the audit doc tracks what remains genuinely blocked (Attacker/Defender variant texts, full 11e stat lines, Solid <3"-gap rule text, per-detachment DP costs).

## Validation
- Headless: `test_secondary_deck_11e` 31/31, `test_primary_missions_11e` 37/37, `test_gdm_sourced_11e` 20/20 — all registered in the pretrigger suite; full suite 1334 passed / 32 failed (same pre-existing 32).
- Windowed: `iss063b_secondary_deck_11e`, `iss064b_primary_disposition_11e`, `iss064c_primary_mission_panel_11e` all PASS; live MainMenu→Start Game run proved the dropdown→pairing path (verify_delivery PASS, 0 log errors).
- Coverage gate green (5 new tiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VUcidaZzoXoRrHUnkzXxu