### PR TITLE
Show game version + recent changes on the main menu

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -1,0 +1,14 @@
+{
+	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
+	"releases": [
+		{
+			"version": "0.1.0",
+			"date": "2026-07-05",
+			"summary": "Show the game version and recent changes on the main menu.",
+			"changes": [
+				"Added a version badge (number + date) beneath the main-menu title so it is easy to tell which build is running.",
+				"Added a 'What's New' panel to the main menu summarizing the most recent changes."
+			]
+		}
+	]
+}

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -136,6 +136,9 @@ func _ready() -> void:
 	# 40kdc dataset licensing credit (see data/40kdc/ATTRIBUTION.md)
 	_create_data_attribution_credit()
 
+	# Version badge + "What's New" summary (helps tell which build is running)
+	_create_version_display()
+
 	print("MainMenu: Ready with default selections")
 
 func _apply_theme() -> void:
@@ -207,6 +210,82 @@ func _create_data_attribution_credit() -> void:
 	credit.grow_vertical = Control.GROW_DIRECTION_BEGIN
 	add_child(credit)
 	print("MainMenu: 40kdc data attribution credit added")
+
+func _create_version_display() -> void:
+	"""Show the game version + a summary of the most recent changes near the top
+	of the menu. Data comes from res://data/version_history.json via VersionInfo
+	so it can be told at a glance which build is running (e.g. itch.io vs GitHub)."""
+	var menu_container := $ScrollContainer/MenuContainer as VBoxContainer
+	if menu_container == null:
+		return
+
+	var title_idx := _get_child_index(menu_container, "TitleLabel")
+
+	# --- Compact version badge directly under the title ---
+	var badge := Label.new()
+	badge.name = "VersionBadge"
+	badge.text = VersionInfo.get_version_badge()
+	badge.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	badge.add_theme_font_size_override("font_size", 13)
+	badge.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_GOLD)
+	menu_container.add_child(badge)
+	if title_idx >= 0:
+		menu_container.move_child(badge, title_idx + 1)
+
+	# --- "What's New" panel listing the latest release summary + changes ---
+	var changes := VersionInfo.get_latest_changes()
+	var summary := VersionInfo.get_latest_summary()
+	if changes.is_empty() and summary.is_empty():
+		return
+
+	var panel := PanelContainer.new()
+	panel.name = "WhatsNewPanel"
+	WhiteDwarfThemeData.apply_to_panel(panel)
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 10)
+	margin.add_theme_constant_override("margin_right", 10)
+	margin.add_theme_constant_override("margin_top", 8)
+	margin.add_theme_constant_override("margin_bottom", 8)
+	panel.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	var header := Label.new()
+	header.name = "WhatsNewHeader"
+	header.text = "What's New — v%s (%s)" % [VersionInfo.get_version(), VersionInfo.get_version_date()]
+	header.add_theme_font_size_override("font_size", 14)
+	header.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_GOLD)
+	vbox.add_child(header)
+
+	if not summary.is_empty():
+		var summary_label := Label.new()
+		summary_label.name = "WhatsNewSummary"
+		summary_label.text = summary
+		summary_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		summary_label.custom_minimum_size = Vector2(560, 0)
+		summary_label.add_theme_font_size_override("font_size", 12)
+		summary_label.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
+		vbox.add_child(summary_label)
+
+	for change in changes:
+		var change_label := Label.new()
+		change_label.text = "•  %s" % str(change)
+		change_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		change_label.custom_minimum_size = Vector2(560, 0)
+		change_label.add_theme_font_size_override("font_size", 12)
+		change_label.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
+		vbox.add_child(change_label)
+
+	menu_container.add_child(panel)
+	# Place the panel just below the version badge, above the first separator.
+	var badge_idx := _get_child_index(menu_container, "VersionBadge")
+	if badge_idx >= 0:
+		menu_container.move_child(panel, badge_idx + 1)
+
+	print("MainMenu: Version display added (%s, %d changes)" % [VersionInfo.get_version(), changes.size()])
 
 func _apply_theme_to_dynamic_elements() -> void:
 	# Style dynamically created dropdowns and buttons

