### PR TITLE
D5: Force-Disposition matchup selects the official 11e terrain layouts

### DIFF
--- a/40k/autoloads/TerrainManager.gd
+++ b/40k/autoloads/TerrainManager.gd
@@ -133,6 +133,27 @@ func get_all_layout_ids() -> Array:
 func get_11e_layout_ids() -> Array:
 	return _layout_ids_11e.duplicate()
 
+## D5: the official 11e layouts for a Force-Disposition pairing. Takes the
+## game's underscore disposition ids (e.g. "take_and_hold", as used by
+## PrimaryMissionData11e.DISPOSITIONS), converts to the dataset's hyphenated
+## form, and tries both orderings of the matchup id — the dataset authors one
+## canonical ordering per unordered pairing (mirrors use "<a>-vs-<a>").
+## Returns the layout metadata dictionaries sorted by variant (1..3);
+## empty if the 11e index isn't present or the pairing is unknown.
+func get_layouts_for_matchup(disposition_a: String, disposition_b: String) -> Array:
+	var a := disposition_a.replace("_", "-")
+	var b := disposition_b.replace("_", "-")
+	for candidate in ["%s-vs-%s" % [a, b], "%s-vs-%s" % [b, a]]:
+		var found: Array = []
+		for layout_id in _layout_ids_11e:
+			var meta = _layout_metadata.get(layout_id, {})
+			if str(meta.get("mission_matchup_id", "")) == candidate:
+				found.append(meta)
+		if not found.is_empty():
+			found.sort_custom(func(x, y): return int(x.get("variant", 0)) < int(y.get("variant", 0)))
+			return found
+	return []
+
 func get_recommended_deployments(layout_id: String) -> Array:
 	var metadata = get_layout_metadata(layout_id)
 	return metadata.get("recommended_deployments", [])

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -70,8 +70,15 @@ var deployment_options = [
 	{"id": "dawn_of_war", "name": "Dawn of War"},
 	{"id": "search_and_destroy", "name": "Search and Destroy"},
 	{"id": "sweeping_engagement", "name": "Sweeping Engagement"},
-	{"id": "crucible_of_battle", "name": "Crucible of Battle"}
+	{"id": "crucible_of_battle", "name": "Crucible of Battle"},
+	{"id": "tipping_point", "name": "Tipping Point"}
 ]
+
+# D5 (docs/40KDC_TERRAIN_MIGRATION_SPEC.md): the base terrain list above is
+# fixed; the dropdown is rebuilt as base + the official 11e layouts for the
+# currently selected Force-Disposition matchup (3 variants per pairing).
+var _base_terrain_options: Array = []
+var _matchup_layouts: Array = []
 
 # Army options - dynamically populated from ArmyListManager
 var army_options = []
@@ -102,6 +109,7 @@ func _ready() -> void:
 		NetworkManager.disconnect_network()
 
 	_apply_theme()
+	_base_terrain_options = terrain_options.duplicate()
 	_setup_dropdowns()
 	_connect_signals()
 	_setup_save_load_dialog()
@@ -110,6 +118,11 @@ func _ready() -> void:
 	terrain_dropdown.selected = _find_option_index(terrain_options, "layout_parse_test")
 	mission_dropdown.selected = 0
 	deployment_dropdown.selected = _find_option_index(deployment_options, "search_and_destroy")
+
+	# D5: list the default matchup's official 11e layouts in the terrain
+	# dropdown. Boot-time refresh preserves the selection above — official
+	# layouts are only auto-selected when a player changes a disposition.
+	_refresh_matchup_terrain_options(false)
 
 	# Set default army selections based on available armies
 	_set_default_army_selections()
@@ -497,6 +510,8 @@ func _create_disposition_ui() -> void:
 		for disp_id in PrimaryMissionData11e.DISPOSITIONS:
 			dropdown.add_item(PrimaryMissionData11e.get_disposition_name(disp_id))
 		dropdown.selected = 0
+		# D5: the disposition pairing selects the official terrain layouts
+		dropdown.item_selected.connect(_on_disposition_changed)
 		row.add_child(dropdown)
 
 		if player == 1:
@@ -505,6 +520,70 @@ func _create_disposition_ui() -> void:
 			p2_disposition_dropdown = dropdown
 
 	print("MainMenu: 11e Force Disposition UI created")
