### PR TITLE
Fix butler retry loop (errexit) so the itch deploy actually retries

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -108,6 +108,10 @@ jobs:
         env:
           BUTLER_API_KEY: ${{ secrets.ITCH_BUTLER_KEY }}
         run: |
+          # NOTE: this step runs under `bash -e`; without `set +e` the
+          # `out=$(butler …)` assignment would abort the whole step the moment
+          # butler returns non-zero, before the retry logic below can run.
+          set +e
           # itch.io rejects a push with a 400 ("latest build is still
           # processing, try again later") while it is still scanning the
           # previous upload. That is transient — retry with backoff instead
@@ -117,7 +121,8 @@ jobs:
           delay=30
           for i in $(seq 1 "$attempts"); do
             echo "::group::butler push attempt $i/$attempts"
-            out="$(./butler push web-build "$target" 2>&1)"; status=$?
+            out="$(./butler push web-build "$target" 2>&1)"
+            status=$?
             echo "$out"
             echo "::endgroup::"
             if [ "$status" -eq 0 ]; then
@@ -130,7 +135,7 @@ jobs:
               delay=$((delay * 2))
               continue
             fi
-            echo "butler push failed with a non-transient error"
+            echo "butler push failed with a non-transient error (see output above)"
             exit "$status"
           done
           echo "butler push still failing after $attempts attempts"


### PR DESCRIPTION
The retry loop added in #493 never actually ran. The step executes under `bash -e` (errexit), so `out="$(./butler push …)"` aborted the entire step the moment butler returned non-zero — before the `grep`/retry logic, and with butler's own output swallowed (the job failed in ~117ms on "attempt 1/6" with no butler error printed).

Fix: `set +e` at the top of the step so the loop controls flow explicitly via the captured status, and butler's error is actually logged.

Merging redeploys current `main` (which already carries the 11th-edition-only fix from #492) with a working retry loop. If itch is still processing a prior upload, the loop now backs off and retries instead of failing instantly.

No game-code changes; only `.github/workflows/deploy-web.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH

---
_Generated by [Claude Code](https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH)_