### PR TITLE
Fix Heroic Intervention game freeze and tighten HI eligibility

### DIFF
--- a/40k/autoloads/StratagemManager.gd
+++ b/40k/autoloads/StratagemManager.gd
@@ -2308,12 +2308,20 @@ func is_heroic_intervention_available(player: int) -> Dictionary:
 	return {"available": true, "reason": ""}
 
 # 11e 15.11: eligibility for the END-of-charge-phase HI window — one
-# friendly unit that is unengaged and within 12" of one or more enemy
-# units (not a VEHICLE unless CHARACTER or WALKER; not battle-shocked).
+# friendly unit that is unengaged, not battle-shocked, not a VEHICLE (unless
+# CHARACTER or WALKER), AND has a legal target for at least one of the two HI
+# modes. The modes (see ChargePhase._closest_hi_target_11e / the HI dialog):
+#   LEAP TO DEFEND: closest enemy that CHARGED this turn, within 12".
+#   INTO THE FRAY:  closest enemy within 6" (regardless of whether it charged).
+# Offering the window on "any enemy within 12"" over-triggers — an enemy that
+# merely sits at 8-12" and did not charge satisfies NEITHER mode, so the prompt
+# was un-actionable (Leap finds no charged target, Fray finds none within 6")
+# and the player was shown a Heroic Intervention offer they could not use.
 func get_heroic_intervention_eligible_units_11e(player: int) -> Array:
 	var eligible: Array = []
 	var snapshot = GameState.create_snapshot()
-	var range_px = Measurement.inches_to_px(12.0)
+	var leap_range_px = Measurement.inches_to_px(12.0)  # LEAP TO DEFEND: charged enemy within 12"
+	var fray_range_px = Measurement.inches_to_px(6.0)   # INTO THE FRAY:  any enemy within 6"
 	for unit_id in snapshot.get("units", {}):
 		var unit = snapshot.units[unit_id]
 		if int(unit.get("owner", 0)) != player:
@@ -2334,26 +2342,30 @@ func get_heroic_intervention_eligible_units_11e(player: int) -> Array:
 			continue
 		if RulesEngine.is_unit_engaged(unit_id, snapshot):
 			continue
-		# enemy within 12" (edge-to-edge)
-		var enemy_near := false
+		# A legal target for at least one HI mode (edge-to-edge):
+		#   any enemy within 6" (Into the Fray), OR
+		#   an enemy that charged this turn within 12" (Leap to Defend).
+		var has_target := false
 		for other_id in snapshot.get("units", {}):
 			var other = snapshot.units[other_id]
 			if int(other.get("owner", 0)) == player:
 				continue
+			var other_charged: bool = other.get("flags", {}).get("charged_this_turn", false)
 			for m in unit.get("models", []):
 				if not m.get("alive", true) or m.get("position") == null:
 					continue
 				for em in other.get("models", []):
 					if not em.get("alive", true) or em.get("position") == null:
 						continue
-					if Measurement.model_to_model_distance_px(m, em) <= range_px:
-						enemy_near = true
+					var d = Measurement.model_to_model_distance_px(m, em)
+					if d <= fray_range_px or (other_charged and d <= leap_range_px):
+						has_target = true
 						break
-				if enemy_near:
+				if has_target:
 					break
-			if enemy_near:
+			if has_target:
 				break