+
+## D5: rebuild the terrain dropdown as base layouts + the official 11e
+## layouts of the currently selected Force-Disposition matchup.
+## select_official=true (player changed a disposition) selects the matchup's
+## variant 1 and snaps the deployment dropdown to its official pattern;
+## select_official=false (boot) preserves the current selection so the
+## first-run defaults and manual overrides stay intact.
+func _refresh_matchup_terrain_options(select_official: bool) -> void:
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null or not tm.has_method("get_layouts_for_matchup"):
+		return
+	var p1_disp = _get_selected_disposition(p1_disposition_dropdown)
+	var p2_disp = _get_selected_disposition(p2_disposition_dropdown)
+	_matchup_layouts = tm.get_layouts_for_matchup(p1_disp, p2_disp)
+
+	var selected_id = ""
+	if terrain_dropdown.selected >= 0 and terrain_dropdown.selected < terrain_options.size():
+		selected_id = terrain_options[terrain_dropdown.selected].id
+
+	terrain_options = _base_terrain_options.duplicate()
+	for meta in _matchup_layouts:
+		terrain_options.append({
+			"id": str(meta.get("id", "")),
+			"name": "11e: %s" % str(meta.get("name", meta.get("id", "")))
+		})
+	terrain_dropdown.clear()
+	for option in terrain_options:
+		terrain_dropdown.add_item(option.name)
+
+	var target_id = selected_id
+	if select_official and _matchup_layouts.size() > 0:
+		target_id = str(_matchup_layouts[0].get("id", selected_id))
+	terrain_dropdown.selected = _find_option_index(terrain_options, target_id)
+	if select_official:
+		_apply_layout_deployment_default()
+	print("MainMenu: matchup %s vs %s -> %d official layouts (terrain: %s)" % [
+		p1_disp, p2_disp, _matchup_layouts.size(), terrain_options[terrain_dropdown.selected].id])
+
+func _on_disposition_changed(_index: int) -> void:
+	_refresh_matchup_terrain_options(true)
+
+func _on_terrain_layout_selected(_index: int) -> void:
+	_apply_layout_deployment_default()
+
+## D5: each official 11e layout card pairs with exactly one deployment
+## pattern — follow it when such a layout is selected. Legacy layouts
+## (several recommendations, player's choice) leave the dropdown alone.
+func _apply_layout_deployment_default() -> void:
+	if terrain_dropdown.selected < 0 or terrain_dropdown.selected >= terrain_options.size():
+		return
+	var layout_id = str(terrain_options[terrain_dropdown.selected].id)
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null:
+		return
+	var meta = tm.get_layout_metadata(layout_id)
+	if str(meta.get("source", "")) != "gw-11e":
+		return
+	var recs: Array = meta.get("recommended_deployments", [])
+	if recs.is_empty():
+		return
+	var idx = _find_option_index(deployment_options, str(recs[0]))
+	if deployment_options[idx].get("id", "") == str(recs[0]) and deployment_dropdown.selected != idx:
+		deployment_dropdown.selected = idx
+		print("MainMenu: deployment defaulted to %s (official pattern for %s)" % [recs[0], layout_id])
 
 func _get_selected_disposition(dropdown: OptionButton) -> String:
 	if dropdown == null or dropdown.selected < 0 or dropdown.selected >= PrimaryMissionData11e.DISPOSITIONS.size():
@@ -817,6 +896,8 @@ func _is_cloud_selection(army_id: String) -> bool:
 	return ArmyListManager and ArmyListManager.is_cloud_army(army_id)
 
 func _connect_signals() -> void:
