### PR TITLE
11th edition only: remove the 10e player mode; fix secondary swaps drawing two cards

### DIFF
--- a/40k/autoloads/SecondaryMissionManager.gd
+++ b/40k/autoloads/SecondaryMissionManager.gd
@@ -185,11 +185,17 @@ func _filter_unachievable_missions_for_ai(deck_ids: Array, player: int) -> int:
 # CARD DRAWING
 # ============================================================================
 
-func draw_missions_to_hand(player: int) -> Array:
+func draw_missions_to_hand(player: int, draw_count: int = 0) -> Array:
 	"""
-	Draw cards until player has MAX_ACTIVE_MISSIONS active cards.
+	Draw secondary mission cards for the player.
+	draw_count = 0: the normal turn draw — 11e draws exactly
+	CARDS_DRAWN_PER_TURN_11E cards (no hand limit); 10e fills the hand up to
+	MAX_ACTIVE_MISSIONS. Called at the start of Command Phase.
+	draw_count > 0: draw exactly that many cards regardless of the turn-draw
+	rules — used by 1-for-1 swaps (replace_drawn_mission, New Orders), which
+	previously drew a full 11e turn draw (2 cards) for a single discard and
+	inflated the hand.
 	Returns array of newly drawn mission dicts.
-	Called at the start of Command Phase.
 	"""
 	var player_key = str(player)
 	var state = _player_state[player_key]
@@ -201,9 +207,10 @@ func draw_missions_to_hand(player: int) -> Array:
 	var drawn = []
 	# 11e (GDM 2026): draw TWO cards each turn with NO hand limit;
 	# 10e: fill the hand up to MAX_ACTIVE_MISSIONS.
-	var draws_remaining_11e := CARDS_DRAWN_PER_TURN_11E
-	while ((GameConstants.edition >= 11 and draws_remaining_11e > 0)
-			or (GameConstants.edition < 11 and state["active"].size() < MAX_ACTIVE_MISSIONS)) \
+	var draws_remaining_11e := CARDS_DRAWN_PER_TURN_11E if draw_count <= 0 else draw_count
+	while ((draw_count > 0 and draws_remaining_11e > 0)
+			or (draw_count <= 0 and GameConstants.edition >= 11 and draws_remaining_11e > 0)
+			or (draw_count <= 0 and GameConstants.edition < 11 and state["active"].size() < MAX_ACTIVE_MISSIONS)) \
 			and state["deck"].size() > 0:
 		var mission_id = state["deck"].pop_front()
 		var mission_data = SecondaryMissionData.get_mission_by_id(mission_id)
@@ -405,7 +412,8 @@ func use_new_orders(player: int, mission_index: int) -> Dictionary:
 	print("SecondaryMissionManager: Player %d used New Orders to discard %s" % [player, discarded["name"]])
 
 	# Draw a replacement