-		if enemy_near:
+		if has_target:
 			eligible.append({
 				"unit_id": unit_id,
 				"unit_name": unit.get("meta", {}).get("name", unit_id)

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -109,6 +109,15 @@ var _reactive_stratagem_overlay_label: Label = null
 var _reactive_stratagem_overlay_timer_label: Label = null
 var _reactive_stratagem_overlay_pulse_tween: Tween = null
 var _reactive_stratagem_pending: bool = false
+# Safety net: the overlay blocks all input while a reactive stratagem window is
+# open. It is normally hidden by the controller that owns the decision dialog
+# (e.g. ChargeController on a Heroic Intervention decline/use). If that callback
+# is ever orphaned — the phase advances and tears the controller down while the
+# window is still open — the overlay would stay up forever and permanently block
+# input (game-freeze-heroic-intervention). This timer guarantees the overlay
+# self-dismisses shortly after every reactive window's own auto-decline elapses.
+var _reactive_stratagem_safety_timer: Timer = null
+const REACTIVE_STRATAGEM_SAFETY_SECONDS: float = 10.0
 
 # T5-V3: Phase transition animation banner
 var phase_transition_banner: PhaseTransitionBanner = null
@@ -1171,6 +1180,16 @@ func _setup_reactive_stratagem_overlay() -> void:
 	vbox.add_child(_reactive_stratagem_overlay_timer_label)
 
 	_reactive_stratagem_overlay.add_child(_reactive_stratagem_overlay_panel)
+
+	# Safety-net timer — see _reactive_stratagem_safety_timer declaration. One-shot;
+	# (re)started every time the overlay is shown, cancelled when it is hidden.
+	_reactive_stratagem_safety_timer = Timer.new()
+	_reactive_stratagem_safety_timer.name = "ReactiveStratagemSafetyTimer"
+	_reactive_stratagem_safety_timer.one_shot = true
+	_reactive_stratagem_safety_timer.wait_time = REACTIVE_STRATAGEM_SAFETY_SECONDS
+	_reactive_stratagem_safety_timer.timeout.connect(_on_reactive_stratagem_safety_timeout)
+	add_child(_reactive_stratagem_safety_timer)
+
 	print("Main: MA-42 Reactive stratagem blocking overlay created")
 
 func show_reactive_stratagem_waiting(stratagem_name: String = "stratagem") -> void:
@@ -1181,6 +1200,11 @@ func show_reactive_stratagem_waiting(stratagem_name: String = "stratagem") -> vo
 	_reactive_stratagem_overlay_label.text = "Waiting for opponent's %s decision..." % stratagem_name
 	_reactive_stratagem_overlay_timer_label.text = "Auto-declining in 5 seconds..."
 	_reactive_stratagem_overlay.visible = true
+
+	# (Re)arm the safety-net auto-dismiss so a lost hide-callback can never leave
+	# the input-blocking overlay up forever.
+	if _reactive_stratagem_safety_timer and is_instance_valid(_reactive_stratagem_safety_timer):
+		_reactive_stratagem_safety_timer.start(REACTIVE_STRATAGEM_SAFETY_SECONDS)
 
 	# Start pulse animation
 	if _reactive_stratagem_overlay_pulse_tween:
@@ -1203,12 +1227,26 @@ func hide_reactive_stratagem_waiting() -> void:
 		return
 	_reactive_stratagem_pending = false
 	_reactive_stratagem_overlay.visible = false
+	if _reactive_stratagem_safety_timer and is_instance_valid(_reactive_stratagem_safety_timer):
+		_reactive_stratagem_safety_timer.stop()
 	if _reactive_stratagem_overlay_pulse_tween:
 		_reactive_stratagem_overlay_pulse_tween.kill()
 		_reactive_stratagem_overlay_pulse_tween = null
 	if _reactive_stratagem_overlay_panel:
 		_reactive_stratagem_overlay_panel.modulate = Color(1, 1, 1, 1)
 	print("Main: MA-42 Hiding reactive stratagem blocking overlay")
+
+func _on_reactive_stratagem_safety_timeout() -> void:
+	# Safety net: the owning controller never called hide_reactive_stratagem_waiting()
+	# (e.g. its decision dialog was orphaned by a phase transition). Force the
+	# input-blocking overlay down so the player is never permanently locked out.
+	# This only clears the UI — the reactive window's own auto-decline already
+	# resolved (or will resolve) the game state via the decision dialog / AI path.
+	if not _reactive_stratagem_pending:
+		return
+	push_warning("Main: Reactive stratagem overlay safety-timeout fired — force-hiding stuck blocking overlay")
+	print("Main: Reactive stratagem overlay safety-timeout fired — force-hiding stuck blocking overlay")
+	hide_reactive_stratagem_waiting()
 
 # =============================================================================
 # P3-56: Web Relay "Waiting for game state" Loading Screen
@@ -8470,6 +8508,15 @@ func _on_phase_changed(new_phase: GameStateData.Phase) -> void:
 
 	# Close any lingering SecondaryMissionReviewDialog from command phase
 	_close_stale_review_dialogs()
+
+	# A reactive-stratagem window (Heroic Intervention, Fire Overwatch, …) never
+	# legitimately spans a phase change — it resolves inside the phase that opened
+	# it. If we reach here with the input-blocking overlay still up, its owning
+	# controller lost the hide-callback (game-freeze-heroic-intervention); clear it
+	# now so the incoming phase is interactable.
+	if _reactive_stratagem_pending:
+		print("Main: Phase changed with reactive stratagem overlay still up — force-hiding it")
+		hide_reactive_stratagem_waiting()
 
 	# Clean up scout UI state when leaving the scout phase
 	if _scout_active_unit_id != "":

--- a/40k/tests/test_reactive_overlay_freeze_pin.gd
+++ b/40k/tests/test_reactive_overlay_freeze_pin.gd
@@ -1,0 +1,94 @@
+extends SceneTree
+
+# Pin test for the "game freezes waiting for opponent's Heroic Intervention
+# decision" bug (branch: game-freeze-heroic-intervention).
+#
+# ROOT CAUSE: Main.gd's reactive-stratagem overlay uses MOUSE_FILTER_STOP to
+# block ALL input while a reactive window (Heroic Intervention, Fire Overwatch,
+# Counter-Offensive, Rapid Ingress...) is open. It was hidden ONLY by the
+# controller that owned the decision dialog (e.g. ChargeController on a Heroic
+# Intervention decline/use). If that callback was orphaned — the phase advanced
+# and tore the controller down while the window was still up — the overlay
+# stayed visible forever and permanently blocked input, even though the game
+# logic had moved on (observed stuck across a whole battle round).
+#
+# FIX (Main.gd): two independent safety nets, both anchored below:
+#   1. A one-shot safety Timer that force-hides the overlay a few seconds after
+#      every reactive window's own auto-decline elapses.
+#   2. _on_phase_changed() force-hides any overlay still up on a phase change —
+#      a reactive window never legitimately spans a phase transition.
+#
+# This is a source-shape regression net (per the project's "pin tests are not
+# validation" note); the live end-to-end validation was done against the running
+# windowed UI. This test just catches a silent revert of the safety nets.
+#
+# Usage: godot --headless --path . -s tests/test_reactive_overlay_freeze_pin.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	print("\n=== test_reactive_overlay_freeze_pin ===\n")
+	_run_tests()
+	print("\n=== %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)
+
+func _read(path: String) -> String:
+	var f = FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return ""
+	var src = f.get_as_text()
+	f.close()
+	return src
+
+func _run_tests():
+	var src = _read("res://scripts/Main.gd")
+	_check("Main.gd is readable", src != "")
+
+	# 1. Safety timer must exist, be armed on show, and stopped on hide.
+	_check("safety timer field declared",
+		"_reactive_stratagem_safety_timer" in src)
+	_check("safety timeout constant declared",
+		"REACTIVE_STRATAGEM_SAFETY_SECONDS" in src)
+	_check("safety timer created in setup",
+		"ReactiveStratagemSafetyTimer" in src)
+	_check("safety timeout handler defined",
+		"func _on_reactive_stratagem_safety_timeout" in src)
+	_check("handler force-hides the overlay",
+		"_on_reactive_stratagem_safety_timeout" in src
+		and "hide_reactive_stratagem_waiting()" in src)
+
+	# The show path must (re)arm the timer; the hide path must stop it.
+	var show_idx = src.find("func show_reactive_stratagem_waiting")
+	var hide_idx = src.find("func hide_reactive_stratagem_waiting")
+	var timeout_idx = src.find("func _on_reactive_stratagem_safety_timeout")
+	_check("show/hide functions present", show_idx != -1 and hide_idx != -1)
+	if show_idx != -1 and hide_idx != -1:
+		var show_body = src.substr(show_idx, hide_idx - show_idx)
+		_check("show arms safety timer",
+			"_reactive_stratagem_safety_timer.start" in show_body,
+			"show_reactive_stratagem_waiting must (re)arm the safety timer")
+		var hide_end = timeout_idx if timeout_idx > hide_idx else src.length()
+		var hide_body = src.substr(hide_idx, hide_end - hide_idx)
+		_check("hide stops safety timer",
+			"_reactive_stratagem_safety_timer.stop" in hide_body,
+			"hide_reactive_stratagem_waiting must cancel the safety timer")
+
+	# 2. Phase change must clear a lingering overlay.
+	var pc_idx = src.find("func _on_phase_changed")
+	_check("_on_phase_changed present", pc_idx != -1)
+	if pc_idx != -1:
+		# grab a generous slice of the handler body
+		var pc_body = src.substr(pc_idx, 3000)
+		_check("phase change clears pending overlay",
+			"_reactive_stratagem_pending" in pc_body
+			and "hide_reactive_stratagem_waiting()" in pc_body,
+			"_on_phase_changed must force-hide a still-pending reactive overlay")

--- a/40k/tests/test_reactive_overlay_freeze_pin.gd.uid
+++ b/40k/tests/test_reactive_overlay_freeze_pin.gd.uid
@@ -1,0 +1,1 @@
+uid://gqe3y7rvih8t

--- a/40k/tests/test_secondary_swap_draw_11e.gd.uid
+++ b/40k/tests/test_secondary_swap_draw_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://nwg1daapoj8o

--- a/40k/tests/unit/test_heroic_intervention.gd
+++ b/40k/tests/unit/test_heroic_intervention.gd
@@ -564,3 +564,63 @@ func test_friendly_units_not_eligible():
 		eligible_ids.append(e.unit_id)
 
 	assert_false("U_CHARGER" in eligible_ids, "Charging unit should not be eligible for its own player's HI")
+
+
+# ==========================================
+# 11e END-OF-PHASE WINDOW eligibility (15.11) — mode-aware tightening
+# ==========================================
+#
+# get_heroic_intervention_eligible_units_11e must only offer the window when a
+# unit has a legal target for at least one HI mode:
+#   LEAP TO DEFEND: an enemy that CHARGED this turn, within 12".
+#   INTO THE FRAY:  any enemy within 6".
+# It previously offered on "any enemy within 12"", so a unit whose only nearby
+# enemy sat at 8-12" and did not charge got an un-actionable Heroic Intervention
+# prompt (neither mode had a target). These tests pin the tightened behaviour.
+
+func _setup_11e_two_unit_board(enemy_offset_inches: float, enemy_charged: bool) -> void:
+	# One P2 defender at a fixed point, one P1 enemy `enemy_offset_inches` south of it.
+	GameState.state.units.clear()
+	var defender = _create_unit("U_DEF", 3, 2, ["INFANTRY"])
+	for i in range(defender.models.size()):
+		defender.models[i].position = {"x": 1000 + i * 20, "y": 1000}
+	GameState.state.units["U_DEF"] = defender
+
+	var offset_px = Measurement.inches_to_px(enemy_offset_inches)
+	var enemy = _create_unit("U_ENEMY", 3, 1, ["INFANTRY"])
+	for i in range(enemy.models.size()):
+		enemy.models[i].position = {"x": 1000 + i * 20, "y": 1000 + offset_px}
+	if enemy_charged:
+		enemy.flags["charged_this_turn"] = true
+	GameState.state.units["U_ENEMY"] = enemy
+
+func _11e_eligible_ids() -> Array:
+	var eligible = StratagemManager.get_heroic_intervention_eligible_units_11e(2)
+	var ids = []
+	for e in eligible:
+		ids.append(e.unit_id)
+	return ids
+
+func test_11e_uncharged_enemy_at_9in_not_eligible():
+	"""Tightening: an enemy at ~9" that did NOT charge triggers neither mode."""
+	_setup_11e_two_unit_board(9.0, false)
+	assert_false("U_DEF" in _11e_eligible_ids(),
+		"Unit whose only nearby enemy is 9\" away and un-charged must NOT be offered HI")
+
+func test_11e_charged_enemy_at_9in_eligible_leap():
+	"""LEAP TO DEFEND: an enemy that charged this turn within 12" is a valid target."""
+	_setup_11e_two_unit_board(9.0, true)
+	assert_true("U_DEF" in _11e_eligible_ids(),
+		"Enemy that charged this turn within 12\" should make the unit HI-eligible (Leap)")
+
+func test_11e_uncharged_enemy_at_4in_eligible_fray():
+	"""INTO THE FRAY: any enemy within 6" is a valid target, charged or not."""
+	_setup_11e_two_unit_board(4.0, false)
+	assert_true("U_DEF" in _11e_eligible_ids(),
+		"Enemy within 6\" should make the unit HI-eligible (Into the Fray)")
+
+func test_11e_charged_enemy_beyond_12in_not_eligible():
+	"""Even a charged enemy is out of Leap range beyond 12"."""
+	_setup_11e_two_unit_board(15.0, true)
+	assert_false("U_DEF" in _11e_eligible_ids(),
+		"Charged enemy beyond 12\" is out of Leap range — unit must NOT be offered HI")


### PR DESCRIPTION
## Problem

The game froze showing **"Waiting for opponent's Heroic Intervention decision… Auto-declining in 5 seconds…"** — an input-blocking overlay that never went away, even though the game logic had already advanced (observed stuck across an entire battle round). Players reported it firing when no models were close enough to intervene.

## Root causes & fixes

### 1. Stuck reactive-stratagem overlay = the freeze (`40k/scripts/Main.gd`)

The reactive-stratagem overlay uses `MOUSE_FILTER_STOP`, so while visible it silently blocks **every** click on the board. It was hidden **only** by the controller that owned the Heroic Intervention decision dialog (`ChargeController`). When that HI window was orphaned — the phase advanced and tore the controller down while the window was still open — the dialog freed itself but its "declined" signal reached a dead handler, so `hide_reactive_stratagem_waiting()` never ran. The overlay had no self-timeout and no phase-change cleanup, so it stayed up forever.

Added two independent safety nets:
- A one-shot **safety `Timer`**, (re)armed whenever the overlay is shown and cancelled when hidden, that force-hides it a few seconds after every reactive window's own 5s auto-decline would have elapsed.
- `_on_phase_changed()` **force-hides** any overlay still up on a phase change — a reactive window never legitimately spans a phase transition.

Both only clear the input-blocking UI; the stratagem's game state is still resolved by its own dialog / AI auto-decline path.

### 2. Un-actionable HI window (the trigger) (`40k/autoloads/StratagemManager.gd`)

`get_heroic_intervention_eligible_units_11e` offered the window on *any enemy within 12"*, but the two 11e modes only accept:
- **Leap to Defend**: closest enemy that **charged this turn**, within 12"
- **Into the Fray**: any enemy within 6"

So a unit whose only nearby enemy sat at 8–12" and didn't charge got a prompt it couldn't use. Eligibility now mirrors the real per-mode targeting: offered only if an enemy is within 6" (Fray) **or** an enemy that charged this turn is within 12" (Leap).

## Validation

- **Live, windowed** (per project gate): reproduced the exact stuck overlay in the running game; confirmed it self-dismisses via the safety timer (warning logged) and immediately on phase change, board interactable afterward; `verify_delivery` verdict **PASS**, 0 errors.
- Eligibility tightening validated live across 5 boundary cases (8" un-charged → not offered; 8" charged → Leap; 4"/5.5" un-charged → Fray; 14" charged → out of range).
- **Tests**: `test_reactive_overlay_freeze_pin.gd` (11/11) as a regression net; 4 new GUT tests in `test_heroic_intervention.gd` for the tightened eligibility (4/4 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SVRgCue1szS9vQ2ZoJ9yKs

---
_Generated by [Claude Code](https://claude.ai/code/session_01SVRgCue1szS9vQ2ZoJ9yKs)_