### PR TITLE
AI plays for Victory Points by the numbers; thinking cards draw their options on the board; AI-vs-AI benchmark

### DIFF
--- a/40k/autoloads/AIBenchmarkRunner.gd
+++ b/40k/autoloads/AIBenchmarkRunner.gd
@@ -1,0 +1,205 @@
+extends Node
+
+# AIBenchmarkRunner — plays one full AI-vs-AI game headless and reports the
+# result as JSON, so a shell loop can benchmark AI changes by win rate / VP
+# differential instead of vibes.
+#
+# Activates only when `--ai-benchmark` is on the cmdline; otherwise a no-op
+# autoload (same pattern as ScenarioRunner).
+#
+# Wire protocol:
+#   godot --path 40k -- --ai-benchmark \
+#     --bench-fixture=audit_baseline_postdeploy \
+#     --bench-seed=42 \
+#     --bench-out=test_results/bench/run_1.json \
+#     [--bench-p1-profile=path.json] [--bench-p2-profile=path.json] \
+#     [--bench-difficulty=1] [--bench-max-seconds=600] [--bench-time-scale=3]
+#
+# Profiles are AIDecisionMaker parameter-override files (the ai_config.json /
+# load_player_profile format): {"parameters": {...}, "rules": [...]}.
+#
+# Output: one JSON file + a parse-friendly `[AIBench] RESULT {...}` line.
+# Exit code 0 = game completed, 2 = stalled/aborted.
+
+var _active: bool = false
+var _fixture: String = "audit_baseline_postdeploy"
+var _seed: int = -1
+var _out_path: String = "test_results/bench/result.json"
+var _p1_profile_path: String = ""
+var _p2_profile_path: String = ""
+var _difficulty: int = 1  # Normal — the default players face
+var _max_seconds: float = 600.0
+var _time_scale: float = 3.0
+
+var _start_ticks: int = 0
+var _last_progress_ticks: int = 0
+var _last_progress_sig: String = ""
+const STALL_SECONDS := 90.0
+
+func _ready() -> void:
+	var args = OS.get_cmdline_args() + OS.get_cmdline_user_args()
+	if not "--ai-benchmark" in args:
+		return
+	for a in args:
+		if typeof(a) != TYPE_STRING:
+			continue
+		if a.begins_with("--bench-fixture="):
+			_fixture = a.split("=", true, 1)[1]
+		elif a.begins_with("--bench-seed="):
+			_seed = int(a.split("=", true, 1)[1])
+		elif a.begins_with("--bench-out="):
+			_out_path = a.split("=", true, 1)[1]
+		elif a.begins_with("--bench-p1-profile="):
+			_p1_profile_path = a.split("=", true, 1)[1]
+		elif a.begins_with("--bench-p2-profile="):
+			_p2_profile_path = a.split("=", true, 1)[1]
+		elif a.begins_with("--bench-difficulty="):
+			_difficulty = int(a.split("=", true, 1)[1])
+		elif a.begins_with("--bench-max-seconds="):
+			_max_seconds = float(a.split("=", true, 1)[1])
+		elif a.begins_with("--bench-time-scale="):
+			_time_scale = float(a.split("=", true, 1)[1])
+	_active = true
+	print("[AIBench] Activating: fixture=%s seed=%d difficulty=%d time_scale=%.1f" % [
+		_fixture, _seed, _difficulty, _time_scale])
+	call_deferred("_kick_off")
+
+func _kick_off() -> void:
+	await get_tree().process_frame
+	await get_tree().process_frame
+
+	# 1) Load the fixture (a post-deployment save = full game from round 1)
+	var save_mgr = get_node_or_null("/root/SaveLoadManager")
+	if save_mgr == null or not save_mgr.load_game(_fixture):
+		_finish_with_error("fixture load failed: %s" % _fixture)
+		return
+	GameState.state["meta"]["from_save"] = true
+	GameConstants.edition = 11
+
+	# 2) Deterministic dice
+	if _seed >= 0:
+		var rules = get_node_or_null("/root/RulesEngine")
+		if rules != null:
+			rules.set_test_seed(_seed)
+
+	# 3) Live battle scene (phases/controllers need it)
+	get_tree().change_scene_to_file("res://scenes/Main.tscn")
+	var waited := 0
+	while waited < 240 and (get_tree().current_scene == null or not get_tree().current_scene.is_node_ready()):
+		await get_tree().process_frame
+		waited += 1
+	for i in range(8):
+		await get_tree().process_frame
+
+	# 4) Both players AI at the requested difficulty, fastest pacing
+	var ai = get_node_or_null("/root/AIPlayer")
+	if ai == null:
+		_finish_with_error("AIPlayer autoload missing")
+		return
+	ai.configure({1: "AI", 2: "AI"}, {1: _difficulty, 2: _difficulty})
+	ai.set_ai_speed_preset(0)  # FAST
+	_load_profile(1, _p1_profile_path)
+	_load_profile(2, _p2_profile_path)
+
+	# 5) Accelerate the AI's pacing timers
+	Engine.time_scale = maxf(1.0, _time_scale)
+
+	# 6) Kick the game from the save's phase (COMMAND at round 1 for the
+	# baseline fixture) and let the AI drive to the end
+	var pm = get_node_or_null("/root/PhaseManager")
+	var start_phase = int(GameState.state.get("meta", {}).get("phase", 6))
+	pm.transition_to_phase(start_phase)
+
+	_start_ticks = Time.get_ticks_msec()
+	_last_progress_ticks = _start_ticks
+	print("[AIBench] Game started (phase %d, round %d)" % [
+		start_phase, GameState.get_battle_round()])
+	_watch_loop()
+
+func _watch_loop() -> void:
+	var pm = get_node_or_null("/root/PhaseManager")
+	var ai = get_node_or_null("/root/AIPlayer")
+	while true:
+		await get_tree().create_timer(0.5).timeout
+		if pm.game_ended:
+			_finish_completed()
+			return
+		var elapsed = (Time.get_ticks_msec() - _start_ticks) / 1000.0
+		if elapsed > _max_seconds:
+			_finish_stalled("max_seconds exceeded (%.0fs)" % elapsed)
+			return
+		# Progress signature: round | phase | actions taken. If it freezes for
+		# STALL_SECONDS of real time, the game is stuck — that is itself a
+		# benchmark finding.
+		var sig = "%d|%d|%d" % [GameState.get_battle_round(), GameState.get_current_phase(),
+			ai._action_log.size() if ai != null else 0]
+		if sig != _last_progress_sig:
+			_last_progress_sig = sig
+			_last_progress_ticks = Time.get_ticks_msec()
+		elif (Time.get_ticks_msec() - _last_progress_ticks) / 1000.0 > STALL_SECONDS:
+			_finish_stalled("no progress for %.0fs at %s" % [STALL_SECONDS, sig])
+			return
+
+func _load_profile(player: int, path: String) -> void:
+	if path == "":
+		return
+	var f = FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		print("[AIBench] WARNING: profile not found: %s" % path)
+		return
+	var parsed = JSON.parse_string(f.get_as_text())
+	f.close()
+	if parsed is Dictionary:
+		AIDecisionMaker.load_player_profile(player, parsed)
+		print("[AIBench] Loaded profile for P%d from %s (%d parameters)" % [
+			player, path, parsed.get("parameters", {}).size()])
+
+func _collect_result(status: String, note: String) -> Dictionary:
+	var mm = get_node_or_null("/root/MissionManager")
+	var vp = mm.get_vp_summary() if mm != null else {}
+	var p1_total = int(vp.get("player1", {}).get("total", 0))
+	var p2_total = int(vp.get("player2", {}).get("total", 0))
+	var winner = 0
+	if p1_total > p2_total:
+		winner = 1
+	elif p2_total > p1_total:
+		winner = 2
+	var ai = get_node_or_null("/root/AIPlayer")
+	return {
+		"status": status,
+		"note": note,
+		"fixture": _fixture,
+		"seed": _seed,
+		"difficulty": _difficulty,
+		"p1_profile": _p1_profile_path,
+		"p2_profile": _p2_profile_path,
+		"winner": winner,
+		"vp": vp,
+		"vp_diff_p2_minus_p1": p2_total - p1_total,
+		"battle_round": GameState.get_battle_round(),
+		"actions_taken": ai._action_log.size() if ai != null else 0,
+		"wall_seconds": (Time.get_ticks_msec() - _start_ticks) / 1000.0,
+		"time_scale": _time_scale,
+	}
+
+func _finish_completed() -> void:
+	_write_and_quit(_collect_result("completed", ""), 0)
+
+func _finish_stalled(reason: String) -> void:
+	_write_and_quit(_collect_result("stalled", reason), 2)
+
+func _finish_with_error(reason: String) -> void:
+	_write_and_quit({"status": "error", "note": reason, "fixture": _fixture, "seed": _seed}, 2)
+
+func _write_and_quit(result: Dictionary, code: int) -> void:
+	Engine.time_scale = 1.0
+	var out = "user://" + _out_path
+	DirAccess.make_dir_recursive_absolute(ProjectSettings.globalize_path(out).get_base_dir())
+	var f = FileAccess.open(out, FileAccess.WRITE)
+	if f != null:
+		f.store_string(JSON.stringify(result, "  "))
+		f.close()
+	print("[AIBench] RESULT %s" % JSON.stringify(result))
+	print("[AIBench] written: %s" % ProjectSettings.globalize_path(out))
+	await get_tree().process_frame
+	get_tree().quit(code)