--- a/40k/scripts/VersionInfo.gd
+++ b/40k/scripts/VersionInfo.gd
@@ -1,0 +1,84 @@
+extends RefCounted
+class_name VersionInfo
+
+# VersionInfo - single access point for the game's version + changelog.
+#
+# The data lives in res://data/version_history.json (newest release first).
+# To record a change, prepend a new entry to that file — see CLAUDE.md
+# 'Version / changelog'. This helper is intentionally tiny and defensive so a
+# malformed/missing file never blocks the main menu from loading.
+
+const VERSION_FILE := "res://data/version_history.json"
+
+# Cached so we only parse the JSON once per run.
+static var _cache: Array = []
+static var _loaded: bool = false
+
+static func _load_releases() -> Array:
+	if _loaded:
+		return _cache
+	_loaded = true
+	_cache = []
+
+	if not FileAccess.file_exists(VERSION_FILE):
+		push_warning("VersionInfo: %s not found" % VERSION_FILE)
+		return _cache
+
+	var f := FileAccess.open(VERSION_FILE, FileAccess.READ)
+	if f == null:
+		push_warning("VersionInfo: could not open %s" % VERSION_FILE)
+		return _cache
+
+	var text := f.get_as_text()
+	f.close()
+
+	var parsed = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY or not parsed.has("releases"):
+		push_warning("VersionInfo: malformed %s (no 'releases' array)" % VERSION_FILE)
+		return _cache
+
+	var releases = parsed.get("releases", [])
+	if typeof(releases) == TYPE_ARRAY:
+		_cache = releases
+	return _cache
+
+## Return the newest release entry, or an empty dict if none exist.
+static func get_latest_release() -> Dictionary:
+	var releases := _load_releases()
+	if releases.is_empty():
+		return {}
+	var first = releases[0]
+	return first if typeof(first) == TYPE_DICTIONARY else {}
+
+## Return the current version string (e.g. "0.1.0"), or "unknown" if unavailable.
+static func get_version() -> String:
+	var latest := get_latest_release()
+	return str(latest.get("version", "unknown"))
+
+## Return the date the current version was published (e.g. "2026-07-05"), or "".
+static func get_version_date() -> String:
+	var latest := get_latest_release()
+	return str(latest.get("date", ""))
+
+## Compact one-line badge, e.g. "v0.1.0 · 2026-07-05".
+static func get_version_badge() -> String:
+	var v := get_version()
+	var d := get_version_date()
+	if d.is_empty():
+		return "v%s" % v
+	return "v%s · %s" % [v, d]
+
+## Return the change bullets for the latest release (Array[String]).
+static func get_latest_changes() -> Array:
+	var latest := get_latest_release()
+	var changes = latest.get("changes", [])
+	return changes if typeof(changes) == TYPE_ARRAY else []
+
+## Return the one-line summary for the latest release, or "".
+static func get_latest_summary() -> String:
+	var latest := get_latest_release()
+	return str(latest.get("summary", ""))
+
+## All releases, newest first (Array[Dictionary]).
+static func get_all_releases() -> Array:
+	return _load_releases()

--- a/40k/scripts/VersionInfo.gd.uid
+++ b/40k/scripts/VersionInfo.gd.uid
@@ -1,0 +1,1 @@
+uid://jq45xbjv7my3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,22 @@ The project we are working on is located at /Users/robertocallaghan/Documents/cl
 
 Do not remove debugging logs unless specifically asked to do so.
 
+## Version / changelog (update on EVERY player-facing change)
+
+The main menu shows the current version + a "What's New" summary so it is easy
+to tell which build is running (e.g. the itch.io release vs the latest GitHub
+branch). The single source of truth is `40k/data/version_history.json`
+(newest release first), surfaced via `40k/scripts/VersionInfo.gd` and rendered
+by `MainMenu._create_version_display()`.
+
+**From now on, whenever you make a player-facing change, PREPEND a new entry to
+`40k/data/version_history.json`** before committing:
+- Bump `version` (semver: patch for fixes, minor for new features).
+- Set `date` to the day the change was made (YYYY-MM-DD).
+- Write a one-line `summary` and a `changes` bullet list a player would understand.
+
+Pure-internal changes (refactors, tests, tooling) do not need a new entry.
+
 If godot is not running in the command line run export PATH="$HOME/bin:$PATH" and try again.
 
 The debug output of godot is being piped to files in the format `<godot-userdata>/40k/logs/debug_YYYYMMDD_HHMMSS.log`.


### PR DESCRIPTION
## Summary

Adds a version badge and a "What's New" panel to the main menu so it's easy to tell which build is running at a glance (e.g. the itch.io release vs the latest GitHub branch).

- **Version badge** in gold directly beneath the title: `v0.1.0 · 2026-07-05`
- **"What's New" panel** (WhiteDwarf-themed) showing the latest release summary and change bullets

## How it works

- `40k/data/version_history.json` — single source of truth, an array of releases newest-first (`version`, `date`, `summary`, `changes[]`). Record a change by prepending one entry.
- `40k/scripts/VersionInfo.gd` — small, defensive helper that reads the JSON (a missing/malformed file never blocks the menu) and exposes `get_version()`, `get_version_badge()`, `get_latest_changes()`, etc.
- `MainMenu._create_version_display()` — renders the badge + panel using the existing theme.
- `CLAUDE.md` — documents the convention: prepend a new entry to the version history on every player-facing change.

## Validation

Driven live in the running game (windowed, MCP bridge): the badge and panel render correctly, `verify_delivery` returns **PASS** with 0 log errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4xw9kcPvN2Vhb2UH7ofte

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4xw9kcPvN2Vhb2UH7ofte)_