+	# D5: picking an official 11e layout snaps deployment to its pattern
+	terrain_dropdown.item_selected.connect(_on_terrain_layout_selected)
 	start_button.pressed.connect(_on_start_button_pressed)
 	multiplayer_button.pressed.connect(_on_multiplayer_button_pressed)
 	load_button.pressed.connect(_on_load_button_pressed)

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2255,6 +2255,33 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "mainmenu.matchup_terrain_selection",
+      "description": "D5: changing a Force-Disposition dropdown rebuilds the terrain dropdown with the matchup's 3 official 11e layouts and auto-selects variant 1 (boot defaults preserved; legacy layouts stay as manual override)",
+      "scenarios": [
+        "terrain_11e_menu_matchup"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "mainmenu.deployment_follows_layout",
+      "description": "D5: selecting an official 11e layout snaps the deployment dropdown to the layout card's paired pattern (incl. the 11e-new tipping_point option); legacy layouts leave it untouched",
+      "scenarios": [
+        "terrain_11e_menu_matchup"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "terrain.layouts_11e.menu_reachable",
+      "description": "A game started from the main menu with an official 11e layout selected actually runs it: current_layout, 44 polygon pieces and the paired deployment_type reach the live game",
+      "scenarios": [
+        "terrain_11e_menu_matchup"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/terrain_11e_menu_matchup.json
+++ b/40k/tests/scenarios/sp/terrain_11e_menu_matchup.json
@@ -1,0 +1,83 @@
+{
+  "id": "terrain_11e_menu_matchup",
+  "covers": [
+    "mainmenu.matchup_terrain_selection",
+    "mainmenu.deployment_follows_layout",
+    "terrain.layouts_11e.menu_reachable"
+  ],
+  "edition": 11,
+  "description": "D5 (docs/40KDC_TERRAIN_MIGRATION_SPEC.md): the Force-Disposition pairing selects the official 11e terrain layouts in the main menu. Boots the MainMenu (no fixture) and asserts the first-run defaults are untouched (layout_parse_test + 13 terrain options: 10 base + the default mirror matchup's 3 variants). Changes P2's disposition to Purge the Foe through the real dropdown handler: the terrain dropdown rebuilds and auto-selects take_and_hold_vs_purge_the_foe_1 and the deployment dropdown snaps to its official pattern (sweeping_engagement). Picking variant 2 in the terrain dropdown moves deployment to search_and_destroy. A mirror-pairing check proves the new tipping_point deployment option works (take_and_hold_mirror_1). Then sets P2 to Human, clicks Start with variant 2 selected, and asserts the started game actually runs the official layout: 44 polygon pieces, current_layout take_and_hold_vs_purge_the_foe_2, deployment_type search_and_destroy. Confirms formations for both players (85c pattern) to reach ROLL_OFF and screenshots the board with the official terrain rendered.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script",
+      "script": "main.get_script().resource_path",
+      "equals": "res://scripts/MainMenu.gd" },
+
+    { "act": "execute_script",
+      "script": "main.terrain_options.size()",
+      "equals": 13 },
+    { "act": "execute_script",
+      "script": "main.terrain_options[main.terrain_dropdown.selected].id",
+      "equals": "layout_parse_test" },
+    { "act": "screenshot", "label": "01_menu_boot_defaults" },
+
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.select(1)" },
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.item_selected.emit(1)" },
+    { "act": "execute_script",
+      "script": "main.terrain_options[main.terrain_dropdown.selected].id",
+      "equals": "take_and_hold_vs_purge_the_foe_1" },
+    { "act": "execute_script",
+      "script": "main.deployment_options[main.deployment_dropdown.selected].id",
+      "equals": "sweeping_engagement" },
+
+    { "act": "execute_script", "script": "main.terrain_dropdown.select(11)" },
+    { "act": "execute_script", "script": "main.terrain_dropdown.item_selected.emit(11)" },
+    { "act": "execute_script",
+      "script": "main.terrain_options[main.terrain_dropdown.selected].id",
+      "equals": "take_and_hold_vs_purge_the_foe_2" },
+    { "act": "execute_script",
+      "script": "main.deployment_options[main.deployment_dropdown.selected].id",
+      "equals": "search_and_destroy" },
+
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.select(0)" },
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.item_selected.emit(0)" },
+    { "act": "execute_script",
+      "script": "main.terrain_options[main.terrain_dropdown.selected].id",
+      "equals": "take_and_hold_mirror_1" },
+    { "act": "execute_script",
+      "script": "main.deployment_options[main.deployment_dropdown.selected].id",
+      "equals": "tipping_point" },
+
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.select(1)" },
+    { "act": "execute_script", "script": "main.p2_disposition_dropdown.item_selected.emit(1)" },
+    { "act": "execute_script", "script": "main.terrain_dropdown.select(11)" },
+    { "act": "execute_script", "script": "main.terrain_dropdown.item_selected.emit(11)" },
+    { "act": "screenshot", "label": "02_matchup_variant2_selected" },
+
+    { "act": "execute_script", "script": "main.player2_type_dropdown.select(0)" },
+    { "act": "execute_script", "script": "main.player2_type_dropdown.item_selected.emit(0)" },
+    { "act": "click_node",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/StartButton",
+      "emit_pressed": true },
+    { "act": "expect_node_visible", "node": "/root/Main/BoardRoot/TokenLayer", "timeout_s": 20.0 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "expect_state", "path": "meta.phase", "equals": 0 },
+    { "act": "expect_state", "path": "meta.deployment_type", "equals": "search_and_destroy" },
+    { "act": "execute_script",
+      "script": "TerrainManager.current_layout",
+      "equals": "take_and_hold_vs_purge_the_foe_2" },
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.size()",
+      "equals": 44 },
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features[0][\"piece_class\"]",
+      "equals": "area" },
+
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_FORMATIONS", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_FORMATIONS", "player": 2 } },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 3 },
+    { "act": "screenshot", "label": "03_official_terrain_on_board" }
+  ]
+}