--- a/40k/autoloads/AIBenchmarkRunner.gd
+++ b/40k/autoloads/AIBenchmarkRunner.gd
@@ -76,6 +76,17 @@ func _kick_off() -> void:
 	GameState.state["meta"]["from_save"] = true
 	GameConstants.edition = 11
 
+	# Both players are AI for the whole game. This must be written into
+	# game_config, not just AIPlayer — engine human-gates (e.g. the 03.03
+	# coherency-removal pause in ScoringPhase) read playerN_type and DEFAULT
+	# to HUMAN, which would stall an unattended game.
+	var meta = GameState.state.get("meta", {})
+	var gc = meta.get("game_config", {})
+	gc["player1_type"] = "AI"
+	gc["player2_type"] = "AI"
+	meta["game_config"] = gc
+	GameState.state["meta"] = meta
+
 	# 2) Deterministic dice
 	if _seed >= 0:
 		var rules = get_node_or_null("/root/RulesEngine")

--- a/40k/autoloads/AIBenchmarkRunner.gd.uid
+++ b/40k/autoloads/AIBenchmarkRunner.gd.uid
@@ -1,0 +1,1 @@
+uid://c05g3cqlnv7p

--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -1489,11 +1489,12 @@ func _execute_next_action(player: int) -> void:
 	# grouped into a collapsible block headed by the decision description so
 	# the left game log stays readable at high verbosity.
 	var thinking_steps = decision.get("_ai_thinking_steps", [])
+	var thinking_context = decision.get("_ai_thinking_context", {})
 	if thinking_steps.size() == 1:
 		_log_ai_thinking(player, thinking_steps[0])
 	elif thinking_steps.size() > 1:
 		var block_header = decision.get("_ai_description", str(decision.get("type", "decision")))
-		_log_ai_thinking_block(player, "Thinking: %s" % block_header, thinking_steps)
+		_log_ai_thinking_block(player, "Thinking: %s" % block_header, thinking_steps, thinking_context)
 
 	# Collect decision records for AI Gameplay Visualizer export
 	var decision_records = decision.get("_ai_decision_records", [])
@@ -2505,16 +2506,18 @@ func _log_ai_thinking(player: int, text: String) -> void:
 	print("AIPlayer: [THINKING] P%d: %s" % [player, text])
 	DebugLogger.info("AIPlayer thinking: %s" % text, {"player": player})
 
-func _log_ai_thinking_block(player: int, header: String, lines: Array) -> void:
+func _log_ai_thinking_block(player: int, header: String, lines: Array, context: Dictionary = {}) -> void:
 	"""Log one decision's reasoning as a single collapsible block in the game
 	log (header + detail lines), while still streaming individual lines to the
-	bottom-right overlay. Falls back to a plain entry when there are no details."""
+	bottom-right overlay. Falls back to a plain entry when there are no details.
+	`context` (optional) carries board positions of the considered options so
+	the log card can highlight them on the board."""
 	if lines.is_empty():
 		_log_ai_thinking(player, header)
 		return
 	var game_event_log = get_node_or_null("/root/GameEventLog")
 	if game_event_log and game_event_log.has_method("add_ai_thinking_block"):
-		game_event_log.add_ai_thinking_block(player, header, lines)
+		game_event_log.add_ai_thinking_block(player, header, lines, context)
 	else:
 		_log_ai_thinking(player, header)
 	# Overlay + stdout still get the full stream, line by line

--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -246,15 +246,28 @@ func add_ai_thinking_entry(player: int, text: String) -> void:
 	var prefix = "P%d AI: " % player
 	_add_entry(prefix + text, "ai_thinking")
 
-func add_ai_thinking_block(player: int, header: String, lines: Array) -> void:
+func add_ai_thinking_block(player: int, header: String, lines: Array, context: Dictionary = {}) -> void:
 	"""One AI decision's reasoning as a single block: a headline plus the
 	detail lines (candidates considered, rejections, scores). GameLogPanel
 	renders this as a collapsible AI-thinking card so verbosity doesn't flood
-	the log. The first line of the entry text is the header; the rest are details."""
+	the log. The first line of the entry text is the header; the rest are details.
+	`context` (optional): board-link data — unit position + candidate positions
+	with chosen/rejected flags — letting the card highlight the considered
+	options on the board when hovered/clicked."""
 	var text = "P%d AI: %s" % [player, header]
 	for line in lines:
 		text += "\n" + str(line)
-	_add_entry(text, "ai_thinking_block")
+	entries.append({"text": text, "type": "ai_thinking_block", "context": context})
+	print("[GameEventLog] %s" % text)
+	DebugLogger.info("GameEventLog: %s" % text, {})
+	emit_signal("entry_added", text, "ai_thinking_block")
+
+func get_last_entry_context() -> Dictionary:
+	"""Board-link context of the most recent entry (empty if none). GameLogPanel
+	reads this synchronously from its entry_added handler."""
+	if entries.is_empty():
+		return {}
+	return entries[entries.size() - 1].get("context", {})
 
 func add_info_entry(text: String) -> void:
 	"""Add a general information entry (VP scoring, mission status, CP generation, etc.)."""

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.4.0",
+			"date": "2026-07-06",
+			"summary": "The AI now plays for Victory Points by the numbers, and its thinking cards can draw their options on the board.",
+			"changes": [
+				"AI decisions are now Victory-Point-denominated: each objective is priced from the AI's actual mission cards (its primary Force-Disposition rules plus active secondaries), so it pushes where the VP really are — and the Game Log states the stakes ('VP stakes this round: obj_center ~9 VP...', 'worth ~5 VP').",
+				"AI thinking cards with a bright blue accent are now board-linked: hover one to see the options that decision weighed drawn on the battlefield — a solid green arrow to the chosen option and dashed red arrows to the rejected ones, each tagged with its score. Click the card to pin the arrows; click again to clear.",
+				"New AI-vs-AI benchmark harness for development: plays full headless games and reports win rate and VP differential, so future AI changes are verified by results (bash 40k/tests/run_ai_benchmark.sh)."
+			]
+		},
+		{
 			"version": "0.3.0",
 			"date": "2026-07-06",
 			"summary": "The AI now plays 11th edition properly — stratagems, faction rules, mission play — and explains every decision in the Game Log.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -3438,6 +3438,31 @@ func get_available_actions() -> Array:
 			})
 	else:
 		log_phase_message("NOT adding SELECT_FIGHTER: active_fighter_id='%s', index=%d, size=%d" % [active_fighter_id, current_fight_index, fight_sequence.size()])
+
+	# ISS-050 / AI-vs-AI benchmark finding: at 11e the sequencer (12.04) is the
+	# selection authority — _validate_select_fighter accepts its candidates even
+	# when the legacy fight_sequence queue is empty (e.g. a Fights-First unit
+	# with no queued fights). If the queue-based branch above offered nothing
+	# while a selection is actually pending, surface the sequencer's candidates
+	# so action-driven players (the AI) can answer instead of hanging.
+	if GameConstants.edition >= 11 and active_fighter_id == "" and sequencer_11e != null:
+		var has_select := false
+		for a in actions:
+			if a.get("type", "") == "SELECT_FIGHTER":
+				has_select = true
+				break
+		if not has_select:
+			var sel_11e = sequencer_11e.next_selection(GameState.state)
+			if not sel_11e.done:
+				for cand_id in sel_11e.candidates:
+					actions.append({
+						"type": "SELECT_FIGHTER",
+						"unit_id": cand_id,
+						"player": sel_11e.player,
+						"description": "Select %s to fight (%s step, 12.04)" % [cand_id, sel_11e.step]
+					})
+				log_phase_message("[11e 12.04] Sequencer offers %d SELECT_FIGHTER candidate(s) for Player %d (%s step)" % [
+					sel_11e.candidates.size(), sel_11e.player, sel_11e.step])
 	
 	# If active fighter is selected, show simple control actions
 	if active_fighter_id != "":

--- a/40k/project.godot
+++ b/40k/project.godot
@@ -66,6 +66,7 @@ KeybindingManager="*res://autoloads/KeybindingManager.gd"
 UIConstants="*res://autoloads/UIConstants.gd"
 MCPServer="*res://addons/godot_mcp/mcp_server.gd"
 ScenarioRunner="*res://autoloads/ScenarioRunner.gd"
+AIBenchmarkRunner="*res://autoloads/AIBenchmarkRunner.gd"
 
 [display]
 

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -377,6 +377,45 @@ static func _add_decision_record(decision_type: String, unit_id: String, unit_na
 	}
 	_decision_records.append(record)
 	_narrate_decision_record(decision_type, unit_name, candidates, chosen_index)
