### PR TITLE
Retry butler push on itch.io "still processing" transient (re-deploys 11e-only fix)

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -108,7 +108,33 @@ jobs:
         env:
           BUTLER_API_KEY: ${{ secrets.ITCH_BUTLER_KEY }}
         run: |
-          ./butler push web-build ${{ env.ITCH_USERNAME }}/${{ env.ITCH_GAME }}:html5
+          # itch.io rejects a push with a 400 ("latest build is still
+          # processing, try again later") while it is still scanning the
+          # previous upload. That is transient — retry with backoff instead
+          # of failing the deploy and leaving stale bits live.
+          target="${{ env.ITCH_USERNAME }}/${{ env.ITCH_GAME }}:html5"
+          attempts=6
+          delay=30
+          for i in $(seq 1 "$attempts"); do
+            echo "::group::butler push attempt $i/$attempts"
+            out="$(./butler push web-build "$target" 2>&1)"; status=$?
+            echo "$out"
+            echo "::endgroup::"
+            if [ "$status" -eq 0 ]; then
+              echo "butler push succeeded on attempt $i"
+              exit 0
+            fi
+            if echo "$out" | grep -q "still processing"; then
+              echo "itch.io is still processing the previous build; retrying in ${delay}s…"
+              sleep "$delay"
+              delay=$((delay * 2))
+              continue
+            fi
+            echo "butler push failed with a non-transient error"
+            exit "$status"
+          done
+          echo "butler push still failing after $attempts attempts"
+          exit 1
 
       - name: Deployment Summary
         run: |


### PR DESCRIPTION
The #492 deploy (11th-edition-only fix + secondary-swap bug) built successfully but **failed at the itch.io push step**, so the fix never went live — players still see the old build with the "Rules Edition" dropdown.

Root cause (from the failed job log):
```
creating build on remote server: itch.io API error (400):
/wharf/builds: channel html5's latest build is still processing, try again later
```
itch.io was still scanning the previous (#491) upload when the #492 deploy pushed, and rejected it. The build artifact and `BUTLER_API_KEY` are both fine — this is a known transient.

This wraps `butler push` in a backoff-retry loop (6 attempts, 30s doubling) that retries **only** the "still processing" transient and fails fast on any other error. Merging re-runs the deploy against current `main` — which already carries the 11e-only edition fix from #492 — using the hardened step, so the fix reaches itch.io.

No game-code changes; only `.github/workflows/deploy-web.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH

---
_Generated by [Claude Code](https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH)_