--- a/docs/40KDC_11E_MIGRATION.md
+++ b/docs/40KDC_11E_MIGRATION.md
@@ -131,13 +131,19 @@ Engine-level (this codebase, pre-existing):
     equals the transposed resolver output (4-dp) for all 1,966 pieces, and
     the windowed scenario `tests/scenarios/sp/terrain_11e_layouts.json`
     drives a converted layout in the live game (LoS block through an
-    obscuring area + the 14.01 terrain-objective control flip). Remaining
-    follow-ups: matchup→layout selection UI (spec D5), layout-sourced
-    objectives (D3-a), and the dataset's `hidden` / `plunging-fire` area
-    keywords (spec §9.5 — no engine rules yet; the current 16 templates
-    carry no such overrides). Walls/windows are intentionally not emitted
-    (spec D2-a): obscuring polygons carry LoS blocking, so converted ruins
-    have no see-through-window nuance.
+    obscuring area + the 14.01 terrain-objective control flip). The
+    matchup→layout selection UI (spec D5) is wired: changing a
+    Force-Disposition dropdown in the main menu offers the pairing's 3
+    official layouts (auto-selecting variant 1) and snaps the deployment
+    dropdown to the layout card's pattern — incl. the 11e-new
+    `tipping_point` option — while the legacy layouts stay available as a
+    manual override (windowed scenario
+    `tests/scenarios/sp/terrain_11e_menu_matchup.json`). Remaining
+    follow-ups: layout-sourced objectives (D3-a) and the dataset's
+    `hidden` / `plunging-fire` area keywords (spec §9.5 — no engine rules
+    yet; the current 16 templates carry no such overrides). Walls/windows
+    are intentionally not emitted (spec D2-a): obscuring polygons carry
+    LoS blocking, so converted ruins have no see-through-window nuance.
 13. **Points validation** treats over-limit armies as warnings, and 11e
     per-army-copy price tiers (2nd+ copies of a datasheet costing more) are
     not enforced by the builder — rosters price every unit at first-copy cost.


### PR DESCRIPTION
Follow-up to #500, implementing **Decision D5** from `docs/40KDC_TERRAIN_MIGRATION_SPEC.md` — the matchup→layout selection UI that makes the 45 converted official layouts actually reachable by a player.

## What's in

**`TerrainManager.get_layouts_for_matchup(a, b)`** — resolves the game's underscore disposition ids (`take_and_hold`, …) against the dataset's hyphenated matchup ids, trying both orderings (mirrors use `a-vs-a`), and returns the pairing's 3 layout metadata entries sorted by variant.

**`MainMenu` wiring**
- Changing either **Force-Disposition dropdown** rebuilds the Terrain dropdown as the 10 base layouts + the matchup's 3 official variants (labeled `11e: <name>`), **auto-selects variant 1**, and **snaps the Deployment dropdown** to the layout card's paired pattern. Picking a different official variant re-snaps deployment; picking a legacy layout leaves it alone (manual override, per the spec).
- **Boot defaults untouched**: the matchup options are appended at startup without changing the selection, so first-run behavior (`layout_parse_test` + `search_and_destroy`) is identical — the existing `main_menu_defaults` scenario still passes.
- `deployment_options` gains the 11e-new **Tipping Point** pattern (its zone JSON shipped with the deployment-zone regeneration; 8 of the 45 official layouts pair with it — it was previously unselectable).

## Validation (windowed, project gate)

New scenario **`tests/scenarios/sp/terrain_11e_menu_matchup.json` — 37/37 steps PASS** via `run_scenarios.sh`. It boots the real MainMenu (no fixture) and:
- asserts boot defaults are preserved (13 terrain options, `layout_parse_test` still selected);
- drives the real dropdown handlers: P2 → Purge the Foe auto-selects `take_and_hold_vs_purge_the_foe_1` + `sweeping_engagement`; picking variant 2 moves deployment to `search_and_destroy`; the mirror pairing selects `take_and_hold_mirror_1` + **`tipping_point`**;
- presses Start and asserts the started game **actually runs the official layout**: `current_layout = take_and_hold_vs_purge_the_foe_2`, 44 polygon pieces, `deployment_type = search_and_destroy`;
- confirms formations for both players to reach ROLL_OFF and screenshots the board with the official terrain rendered.

Also validated interactively in the running game via the MCP bridge before pinning the scenario (same flow, zero debug-log errors).

Regression: changed-files batch **11/11 pass** (incl. `main_menu_defaults` and the legacy `parse_test_terrain_screenshot`); `check_coverage.py` fully passes with 3 new tiles; docs gap #12 updated (D5 no longer listed as a follow-up).

## Still out of scope

Layout-sourced objectives (**D3-a**) / 6-objective scoring (**D4**), and the `hidden`/`plunging-fire` keywords (spec §9.5) — unchanged from #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019q5GhEte43sFWfNiadxmPP

---
_Generated by [Claude Code](https://claude.ai/code/session_019q5GhEte43sFWfNiadxmPP)_