+	_capture_thinking_context(decision_type, unit_id, unit_name, candidates, chosen_index, context)
+
+# Board-link context: when a decision's candidates carry board positions,
+# capture a structured summary so the game log can draw the considered
+# options on the board (chosen vs rejected) when the player hovers the card.
+static var _thinking_context: Dictionary = {}
+
+static func _capture_thinking_context(decision_type: String, unit_id: String,
+		unit_name: String, candidates: Array, chosen_index: int, context: Dictionary) -> void:
+	var linked: Array = []
+	for i in range(candidates.size()):
+		var cand = candidates[i]
+		var pos = cand.get("pos", [])
+		if pos is Array and pos.size() == 2:
+			linked.append({
+				"label": str(cand.get("description", "")),
+				"score": float(cand.get("score", 0.0)),
+				"pos": [float(pos[0]), float(pos[1])],
+				"chosen": i == chosen_index,
+			})
+	if linked.is_empty():
+		return
+	# Keep the FIRST linkable record per decision — one card, one spatial story
+	if not _thinking_context.is_empty():
+		return
+	_thinking_context = {
+		"decision_type": decision_type,
+		"unit_id": unit_id,
+		"unit_name": unit_name,
+		"unit_pos": context.get("unit_pos", []),
+		"candidates": linked,
+	}
+
+static func take_thinking_context() -> Dictionary:
+	"""Return and clear the captured board-link context (paired with the
+	thinking steps taken by the same decision)."""
+	var ctx = _thinking_context
+	_thinking_context = {}
+	return ctx
 
 # Turn a structured decision record into verbose thinking text: the chosen
 # option plus the best rejected alternatives with scores, so the player can
@@ -462,6 +501,12 @@ const HEAVY_STATIONARY_MIN_BENEFIT: float = 0.15    # ~1 extra expected hit acro
 const HEAVY_STATIONARY_OBJ_OVERRIDE_SCORE: float = 10.0  # High-priority objectives override Heavy hold
 
 # Movement AI tuning weights
+# VP-denominated objective scoring: expected VP an objective yields at the
+# next scoring point (from the player's actual primary + secondary cards)
+# feeds the priority at this weight per VP. A 5-VP objective adds 6.0 —
+# comparable to the strongest heuristic weight without drowning the tuned
+# base (threat, screening, OC efficiency all still matter).
+const WEIGHT_VP_PER_POINT: float = 1.2
 const WEIGHT_UNCONTROLLED_OBJ: float = 10.0
 const WEIGHT_CONTESTED_OBJ: float = 8.0
 const WEIGHT_ENEMY_WEAK_OBJ: float = 7.0