-	var drawn = draw_missions_to_hand(player)
+	# New Orders is a 1-for-1 swap — draw exactly one card.
+	var drawn = draw_missions_to_hand(player, 1)
 
 	return {
 		"success": true,
@@ -451,8 +459,9 @@ func replace_drawn_mission(player: int, mission_index: int) -> Dictionary:
 	# After drawing, we insert the replaced card back and re-shuffle.
 	_shuffle_array(state["deck"])
 
-	# Draw a replacement (replaced card is NOT in the deck yet)
-	var drawn = draw_missions_to_hand(player)
+	# Draw exactly ONE replacement (replaced card is NOT in the deck yet).
+	# A plain turn-draw here would deal 2 cards at 11e and inflate the hand.
+	var drawn = draw_missions_to_hand(player, 1)
 
 	# Now put the replaced card back into the deck and shuffle
 	state["deck"].append(replaced_id)

--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -58,7 +58,9 @@ var auto_allocate_wounds: bool = true
 # (ISS-A0 / 11e migration go-live; default flipped to 11 per owner request.)
 # NOTE: the automated test/scenario harness controls edition explicitly and
 # keeps a 10e baseline — _ready() below does NOT apply this default there.
-var rules_edition: int = 11
+# Rules edition is no longer a player setting — the game is 11th edition
+# only (the 10e data/code paths survive solely for the legacy regression
+# suite and are pinned by the harness carve-out in _ready).
 
 # Board texture style: "grass", "mud", "desert", "stone", "felt", "tilepack", "none"
 var board_style: String = "grass"
@@ -75,7 +77,6 @@ signal unit_labels_visibility_changed(visible: bool)
 signal board_style_changed(new_style: String)
 signal ruins_style_changed(new_style: String)
 signal auto_allocate_wounds_changed(enabled: bool)
-signal rules_edition_changed(new_edition: int)
 
 # P3-111: Settings config file path
 const SETTINGS_FILE_PATH: String = "user://settings.cfg"
@@ -118,17 +119,19 @@ func _ready() -> void:
 	# P3-111: Load persisted settings before applying anything
 	_load_settings()
 
-	# 11e go-live: apply the persisted rules edition to the global rules switch
-	# (GameConstants is a static class) before any rules autoload initializes.
-	# EXCEPTION: in the automated test/scenario harness the edition is controlled
-	# explicitly (per scenario JSON `edition`, or per GUT test) against a 10e
-	# baseline — do not let the player default (11) override that, or the ~70
-	# fieldless scenarios and edition-default assertions would silently flip.
+	# The game is 11th edition only: every player launch runs at 11, no matter
+	# what an old settings.cfg carried (pre-removal builds persisted a
+	# rules_edition that could silently pin players to 10e).
+	# EXCEPTION: the automated test/scenario harness keeps the historical 10e
+	# baseline — scenarios/GUT tests control the edition explicitly, and the
+	# ~70 fieldless legacy scenarios were authored against 10e. This carve-out
+	# disappears when the 10e code paths are deleted.
 	if _is_automated_harness():
-		print("[SettingsService] Automated harness — leaving GameConstants.edition at default %d (not applying player setting %d)" % [GameConstants.edition, rules_edition])
+		GameConstants.edition = 10
+		print("[SettingsService] Automated harness — GameConstants.edition pinned to the legacy 10e test baseline")
 	else:
-		GameConstants.edition = rules_edition
-		print("[SettingsService] Rules edition applied: %d" % rules_edition)
+		GameConstants.edition = 11
+		print("[SettingsService] Rules edition: 11 (11th edition only)")
 
 	# P3-111: Set up audio buses and apply saved audio settings
 	_setup_audio_buses()
@@ -296,17 +299,6 @@ func set_ruins_style(style: String) -> void:
 	_save_settings()
 	print("[SettingsService] Ruins style set to %s" % style)
 
-func get_rules_edition() -> int:
-	return rules_edition
-
-func set_rules_edition(edition: int) -> void:
-	var e := 11 if edition >= 11 else 10
-	rules_edition = e
-	GameConstants.edition = e
-	_save_settings()
-	emit_signal("rules_edition_changed", e)
-	print("[SettingsService] Rules edition set to %d" % e)
-
 func get_auto_allocate_wounds() -> bool:
 	return auto_allocate_wounds
 
@@ -356,7 +348,6 @@ func _save_settings() -> void:
 
 	# Gameplay
 	config.set_value("gameplay", "auto_allocate_wounds", auto_allocate_wounds)
-	config.set_value("gameplay", "rules_edition", rules_edition)
 
 	var err = config.save(SETTINGS_FILE_PATH)
 	if err != OK:
@@ -398,6 +389,5 @@ func _load_settings() -> void:
 	auto_allocate_wounds = config.get_value("gameplay", "auto_allocate_wounds", true)
 	# Default 11e for configs that predate the edition setting / fresh installs.
 	# A config that explicitly saved 10 is respected (the player chose 10th).
-	rules_edition = int(config.get_value("gameplay", "rules_edition", 11))
 
 	print("[SettingsService] Settings loaded from %s" % SETTINGS_FILE_PATH)

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -256,9 +256,6 @@ func _setup_dropdowns() -> void:
 	# 11e GDM 2026: Force Disposition selection (primary mission pairing)
 	_create_disposition_ui()
 
-	# 11e go-live: rules edition selector
-	_create_edition_dropdown()
-
 	# Create army sort dropdown
 	_create_army_sort_dropdown()
 
@@ -361,40 +358,6 @@ func _on_player2_type_changed(index: int) -> void:
 		print("MainMenu: Player 2 type changed to %s, difficulty visible: %s" % [
 			"AI" if index == 1 else "Human", player2_difficulty_container.visible])
 	_update_ai_speed_visibility()
-
-func _create_edition_dropdown() -> void:
-	"""11e go-live: let the player choose the rules edition (10th / 11th).
-	Persisted via SettingsService and applied to GameConstants.edition."""
-	var mission_section = $ScrollContainer/MenuContainer/MissionSection
-
-	var edition_container := HBoxContainer.new()
-	edition_container.name = "EditionContainer"
-
-	var edition_label := Label.new()
-	edition_label.text = "Rules Edition:"
-	edition_label.custom_minimum_size = Vector2(150, 0)
-	edition_container.add_child(edition_label)
-
-	var edition_dropdown := OptionButton.new()
-	edition_dropdown.name = "EditionDropdown"
-	edition_dropdown.custom_minimum_size = Vector2(300, 0)
-	edition_dropdown.add_item("10th Edition")            # index 0 → edition 10
-	edition_dropdown.add_item("11th Edition (beta)")     # index 1 → edition 11
-	var cur_edition := 10
-	if has_node("/root/SettingsService"):
-		cur_edition = SettingsService.get_rules_edition()
-	edition_dropdown.selected = 1 if cur_edition >= 11 else 0
-	edition_dropdown.item_selected.connect(_on_edition_selected)
-	edition_container.add_child(edition_dropdown)
-
-	mission_section.add_child(edition_container)
-	print("MainMenu: rules edition dropdown created (current=%d)" % cur_edition)
-
-func _on_edition_selected(index: int) -> void:
-	var edition := 11 if index == 1 else 10
-	if has_node("/root/SettingsService"):
-		SettingsService.set_rules_edition(edition)
-	print("MainMenu: rules edition selected → %d" % edition)
 
 func _create_ai_speed_dropdown() -> void:
 	"""T7-36: Create an AI speed dropdown in the army section, shown when any player is AI."""

--- a/40k/scripts/rules/GameConstants.gd
+++ b/40k/scripts/rules/GameConstants.gd
@@ -17,9 +17,13 @@ extends RefCounted
 ##   11 — the new-edition core rules (see PRD.md / warhammer40k_core_rules8).
 ## Enforced by tests/test_iss002_game_constants.gd.
 
-## Active rules edition. Default 10 until the 11e migration lands (ISS-037+
-## will wire this to settings/save state).
-static var edition: int = 10
+## Active rules edition. The game is 11th edition only — every player launch
+## runs at 11 (SettingsService re-asserts this at boot). The variable remains
+## writable solely for the legacy regression suite: the automated harness
+## (SettingsService._is_automated_harness) pins it to the historical 10e
+## baseline, and scenarios/tests may set it explicitly, until the 10e code
+## paths are deleted outright.
+static var edition: int = 11
 
 
 # ── Engagement range ────────────────────────────────────────────────

--- a/40k/tests/test_iss002_game_constants.gd
+++ b/40k/tests/test_iss002_game_constants.gd
@@ -45,7 +45,9 @@ func _run_tests():
 
 func _test_edition_values() -> void:
 	print("\n-- A: GameConstants edition values --")
-	_check("default edition is 10", GameConstants.edition == 10)
+	# The static default is 11 (11th edition only); the automated harness pins
+	# GameConstants.edition to the legacy 10e baseline for this suite.
+	_check("harness baseline edition is 10", GameConstants.edition == 10)
 	_check("edition 10: engagement range 1.0\"",
 		GameConstants.engagement_range_inches() == 1.0)
 	_check("vertical engagement range 5.0\"",

--- a/40k/tests/test_secondary_swap_draw_11e.gd
+++ b/40k/tests/test_secondary_swap_draw_11e.gd
@@ -1,0 +1,70 @@
+extends SceneTree
+
+# Regression: 1-for-1 secondary swaps must not deal a full 11e turn draw.
+#
+# At 11e the normal turn draw deals exactly 2 cards with no hand limit.
+# replace_drawn_mission (1 CP, back-to-deck) and use_new_orders (discard+draw)
+# previously drew the replacement via a plain turn draw — removing 1 card and
+# dealing 2, so a turn-one replace left the player with THREE active
+# secondaries. Both swaps must be net-neutral: hand size unchanged.
+#
+# Usage: godot --headless --path . -s tests/test_secondary_swap_draw_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _initialize():
+	await create_timer(0.2).timeout
+	var mgr = root.get_node_or_null("SecondaryMissionManager")
+	if mgr == null:
+		print("FAIL: missing SecondaryMissionManager autoload")
+		quit(1)
+		return
+	GameConstants.edition = 11
+
+	print("\n=== test_secondary_swap_draw_11e ===\n")
+
+	# --- Turn-one state: draw the normal 11e two cards -----------------------
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	var drawn = mgr.draw_missions_to_hand(1)
+	_check("turn draw deals exactly 2 cards at 11e", drawn.size() == 2, str(drawn.size()))
+	_check("hand is 2 after the turn draw",
+		mgr.get_active_missions(1).size() == 2, str(mgr.get_active_missions(1).size()))
+
+	# --- replace_drawn_mission is net-neutral --------------------------------
+	var deck_before = mgr.get_deck_size(1)
+	var res = mgr.replace_drawn_mission(1, 0)
+	_check("replace succeeds", res.get("success", false), str(res))
+	_check("replace draws exactly ONE card (hand stays 2)",
+		mgr.get_active_missions(1).size() == 2, str(mgr.get_active_missions(1).size()))
+	_check("deck unchanged after replace (one out, one back in)",
+		mgr.get_deck_size(1) == deck_before, "%d -> %d" % [deck_before, mgr.get_deck_size(1)])
+	_check("replacement differs from the replaced card",
+		res.get("drawn", "") != res.get("replaced", ""), str(res))
+
+	# --- use_new_orders is net-neutral ----------------------------------------
+	deck_before = mgr.get_deck_size(1)
+	var res2 = mgr.use_new_orders(1, 0)
+	_check("New Orders succeeds", res2.get("success", false), str(res2))
+	_check("New Orders draws exactly ONE card (hand stays 2)",
+		mgr.get_active_missions(1).size() == 2, str(mgr.get_active_missions(1).size()))
+	_check("deck shrinks by one after New Orders (discarded card does not return)",
+		mgr.get_deck_size(1) == deck_before - 1, "%d -> %d" % [deck_before, mgr.get_deck_size(1)])
+
+	# --- exact-count draw helper ----------------------------------------------
+	var one = mgr.draw_missions_to_hand(1, 1)
+	_check("draw_missions_to_hand(player, 1) deals exactly one card",
+		one.size() == 1 and mgr.get_active_missions(1).size() == 3,
+		"drawn=%d active=%d" % [one.size(), mgr.get_active_missions(1).size()])
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/docs/40KDC_11E_MIGRATION.md
+++ b/docs/40KDC_11E_MIGRATION.md
@@ -44,10 +44,14 @@ faction block (nearest-anchor assignment; 0 unresolved references across all
 
 Removed 10e-only roster content: units with no 11e datasheet (Kaptin
 Badrukk, Big Gunz), placeholder "Strike Force" import artifacts, retired
-enhancements (Tellyporta, Adamantine Talisman). The engine's 10e *mode*
-(edition-gated mission/secondary/stratagem code paths behind
-`GameConstants.edition < 11`) is retained so old saves, scenarios, and the
-10e regression suite keep working; it no longer leaks into 11e play.
+enhancements (Tellyporta, Adamantine Talisman).
+
+**The game is 11th edition only.** `GameConstants.edition` defaults to 11,
+every player launch re-asserts 11 at boot (a stale `settings.cfg` from older
+builds can no longer pin a player to 10e), and the main-menu "Rules Edition"
+selector was removed. The 10e code paths and data tables survive *only* for
+the legacy regression suite — the automated harness pins its historical 10e
+baseline explicitly — until they are deleted outright.
 
 ## Licensing
 


### PR DESCRIPTION
Follow-up to #491, addressing two player reports from the itch.io web build.

## 11th edition only

Players can no longer end up in 10th-edition mode:

- `GameConstants.edition` now defaults to **11**, and `SettingsService` re-asserts 11 on every player launch. Older builds persisted a `rules_edition` value in `settings.cfg` that could silently pin a player to 10e — that setting is removed and a stale file has no effect.
- The main-menu **"Rules Edition" selector is removed**.
- The automated test harness pins its historical 10e baseline explicitly (scenario runner / GUT / `-s` script runs), so the legacy regression suite and the ~70 fieldless scenarios keep their existing behavior until the 10e code paths are deleted outright.

## Bug fix: 1-for-1 secondary swaps drew two cards

`replace_drawn_mission` (1 CP, back-to-deck) and `use_new_orders` drew the replacement via a full turn draw — which at 11e deals **two** cards (no hand limit) — so a turn-one replace left the player with three active secondaries. Both swaps now draw exactly one card via a new exact-count mode on `draw_missions_to_hand`, pinned by `tests/test_secondary_swap_draw_11e.gd` (10/0).

## Validation

- Live windowed run with a stale `rules_edition=10` settings.cfg planted: boots at edition 11, no edition dropdown on the menu, and the real `SecondaryMissionReviewDialog` renders the official 11e card text (Assassination: fixed 3 VP/character +1 for W4+, tactical flat 5).
- Suites: secondary deck 100/0, swap regression 10/0, MP scoring 7/0, primaries 56/0, GDM pins 21/0, legacy 10e secondaries 373/1 (same single pre-existing failure as baseline), GameConstants pins 13/0, army-load gate 9/9.
- Windowed scenarios: iss063b, iss064f, iss064i all pass.

Note for the itch.io build: the web deploy that includes the #491 data migration completed at 19:38 UTC — sessions started before that (or on a browser-cached copy) still showed 10e card text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH

---
_Generated by [Claude Code](https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH)_