### PR TITLE
ci: probe deploy to test itch.io channel is unblocked

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,4 +1,5 @@
 # GitHub Actions workflow to build and deploy web export to itch.io
+# (probe: re-trigger deploy to test the itch.io html5 channel is unblocked)
 name: Deploy Web Build
 
 on:


### PR DESCRIPTION
Comment-only touch to `.github/workflows/deploy-web.yml` to re-trigger the web deploy and check whether itch.io's `html5` channel has cleared the build that was stuck in "processing". No functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH

---
_Generated by [Claude Code](https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH)_