@@ -889,6 +934,7 @@ static func decide(phase: int, snapshot: Dictionary, available_actions: Array, p
 		evaluate_rules(player, rule_context)
 	_thinking_steps.clear()  # Reset thinking log for this decision
 	_decision_records.clear()  # Reset decision records for this decision
+	_thinking_context = {}  # Reset board-link context for this decision
 	var diff_name = AIDifficultyConfigData.difficulty_name(difficulty)
 	# T7-43: Log round strategy mode
 	var current_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
@@ -999,6 +1045,9 @@ static func decide(phase: int, snapshot: Dictionary, available_actions: Array, p
 		result["_ai_thinking_steps"] = _thinking_steps.duplicate()
 	if not _decision_records.is_empty() and not result.is_empty():
 		result["_ai_decision_records"] = _decision_records.duplicate(true)
+	if not _thinking_context.is_empty() and not result.is_empty():
+		result["_ai_thinking_context"] = _thinking_context.duplicate(true)
+		_thinking_context = {}
 	return result
 
 # =============================================================================
@@ -5659,6 +5708,21 @@ static func _evaluate_all_objectives(
 	var evaluations = []
 	var obj_data = snapshot.get("board", {}).get("objectives", [])
 
+	# Pre-pass: OC per objective + current hold counts (the VP estimator's
+	# marginal analysis for hold-N / majority rules needs the totals).
+	var oc_cache: Array = []
+	var my_holds := 0
+	var their_holds := 0
+	for i in range(objectives.size()):
+		var pre_f_oc = _get_oc_at_position(objectives[i], friendly_units, player, true)
+		var pre_e_oc = _get_oc_at_position(objectives[i], enemies, player, false)
+		oc_cache.append({"f": pre_f_oc, "e": pre_e_oc})
+		if pre_f_oc > 0 and pre_f_oc > pre_e_oc:
+			my_holds += 1
+		elif pre_e_oc > 0 and pre_e_oc > pre_f_oc:
+			their_holds += 1
+	var vp_stake_notes: Array = []
+
 	for i in range(objectives.size()):
 		var obj_pos = objectives[i]
 		var obj_id = ""
@@ -5667,9 +5731,9 @@ static func _evaluate_all_objectives(
 			obj_id = obj_data[i].get("id", "obj_%d" % i)
 			obj_zone = obj_data[i].get("zone", "no_mans_land")
 
-		# Calculate OC totals within control range
-		var friendly_oc = _get_oc_at_position(obj_pos, friendly_units, player, true)
-		var enemy_oc = _get_oc_at_position(obj_pos, enemies, player, false)
+		# OC totals within control range (from the pre-pass)
+		var friendly_oc = oc_cache[i].f
+		var enemy_oc = oc_cache[i].e
 
 		# Count friendly/enemy units nearby (within 12")
 		var friendly_nearby = _count_units_near_position(obj_pos, friendly_units, CHARGE_RANGE_PX)
@@ -5804,7 +5868,22 @@ static func _evaluate_all_objectives(
 			priority += threatened_retention
 			print("AIDecisionMaker: [OBJ-DEFEND] Objective %s: +%.1f threatened retention bonus (round=%d)" % [obj_id, threatened_retention, battle_round])
 
-		print("AIDecisionMaker: Objective %s: state=%s, friendly_oc=%d, enemy_oc=%d, priority=%.1f (tempo=%.2f)" % [obj_id, state, friendly_oc, enemy_oc, priority, tempo_mod])
+		# VP-denominated value: what THIS objective pays at the next scoring
+		# point per the player's actual cards. This is the dominant mission
+		# term — the heuristic weights above keep handling threat/tempo/OC.
+		var is_central = obj_pos.distance_to(Vector2(BOARD_WIDTH_PX / 2.0, BOARD_HEIGHT_PX / 2.0)) <= 4.0 * PIXELS_PER_INCH
+		var vp_result = _estimate_objective_vp_value({
+			"is_home": is_home,
+			"is_enemy_home": is_enemy_home,
+			"is_central": is_central,
+			"is_held_by_me": friendly_oc > 0 and friendly_oc > enemy_oc,
+		}, player, my_holds, their_holds)
+		var vp_value: float = vp_result.vp
+		if vp_value > 0.0:
+			priority += vp_value * get_param("WEIGHT_VP_PER_POINT", WEIGHT_VP_PER_POINT)
+			vp_stake_notes.append({"id": obj_id, "vp": vp_value, "sources": vp_result.sources})
+
+		print("AIDecisionMaker: Objective %s: state=%s, friendly_oc=%d, enemy_oc=%d, priority=%.1f (tempo=%.2f, vp=%.1f)" % [obj_id, state, friendly_oc, enemy_oc, priority, tempo_mod, vp_value])
 
 		evaluations.append({
 			"index": i,
@@ -5819,8 +5898,20 @@ static func _evaluate_all_objectives(
 			"is_home": is_home,
 			"is_enemy_home": is_enemy_home,
 			"priority": priority,
+			"vp_value": vp_value,
+			"vp_sources": vp_result.sources,
 			"oc_needed": max(0, enemy_oc - friendly_oc + 1)  # OC we need to add to flip control
 		})
+
+	# Narrate the VP stakes once per evaluation (top objectives by VP), so the
+	# player sees WHAT the AI is playing for in mission terms.
+	if not vp_stake_notes.is_empty():
+		vp_stake_notes.sort_custom(func(a, b): return a.vp > b.vp)
+		var stake_parts: Array = []
+		for n in range(min(3, vp_stake_notes.size())):
+			var note = vp_stake_notes[n]
+			stake_parts.append("%s ~%.0f VP (%s)" % [note.id, note.vp, "; ".join(note.sources.slice(0, 2))])
+		_add_thinking_step("VP stakes this round (holding %d, enemy %d): %s" % [my_holds, their_holds, ", ".join(stake_parts)])
 
 	return evaluations
 
@@ -6183,7 +6274,8 @@ static func _assign_units_to_objectives(
 				"distance": dist_px,
 				"unit_oc": unit_oc,
 				"already_on_obj": already_on_obj,
-				"turns_to_reach": turns_to_reach
+				"turns_to_reach": turns_to_reach,
+				"vp_value": eval.get("vp_value", 0.0)
 			})
 
 	# Sort by score (highest first)
@@ -6467,17 +6559,24 @@ static func _assign_units_to_objectives(
 		var a = assignments[uid]
 		var u = snapshot.get("units", {}).get(uid, {})
 		var u_name = u.get("meta", {}).get("name", uid)
+		var u_pos = _get_unit_centroid(u)
 		# Find all candidates for this unit from the sorted candidates array
 		var unit_candidates = []
 		var chosen_idx = 0
 		var c_idx = 0
 		for cand in candidates:
 			if cand.unit_id == uid:
+				var cand_vp = float(cand.get("vp_value", 0.0))
+				var vp_note = " — worth ~%.0f VP" % cand_vp if cand_vp >= 1.0 else ""
 				unit_candidates.append({
-					"description": "%s %s (%s)" % [cand.action.capitalize(), cand.objective_id, cand.reason],
+					"description": "%s %s (%s%s)" % [cand.action.capitalize(), cand.objective_id, cand.reason, vp_note],
 					"score": cand.score,
+					# Board-link context: recorded positions let the game log
+					# draw this consideration on the board later.
+					"pos": [cand.objective_pos.x, cand.objective_pos.y],
 					"score_breakdown": {
 						"objective_priority": cand.score,
+						"expected_vp": cand_vp,
 						"distance_inches": cand.distance / PIXELS_PER_INCH if cand.distance > 0 else 0.0,
 						"unit_oc": cand.unit_oc,
 					}
@@ -6489,8 +6588,9 @@ static func _assign_units_to_objectives(
 			_add_decision_record("movement", uid, u_name, unit_candidates, chosen_idx,
 				{"WEIGHT_UNCONTROLLED_OBJ": get_param("WEIGHT_UNCONTROLLED_OBJ", WEIGHT_UNCONTROLLED_OBJ),
 				 "WEIGHT_CONTESTED_OBJ": get_param("WEIGHT_CONTESTED_OBJ", WEIGHT_CONTESTED_OBJ),
-				 "WEIGHT_HOME_UNDEFENDED": get_param("WEIGHT_HOME_UNDEFENDED", WEIGHT_HOME_UNDEFENDED)},
-				{"phase": "movement", "round": battle_round})
+				 "WEIGHT_VP_PER_POINT": get_param("WEIGHT_VP_PER_POINT", WEIGHT_VP_PER_POINT)},
+				{"phase": "movement", "round": battle_round,
+				 "unit_pos": [u_pos.x, u_pos.y] if u_pos != Vector2.INF else []})
 
 	return assignments
 
@@ -11166,9 +11266,11 @@ static func _evaluate_best_charge(snapshot: Dictionary, available_actions: Array
 			# Score comes from best_score for the chosen target, 0.0 for others
 			if tid == best_action.get("payload", {}).get("target_unit_ids", [null])[0] if not best_action.get("payload", {}).get("target_unit_ids", []).is_empty() else "":
 				t_score = best_score
+			var t_pos = _get_unit_centroid(t_unit) if not t_unit.is_empty() else Vector2.INF
 			charge_candidates.append({
 				"description": "Charge %s (%.1f\" away, %.0f%% chance)" % [t_name, t_dist, t_prob * 100.0],
 				"score": t_score,
+				"pos": [t_pos.x, t_pos.y] if t_pos != Vector2.INF else [],
 				"score_breakdown": {
 					"charge_probability": t_prob,
 					"melee_damage": t_melee,
@@ -11180,11 +11282,13 @@ static func _evaluate_best_charge(snapshot: Dictionary, available_actions: Array
 				charge_chosen_idx = idx
 			idx += 1
 	if not charge_candidates.is_empty():
+		var charger_pos = _get_unit_centroid(charge_unit)
 		_add_decision_record("charge", charge_unit_id, charge_unit_name,
 			charge_candidates, charge_chosen_idx,
 			{"TEMPO_CHARGE_THRESHOLD_REDUCTION": TEMPO_CHARGE_THRESHOLD_REDUCTION,
 			 "charge_threshold": charge_threshold},
-			{"phase": "charge", "round": ct_battle_round})
+			{"phase": "charge", "round": ct_battle_round,
+			 "unit_pos": [charger_pos.x, charger_pos.y] if charger_pos != Vector2.INF else []})
 
 	var result = best_action.duplicate()
 	result["_ai_description"] = best_description
@@ -14351,6 +14455,9 @@ static func _build_primary_awareness(snapshot: Dictionary, player: int) -> Dicti
 		"kill_pressure": false,      # kill-based rules (destroyed_min / killed_more)
 		"quarters": false,           # table-quarter presence rules
 		"active_rules": 0,
+		# The card's objective rules active THIS round, verbatim — the VP
+		# estimator prices individual objectives from these.
+		"vp_rules": [],
 	}
 
 	var mm = _mission_manager()
@@ -14369,6 +14476,7 @@ static func _build_primary_awareness(snapshot: Dictionary, player: int) -> Dicti
 		if battle_round < int(rounds[0]) or battle_round > int(rounds[1]):
 			continue
 		awareness.active_rules += 1
+		awareness.vp_rules.append(rule)
 		var vp = float(rule.get("vp", rule.get("vp_per", 0)))
 		match str(rule.get("type", "")):
 			"hold_min", "per_objective", "per_new_objective", "hold_new":
@@ -14408,6 +14516,101 @@ static func _get_primary_awareness(player: int) -> Dictionary:
 	if player == 1:
 		return _primary_awareness_p1
 	return _primary_awareness_p2
+
+# =============================================================================
+# VP-DENOMINATED OBJECTIVE VALUE
+# =============================================================================
+
+static func _estimate_objective_vp_value(obj_info: Dictionary, player: int,
+		my_holds: int, their_holds: int) -> Dictionary:
+	"""Price ONE objective in expected VP at the next scoring point, from the
+	player's ACTUAL mission cards (primary rules via _build_primary_awareness's
+	vp_rules + secondary vp_objective_hints). Marginal analysis: a hold_min-3
+	rule pays nothing for a 4th objective, everything for the 3rd.
+	obj_info: {is_home, is_enemy_home, is_central, is_held_by_me}
+	Returns {vp: float, sources: [String]} — sources feed the narration."""
+	var vp := 0.0
+	var sources: Array = []
+	var is_home: bool = obj_info.get("is_home", false)
+	var is_enemy_home: bool = obj_info.get("is_enemy_home", false)
+	var is_central: bool = obj_info.get("is_central", false)
+	var is_held: bool = obj_info.get("is_held_by_me", false)
+
+	# --- Primary card rules (active this round) ---
+	var primary = _get_primary_awareness(player)
+	for rule in primary.get("vp_rules", []):
+		var rule_vp = float(rule.get("vp", rule.get("vp_per", 0)))
+		if rule_vp <= 0.0:
+			continue
+		match str(rule.get("type", "")):
+			"per_objective":
+				if rule.get("exclude_home", false) and is_home:
+					# Home doesn't pay directly, but a require_hold_home rider
+					# makes holding home the enabler for every other payout.
+					if rule.get("require_hold_home", false):
+						vp += rule_vp
+						sources.append("home enables +%s/obj (primary)" % str(rule_vp))
+				else:
+					vp += rule_vp
+					sources.append("+%s/obj (primary)" % str(rule_vp))
+			"hold_min":
+				if rule.get("exclude_home", false) and is_home:
+					continue
+				var needed = int(rule.get("min", 1))
+				# Marginal value: full VP for the objective that reaches the
+				# threshold, a taper for insurance/overshoot.
+				if my_holds < needed:
+					if is_held or my_holds + 1 >= needed:
+						vp += rule_vp
+						sources.append("reaches hold-%d (%s VP primary)" % [needed, str(rule_vp)])
+					else:
+						vp += rule_vp * 0.5
+						sources.append("builds toward hold-%d (primary)" % needed)
+				elif is_held and my_holds == needed:
+					# Already exactly at threshold — losing THIS one loses the VP
+					vp += rule_vp
+					sources.append("keeps hold-%d alive (%s VP primary)" % [needed, str(rule_vp)])
+				else:
+					vp += rule_vp * 0.2
+					sources.append("insurance for hold-%d (primary)" % needed)
+			"hold_more":
+				# Majority: full value when this objective flips or preserves it
+				var decisive = (my_holds == their_holds) or (is_held and my_holds == their_holds + 1)
+				vp += rule_vp if decisive else rule_vp * 0.3
+				if decisive:
+					sources.append("swings majority (%s VP primary)" % str(rule_vp))
+			"hold_enemy_home":
+				if is_enemy_home:
+					vp += rule_vp
+					sources.append("ENEMY HOME pays %s VP (primary)" % str(rule_vp))
+			"hold_central", "hold_central_plus_nml":
+				if is_central:
+					vp += rule_vp
+					sources.append("CENTRE pays %s VP (primary)" % str(rule_vp))
+				elif str(rule.get("type", "")) == "hold_central_plus_nml" and not is_home and not is_enemy_home:
+					vp += rule_vp * 0.4
+					sources.append("NML rider on centre rule (primary)")
+			"hold_new", "per_new_objective":
+				if not is_held:
+					vp += rule_vp
+					sources.append("newly taken pays %s VP (primary)" % str(rule_vp))
+
+	# --- Secondary card hints ---
+	var secondary = _get_secondary_awareness(player)
+	for hint in secondary.get("vp_objective_hints", []):
+		var kind = str(hint.get("kind", ""))
+		var matched = false
+		match kind:
+			"enemy_home": matched = is_enemy_home
+			"home": matched = is_home
+			"central": matched = is_central
+			"nml": matched = not is_home and not is_enemy_home
+			"any": matched = true
+		if matched:
+			vp += float(hint.get("vp", 0.0))
+			sources.append("%s pays %s VP" % [hint.get("card", "secondary"), str(hint.get("vp", 0))])
+
+	return {"vp": vp, "sources": sources}
 
 static func _evaluate_mission_achievability(snapshot: Dictionary, mission: Dictionary, player: int, battle_round: int) -> float:
 	"""
@@ -15352,6 +15555,10 @@ static func _build_secondary_awareness(snapshot: Dictionary, player: int) -> Dic
 		"nml_priority": 0.0,           # bonus for no man's land positioning
 		"defend_home": 0.0,            # bonus for defending own zone objectives
 		"active_mission_ids": [],      # for reference/logging
+		# Secondary cards that pay VP for CONTROLLING objectives — the VP
+		# estimator prices individual objectives from these hints.
+		# Each hint: {kind: "enemy_home"|"home"|"nml"|"central"|"any", vp: float}
+		"vp_objective_hints": [],
 	}
 
 	var secondary_mgr = _secondary_mission_manager()
@@ -15408,17 +15615,20 @@ static func _build_secondary_awareness(snapshot: Dictionary, player: int) -> Dic
 				# Need to control objectives in own deployment zone
 				awareness.defend_home = get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
 				awareness.objective_zone_bonuses[player_zone] = awareness.objective_zone_bonuses.get(player_zone, 0.0) + get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
+				awareness.vp_objective_hints.append({"kind": "home", "vp": 3.0, "card": "Defend Stronghold"})
 				print("AIDecisionMaker: [T7-25] Defend Stronghold active — defending home zone objectives")
 
 			"secure_no_mans_land":
 				# Need to control NML objectives
 				awareness.nml_priority += get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
 				awareness.objective_zone_bonuses["no_mans_land"] = awareness.objective_zone_bonuses.get("no_mans_land", 0.0) + get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
+				awareness.vp_objective_hints.append({"kind": "nml", "vp": 2.5, "card": "Secure No Man's Land"})
 				print("AIDecisionMaker: [T7-25] Secure NML active — prioritizing no man's land objectives")
 
 			"a_tempting_target":
 				# Need to control opponent-selected objective (in NML)
 				awareness.objective_zone_bonuses["no_mans_land"] = awareness.objective_zone_bonuses.get("no_mans_land", 0.0) + get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
+				awareness.vp_objective_hints.append({"kind": "nml", "vp": 2.0, "card": "A Tempting Target"})
 				print("AIDecisionMaker: [T7-25] A Tempting Target active — contesting NML objectives")
 
 			"extend_battle_lines":
@@ -15485,6 +15695,8 @@ static func _build_secondary_awareness(snapshot: Dictionary, player: int) -> Dic
 				awareness.enemy_zone_push = maxf(awareness.enemy_zone_push, get_param("SECONDARY_ENEMY_ZONE_PUSH_BONUS", SECONDARY_ENEMY_ZONE_PUSH_BONUS) * 0.8)
 				awareness.objective_zone_bonuses[enemy_zone] = awareness.objective_zone_bonuses.get(enemy_zone, 0.0) + get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS)
 				awareness.nml_priority += get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS) * 0.5
+				awareness.vp_objective_hints.append({"kind": "enemy_home", "vp": 5.0, "card": "Forward Position"})
+				awareness.vp_objective_hints.append({"kind": "nml", "vp": 2.5, "card": "Forward Position"})
 				_add_thinking_step("Secondary 'Forward Position': 5 VP for holding the enemy home / an expansion objective — pushing forward")
 
 			"burden_of_trust":
@@ -15493,12 +15705,14 @@ static func _build_secondary_awareness(snapshot: Dictionary, player: int) -> Dic
 				awareness.defend_home = maxf(awareness.defend_home, get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS) * 0.7)
 				awareness.nml_priority += get_param("SECONDARY_OBJECTIVE_ZONE_BONUS", SECONDARY_OBJECTIVE_ZONE_BONUS) * 0.7
 				awareness["hold_objectives"] = true
+				awareness.vp_objective_hints.append({"kind": "any", "vp": 2.0, "card": "Burden of Trust"})
 				_add_thinking_step("Secondary 'Burden of Trust': scores per objective still guarded at the END of the enemy turn — holding ground beats pushing")
 
 			"centre_ground":
 				# 3/5 VP tiers around the board centre (enemy exclusion 3\"/6\")
 				awareness.center_priority = maxf(awareness.center_priority, get_param("SECONDARY_CENTER_BONUS", SECONDARY_CENTER_BONUS))
 				awareness["kill_proximity"] = true  # clearing enemies off the centre doubles the tier
+				awareness.vp_objective_hints.append({"kind": "central", "vp": 4.0, "card": "Centre Ground"})
 				_add_thinking_step("Secondary 'Centre Ground': 3-5 VP for owning the middle — pushing centre and clearing enemies near it")
 
 			"beacon":

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -14318,6 +14318,23 @@ static func _decide_scoring(snapshot: Dictionary, available_actions: Array, play
 			action_types_map[t] = []
 		action_types_map[t].append(action)
 
+	# 11e 03.03: out-of-coherency model removal is a MANDATORY gate — nothing
+	# else (including END_TURN) is offered until it resolves. Answer it or the
+	# turn stalls forever (found by the AI-vs-AI benchmark: a fixture without
+	# player types made the engine treat AI units as human-gated here).
+	if action_types_map.has("REMOVE_MODEL_FOR_COHERENCY"):
+		var rm = action_types_map["REMOVE_MODEL_FOR_COHERENCY"][0]
+		var rm_unit = snapshot.get("units", {}).get(rm.get("unit_id", ""), {})
+		var rm_name = rm_unit.get("meta", {}).get("name", rm.get("unit_id", ""))
+		_add_thinking_step("%s is out of coherency — removing %s to satisfy 03.03 (mandatory)" % [
+			rm_name, rm.get("model_id", "?")])
+		return {
+			"type": "REMOVE_MODEL_FOR_COHERENCY",
+			"unit_id": rm.get("unit_id", ""),
+			"model_id": rm.get("model_id", ""),
+			"_ai_description": "Remove %s from %s (out of coherency, 03.03)" % [rm.get("model_id", "?"), rm_name]
+		}
+
 	if action_types_map.has("ACROBATIC_ESCAPE_VANISH"):
 		var ae_action = action_types_map["ACROBATIC_ESCAPE_VANISH"][0]
 		var ae_unit_id = ae_action.get("unit_id", "")

--- a/40k/scripts/AIThoughtLinkVisual.gd
+++ b/40k/scripts/AIThoughtLinkVisual.gd
@@ -1,0 +1,109 @@
+extends Node2D
+class_name AIThoughtLinkVisual
+
+## Draws one AI decision's considered options on the board: the deciding unit,
+## a solid green arrow to the CHOSEN option and faded red arrows to the
+## REJECTED ones, each labelled with its score. Driven by the AI thinking
+## cards in GameLogPanel (hover to preview, click to pin).
+## Coordinates are board px — this node lives under BoardRoot, the same space
+## tokens and objectives use.
+
+const COLOR_CHOSEN := Color(0.35, 0.85, 0.45, 0.95)
+const COLOR_REJECTED := Color(0.85, 0.35, 0.35, 0.55)
+const COLOR_UNIT_RING := Color(0.55, 0.75, 1.0, 0.9)
+const LINE_WIDTH_CHOSEN := 4.0
+const LINE_WIDTH_REJECTED := 2.5
+const ARROW_SIZE := 14.0
+const UNIT_RING_RADIUS := 26.0
+const LABEL_FONT_SIZE := 13
+
+var _context: Dictionary = {}
+
+func _ready() -> void:
+	name = "AIThoughtLinkVisual"
+	z_index = 900  # Above tokens/terrain, below transient dialogs
+	visible = false
+
+func show_links(context: Dictionary) -> void:
+	"""Display the option arrows for one decision context:
+	{unit_name, unit_pos: [x,y], candidates: [{label, score, pos: [x,y], chosen}]}"""
+	_context = context if context != null else {}
+	visible = not _context.is_empty()
+	queue_redraw()
+
+func clear_links() -> void:
+	_context = {}
+	visible = false
+	queue_redraw()
+
+func is_active() -> bool:
+	return visible and not _context.is_empty()
+
+func get_link_count() -> int:
+	return _context.get("candidates", []).size()
+
+func _draw() -> void:
+	if _context.is_empty():
+		return
+	var font: Font = ThemeDB.fallback_font
+	var unit_pos_arr = _context.get("unit_pos", [])
+	var has_origin: bool = unit_pos_arr is Array and unit_pos_arr.size() == 2
+	var origin := Vector2.ZERO
+	if has_origin:
+		origin = Vector2(float(unit_pos_arr[0]), float(unit_pos_arr[1]))
+		# Ring + name on the deciding unit's recorded position
+		draw_arc(origin, UNIT_RING_RADIUS, 0.0, TAU, 40, COLOR_UNIT_RING, 3.0, true)
+		var unit_name = str(_context.get("unit_name", ""))
+		if unit_name != "":
+			_draw_label(font, origin + Vector2(-UNIT_RING_RADIUS, -UNIT_RING_RADIUS - 8.0), unit_name, COLOR_UNIT_RING)
+
+	# Draw rejected arrows first so the chosen one renders on top
+	for pass_chosen in [false, true]:
+		for cand in _context.get("candidates", []):
+			if bool(cand.get("chosen", false)) != pass_chosen:
+				continue
+			var pos_arr = cand.get("pos", [])
+			if not (pos_arr is Array and pos_arr.size() == 2):
+				continue
+			var target := Vector2(float(pos_arr[0]), float(pos_arr[1]))
+			var color: Color = COLOR_CHOSEN if pass_chosen else COLOR_REJECTED
+			var width: float = LINE_WIDTH_CHOSEN if pass_chosen else LINE_WIDTH_REJECTED
+
+			if has_origin and origin.distance_to(target) > 1.0:
+				var dir := (target - origin).normalized()
+				var start := origin + dir * UNIT_RING_RADIUS
+				var tip := target - dir * 10.0
+				if pass_chosen:
+					draw_line(start, tip, color, width, true)
+				else:
+					_draw_dashed(start, tip, color, width)
+				# Arrowhead
+				var left := tip - dir.rotated(0.45) * ARROW_SIZE
+				var right := tip - dir.rotated(-0.45) * ARROW_SIZE
+				draw_colored_polygon(PackedVector2Array([tip, left, right]), color)
+			else:
+				# No origin — mark the option position alone
+				draw_arc(target, 16.0, 0.0, TAU, 24, color, width, true)
+
+			# Score tag near the option
+			var score := float(cand.get("score", 0.0))
+			var tag := "✓ %.1f" % score if pass_chosen else "✗ %.1f" % score
+			_draw_label(font, target + Vector2(14.0, -10.0), tag, color)
+
+func _draw_dashed(from: Vector2, to: Vector2, color: Color, width: float) -> void:
+	var seg := 14.0
+	var gap := 8.0
+	var dir := (to - from).normalized()
+	var total := from.distance_to(to)
+	var t := 0.0
+	while t < total:
+		var a := from + dir * t
+		var b := from + dir * minf(t + seg, total)
+		draw_line(a, b, color, width, true)
+		t += seg + gap
+
+func _draw_label(font: Font, pos: Vector2, text: String, color: Color) -> void:
+	# Dark backing so labels stay readable over any board art
+	var size := font.get_string_size(text, HORIZONTAL_ALIGNMENT_LEFT, -1, LABEL_FONT_SIZE)
+	draw_rect(Rect2(pos - Vector2(3, size.y - 3), size + Vector2(6, 4)), Color(0.05, 0.05, 0.08, 0.75))
+	draw_string(font, pos, text, HORIZONTAL_ALIGNMENT_LEFT, -1, LABEL_FONT_SIZE, color)

--- a/40k/scripts/AIThoughtLinkVisual.gd.uid
+++ b/40k/scripts/AIThoughtLinkVisual.gd.uid
@@ -1,0 +1,1 @@
+uid://b8r56hejsxa88

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -68,6 +68,10 @@ var _collapse_button: Button
 var _ai_filter_button: Button
 var _show_ai_thinking: bool = true
 var _ai_cards: Array[PanelContainer] = []
+# Board-linked thinking cards (carry ai_link_context metadata) + pin state
+var _linked_ai_cards: Array[PanelContainer] = []
+var _pinned_link_card: PanelContainer = null
+var _thought_link_visual: Node2D = null
 var _card_count: int = 0
 var _is_visible: bool = true
 var _current_combat_card: PanelContainer = null
@@ -205,6 +209,64 @@ func get_ai_card_count() -> int:
 	"""Live AI thinking cards currently in the panel (scenario assertions)."""
 	var n := 0
 	for c in _ai_cards:
+		if is_instance_valid(c):
+			n += 1
+	return n
+
+# ==========================================================================
+# Board-linked thinking — hover/click a card to see the options on the board
+# ==========================================================================
+
+func _get_thought_link_visual() -> Node2D:
+	"""Lazily create the AIThoughtLinkVisual under Main/BoardRoot so arrows
+	draw in board space alongside tokens."""
+	if _thought_link_visual != null and is_instance_valid(_thought_link_visual):
+		return _thought_link_visual
+	var main = get_parent()
+	if main == null:
+		return null
+	var board_root = main.get_node_or_null("BoardRoot")
+	if board_root == null:
+		return null
+	_thought_link_visual = board_root.get_node_or_null("AIThoughtLinkVisual")
+	if _thought_link_visual == null:
+		_thought_link_visual = preload("res://scripts/AIThoughtLinkVisual.gd").new()
+		board_root.add_child(_thought_link_visual)
+		print("GameLogPanel: Created AIThoughtLinkVisual in BoardRoot")
+	return _thought_link_visual
+
+func _show_thought_links(context: Dictionary) -> void:
+	var visual = _get_thought_link_visual()
+	if visual:
+		visual.show_links(context)
+
+func _hide_thought_links() -> void:
+	if _thought_link_visual != null and is_instance_valid(_thought_link_visual):
+		_thought_link_visual.clear_links()
+
+func _toggle_thought_link_pin(card: PanelContainer) -> void:
+	"""Click behaviour: pin this card's option arrows on the board; clicking
+	the pinned card again (or another linked card) unpins/switches."""
+	if _pinned_link_card == card:
+		_pinned_link_card = null
+		_hide_thought_links()
+		return
+	_pinned_link_card = card
+	_show_thought_links(card.get_meta("ai_link_context", {}))
+
+func activate_latest_ai_link() -> bool:
+	"""Pin the most recent board-linked thinking card — same path as clicking
+	it. Used by windowed scenarios to validate the feature end-to-end."""
+	for i in range(_linked_ai_cards.size() - 1, -1, -1):
+		var card = _linked_ai_cards[i]
+		if is_instance_valid(card):
+			_toggle_thought_link_pin(card)
+			return _pinned_link_card == card
+	return false
+
+func get_linked_ai_card_count() -> int:
+	var n := 0
+	for c in _linked_ai_cards:
 		if is_instance_valid(c):
 			n += 1
 	return n
@@ -635,7 +697,13 @@ func _create_simple_card(text: String, entry_type: String, animate: bool) -> voi
 		"ai_thinking":
 			card = _make_simple_entry_card(text, entry_type, EntryCategory.AI_THINKING)
 		"ai_thinking_block":
-			card = _make_ai_thinking_block_card(text)
+			# Board-link context (unit + candidate positions) travels alongside
+			# the entry — read it synchronously from the emitting autoload.
+			var block_context: Dictionary = {}
+			var gel = Engine.get_main_loop().root.get_node_or_null("GameEventLog") if Engine.get_main_loop() else null
+			if gel and gel.has_method("get_last_entry_context"):
+				block_context = gel.get_last_entry_context()
+			card = _make_ai_thinking_block_card(text, block_context)
 		_:
 			card = _make_simple_entry_card(text, entry_type, category)
 
@@ -785,22 +853,42 @@ func _make_simple_entry_card(text: String, entry_type: String, category: int) ->
 
 	return card
 
-func _make_ai_thinking_block_card(text: String) -> PanelContainer:
+func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -> PanelContainer:
 	"""Collapsible card for one AI decision's verbose reasoning.
 	First line of `text` is the headline; remaining lines are the considered
 	options / rejections, hidden behind a 'considerations' toggle so heavy
-	verbosity stays scannable."""
+	verbosity stays scannable. When `link_context` carries board positions,
+	the card becomes interactive: hover previews the considered options as
+	arrows on the board (chosen green, rejected red); click pins them."""
 	var lines = text.split("\n")
 	var header_text = lines[0] if lines.size() > 0 else text
 	var detail_lines: Array = []
 	for i in range(1, lines.size()):
 		detail_lines.append(lines[i])
 
+	var is_linked: bool = not link_context.is_empty() and not link_context.get("candidates", []).is_empty()
 	var accent = BORDER_COLORS[EntryCategory.AI_THINKING]
+	if is_linked:
+		# Brighter accent signals "hover me — I draw on the board"
+		accent = Color(0.45, 0.65, 0.9)
 	var card = PanelContainer.new()
-	card.add_theme_stylebox_override("panel", _make_card_style(Color(0.08, 0.08, 0.11, 0.7), accent, 2))
+	card.add_theme_stylebox_override("panel", _make_card_style(Color(0.08, 0.08, 0.11, 0.7), accent, 3 if is_linked else 2))
 	card.custom_minimum_size = Vector2(0, 24)
 	card.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	if is_linked:
+		card.set_meta("ai_link_context", link_context)
+		card.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+		card.tooltip_text = "Hover: show this decision's options on the board. Click: pin/unpin."
+		card.mouse_entered.connect(func():
+			if _pinned_link_card == null:
+				_show_thought_links(link_context))
+		card.mouse_exited.connect(func():
+			if _pinned_link_card == null:
+				_hide_thought_links())
+		card.gui_input.connect(func(event):
+			if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+				_toggle_thought_link_pin(card))
+		_linked_ai_cards.append(card)
 
 	var card_vbox = VBoxContainer.new()
 	card_vbox.add_theme_constant_override("separation", 2)
@@ -821,6 +909,8 @@ func _make_ai_thinking_block_card(text: String) -> PanelContainer:
 	header_label.add_theme_font_size_override("normal_font_size", 11)
 	header_label.add_theme_font_size_override("bold_font_size", 12)
 	header_label.append_text("[i][color=#8899AA]%s[/color][/i]" % header_text)
+	# Let the card itself receive hover/click for the board-link interaction
+	header_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	header_hbox.add_child(header_label)
 
 	if detail_lines.is_empty():
@@ -842,6 +932,7 @@ func _make_ai_thinking_block_card(text: String) -> PanelContainer:
 	details.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	details.add_theme_font_size_override("normal_font_size", 10)
 	details.visible = false
+	details.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	for line in detail_lines:
 		var l = str(line)
 		# Rejections get a dim red tint so declined options stand out from
@@ -1117,6 +1208,11 @@ func _trim_old_cards(count: int) -> void:
 		var old_card = _card_container.get_child(0)
 		if old_card in _ai_cards:
 			_ai_cards.erase(old_card)
+		if old_card in _linked_ai_cards:
+			_linked_ai_cards.erase(old_card)
+		if old_card == _pinned_link_card:
+			_pinned_link_card = null
+			_hide_thought_links()
 		_card_container.remove_child(old_card)
 		old_card.queue_free()
 		_card_count -= 1

--- a/40k/tests/run_ai_benchmark.sh
+++ b/40k/tests/run_ai_benchmark.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# AI-vs-AI benchmark: play N full games headless and report win rate / VP
+# differential. Use it to verify an AI change actually wins more games, or to
+# compare parameter profiles (AIDecisionMaker load_player_profile format).
+#
+# Usage:
+#   bash 40k/tests/run_ai_benchmark.sh [GAMES] [FIXTURE] [P1_PROFILE] [P2_PROFILE]
+#
+#   GAMES       number of games (default 3)
+#   FIXTURE     save fixture to start from (default audit_baseline_postdeploy —
+#               Custodes P1 vs Orks P2, round 1 Command, post-deployment)
+#   P1_PROFILE / P2_PROFILE  optional parameter-override JSON paths
+#
+# Env overrides: BENCH_DIFFICULTY (default 1=Normal), BENCH_TIME_SCALE (3),
+#   BENCH_MAX_SECONDS (600), BENCH_SEED_BASE (1000)
+#
+# Output: per-game JSON under <godot-userdata>/test_results/bench/ + an
+# aggregated bench_report.json/md, summary printed to stdout.
+
+set -u
+
+GAMES="${1:-3}"
+FIXTURE="${2:-audit_baseline_postdeploy}"
+P1_PROFILE="${3:-}"
+P2_PROFILE="${4:-}"
+DIFFICULTY="${BENCH_DIFFICULTY:-1}"
+TIME_SCALE="${BENCH_TIME_SCALE:-3}"
+MAX_SECONDS="${BENCH_MAX_SECONDS:-600}"
+SEED_BASE="${BENCH_SEED_BASE:-1000}"
+
+cd "$(dirname "$0")/.."
+export PATH="$HOME/bin:$PATH"
+
+# Fixtures live in tests/saves but load from saves/
+mkdir -p saves
+cp -n tests/saves/*.w40ksave saves/ 2>/dev/null || true
+
+# Resolve the userdata dir for this platform (where user:// lands)
+USERDATA=$(godot --headless --path . --quit-after 1 2>/dev/null >/dev/null; echo "$HOME/.local/share/godot/app_userdata/40k")
+if [ "$(uname)" = "Darwin" ]; then
+    USERDATA="$HOME/Library/Application Support/Godot/app_userdata/40k"
+fi
+BENCH_DIR="$USERDATA/test_results/bench"
+mkdir -p "$BENCH_DIR"
+
+STAMP=$(date +%Y%m%d_%H%M%S)
+echo "================================================================"
+echo "AI benchmark: $GAMES game(s), fixture=$FIXTURE, difficulty=$DIFFICULTY"
+echo "profiles: P1='${P1_PROFILE:-default}' P2='${P2_PROFILE:-default}'"
+echo "================================================================"
+
+RESULTS=()
+for i in $(seq 1 "$GAMES"); do
+    SEED=$((SEED_BASE + i))
+    OUT_REL="test_results/bench/${STAMP}_game_${i}.json"
+    echo "--- game $i/$GAMES (seed $SEED) ---"
+    ARGS=(--headless --path . -- --ai-benchmark
+        "--bench-fixture=$FIXTURE" "--bench-seed=$SEED"
+        "--bench-out=$OUT_REL" "--bench-difficulty=$DIFFICULTY"
+        "--bench-time-scale=$TIME_SCALE" "--bench-max-seconds=$MAX_SECONDS")
+    [ -n "$P1_PROFILE" ] && ARGS+=("--bench-p1-profile=$P1_PROFILE")
+    [ -n "$P2_PROFILE" ] && ARGS+=("--bench-p2-profile=$P2_PROFILE")
+
+    timeout $((MAX_SECONDS + 120)) godot "${ARGS[@]}" 2>&1 | grep -E "^\[AIBench\]" | tail -4
+    RESULTS+=("$BENCH_DIR/${STAMP}_game_${i}.json")
+done
+
+# Aggregate
+python3 - "$BENCH_DIR/${STAMP}_report" "${RESULTS[@]}" <<'PYEOF'
+import json, sys
+
+report_base, paths = sys.argv[1], sys.argv[2:]
+games = []
+for p in paths:
+    try:
+        games.append(json.load(open(p)))
+    except Exception as e:
+        games.append({"status": "missing", "note": str(e), "path": p})
+
+completed = [g for g in games if g.get("status") == "completed"]
+stalled = [g for g in games if g.get("status") in ("stalled", "error", "missing")]
+p1_wins = sum(1 for g in completed if g.get("winner") == 1)
+p2_wins = sum(1 for g in completed if g.get("winner") == 2)
+draws = sum(1 for g in completed if g.get("winner") == 0)
+diffs = [g.get("vp_diff_p2_minus_p1", 0) for g in completed]
+avg_diff = sum(diffs) / len(diffs) if diffs else 0.0
+
+summary = {
+    "games": len(games), "completed": len(completed), "stalled_or_error": len(stalled),
+    "p1_wins": p1_wins, "p2_wins": p2_wins, "draws": draws,
+    "avg_vp_diff_p2_minus_p1": round(avg_diff, 2),
+    "per_game": [
+        {"seed": g.get("seed"), "status": g.get("status"), "winner": g.get("winner"),
+         "vp_p1": g.get("vp", {}).get("player1", {}).get("total"),
+         "vp_p2": g.get("vp", {}).get("player2", {}).get("total"),
+         "rounds": g.get("battle_round"), "actions": g.get("actions_taken"),
+         "wall_seconds": round(g.get("wall_seconds", 0), 1), "note": g.get("note", "")}
+        for g in games],
+}
+json.dump(summary, open(report_base + ".json", "w"), indent=2)
+
+lines = ["# AI benchmark report", "",
+         f"Games: {summary['games']} (completed {summary['completed']}, stalled/error {summary['stalled_or_error']})",
+         f"P1 wins: {p1_wins}  P2 wins: {p2_wins}  Draws: {draws}",
+         f"Avg VP diff (P2-P1): {summary['avg_vp_diff_p2_minus_p1']}", "",
+         "| seed | status | winner | VP P1 | VP P2 | rounds | actions | wall s | note |",
+         "|---|---|---|---|---|---|---|---|---|"]
+for g in summary["per_game"]:
+    lines.append("| {seed} | {status} | {winner} | {vp_p1} | {vp_p2} | {rounds} | {actions} | {wall_seconds} | {note} |".format(**g))
+open(report_base + ".md", "w").write("\n".join(lines) + "\n")
+
+print()
+print("\n".join(lines))
+print(f"\nreport: {report_base}.md")
+PYEOF
+
+echo "================================================================"

--- a/40k/tests/scenarios/sp/ai_11e_verbose_thinking.json
+++ b/40k/tests/scenarios/sp/ai_11e_verbose_thinking.json
@@ -7,6 +7,7 @@
     "ui.GameLogPanel.ai_thinking_cards"
   ],
   "fixture": "audit_382_cp_grant",
+  "edition": 11,
   "rng_seed": 11,
   "description": "AI 11e upgrade gate: P2 (Orks, AI at default Normal difficulty) plays its Command phase live. Asserts (a) verbose AI reasoning reaches GameEventLog — including at least one NEGATIVE decision (hold/decline/reject/skip) with its why, (b) the left GameLogPanel actually renders AI thinking cards, (c) the AI drives its faction rules: round 2 means WAAAGH! must be called per its own stated timing rule. Screenshots capture the left panel with the reasoning visible.",
   "steps": [

--- a/40k/tests/scenarios/sp/ai_vp_thought_links.json
+++ b/40k/tests/scenarios/sp/ai_vp_thought_links.json
@@ -1,0 +1,32 @@
+{
+  "id": "ai_vp_thought_links",
+  "covers": [
+    "ai.thinking.vp_denominated_scoring",
+    "ai.thinking.board_linked_cards",
+    "ui.AIThoughtLinkVisual.render"
+  ],
+  "fixture": "audit_382_cp_grant",
+  "rng_seed": 7,
+  "description": "Follow-up gate: (a) the AI's objective decisions are VP-denominated — the log states the VP stakes derived from its actual mission cards; (b) thinking cards are board-linked — activating the latest linked card (same handler as clicking it) draws the considered options on the board via AIThoughtLinkVisual. Screenshot captures the arrows.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
+    { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(1)" },
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "GameState.set_active_player(2)" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(6)" },
+
+    { "act": "wait_seconds", "seconds": 10.0 },
+
+    { "act": "execute_script", "script": "GameEventLog.has_ai_entry_containing_any([\"VP stakes\", \"worth ~\"])", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.get_linked_ai_card_count()", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.activate_latest_ai_link()", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "main.get_node(\"BoardRoot/AIThoughtLinkVisual\").is_active()", "equals": true },
+    { "act": "execute_script", "script": "main.get_node(\"BoardRoot/AIThoughtLinkVisual\").get_link_count()", "expect_min": 2 },
+    { "act": "screenshot", "label": "01_thought_links_on_board" },
+    { "act": "execute_script", "script": "main.game_log_panel.activate_latest_ai_link()", "equals": false },
+    { "act": "execute_script", "script": "main.get_node(\"BoardRoot/AIThoughtLinkVisual\").is_active()", "equals": false },
+    { "act": "screenshot", "label": "02_links_cleared", "region": [0, 105, 400, 720] }
+  ]
+}

--- a/40k/tests/scenarios/sp/ai_vp_thought_links.json
+++ b/40k/tests/scenarios/sp/ai_vp_thought_links.json
@@ -6,12 +6,14 @@
     "ui.AIThoughtLinkVisual.render"
   ],
   "fixture": "audit_382_cp_grant",
+  "edition": 11,
   "rng_seed": 7,
   "description": "Follow-up gate: (a) the AI's objective decisions are VP-denominated — the log states the VP stakes derived from its actual mission cards; (b) thinking cards are board-linked — activating the latest linked card (same handler as clicking it) draws the considered options on the board via AIThoughtLinkVisual. Screenshot captures the arrows.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.6 },
     { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
     { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(1)" },
+    { "act": "execute_script", "script": "MissionManager.initialize_dispositions_11e(\"take_and_hold\", \"purge_the_foe\")" },
     { "act": "execute_script", "script": "GameEventLog.clear()" },
     { "act": "execute_script", "script": "GameState.set_active_player(2)" },
     { "act": "execute_script", "script": "PhaseManager.transition_to_phase(6)" },

--- a/docs/AI_11E_UPGRADE_PLAN.md
+++ b/docs/AI_11E_UPGRADE_PLAN.md
@@ -28,6 +28,35 @@ Implementation findings that amended the plan:
   pass/fail logic), and an AI Custodes fight activation could stall forever
   on the unanswered Ka'tah stance window.
 
+## Follow-up wave (v0.4.0, same branch)
+
+Implemented per the agreed priority order from the improvement review:
+
+1. **VP-denominated objective scoring** — `_estimate_objective_vp_value`
+   prices each objective from the player's ACTIVE primary rules
+   (`_build_primary_awareness.vp_rules`, with marginal analysis for
+   hold-min/majority) plus secondary `vp_objective_hints`; feeds
+   `_evaluate_all_objectives` at `WEIGHT_VP_PER_POINT` and is narrated
+   ("VP stakes this round: …"; candidates say "worth ~N VP").
+2. **Board-linked thinking cards** — decision records with positions
+   (movement objective candidates, charge targets) produce an
+   `_ai_thinking_context` that rides the thinking block into the log;
+   linked cards (bright accent) hover-preview / click-pin the considered
+   options on the board via the new `AIThoughtLinkVisual` (chosen = solid
+   green arrow, rejected = dashed red, score tags).
+3. **AI-vs-AI benchmark harness** — `AIBenchmarkRunner` autoload
+   (`--ai-benchmark`, ScenarioRunner-style activation) plays one full
+   headless game from a post-deployment fixture with optional
+   `load_player_profile` parameter overrides; `tests/run_ai_benchmark.sh N`
+   loops games and aggregates win rate / VP differential into a report.
+   This is the regression bar for future AI changes: run the benchmark,
+   demand the win rate holds.
+
+Remaining suggestions from the review (not yet implemented): one-ply
+opponent-response netting, shared CP planner, overwatch-bait charge
+sequencing, per-phase plan card, verbosity setting, faction voice, thinking
+in turn replay/saves.
+
 ## Why
 
 The engine, data, phases, missions and scoring are fully 11th edition


### PR DESCRIPTION
Follow-up wave to #507, implementing the agreed priority order from the AI improvement review: one strength upgrade, one presentation upgrade, and the benchmark to lock in gains. Version 0.4.0. Plan/findings updated in `docs/AI_11E_UPGRADE_PLAN.md`.

## VP-denominated objective scoring
- New `_estimate_objective_vp_value`: each objective is priced in expected VP from the player's **actual mission cards** — the active primary Force-Disposition rules (`vp_rules` captured by `_build_primary_awareness`) plus secondary `vp_objective_hints` (Forward Position 5 on enemy home, Burden of Trust 2/obj, Centre Ground 4 central, Defend Stronghold, Secure NML, A Tempting Target).
- Marginal analysis for threshold rules: a hold-min-2 rule pays full VP for the objective that reaches (or keeps) the threshold, taper for overshoot; hold-more pays fully when the objective swings the majority.
- Feeds `_evaluate_all_objectives` at `WEIGHT_VP_PER_POINT` on top of the tuned heuristic base, and narrates: *"VP stakes this round (holding 1, enemy 2): obj_center ~12 VP (+4.0/obj (primary); newly taken pays 3.0 VP)…"*; movement candidates append "worth ~N VP".

## Board-linked thinking cards
- Decision records with board positions (movement objective candidates, charge targets) produce an `_ai_thinking_context` that rides the thinking block through `GameEventLog` into the log panel.
- Linked cards get a bright accent + pointer cursor: **hover previews, click pins** the decision's options on the battlefield via the new `AIThoughtLinkVisual` (BoardRoot) — solid green arrow to the chosen option, dashed red arrows to rejected ones, score tags, ring + name on the deciding unit. Trim/clear handling releases pins safely.
- `GameLogPanel.activate_latest_ai_link()` drives the same handler for windowed scenarios.

## AI-vs-AI benchmark harness
- `AIBenchmarkRunner` autoload (ScenarioRunner-style activation via `--ai-benchmark`): plays one full headless game from a post-deployment fixture, both players AI, optional `load_player_profile` parameter-override JSONs, deterministic seeds, stall watchdog, JSON result (winner, VP split, rounds, actions, wall time).
- `tests/run_ai_benchmark.sh N` loops games and aggregates win rate / VP differential into a report — the regression bar for future AI changes.
- **It caught two real deadlocks on its first runs, both fixed here:**
  1. Round-2 stall: the 11e 03.03 coherency-removal gate treats untyped players as HUMAN and waits forever. The benchmark now writes `playerN_type: "AI"` into game_config, and `_decide_scoring` answers the mandatory `REMOVE_MODEL_FOR_COHERENCY` gate itself as a backstop (narrated).
  2. Round-5 fight-phase hang: `fight_selection_required` asked for a Fights-First selection that `get_available_actions` could not express (legacy `fight_sequence` empty), so action-driven players had nothing to dispatch. The action surface now falls back to `sequencer_11e.next_selection()` candidates — the same source `_validate_select_fighter` accepts.
- After the fixes: complete 5-round game, 221s wall, Orks 37–22.

## Harness finding
The automated test harness pins `GameConstants.edition` to the historical 10e baseline, silently no-opping every `edition >= 11` AI gate inside scenarios (while live play worked). Both AI scenarios now declare the schema's `"edition": 11` key, and `ai_vp_thought_links` initializes Force Dispositions on the pre-disposition fixture.

## Validation
- New windowed scenario `sp/ai_vp_thought_links.json` — **18/18**: VP stakes narrated from the real card, ≥1 linked card, `activate_latest_ai_link()` pins `AIThoughtLinkVisual` with ≥2 arrows, unpin clears; screenshots captured.
- `sp/ai_11e_verbose_thinking.json` re-passes **18/18** at edition 11.
- Live MCP validation: pinned arrows captured on the board mid-game; the AI also fired 'Ere We Go on its Warboss unprompted during the run; zero debug-log errors.
- Benchmark smoke run: 1 game completed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KN9gqeFfR5xiQeLqBTMvEW

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN9gqeFfR5xiQeLqBTMvEW)_