### PR TITLE
ci: redeploy now that the itch.io stuck build is cleared

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,5 +1,4 @@
 # GitHub Actions workflow to build and deploy web export to itch.io
-# (probe: re-trigger deploy to test the itch.io html5 channel is unblocked)
 name: Deploy Web Build
 
 on:


### PR DESCRIPTION
The stuck "processing" build was deleted from itch.io, so the `html5` channel is unblocked. Removes the temporary probe comment and re-triggers the web deploy — the push should now succeed on the first attempt, taking all merged fixes (11e data, 11e-only edition, secondary-swap fix) live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH

---
_Generated by [Claude Code](https://claude.ai/code/session_017L6ZD3KNrzM69zMnG4HCEH)_