### PR TITLE
11e secondaries fully playable: opponent/drawer prompts, card actions, official clauses

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -139,6 +139,10 @@ func _ready() -> void:
 		var secondary_mgr = get_node("/root/SecondaryMissionManager")
 		secondary_mgr.when_drawn_requires_interaction.connect(_on_secondary_requires_interaction)
 		print("AIPlayer: Connected to SecondaryMissionManager.when_drawn_requires_interaction")
+		# Resume a paused AI turn as soon as the human resolves an interaction
+		# (Tempting Target objective pick, Beacon designation, MFD targets).
+		if secondary_mgr.has_signal("interaction_resolved"):
+			secondary_mgr.interaction_resolved.connect(_on_secondary_interaction_resolved)
 
 	# Load AI config overrides on startup
 	AIDecisionMaker.load_config_overrides()
@@ -1387,6 +1391,16 @@ func _evaluate_and_act() -> void:
 		_end_ai_thinking()
 		return
 
+	# Pause the AI turn while a secondary-mission when-drawn interaction is
+	# waiting on a HUMAN decision (e.g. AI drew A Tempting Target — the human
+	# opponent must pick the objective before the game moves on). The watchdog
+	# re-evaluates every couple of seconds, and interaction_resolved nudges an
+	# immediate resume when the human confirms their choice.
+	if _human_secondary_interaction_pending():
+		DebugLogger.info("AIPlayer._evaluate_and_act - waiting on human secondary-mission interaction", {})
+		_end_ai_thinking()
+		return
+
 	# Safety check - prevent infinite action loops
 	if _current_phase_actions >= MAX_ACTIONS_PER_PHASE:
 		push_error("AIPlayer: Hit max actions (%d) for current phase! Attempting to end phase." % MAX_ACTIONS_PER_PHASE)
@@ -2283,9 +2297,40 @@ func _on_vp_scored(player: int, points: int, reason: String) -> void:
 		return
 	record_ai_key_moment(player, "Scored %d VP (%s)" % [points, reason])
 
+func _human_secondary_interaction_pending() -> bool:
+	"""True while any when-drawn secondary interaction is waiting on a HUMAN
+	responder — the AI must not advance the game past the decision window."""
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr or not secondary_mgr.has_method("get_pending_interactions"):
+		return false
+	for pending in secondary_mgr.get_pending_interactions():
+		if not is_ai_player(int(pending.get("responder", 0))):
+			return true
+		# Marked for Death resolves in two steps: after an AI opponent picks
+		# alphas, a HUMAN drawer still owes the gamma pick — keep waiting
+		# while the card is pending and any human is involved.
+		if pending.get("interaction_type", "") == "opponent_selects_units" \
+				and not is_ai_player(int(pending.get("player", 0))):
+			return true
+	return false
+
+func _on_secondary_interaction_resolved(_player: int, _mission_id: String) -> void:
+	"""A pending when-drawn interaction was resolved (usually by a human via
+	dialog) — nudge the AI so a turn paused on the interaction gate resumes
+	immediately instead of waiting for the watchdog."""
+	if enabled:
+		_request_evaluation()
+
 func _on_secondary_requires_interaction(player: int, mission_id: String, interaction_type: String, details: Dictionary) -> void:
-	"""Auto-resolve secondary mission interactions for AI players."""
-	# Determine which player needs to respond — it's typically the opponent
+	"""Auto-resolve secondary mission interactions when the deciding player is
+	an AI. The RESPONDER depends on the card:
+	- opponent_selects_objective (A Tempting Target): the DRAWER's OPPONENT picks
+	- opponent_selects_units (Marked for Death): the OPPONENT picks alphas,
+	  then the DRAWER picks the gamma
+	- drawer_selects_unit (Beacon): the DRAWER picks
+	When the responder is HUMAN this handler must NOT resolve anything — the
+	CommandController shows the selection dialog and _evaluate_and_act pauses
+	the AI turn until the human decides."""
 	var opponent = 2 if player == 1 else 1
 	# For AI-vs-AI, the "opponent" is also AI, so auto-resolve regardless
 	if not is_ai_player(player) and not is_ai_player(opponent):
@@ -2301,6 +2346,11 @@ func _on_secondary_requires_interaction(player: int, mission_id: String, interac
 			# Step 1: OPPONENT selects Alpha targets from their own army
 			# Step 2: CARD HOLDER (drawing player) selects Gamma target from remaining opponent units
 			# 'player' here is the DRAWING player. 'opponent' selects from the OPPONENT's army.
+			if not is_ai_player(opponent):
+				# Human opponent picks alphas via the MarkedForDeathDialog —
+				# never steal that choice.
+				print("AIPlayer: Marked for Death drawn by AI P%d — HUMAN opponent P%d selects via dialog (not auto-resolving)" % [player, opponent])
+				return
 			var required_alpha = details.get("alpha_targets", 3)
 			var snapshot = GameState.create_snapshot()
 			var units = snapshot.get("units", {})
@@ -2368,19 +2418,116 @@ func _on_secondary_requires_interaction(player: int, mission_id: String, interac
 				print("AIPlayer: Cannot resolve Marked for Death — no valid targets")
 
 		"opponent_selects_objective":
-			# A Tempting Target — opponent selects an objective in no man's land
-			var objectives = GameState.state.get("board", {}).get("objectives", [])
-			var nml_objectives = []
-			for obj in objectives:
-				if obj.get("zone", "") == "no_mans_land":
-					nml_objectives.append(obj.get("id", ""))
-			if nml_objectives.size() > 0:
-				# Pick randomly
-				var chosen = nml_objectives[randi() % nml_objectives.size()]
+			# A Tempting Target — the DRAWER'S OPPONENT selects an objective in
+			# no man's land. Only auto-resolve when that opponent is an AI; a
+			# human opponent picks via the TemptingTargetDialog and the AI turn
+			# waits on the pending interaction (see _evaluate_and_act gate).
+			if not is_ai_player(opponent):
+				print("AIPlayer: A Tempting Target drawn by AI P%d — HUMAN opponent P%d selects via dialog (not auto-resolving)" % [player, opponent])
+				return
+			var chosen = _pick_tempting_target_objective(player, opponent)
+			if chosen != "":
 				secondary_mgr.resolve_tempting_target(player, chosen)
-				print("AIPlayer: Auto-resolved A Tempting Target for Player %d — objective: %s" % [player, chosen])
+				print("AIPlayer: Auto-resolved A Tempting Target for Player %d — opponent P%d chose objective: %s" % [player, opponent, chosen])
 			else:
 				print("AIPlayer: Cannot resolve A Tempting Target — no NML objectives found")
+
+		"drawer_selects_unit":
+			# 11e Beacon — the DRAWER designates one friendly unit. Only
+			# auto-resolve when the drawer is an AI; a human drawer picks via
+			# the BeaconUnitDialog.
+			if not is_ai_player(player):
+				print("AIPlayer: Beacon drawn by HUMAN P%d — designation via dialog (not auto-resolving)" % player)
+				return
+			var beacon_id = _pick_beacon_unit(player)
+			if beacon_id != "":
+				secondary_mgr.resolve_beacon_unit(player, beacon_id)
+				print("AIPlayer: Auto-resolved Beacon for Player %d — designated %s" % [player, beacon_id])
+			else:
+				print("AIPlayer: Cannot resolve Beacon — no eligible friendly units")
+
+## A Tempting Target: the chooser (the drawer's opponent) wants the objective
+## the DRAWER is least likely to control — prefer markers far from the
+## drawer's units and close to the chooser's own forces.
+func _pick_tempting_target_objective(drawing_player: int, chooser: int) -> String:
+	var objectives = GameState.state.get("board", {}).get("objectives", [])
+	var units = GameState.state.get("units", {})
+	var best_id = ""
+	var best_score = -INF
+	for obj in objectives:
+		if obj.get("zone", "") != "no_mans_land":
+			continue
+		var obj_id = str(obj.get("id", ""))
+		var obj_pos = obj.get("position", null)
+		if obj_id == "" or obj_pos == null:
+			continue
+		if obj_pos is Dictionary:
+			obj_pos = Vector2(obj_pos.get("x", 0), obj_pos.get("y", 0))
+		var drawer_dist = _nearest_unit_distance_px(units, drawing_player, obj_pos)
+		var chooser_dist = _nearest_unit_distance_px(units, chooser, obj_pos)
+		# Far from the drawer, near the chooser; big bonus if the chooser
+		# already controls it (the drawer must wrestle it away).
+		var score = drawer_dist - 0.5 * chooser_dist
+		if MissionManager.objective_control_state.get(obj_id, 0) == chooser:
+			score += Measurement.inches_to_px(24.0)
+		elif MissionManager.objective_control_state.get(obj_id, 0) == drawing_player:
+			score -= Measurement.inches_to_px(24.0)
+		if score > best_score:
+			best_score = score
+			best_id = obj_id
+	return best_id
+
+func _nearest_unit_distance_px(units: Dictionary, player: int, point: Vector2) -> float:
+	var best := INF
+	for unit_id in units:
+		var unit = units[unit_id]
+		if unit.get("owner", 0) != player:
+			continue
+		for model in unit.get("models", []):
+			if not model.get("alive", true):
+				continue
+			var pos = model.get("position")
+			if pos == null:
+				continue
+			if pos is Dictionary:
+				pos = Vector2(pos.get("x", 0), pos.get("y", 0))
+			best = minf(best, pos.distance_to(point))
+	return best if best != INF else Measurement.inches_to_px(120.0)
+
+## Beacon: prefer a durable unit that is already outside the AI's deployment
+## zone (immediately worth 3-5 VP), tie-broken by total remaining wounds.
+func _pick_beacon_unit(player: int) -> String:
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		return ""
+	var eligible = secondary_mgr.get_beacon_eligible_units(player)
+	if eligible.is_empty():
+		return ""
+	var own_zone = secondary_mgr._get_deployment_zone_polygon(player)
+	var units = GameState.state.get("units", {})
+	var best_id = ""
+	var best_score = -INF
+	for entry in eligible:
+		var unit_id = str(entry.get("unit_id", ""))
+		var unit = units.get(unit_id, {})
+		var wounds_total := 0.0
+		var outside_dz := true
+		for model in unit.get("models", []):
+			if not model.get("alive", true):
+				continue
+			wounds_total += float(model.get("current_wounds", model.get("wounds", 1)))
+			var pos = model.get("position")
+			if pos == null:
+				continue
+			if pos is Dictionary:
+				pos = Vector2(pos.get("x", 0), pos.get("y", 0))
+			if not own_zone.is_empty() and Geometry2D.is_point_in_polygon(pos, own_zone):
+				outside_dz = false
+		var score = wounds_total + (100.0 if outside_dz and not entry.get("embarked", false) else 0.0)
+		if score > best_score:
+			best_score = score
+			best_id = unit_id
+	return best_id
 
 # =============================================================================
 # T7-57: Post-Game Performance Summary

--- a/40k/autoloads/SecondaryMissionManager.gd
+++ b/40k/autoloads/SecondaryMissionManager.gd
@@ -15,6 +15,10 @@ signal secondary_vp_scored(player: int, vp: int, mission_id: String)
 signal deck_depleted(player: int)
 signal when_drawn_requires_interaction(player: int, mission_id: String, interaction_type: String, details: Dictionary)
 signal missions_drawn_for_review(player: int, drawn_missions: Array)
+## Emitted when a pending when-drawn interaction is resolved (Tempting Target
+## objective picked, Beacon unit designated, Marked for Death targets set).
+## AIPlayer listens so a waiting AI turn resumes immediately.
+signal interaction_resolved(player: int, mission_id: String)
 
 # VP caps per Chapter Approved 2025-26
 const MAX_SECONDARY_VP = 40
@@ -259,6 +263,11 @@ func draw_missions_to_hand(player: int, draw_count: int = 0) -> Array:
 		emit_signal("mission_drawn", player, mission_id)
 		print("SecondaryMissionManager: Player %d drew %s" % [player, mission_data["name"]])
 
+		# 11e Burden of Trust: guards can be selected when drawn — auto-assign
+		# a backstop now; a human owner may revise via the Command-phase prompt.
+		if mission_id == "burden_of_trust":
+			_auto_assign_guards(player, active_mission)
+
 	if state["deck"].size() == 0 and state["active"].size() < MAX_ACTIVE_MISSIONS:
 		emit_signal("deck_depleted", player)
 		print("SecondaryMissionManager: Player %d deck is depleted!" % player)
@@ -325,6 +334,21 @@ func _handle_when_drawn(player: int, mission_data: Dictionary) -> Dictionary:
 			return {
 				"action": "requires_interaction",
 				"interaction_type": "opponent_selects_objective",
+				"details": when_drawn.get("details", {}),
+			}
+
+		"drawer_selects_unit":
+			# 11e Beacon — the DRAWER designates one friendly unit on the
+			# battlefield (or embarked in a TRANSPORT on the battlefield).
+			if _get_beacon_eligible_units(player).is_empty():
+				# No unit to designate (all destroyed / in reserves) — the card
+				# can never score this turn; keep official behavior (no redraw
+				# clause) and just add it without a designation.
+				print("SecondaryMissionManager: No eligible Beacon units for Player %d — card added without designation" % player)
+				return {"action": "add_to_active"}
+			return {
+				"action": "requires_interaction",
+				"interaction_type": "drawer_selects_unit",
 				"details": when_drawn.get("details", {}),
 			}
 
@@ -500,7 +524,7 @@ func voluntary_discard(player: int, mission_index: int) -> Dictionary:
 	state["active"].remove_at(mission_index)
 	state["discard"].append(discarded["id"])
 
-	# Clear visual indicators if this was A Tempting Target or Marked for Death
+	# Clear visual indicators if this was A Tempting Target, Marked for Death or Beacon
 	if discarded["id"] == "a_tempting_target":
 		var target_id = discarded.get("mission_data", {}).get("tempting_target_id", "")
 		if target_id != "":
@@ -508,6 +532,8 @@ func voluntary_discard(player: int, mission_index: int) -> Dictionary:
 	elif discarded["id"] == "marked_for_death":
 		var mfd_data = discarded.get("mission_data", {})
 		_clear_mfd_target_visuals(mfd_data.get("alpha_targets", []), mfd_data.get("gamma_target", ""))
+	elif discarded["id"] == "beacon":
+		_clear_beacon_visual(discarded.get("mission_data", {}).get("beacon_unit_id", ""))
 
 	# Grant 1 CP if it's the player's turn (subject to bonus CP cap per battle round)
 	var cp_gained = 0
@@ -539,11 +565,15 @@ func voluntary_discard(player: int, mission_index: int) -> Dictionary:
 # SCORING
 # ============================================================================
 
-func score_secondary_missions_for_player(player: int) -> Array:
+func score_secondary_missions_for_player(player: int, final_turn: bool = false) -> Array:
 	"""
 	Evaluate and score all active secondary missions for a player.
 	Called at end of player's turn (for end_of_your_turn missions)
 	or at end of either player's turn (for end_of_either_turn missions).
+	final_turn: the game's last turn is ending — 11e cards whose text says
+	"at the end of your opponent's turn OR the end of the fifth battle round,
+	whichever comes first" (final_round_clause) also score for the ACTIVE
+	player, who otherwise gets no further opponent-turn end.
 	Returns array of scoring results.
 	"""
 	var player_key = str(player)
@@ -571,6 +601,12 @@ func score_secondary_missions_for_player(player: int) -> Array:
 				should_score = true
 			SecondaryMissionData.TIMING_END_OF_OPPONENT_TURN:
 				should_score = (active_player != player)
+				# "…or the end of the fifth battle round, whichever comes
+				# first": the last player of the final round scores these at
+				# the end of their own turn (end of the battle round).
+				if final_turn and active_player == player and scoring.get("final_round_clause", false):
+					should_score = true
+					print("SecondaryMissionManager: [FINAL-ROUND] P%d '%s' scores at end of the final battle round" % [player, mission.get("name", "?")])
 			SecondaryMissionData.TIMING_WHILE_ACTIVE:
 				# While-active missions are scored via events (unit destruction etc.)
 				# At end of turn we just finalize the accumulated VP
@@ -765,9 +801,9 @@ func _check_condition(player: int, check: String, params: Dictionary, mission: D
 		"units_near_board_edges":
 			return _check_units_near_board_edges(player, params)
 		"unit_outside_own_dz":
-			return _check_unit_outside_own_dz(player, params)
+			return _check_unit_outside_own_dz(player, params, mission)
 		"unit_outside_own_territory":
-			return _check_unit_outside_own_territory(player, params)
+			return _check_unit_outside_own_territory(player, params, mission)
 		"units_recovered_assets":
 			return _check_recovered_assets(player, params)
 
@@ -804,7 +840,7 @@ func _count_condition(player: int, check: String, params: Dictionary, _mission: 
 		"units_wholly_in_opponent_deployment_zone":
 			return _count_units_in_opponent_zone(player, params)
 		"guarded_objectives":
-			return _count_guarded_objectives(player, params)
+			return _count_guarded_objectives(player, params, _mission)
 		_:
 			push_warning("SecondaryMissionManager: Unknown count condition check: %s" % check)
 			return 0
@@ -1193,14 +1229,42 @@ func _count_destroyed_models_with_wounds(destroyed: Dictionary, min_wounds: int)
 		return int(destroyed.get("starting_strength", 1))
 	return 0
 
-## Burden of Trust (guard selection auto-resolved): every objective the
-## player controls counts as guarded — controlling an objective implies a
-## friendly unit within range of it acting as the guard.
-func _count_guarded_objectives(player: int, _params: Dictionary) -> int:
+## Burden of Trust: an objective is guarded while its designated guard unit is
+## within range of it AND the player controls it. Uses the guards map selected
+## when drawn / at the start of the holder's turns (mission_data.guards).
+## Legacy saves without a guards map fall back to the old approximation
+## (every controlled objective counts as guarded).
+func _count_guarded_objectives(player: int, _params: Dictionary, mission: Dictionary = {}) -> int:
+	var guards: Dictionary = mission.get("mission_data", {}).get("guards", {})
+	if guards.is_empty() and not mission.get("mission_data", {}).has("guards"):
+		# Legacy fallback: no designation data at all
+		var legacy_count = 0
+		for obj_id in MissionManager.objective_control_state:
+			if MissionManager.objective_control_state.get(obj_id, 0) == player:
+				legacy_count += 1
+		return legacy_count
+
+	var control_radius = Measurement.inches_to_px(3.0) + Measurement.base_radius_px(40)
+	var objectives = GameState.state.get("board", {}).get("objectives", [])
 	var count = 0
-	for obj_id in MissionManager.objective_control_state:
-		if MissionManager.objective_control_state.get(obj_id, 0) == player:
+	for obj_id in guards:
+		if MissionManager.objective_control_state.get(obj_id, 0) != player:
+			continue
+		var unit = GameState.state.get("units", {}).get(str(guards[obj_id]), {})
+		if unit.is_empty() or _is_unit_excluded(unit, []):
+			continue  # guard destroyed or off the battlefield
+		var obj_pos = null
+		for obj in objectives:
+			if str(obj.get("id", "")) == str(obj_id):
+				obj_pos = obj.get("position", null)
+				break
+		if obj_pos == null:
+			continue
+		if obj_pos is Dictionary:
+			obj_pos = Vector2(obj_pos.get("x", 0), obj_pos.get("y", 0))
+		if _has_model_within_range(unit, obj_pos, control_radius):
 			count += 1
+			print("SecondaryMissionManager: [GUARD] P%d objective %s is guarded by %s" % [player, obj_id, guards[obj_id]])
 	return count
 
 # ============================================================================
@@ -1225,13 +1289,38 @@ func _check_locus_opponent_zone(player: int) -> bool:
 
 func _check_objectives_cleansed(player: int, params: Dictionary) -> bool:
 	"""Check if objectives were cleansed/looted this turn. The 11e Plunder
-	card reuses this check with its own action name."""
+	card reuses this check with its own action name.
+
+	11e Cleanse rules honoured here:
+	- "one objective each": DISTINCT objectives count, not raw action count
+	  (two units cleansing the same marker is still one cleansed objective).
+	- "completes at the end of your turn if that unit is controlling that
+	  objective": at 11e a cleanse only counts if the performing unit is still
+	  alive and the player controls the target objective when scoring."""
 	var required = params.get("count", 1)
 	var wanted_action = str(params.get("action_name", "Cleanse"))
 	var count = 0
+	var seen_objectives = {}
 	for action in _active_actions[str(player)]:
-		if action.get("action_name", "") == wanted_action and action.get("completed", false):
-			count += 1
+		if action.get("action_name", "") != wanted_action or not action.get("completed", false):
+			continue
+		var obj_id = str(action.get("objective_id", ""))
+		if obj_id == "":
+			count += 1  # actions without an objective target (e.g. Plunder) count directly
+			continue
+		if seen_objectives.has(obj_id):
+			continue
+		if GameConstants.edition >= 11 and wanted_action == "Cleanse":
+			# Completion condition: performing unit alive + objective controlled.
+			if MissionManager.objective_control_state.get(obj_id, 0) != player:
+				print("SecondaryMissionManager: [CLEANSE] %s not controlled by P%d at end of turn — cleanse does not complete" % [obj_id, player])
+				continue
+			var unit = GameState.state.get("units", {}).get(str(action.get("unit_id", "")), {})
+			if unit.is_empty() or _is_unit_excluded(unit, []):
+				print("SecondaryMissionManager: [CLEANSE] cleansing unit %s destroyed — cleanse of %s does not complete" % [str(action.get("unit_id", "")), obj_id])
+				continue
+		seen_objectives[obj_id] = true
+		count += 1
 	return count >= required
 
 func _check_teleport_homer(player: int, in_opponent_zone: bool, params: Dictionary = {}) -> bool:
@@ -1337,7 +1426,7 @@ func _discard_achieved_missions(player: int) -> void:
 	for mission in state["active"]:
 		if mission["achieved"]:
 			state["discard"].append(mission["id"])
-			# Clear visual indicators if this was A Tempting Target or Marked for Death
+			# Clear visual indicators if this was A Tempting Target, Marked for Death or Beacon
 			if mission["id"] == "a_tempting_target":
 				var target_id = mission.get("mission_data", {}).get("tempting_target_id", "")
 				if target_id != "":
@@ -1345,6 +1434,8 @@ func _discard_achieved_missions(player: int) -> void:
 			elif mission["id"] == "marked_for_death":
 				var mfd_data = mission.get("mission_data", {})
 				_clear_mfd_target_visuals(mfd_data.get("alpha_targets", []), mfd_data.get("gamma_target", ""))
+			elif mission["id"] == "beacon":
+				_clear_beacon_visual(mission.get("mission_data", {}).get("beacon_unit_id", ""))
 			print("SecondaryMissionManager: Player %d achieved and discarded %s" % [player, mission["name"]])
 		else:
 			remaining.append(mission)
@@ -1489,14 +1580,18 @@ func _check_units_near_board_edges(player: int, params: Dictionary) -> bool:
 		return edges_hit.size() >= min_edges
 	return count >= required
 
-## Beacon (sourced, pick auto-resolved): a friendly unit is alive on the
-## battlefield with every model outside the player's own deployment zone.
-func _check_unit_outside_own_dz(player: int, params: Dictionary) -> bool:
+## Beacon: the DESIGNATED beacon unit is alive on the battlefield with every
+## model outside the player's own deployment zone. When no designation exists
+## (legacy save), any friendly unit qualifies.
+func _check_unit_outside_own_dz(player: int, params: Dictionary, mission: Dictionary = {}) -> bool:
 	var exclude = params.get("exclude", [])
 	var own_zone = _get_deployment_zone_polygon(player)
 	if own_zone.is_empty():
 		return false
+	var beacon_id = str(mission.get("mission_data", {}).get("beacon_unit_id", ""))
 	for unit_id in GameState.state.get("units", {}):
+		if beacon_id != "" and str(unit_id) != beacon_id:
+			continue
 		var unit = GameState.state.units[unit_id]
 		if int(unit.get("owner", 0)) != player:
 			continue
@@ -1519,14 +1614,18 @@ func _check_unit_outside_own_dz(player: int, params: Dictionary) -> bool:
 	return false
 
 ## Beacon 5 VP tier (official). "Your territory" is approximated as the
-## player's board half (see _get_own_territory_rect): a friendly unit is
-## alive on the battlefield with no model within that half.
-func _check_unit_outside_own_territory(player: int, params: Dictionary) -> bool:
+## player's board half (see _get_own_territory_rect): the DESIGNATED beacon
+## unit is alive on the battlefield with no model within that half. When no
+## designation exists (legacy save), any friendly unit qualifies.
+func _check_unit_outside_own_territory(player: int, params: Dictionary, mission: Dictionary = {}) -> bool:
 	var exclude = params.get("exclude", [])
 	var rect = _get_own_territory_rect(player)
 	if rect.is_empty():
 		return false
+	var beacon_id = str(mission.get("mission_data", {}).get("beacon_unit_id", ""))
 	for unit_id in GameState.state.get("units", {}):
+		if beacon_id != "" and str(unit_id) != beacon_id:
+			continue
 		var unit = GameState.state.units[unit_id]
 		if int(unit.get("owner", 0)) != player:
 			continue
@@ -1615,6 +1714,12 @@ func on_turn_start(player: int) -> void:
 	_objective_control_at_turn_start = MissionManager.objective_control_state.duplicate()
 	# Clear completed actions from previous turn
 	_active_actions[str(player)].clear()
+	# 11e Burden of Trust: "at the start of each of your turns you can select
+	# one friendly unit per objective to guard it" — refresh the auto picks and
+	# reopen the revision window for the card holder.
+	for mission in _player_state[str(player)]["active"]:
+		if mission.get("id", "") == "burden_of_trust" and not mission.get("pending_interaction", false):
+			_auto_assign_guards(player, mission)
 	print("SecondaryMissionManager: Turn start for Player %d - snapshot objectives" % player)
 
 func on_unit_destroyed(destroyed_unit: Dictionary) -> void:
@@ -1814,6 +1919,7 @@ func resolve_marked_for_death(player: int, alpha_targets: Array, gamma_target: S
 			print("SecondaryMissionManager: Marked for Death resolved - Alpha: %s, Gamma: %s" % [str(alpha_targets), gamma_target])
 			# Set visual flags on targeted units
 			_mark_mfd_target_visuals(alpha_targets, gamma_target, player)
+			emit_signal("interaction_resolved", player, "marked_for_death")
 			return
 
 func resolve_tempting_target(player: int, objective_id: String) -> void:
@@ -1828,7 +1934,221 @@ func resolve_tempting_target(player: int, objective_id: String) -> void:
 			print("SecondaryMissionManager: A Tempting Target resolved - Objective: %s" % objective_id)
 			# Mark the objective visually on the board
 			_mark_tempting_target_visual(objective_id, player)
+			emit_signal("interaction_resolved", player, "a_tempting_target")
 			return
+
+func resolve_beacon_unit(player: int, unit_id: String) -> void:
+	"""Resolve the 11e Beacon designation — the drawer selected their beacon unit."""
+	var player_key = str(player)
+	var state = _player_state[player_key]
+
+	for mission in state["active"]:
+		if mission["id"] == "beacon" and mission.get("pending_interaction", false):
+			mission["mission_data"]["beacon_unit_id"] = unit_id
+			mission["pending_interaction"] = false
+			print("SecondaryMissionManager: Beacon resolved — Player %d designated %s" % [player, unit_id])
+			_mark_beacon_visual(unit_id)
+			emit_signal("interaction_resolved", player, "beacon")
+			return
+
+## Units the drawer may designate as their Beacon: friendly, at least one
+## alive model, and either deployed on the battlefield or embarked in a
+## TRANSPORT that is on the battlefield.
+func get_beacon_eligible_units(player: int) -> Array:
+	return _get_beacon_eligible_units(player)
+
+func _get_beacon_eligible_units(player: int) -> Array:
+	var result = []
+	var units = GameState.state.get("units", {})
+	for unit_id in units:
+		var unit = units[unit_id]
+		if unit.get("owner", 0) != player:
+			continue
+		var has_alive = false
+		for model in unit.get("models", []):
+			if model.get("alive", true):
+				has_alive = true
+				break
+		if not has_alive:
+			continue
+		var status = unit.get("status", GameStateData.UnitStatus.UNDEPLOYED)
+		var embarked_in = unit.get("embarked_in", null)
+		var on_field = (status == GameStateData.UnitStatus.DEPLOYED)
+		var embarked_on_field = false
+		if embarked_in != null:
+			var transport = units.get(embarked_in, {})
+			embarked_on_field = transport.get("status", GameStateData.UnitStatus.UNDEPLOYED) == GameStateData.UnitStatus.DEPLOYED
+		if not on_field and not embarked_on_field:
+			continue
+		result.append({
+			"unit_id": unit_id,
+			"unit_name": unit.get("meta", {}).get("name", unit_id),
+			"embarked": embarked_in != null,
+		})
+	return result
+
+func _mark_beacon_visual(unit_id: String) -> void:
+	"""Set the 'beacon' flag on the designated unit so TokenVisual draws a badge."""
+	var unit = GameState.state.get("units", {}).get(unit_id, {})
+	if not unit.is_empty():
+		if not unit.has("flags"):
+			unit["flags"] = {}
+		unit["flags"]["beacon"] = true
+		print("SecondaryMissionManager: Marked unit %s as Beacon" % unit_id)
+
+func _clear_beacon_visual(unit_id: String) -> void:
+	"""Remove the 'beacon' flag from a previously designated unit."""
+	if unit_id == "":
+		return
+	var unit = GameState.state.get("units", {}).get(unit_id, {})
+	if not unit.is_empty() and unit.has("flags"):
+		unit["flags"].erase("beacon")
+
+func _restore_beacon_visuals() -> void:
+	"""Re-apply Beacon flags after loading save data."""
+	for player_key in _player_state:
+		for mission in _player_state[player_key].get("active", []):
+			if mission.get("id", "") == "beacon":
+				var beacon_id = mission.get("mission_data", {}).get("beacon_unit_id", "")
+				if beacon_id != "":
+					_mark_beacon_visual(beacon_id)
+
+# ============================================================================
+# BURDEN OF TRUST — GUARD SELECTION (11e)
+# ============================================================================
+
+## Auto-assign one distinct friendly unit per objective as its guard (backstop
+## pick, revisable by a human owner). A unit qualifies for an objective while
+## it has a model within objective-control range of the marker.
+func _auto_assign_guards(player: int, mission: Dictionary) -> void:
+	var guards: Dictionary = {}
+	var used_units: Dictionary = {}
+	var control_radius = Measurement.inches_to_px(3.0) + Measurement.base_radius_px(40)
+	var objectives = GameState.state.get("board", {}).get("objectives", [])
+	var units = GameState.state.get("units", {})
+
+	for obj in objectives:
+		var obj_id = str(obj.get("id", ""))
+		var obj_pos = obj.get("position", null)
+		if obj_id == "" or obj_pos == null:
+			continue
+		if obj_pos is Dictionary:
+			obj_pos = Vector2(obj_pos.get("x", 0), obj_pos.get("y", 0))
+		# Prefer the highest-OC unassigned friendly unit within range.
+		var best_unit = ""
+		var best_oc = -1
+		for unit_id in units:
+			var unit = units[unit_id]
+			if unit.get("owner", 0) != player or used_units.has(unit_id):
+				continue
+			if _is_unit_excluded(unit, []):
+				continue
+			if not _has_model_within_range(unit, obj_pos, control_radius):
+				continue
+			var oc = int(unit.get("meta", {}).get("stats", {}).get("objective_control", 0))
+			if oc > best_oc:
+				best_oc = oc
+				best_unit = unit_id
+		if best_unit != "":
+			guards[obj_id] = best_unit
+			used_units[best_unit] = true
+
+	mission["mission_data"]["guards"] = guards
+	mission["mission_data"]["guards_prompt_pending"] = true
+	print("SecondaryMissionManager: Burden of Trust auto-guards for Player %d: %s" % [player, str(guards)])
+
+## The pending guard-revision window for the Command-phase prompt. Returns {}
+## when no Burden of Trust card is waiting on the player.
+func get_pending_guard_choice(player: int) -> Dictionary:
+	for mission in _player_state[str(player)]["active"]:
+		if mission.get("id", "") != "burden_of_trust" or mission.get("pending_interaction", false):
+			continue
+		if not mission.get("mission_data", {}).get("guards_prompt_pending", false):
+			continue
+		var control_radius = Measurement.inches_to_px(3.0) + Measurement.base_radius_px(40)
+		var objectives_out = []
+		var units = GameState.state.get("units", {})
+		for obj in GameState.state.get("board", {}).get("objectives", []):
+			var obj_id = str(obj.get("id", ""))
+			var obj_pos = obj.get("position", null)
+			if obj_id == "" or obj_pos == null:
+				continue
+			if obj_pos is Dictionary:
+				obj_pos = Vector2(obj_pos.get("x", 0), obj_pos.get("y", 0))
+			var eligible = []
+			for unit_id in units:
+				var unit = units[unit_id]
+				if unit.get("owner", 0) != player:
+					continue
+				if _is_unit_excluded(unit, []):
+					continue
+				if _has_model_within_range(unit, obj_pos, control_radius):
+					eligible.append({"unit_id": unit_id, "unit_name": unit.get("meta", {}).get("name", unit_id)})
+			if not eligible.is_empty():
+				objectives_out.append({"objective_id": obj_id, "eligible": eligible})
+		return {
+			"mission_id": "burden_of_trust",
+			"guards": mission.get("mission_data", {}).get("guards", {}).duplicate(),
+			"objectives": objectives_out,
+		}
+	return {}
+
+## Apply the player's revised guard picks. Enforces one distinct unit per
+## objective; unknown objectives/units are dropped.
+func resolve_burden_guards(player: int, guards: Dictionary) -> Dictionary:
+	for mission in _player_state[str(player)]["active"]:
+		if mission.get("id", "") != "burden_of_trust":
+			continue
+		var clean: Dictionary = {}
+		var used: Dictionary = {}
+		var units = GameState.state.get("units", {})
+		for obj_id in guards:
+			var unit_id = str(guards[obj_id])
+			if unit_id == "" or used.has(unit_id):
+				continue
+			var unit = units.get(unit_id, {})
+			if unit.is_empty() or unit.get("owner", 0) != player:
+				continue
+			clean[str(obj_id)] = unit_id
+			used[unit_id] = true
+		mission["mission_data"]["guards"] = clean
+		mission["mission_data"]["guards_prompt_pending"] = false
+		print("SecondaryMissionManager: Burden of Trust guards set by Player %d: %s" % [player, str(clean)])
+		emit_signal("interaction_resolved", player, "burden_of_trust")
+		return {"success": true, "guards": clean}
+	return {"success": false, "error": "No active Burden of Trust card for player %d" % player}
+
+func dismiss_guard_prompt(player: int) -> void:
+	"""The player kept the auto-assigned guards — close the revision window."""
+	for mission in _player_state[str(player)]["active"]:
+		if mission.get("id", "") == "burden_of_trust":
+			mission["mission_data"]["guards_prompt_pending"] = false
+
+# ============================================================================
+# PENDING-INTERACTION QUERY (AI wait gate)
+# ============================================================================
+
+## All when-drawn interactions still waiting on a decision, with the player
+## who must decide ("responder"). AIPlayer uses this to pause its turn while
+## a HUMAN responder has a selection dialog open.
+func get_pending_interactions() -> Array:
+	var pending = []
+	for player_key in _player_state:
+		var player = int(player_key)
+		for mission in _player_state[player_key].get("active", []):
+			if not mission.get("pending_interaction", false):
+				continue
+			var itype = mission.get("interaction_type", "")
+			var responder = player  # drawer decides by default (e.g. Beacon)
+			if itype in ["opponent_selects_objective", "opponent_selects_units"]:
+				responder = 2 if player == 1 else 1
+			pending.append({
+				"player": player,
+				"mission_id": mission.get("id", ""),
+				"interaction_type": itype,
+				"responder": responder,
+			})
+	return pending
 
 func _mark_tempting_target_visual(objective_id: String, player: int) -> void:
 	"""Mark an objective on the board as the Tempting Target for the given player."""
@@ -2432,6 +2752,7 @@ func load_save_data(data: Dictionary) -> void:
 	# Restore visual indicators after load
 	_restore_tempting_target_visuals()
 	_restore_mfd_target_visuals()
+	_restore_beacon_visuals()
 
 func _restore_tempting_target_visuals() -> void:
 	"""Re-apply Tempting Target visual indicators after loading save data."""

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,19 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.5.0",
+			"date": "2026-07-06",
+			"summary": "11th-edition secondary missions are now fully playable: every card that needs your input asks for it, and every card action has a button.",
+			"changes": [
+				"A Tempting Target fixed: when your AI opponent draws it, YOU now get the objective-selection dialog (the AI used to pick secretly on your behalf). The AI waits at its Command phase until you choose, and picks sensibly when the roles are reversed.",
+				"Beacon: when you draw it you now designate your beacon unit in a new dialog (embarked units included); the chosen unit shows a pulsing cyan beacon badge, and only that unit scores the card.",
+				"Burden of Trust: guards are now real — one distinct unit per objective, auto-assigned each of your turns with a revision dialog; an objective only scores while its guard is alive, in range and you control it.",
+				"Plunder finally has its Shooting-phase action: a unit inside a terrain feature outside your territory shows a 'Plunder … (5 VP)' button (once per turn) — previously the card could never be scored by anyone.",
+				"Cleanse now follows the 11e card: home objectives can't be cleansed, two units cleansing the same marker count once, and a cleanse only completes if you still control the objective at the end of your turn.",
+				"Beacon, Burden of Trust and Defend Stronghold now also score at the end of the fifth battle round for the second player, per their 'whichever comes first' clause."
+			]
+		},
+		{
 			"version": "0.4.0",
 			"date": "2026-07-06",
 			"summary": "The AI now plays for Victory Points by the numbers, and its thinking cards can draw their options on the board.",

--- a/40k/dialogs/TemptingTargetDialog.gd
+++ b/40k/dialogs/TemptingTargetDialog.gd
@@ -27,6 +27,7 @@ func setup(opponent: int, objectives: Array) -> void:
 
 func _build_ui() -> void:
 	var main_container = VBoxContainer.new()
+	main_container.name = "MainContainer"
 	main_container.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
 
 	# Header
@@ -57,6 +58,7 @@ func _build_ui() -> void:
 
 	# Scroll container for objective list
 	var scroll = ScrollContainer.new()
+	scroll.name = "ObjectiveScroll"
 	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 150)
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 
@@ -94,6 +96,7 @@ func _populate_objective_list() -> void:
 			pos_text = " (%.0f\", %.0f\")" % [obj_pos.get("x", 0), obj_pos.get("y", 0)]
 
 		var btn = Button.new()
+		btn.name = "Pick_%s" % obj_id
 		btn.text = "%s%s" % [obj_id.replace("obj_", "Objective ").to_upper(), pos_text]
 		btn.custom_minimum_size = Vector2(410, 40)
 		btn.pressed.connect(_on_objective_selected.bind(obj_id))

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -708,6 +708,12 @@ func validate_action(action: Dictionary) -> Dictionary:
 			errors = _validate_resolve_marked_for_death(action)
 		"RESOLVE_TEMPTING_TARGET":
 			errors = _validate_resolve_tempting_target(action)
+		"RESOLVE_BEACON_UNIT":
+			errors = _validate_resolve_beacon_unit(action)
+		"RESOLVE_GUARDS":
+			errors = _validate_resolve_guards(action)
+		"DISMISS_GUARDS":
+			pass  # Always valid — keeps the auto-assigned guards
 		"RESOLVE_CONDEMN":
 			errors = _validate_resolve_condemn(action)
 		"DISMISS_CONDEMN":
@@ -801,6 +807,12 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _handle_resolve_marked_for_death(action)
 		"RESOLVE_TEMPTING_TARGET":
 			return _handle_resolve_tempting_target(action)
+		"RESOLVE_BEACON_UNIT":
+			return _handle_resolve_beacon_unit(action)
+		"RESOLVE_GUARDS":
+			return _handle_resolve_guards(action)
+		"DISMISS_GUARDS":
+			return _handle_dismiss_guards(action)
 		"RESOLVE_CONDEMN":
 			return _handle_resolve_condemn(action)
 		"DISMISS_CONDEMN":
@@ -2215,6 +2227,121 @@ func _handle_resolve_tempting_target(action: Dictionary) -> Dictionary:
 		"success": true,
 		"message": "A Tempting Target resolved — Objective: %s" % objective_id
 	}
+
+# ============================================================================
+# 11e BEACON — DESIGNATION RESOLUTION
+# ============================================================================
+
+func _validate_resolve_beacon_unit(action: Dictionary) -> Array:
+	var errors = []
+	var player = action.get("player", 0)
+	var unit_id = str(action.get("unit_id", ""))
+
+	if player == 0:
+		errors.append("Missing player for RESOLVE_BEACON_UNIT")
+		return errors
+	if unit_id == "":
+		errors.append("Missing unit_id for RESOLVE_BEACON_UNIT")
+		return errors
+
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		errors.append("SecondaryMissionManager not available")
+		return errors
+
+	var found_pending = false
+	for mission in secondary_mgr._player_state.get(str(player), {}).get("active", []):
+		if mission["id"] == "beacon" and mission.get("pending_interaction", false):
+			found_pending = true
+			break
+	if not found_pending:
+		errors.append("No pending Beacon designation for player %d" % player)
+		return errors
+
+	var eligible = secondary_mgr.get_beacon_eligible_units(player)
+	var is_eligible = false
+	for entry in eligible:
+		if str(entry.get("unit_id", "")) == unit_id:
+			is_eligible = true
+			break
+	if not is_eligible:
+		errors.append("Unit %s is not an eligible Beacon unit" % unit_id)
+
+	return errors
+
+func _handle_resolve_beacon_unit(action: Dictionary) -> Dictionary:
+	var player = action.get("player", 0)
+	var unit_id = str(action.get("unit_id", ""))
+
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		return {"success": false, "error": "SecondaryMissionManager not available"}
+
+	secondary_mgr.resolve_beacon_unit(player, unit_id)
+
+	DebugLogger.info(str("CommandPhase: Resolved Beacon for player %d — unit %s" % [player, unit_id]))
+	GameState.add_action_to_phase_log({
+		"type": "RESOLVE_BEACON_UNIT",
+		"player": player,
+		"unit_id": unit_id,
+		"turn": GameState.get_battle_round()
+	})
+
+	return {"success": true, "message": "Beacon designated — %s" % unit_id}
+
+# ============================================================================
+# 11e BURDEN OF TRUST — GUARD RESOLUTION
+# ============================================================================
+
+func _validate_resolve_guards(action: Dictionary) -> Array:
+	var errors = []
+	var player = action.get("player", 0)
+	if player == 0:
+		errors.append("Missing player for RESOLVE_GUARDS")
+		return errors
+	if not (action.get("guards", null) is Dictionary):
+		errors.append("RESOLVE_GUARDS requires a guards dictionary")
+		return errors
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		errors.append("SecondaryMissionManager not available")
+		return errors
+	var has_burden = false
+	for mission in secondary_mgr._player_state.get(str(player), {}).get("active", []):
+		if mission["id"] == "burden_of_trust":
+			has_burden = true
+			break
+	if not has_burden:
+		errors.append("No active Burden of Trust card for player %d" % player)
+	return errors
+
+func _handle_resolve_guards(action: Dictionary) -> Dictionary:
+	var player = action.get("player", 0)
+	var guards = action.get("guards", {})
+
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		return {"success": false, "error": "SecondaryMissionManager not available"}
+
+	var res = secondary_mgr.resolve_burden_guards(player, guards)
+	if not res.get("success", false):
+		return {"success": false, "error": res.get("error", "Guard assignment failed")}
+
+	DebugLogger.info(str("CommandPhase: Burden of Trust guards for player %d: %s" % [player, str(res.get("guards", {}))]))
+	GameState.add_action_to_phase_log({
+		"type": "RESOLVE_GUARDS",
+		"player": player,
+		"guards": res.get("guards", {}),
+		"turn": GameState.get_battle_round()
+	})
+	return {"success": true, "message": "Guards assigned"}
+
+func _handle_dismiss_guards(action: Dictionary) -> Dictionary:
+	var player = action.get("player", get_current_player())
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr:
+		secondary_mgr.dismiss_guard_prompt(player)
+	return {"success": true, "message": "Auto-assigned guards kept"}
 
 # ============================================================================
 # 11e GDM PUNISHMENT — CONDEMN CHOICE (turn start)

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -107,8 +107,16 @@ func _on_phase_enter() -> void:
 	var game_event_log = get_node_or_null("/root/GameEventLog")
 	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
 	if secondary_mgr and secondary_mgr.is_initialized(current_player):
-		# Score end-of-your-turn missions for active player
-		_secondary_results = secondary_mgr.score_secondary_missions_for_player(current_player)
+		# Score end-of-your-turn missions for active player.
+		# 11e: on the game's FINAL turn (P2, last battle round) cards that say
+		# "at the end of your opponent's turn or the end of the fifth battle
+		# round, whichever comes first" (Beacon, Burden of Trust, Defend
+		# Stronghold) also score for the active player — they get no further
+		# opponent-turn end.
+		var is_final_turn: bool = GameConstants.edition >= 11 \
+			and current_player == 2 \
+			and GameState.get_battle_round() >= GameState.MAX_BATTLE_ROUNDS
+		_secondary_results = secondary_mgr.score_secondary_missions_for_player(current_player, is_final_turn)
 		if _secondary_results.size() > 0:
 			DebugLogger.info(str("ScoringPhase: Player %d scored secondary missions:" % current_player))
 			for result in _secondary_results:

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -744,6 +744,14 @@ func _validate_perform_secondary_action(action: Dictionary) -> Dictionary:
 	if action_name == "":
 		return {"valid": false, "errors": ["Missing action_name in payload"]}
 
+	# 11e Plunder: once per turn, and the unit must be within a terrain area
+	# that is not within the player's territory.
+	if action_name == "Plunder":
+		if _plunder_done_this_turn(get_current_player()):
+			return {"valid": false, "errors": ["Plunder has already been performed this turn (once per turn)"]}
+		if _get_plunder_terrain_for_unit(unit_id, get_current_player()).is_empty():
+			return {"valid": false, "errors": ["Unit is not within a terrain area outside your territory"]}
+
 	return {"valid": true, "errors": []}
 
 func _validate_shoot(action: Dictionary) -> Dictionary:
@@ -1567,6 +1575,11 @@ func _process_perform_secondary_action(action: Dictionary) -> Dictionary:
 			var obj_id = _determine_cleanse_objective(unit_id)
 			if obj_id != "":
 				action_data["objective_id"] = obj_id
+		"Plunder":
+			# Eligibility was checked in _validate_perform_secondary_action.
+			action_data["location"] = "terrain"
+			var terrain = _get_plunder_terrain_for_unit(unit_id, player)
+			action_data["terrain_id"] = terrain.get("id", "")
 
 	# Report action completion to SecondaryMissionManager
 	SecondaryMissionManager.on_action_completed(player, action_data)
@@ -1936,19 +1949,89 @@ func _determine_homer_location(unit_id: String, player: int) -> String:
 	return "other"
 
 func _determine_cleanse_objective(unit_id: String) -> String:
-	"""Find the objective within control range (3\" + 20mm marker base) of a unit's model for Cleanse action. Returns objective id or empty."""
+	"""Find the objective within control range (3\" + 20mm marker base) of a unit's model for Cleanse action. Returns objective id or empty.
+	11e: only NON-HOME objectives are cleansable, and an objective another
+	unit already cleansed this turn is skipped in favour of a fresh one
+	(officially each Cleanse targets one objective; duplicates score nothing)."""
 	var unit = get_unit(unit_id)
 	var objectives = GameState.state.get("board", {}).get("objectives", [])
 	var control_radius = Measurement.inches_to_px(3.78740157)
+	var player = get_current_player()
 
+	var fallback := ""
 	for obj in objectives:
 		var obj_pos = obj.get("position", Vector2.ZERO)
 		if obj_pos == Vector2.ZERO:
 			continue
-		if SecondaryMissionManager._has_model_within_range(unit, obj_pos, control_radius):
-			return obj.get("id", "")
+		var obj_id = str(obj.get("id", ""))
+		if GameConstants.edition >= 11 and _is_home_objective(obj):
+			continue
+		if not SecondaryMissionManager._has_model_within_range(unit, obj_pos, control_radius):
+			continue
+		if _objective_cleansed_this_turn(player, obj_id):
+			if fallback == "":
+				fallback = obj_id
+			continue
+		return obj_id
 
-	return ""
+	return fallback
+
+func _is_home_objective(obj: Dictionary) -> bool:
+	"""A home objective sits in a player's deployment zone (zone 'player1'/'player2')."""
+	return str(obj.get("zone", "")).begins_with("player")
+
+func _objective_cleansed_this_turn(player: int, obj_id: String) -> bool:
+	for action in SecondaryMissionManager._active_actions.get(str(player), []):
+		if action.get("action_name", "") == "Cleanse" and action.get("completed", false) \
+				and str(action.get("objective_id", "")) == obj_id:
+			return true
+	return false
+
+func _plunder_done_this_turn(player: int) -> bool:
+	"""11e Plunder is once per turn."""
+	for action in SecondaryMissionManager._active_actions.get(str(player), []):
+		if action.get("action_name", "") == "Plunder" and action.get("completed", false):
+			return true
+	return false
+
+func _get_plunder_terrain_for_unit(unit_id: String, player: int) -> Dictionary:
+	"""11e Plunder: the unit must be within a terrain area that is NOT within
+	the player's territory (approximated as their board half, matching the
+	Outflank/Beacon territory approximation). Returns the terrain dict or {}."""
+	var unit = get_unit(unit_id)
+	var terrain_mgr = get_node_or_null("/root/TerrainManager")
+	if not terrain_mgr:
+		return {}
+	var territory = SecondaryMissionManager._get_own_territory_rect(player)
+
+	for terrain in terrain_mgr.terrain_features:
+		if terrain.get("type", "") == "barricade":
+			continue  # barricades are obstacles, not terrain areas
+		var polygon: PackedVector2Array = terrain.get("polygon", PackedVector2Array())
+		if polygon.is_empty():
+			continue
+		# "not within your territory": no part of the terrain area inside it
+		if not territory.is_empty():
+			var any_inside := false
+			for p in polygon:
+				if p.x >= territory["min"].x and p.x <= territory["max"].x \
+						and p.y >= territory["min"].y and p.y <= territory["max"].y:
+					any_inside = true
+					break
+			if any_inside:
+				continue
+		# Unit is within the terrain area while any alive model is inside it
+		for model in unit.get("models", []):
+			if not model.get("alive", true):
+				continue
+			var pos = model.get("position")
+			if pos == null:
+				continue
+			if pos is Dictionary:
+				pos = Vector2(pos.get("x", 0), pos.get("y", 0))
+			if Geometry2D.is_point_in_polygon(pos, polygon):
+				return terrain
+	return {}
 
 # ── B1: 11e ACTIONS (16.00-16.01) — start a generic action, giving up shooting ──
 
@@ -2084,6 +2167,8 @@ func _get_secondary_action_options(unit_id: String) -> Array:
 
 			"cleanse":
 				# Check if unit has a model within objective control range (3" + 20mm marker base)
+				# 11e: only NON-HOME objectives can be cleansed; prefer one not
+				# already cleansed this turn (each Cleanse targets one objective).
 				var objectives = GameState.state.get("board", {}).get("objectives", [])
 				var control_radius = Measurement.inches_to_px(3.78740157)
 				DebugLogger.info(str("ShootingPhase: Cleanse check - %d objectives, control_radius=%.1fpx, unit=%s" % [objectives.size(), control_radius, unit_id]))
@@ -2093,8 +2178,14 @@ func _get_secondary_action_options(unit_id: String) -> Array:
 					if obj_pos == Vector2.ZERO:
 						DebugLogger.info("ShootingPhase: Cleanse - skipping objective with zero position")
 						continue
-					var in_range = SecondaryMissionManager._has_model_within_range(unit, obj_pos, control_radius)
 					var obj_id = obj.get("id", "unknown")
+					if GameConstants.edition >= 11 and _is_home_objective(obj):
+						DebugLogger.info(str("ShootingPhase: Cleanse - %s is a home objective (11e: non-home only)" % obj_id))
+						continue
+					if _objective_cleansed_this_turn(player, str(obj_id)):
+						DebugLogger.info(str("ShootingPhase: Cleanse - %s already cleansed this turn" % obj_id))
+						continue
+					var in_range = SecondaryMissionManager._has_model_within_range(unit, obj_pos, control_radius)
 					DebugLogger.info(str("ShootingPhase: Cleanse - obj %s at %s, in_range=%s" % [obj_id, obj_pos, in_range]))
 					if in_range:
 						var obj_label = _friendly_objective_name(obj_id)
@@ -2110,6 +2201,26 @@ func _get_secondary_action_options(unit_id: String) -> Array:
 						break  # One cleanse per unit
 				if not found_cleanse:
 					DebugLogger.info(str("ShootingPhase: Cleanse - no objective in range for unit %s" % unit_id))
+
+			"plunder":
+				# 11e Plunder: one unit within a terrain area outside your
+				# territory; once per turn; flat 5 VP at end of your turn.
+				if _plunder_done_this_turn(player):
+					DebugLogger.info("ShootingPhase: Plunder - already performed this turn (once per turn)")
+					continue
+				var terrain = _get_plunder_terrain_for_unit(unit_id, player)
+				if terrain.is_empty():
+					DebugLogger.info(str("ShootingPhase: Plunder - %s is not within an eligible terrain area" % unit_id))
+					continue
+				var terrain_label = str(terrain.get("id", "terrain")).replace("_", " ").capitalize()
+				options.append({
+					"action_name": action_name,
+					"location": "terrain",
+					"description": "Plunder %s (5 VP)" % terrain_label,
+					"mission_id": mission_id,
+					"vp_value": 5,
+					"terrain_id": terrain.get("id", "")
+				})
 
 	return options
 

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -15207,10 +15207,20 @@ static func _assess_burden_of_trust(units: Dictionary, snapshot: Dictionary, pla
 	return 0.3
 
 static func _assess_beacon(units: Dictionary, player: int) -> float:
-	"""11e 'Beacon': a friendly unit outside my DZ/territory at the end of the
-	opponent's turn. Needs at least one healthy unit past the halfway line."""
+	"""11e 'Beacon': the DESIGNATED beacon unit outside my DZ/territory at the
+	end of the opponent's turn. When a designation exists only that unit
+	matters (destroyed beacon = the card can never score — discard fodder)."""
+	var beacon_id := ""
+	var secondary_mgr = Engine.get_main_loop().root.get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr:
+		for mission in secondary_mgr.get_active_missions(player):
+			if mission.get("id", "") == "beacon":
+				beacon_id = str(mission.get("mission_data", {}).get("beacon_unit_id", ""))
+				break
 	var best = 0.0
 	for unit_id in units:
+		if beacon_id != "" and str(unit_id) != beacon_id:
+			continue
 		var unit = units[unit_id]
 		if unit.get("owner", 0) != player:
 			continue
@@ -15225,8 +15235,12 @@ static func _assess_beacon(units: Dictionary, player: int) -> float:
 		if in_enemy_half:
 			# Durability matters — it must SURVIVE the opponent's turn
 			best = maxf(best, 0.5 + minf(0.35, alive.size() * 0.05))
+		elif beacon_id != "":
+			best = maxf(best, 0.4)  # designated unit alive but not forward yet
 	if best > 0.0:
 		return best
+	if beacon_id != "":
+		return 0.0  # designated beacon unit destroyed — card is dead weight
 	return 0.4  # Nobody forward yet, but any advance can qualify
 
 static func _assess_outflank(units: Dictionary, player: int) -> float:

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -883,6 +883,10 @@ func set_phase(phase: BasePhase) -> void:
 		# 11e Extract Relic / Locate and Deny: the Disruption player may
 		# revise the auto-picked marker terrain in their first Command phase.
 		_check_pending_relic_setup()
+
+		# 11e Burden of Trust: the holder may revise the auto-assigned guard
+		# units at the start of each of their turns.
+		_check_pending_guard_prompt()
 	else:
 		hide()
 
@@ -1112,6 +1116,14 @@ func _check_pending_interactions(secondary_mgr) -> void:
 	var player_key = str(current_player)
 	var state = secondary_mgr._player_state.get(player_key, {})
 
+	# Let the player read the drawn-missions review dialog first — two
+	# exclusive popups in the same frame trip the engine's exclusive-child
+	# guard. Re-check once the review closes (same pattern as Condemn).
+	if _active_review_dialog and is_instance_valid(_active_review_dialog):
+		if not _active_review_dialog.tree_exited.is_connected(_on_review_closed_recheck_condemn):
+			_active_review_dialog.tree_exited.connect(_on_review_closed_recheck_condemn)
+		return
+
 	for mission in state.get("active", []):
 		if not mission.get("pending_interaction", false):
 			continue
@@ -1129,6 +1141,8 @@ func _check_pending_interactions(secondary_mgr) -> void:
 				_show_marked_for_death_dialog(current_player, opponent, details)
 			"opponent_selects_objective":
 				_show_tempting_target_dialog(current_player, opponent, details)
+			"drawer_selects_unit":
+				_show_beacon_dialog(current_player)
 			_:
 				print("CommandController: Unknown pending interaction type: %s" % interaction_type)
 
@@ -1163,6 +1177,12 @@ func _on_review_closed_recheck_condemn() -> void:
 		return
 	call_deferred("_check_pending_condemn_prompt")
 	call_deferred("_check_pending_relic_setup")
+	# Secondary-card prompts queued behind the review dialog (Beacon
+	# designation, Tempting Target pick, Burden of Trust guards).
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr:
+		call_deferred("_check_pending_interactions", secondary_mgr)
+	call_deferred("_check_pending_guard_prompt")
 
 func _show_condemn_dialog(pending: Dictionary, player: int) -> void:
 	var existing = get_tree().root.get_node_or_null("CondemnChoiceDialog")
@@ -1455,6 +1475,8 @@ func _on_when_drawn_requires_interaction(player: int, mission_id: String, intera
 			_show_marked_for_death_dialog(player, opponent, details)
 		"opponent_selects_objective":
 			_show_tempting_target_dialog(player, opponent, details)
+		"drawer_selects_unit":
+			_show_beacon_dialog(player)
 		_:
 			push_error("CommandController: Unknown interaction type: %s" % interaction_type)
 
@@ -1560,6 +1582,11 @@ func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: D
 		print("CommandController: Skipping Tempting Target dialog for AI player %d" % opponent)
 		return
 
+	# Dedup: the direct signal AND the set_phase pending-recheck can both fire
+	var existing = get_tree().root.get_node_or_null("TemptingTargetDialog")
+	if existing != null and not existing.is_queued_for_deletion():
+		return
+
 	# Get objectives in No Man's Land
 	var all_objectives = GameState.state.get("board", {}).get("objectives", [])
 	var nml_objectives = []
@@ -1572,6 +1599,7 @@ func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: D
 		return
 
 	var dialog = TemptingTargetDialog.new()
+	dialog.name = "TemptingTargetDialog"
 	dialog.setup(opponent, nml_objectives)
 	dialog.tempting_target_resolved.connect(_on_tempting_target_resolved.bind(drawing_player))
 	get_tree().root.add_child(dialog)
@@ -1587,6 +1615,267 @@ func _on_tempting_target_resolved(objective_id: String, drawing_player: int) -> 
 		"player": drawing_player,
 		"objective_id": objective_id,
 	})
+
+# ============================================================================
+# 11e BEACON — DRAWER DESIGNATES THE BEACON UNIT
+# ============================================================================
+
+func _show_beacon_dialog(drawing_player: int) -> void:
+	"""11e Beacon: the DRAWER designates one friendly unit on the battlefield
+	(or embarked in a TRANSPORT on the battlefield) as their beacon unit."""
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(drawing_player):
+		print("CommandController: Skipping Beacon dialog for AI player %d" % drawing_player)
+		return
+
+	var existing = get_tree().root.get_node_or_null("BeaconUnitDialog")
+	if existing != null and not existing.is_queued_for_deletion():
+		return
+
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr:
+		return
+	var eligible = secondary_mgr.get_beacon_eligible_units(drawing_player)
+	if eligible.is_empty():
+		print("CommandController: No eligible Beacon units for player %d — skipping dialog" % drawing_player)
+		return
+
+	var dialog = AcceptDialog.new()
+	dialog.name = "BeaconUnitDialog"
+	dialog.title = "Beacon — Designate Your Beacon Unit"
+	dialog.min_size = DialogConstants.MEDIUM
+	dialog.get_ok_button().visible = false
+	WhiteDwarfTheme.apply_to_dialog(dialog)
+
+	var content = VBoxContainer.new()
+	content.name = "Content"
+	content.add_theme_constant_override("separation", 8)
+	content.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "BEACON"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	content.add_child(header)
+
+	var desc = Label.new()
+	desc.text = "Designate one friendly unit as your beacon unit.\nScore at the end of your opponent's turn: 3 VP if it is on the battlefield and not within your deployment zone, 5 VP if it is not within your territory."
+	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc.add_theme_font_size_override("font_size", 12)
+	desc.add_theme_color_override("font_color", Color.GRAY)
+	content.add_child(desc)
+	content.add_child(HSeparator.new())
+
+	var scroll = ScrollContainer.new()
+	scroll.name = "UnitScroll"
+	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 220)
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	var unit_list = VBoxContainer.new()
+	unit_list.name = "UnitList"
+	unit_list.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(unit_list)
+	content.add_child(scroll)
+
+	var resolved = [false]
+	for entry in eligible:
+		var unit_id: String = str(entry.get("unit_id", ""))
+		var label: String = str(entry.get("unit_name", unit_id))
+		if entry.get("embarked", false):
+			label += " (embarked)"
+		var btn = Button.new()
+		btn.name = "Pick_%s" % unit_id
+		btn.text = label
+		btn.custom_minimum_size = Vector2(410, 36)
+		btn.pressed.connect(func():
+			if resolved[0]:
+				return
+			resolved[0] = true
+			emit_signal("command_action_requested", {
+				"type": "RESOLVE_BEACON_UNIT",
+				"player": drawing_player,
+				"unit_id": unit_id,
+			})
+			dialog.queue_free())
+		unit_list.add_child(btn)
+
+	# Closing without picking is not a dead end — the card just stays pending
+	# and the prompt reopens on the next Command phase entry.
+	dialog.add_child(content)
+	get_tree().root.add_child(dialog)
+	dialog.popup_centered()
+	print("CommandController: Beacon designation dialog shown for player %d (%d eligible units)" % [drawing_player, eligible.size()])
+
+# ============================================================================
+# 11e BURDEN OF TRUST — GUARD SELECTION PROMPT
+# ============================================================================
+
+func _check_pending_guard_prompt() -> void:
+	"""11e Burden of Trust: guards were auto-assigned when drawn / at turn
+	start. Offer the HUMAN holder a dialog to revise them."""
+	var current_player = GameState.get_active_player()
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(current_player):
+		return  # AI keeps the auto picks
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if not secondary_mgr or not secondary_mgr.has_method("get_pending_guard_choice"):
+		return
+	var pending = secondary_mgr.get_pending_guard_choice(current_player)
+	if pending.is_empty():
+		return
+	# Sequence behind the drawn-missions review dialog (exclusive popups).
+	if _active_review_dialog and is_instance_valid(_active_review_dialog):
+		if not _active_review_dialog.tree_exited.is_connected(_on_review_closed_recheck_condemn):
+			_active_review_dialog.tree_exited.connect(_on_review_closed_recheck_condemn)
+		return
+	_show_guard_dialog(pending, current_player)
+
+func _show_guard_dialog(pending: Dictionary, player: int) -> void:
+	var existing = get_tree().root.get_node_or_null("GuardSelectionDialog")
+	if existing != null and not existing.is_queued_for_deletion():
+		return
+	var objectives: Array = pending.get("objectives", [])
+	if objectives.is_empty():
+		# Nothing in range of any marker — keep the (empty) auto picks quietly.
+		emit_signal("command_action_requested", {"type": "DISMISS_GUARDS", "player": player})
+		return
+
+	var current_guards: Dictionary = pending.get("guards", {})
+
+	var dialog = AcceptDialog.new()
+	dialog.name = "GuardSelectionDialog"
+	dialog.title = "Burden of Trust — Assign Guards"
+	dialog.min_size = DialogConstants.MEDIUM
+	dialog.get_ok_button().visible = false
+	WhiteDwarfTheme.apply_to_dialog(dialog)
+
+	var content = VBoxContainer.new()
+	content.name = "Content"
+	content.add_theme_constant_override("separation", 8)
+	content.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "SELECT ONE FRIENDLY UNIT PER OBJECTIVE TO GUARD IT"
+	header.add_theme_font_size_override("font_size", 16)
+	header.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	content.add_child(header)
+
+	var desc = Label.new()
+	desc.text = "At the end of your opponent's turn you score 2 VP (max 5) for each guarded objective you control while its guard is within range of it."
+	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc.add_theme_font_size_override("font_size", 12)
+	desc.add_theme_color_override("font_color", Color.GRAY)
+	content.add_child(desc)
+	content.add_child(HSeparator.new())
+
+	var scroll = ScrollContainer.new()
+	scroll.name = "ObjectiveScroll"
+	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 220)
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	var rows = VBoxContainer.new()
+	rows.name = "ObjectiveRows"
+	rows.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(rows)
+	content.add_child(scroll)
+
+	var pickers: Array = []  # [{objective_id, option_button, unit_ids}]
+	for entry in objectives:
+		var obj_id: String = str(entry.get("objective_id", ""))
+		var row = HBoxContainer.new()
+		row.name = "Row_%s" % obj_id
+		row.add_theme_constant_override("separation", 8)
+		var obj_label = Label.new()
+		obj_label.text = obj_id.replace("obj_", "Objective ").replace("_", " ").capitalize()
+		obj_label.custom_minimum_size = Vector2(150, 0)
+		row.add_child(obj_label)
+
+		var picker = OptionButton.new()
+		picker.name = "Guard_%s" % obj_id
+		picker.custom_minimum_size = Vector2(230, 32)
+		picker.add_item("— No guard —")
+		picker.set_item_metadata(0, "")
+		var unit_ids := [""]
+		var idx := 1
+		for eu in entry.get("eligible", []):
+			var uid: String = str(eu.get("unit_id", ""))
+			picker.add_item(str(eu.get("unit_name", uid)))
+			picker.set_item_metadata(idx, uid)
+			unit_ids.append(uid)
+			if str(current_guards.get(obj_id, "")) == uid:
+				picker.select(idx)
+			idx += 1
+		row.add_child(picker)
+		rows.add_child(row)
+		pickers.append({"objective_id": obj_id, "picker": picker})
+
+	content.add_child(HSeparator.new())
+	var status = Label.new()
+	status.name = "StatusLabel"
+	status.text = ""
+	status.add_theme_color_override("font_color", Color.ORANGE)
+	content.add_child(status)
+
+	var button_row = HBoxContainer.new()
+	button_row.name = "Actions"
+	button_row.alignment = BoxContainer.ALIGNMENT_CENTER
+	button_row.add_theme_constant_override("separation", 12)
+
+	var resolved = [false]
+	var confirm_btn = Button.new()
+	confirm_btn.name = "ConfirmGuards"
+	confirm_btn.text = "Confirm Guards"
+	confirm_btn.custom_minimum_size = Vector2(170, 36)
+	confirm_btn.pressed.connect(func():
+		if resolved[0]:
+			return
+		# One distinct unit per objective — refuse duplicate picks in place.
+		var picks: Dictionary = {}
+		var used: Dictionary = {}
+		for p in pickers:
+			var picker: OptionButton = p["picker"]
+			var uid = str(picker.get_item_metadata(picker.selected)) if picker.selected >= 0 else ""
+			if uid == "":
+				continue
+			if used.has(uid):
+				status.text = "Each unit can guard only one objective."
+				return
+			used[uid] = true
+			picks[p["objective_id"]] = uid
+		resolved[0] = true
+		emit_signal("command_action_requested", {
+			"type": "RESOLVE_GUARDS",
+			"player": player,
+			"guards": picks,
+		})
+		dialog.queue_free())
+	button_row.add_child(confirm_btn)
+
+	var skip_btn = Button.new()
+	skip_btn.name = "KeepAutoGuards"
+	skip_btn.text = "Keep Auto Picks"
+	skip_btn.custom_minimum_size = Vector2(150, 36)
+	skip_btn.pressed.connect(func():
+		if resolved[0]:
+			return
+		resolved[0] = true
+		emit_signal("command_action_requested", {"type": "DISMISS_GUARDS", "player": player})
+		dialog.queue_free())
+	button_row.add_child(skip_btn)
+	content.add_child(button_row)
+
+	# Escape/close keeps the auto picks — never a dead end.
+	dialog.canceled.connect(func():
+		if resolved[0]:
+			return
+		resolved[0] = true
+		emit_signal("command_action_requested", {"type": "DISMISS_GUARDS", "player": player})
+		dialog.queue_free())
+
+	dialog.add_child(content)
+	get_tree().root.add_child(dialog)
+	dialog.popup_centered()
+	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives)" % [player, objectives.size()])
 
 
 # T-096: compute command phase sub-step progress (1/3 → 3/3)

--- a/40k/scripts/TokenVisual.gd
+++ b/40k/scripts/TokenVisual.gd
@@ -414,6 +414,9 @@ func _process(delta: float) -> void:
 	elif _has_marked_for_death_flag():
 		# Marked for Death pulsing indicator
 		needs_redraw = true
+	elif _has_beacon_flag():
+		# Beacon designation pulsing indicator
+		needs_redraw = true
 	elif _has_performed_action_flag():
 		# Secondary action pulsing indicator
 		needs_redraw = true
@@ -484,6 +487,7 @@ func _draw() -> void:
 			_draw_fought_overlay(classic_radius, base_shape.get_type(), classic_rot)
 			_draw_engaged_overlay(classic_radius)
 			_draw_marked_for_death_indicator(classic_radius)
+			_draw_beacon_indicator(classic_radius)
 			_draw_action_overlay(classic_radius)
 
 	# MA-20: Draw model type colored ring (all styles except letter which handles it separately)
@@ -600,6 +604,9 @@ func _draw_enhanced(fill_color: Color, border_color: Color) -> void:
 
 	# --- Layer 7b: Marked for Death target indicator ---
 	_draw_marked_for_death_indicator(radius)
+
+	# --- Layer 7b2: Beacon designation indicator (11e secondary) ---
+	_draw_beacon_indicator(radius)
 
 	# --- Layer 7c: Secondary action indicator ---
 	_draw_action_overlay(radius)
@@ -1048,6 +1055,38 @@ func _draw_marked_for_death_indicator(radius: float) -> void:
 			var label_pos = Vector2(indicator_radius * 0.6, -indicator_radius * 0.6)
 			draw_string(font, label_pos + Vector2(1, 1), "G", HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color.BLACK)
 			draw_string(font, label_pos, "G", HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color(1.0, 0.8, 0.2))
+
+func _draw_beacon_indicator(radius: float) -> void:
+	"""11e Beacon secondary: cyan pulsing ring + 'B' label on the designated unit."""
+	if not has_meta("unit_id"):
+		return
+	var unit_id = get_meta("unit_id")
+	var unit = GameState.get_unit(unit_id)
+	if unit.is_empty():
+		return
+	if not unit.get("flags", {}).get("beacon", false):
+		return
+
+	var pulse = (sin(_pulse_time * 3.0) + 1.0) / 2.0
+	var indicator_radius = radius + 6.0
+	var alpha_val = 0.45 + pulse * 0.35
+	var ring_color = Color(0.2, 0.9, 1.0, alpha_val)
+	draw_arc(Vector2.ZERO, indicator_radius, 0, TAU, 48, ring_color, 2.0)
+	# Rotating "signal" dot on the ring for a beacon feel
+	var dot_angle = fmod(_pulse_time * 2.0, TAU)
+	var dot_pos = Vector2(cos(dot_angle), sin(dot_angle)) * indicator_radius
+	draw_circle(dot_pos, 3.0, ring_color)
+	var font = ThemeDB.fallback_font
+	if font:
+		var label_pos = Vector2(indicator_radius * 0.6, -indicator_radius * 0.6)
+		draw_string(font, label_pos + Vector2(1, 1), "B", HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color.BLACK)
+		draw_string(font, label_pos, "B", HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color(0.4, 0.95, 1.0))
+
+func _has_beacon_flag() -> bool:
+	if not has_meta("unit_id"):
+		return false
+	var unit = GameState.get_unit(get_meta("unit_id"))
+	return not unit.is_empty() and unit.get("flags", {}).get("beacon", false)
 
 func _draw_selection_ring(radius: float) -> void:
 	var pulse = (sin(_pulse_time * 4.0) + 1.0) / 2.0

--- a/40k/scripts/data/SecondaryMissionData.gd
+++ b/40k/scripts/data/SecondaryMissionData.gd
@@ -174,12 +174,14 @@ static func _load_missions() -> void:
 				{"check": "control_objectives_in_own_deployment_zone", "params": {"count": 1}, "vp": 2},
 			],
 		},
-		# 11e official: from round 2, at the end of the OPPONENT's turn —
-		# 3 VP for holding your home objective + cumulative 2 VP if no enemy
-		# units are wholly within your deployment zone. Redraw in round 1.
+		# 11e official: from round 2, at the end of the OPPONENT's turn (or the
+		# end of the fifth battle round, whichever comes first) — 3 VP for
+		# holding your home objective + cumulative 2 VP if no enemy units are
+		# wholly within your deployment zone. Redraw in round 1.
 		"scoring_11e": {
 			"when": TIMING_END_OF_OPPONENT_TURN,
 			"min_round": 2,
+			"final_round_clause": true,
 			"conditions": [
 				{"check": "control_objectives_in_own_deployment_zone", "params": {"count": 1}, "vp": 3},
 				{"check": "no_enemy_units_wholly_in_own_deployment_zone", "params": {}, "vp": 2, "cumulative": true},
@@ -535,13 +537,18 @@ static func _load_missions() -> void:
 		"number": 21,
 		"category": "Battlefield Supremacy",
 		"edition": 11,
-		# Guard-unit selection is auto-resolved: every objective you control
-		# counts as guarded (controlling implies a friendly unit in range).
-		"approximate": true,
 		"description": "Guard objectives — score per guarded objective at the end of your opponent's turn.",
-		# Official: 2 VP per guarded objective, max 5, end of OPPONENT's turn.
+		# Official: when drawn and at the start of each of your turns, select
+		# one friendly unit per objective to guard it. An objective is guarded
+		# while that unit is within range of it and you control it. 2 VP per
+		# guarded objective, max 5, at the end of the OPPONENT's turn (or the
+		# end of the fifth battle round, whichever comes first). Guards are
+		# auto-assigned as a backstop; a human owner can revise via the
+		# Command-phase prompt. Legacy saves without a guards map fall back to
+		# "every controlled objective counts".
 		"scoring": {
 			"when": TIMING_END_OF_OPPONENT_TURN,
+			"final_round_clause": true,
 			"conditions": [
 				{"check": "guarded_objectives", "per_count": true, "params": {}, "vp": 2, "vp_max": 5},
 			],
@@ -579,15 +586,18 @@ static func _load_missions() -> void:
 		"number": 23,
 		"category": "Shadow Operations",
 		"edition": 11,
-		# Beacon designation is auto-resolved (any qualifying friendly unit
-		# counts) and "your territory" is approximated as your board half.
+		# "Your territory" is approximated as your board half; the beacon unit
+		# itself is a real when-drawn designation (drawer selects one friendly
+		# unit; falls back to any-unit for legacy saves without a designation).
 		"approximate": true,
 		"description": "Your Beacon unit pushes into enemy-held ground; scored at the end of your opponent's turn.",
 		# Official tiers (exclusive — best applies): 3 VP if the beacon unit
 		# is on the battlefield and not within your deployment zone; 5 VP if
-		# it is on the battlefield and not within your territory.
+		# it is on the battlefield and not within your territory. Also scores
+		# at the end of the fifth battle round, whichever comes first.
 		"scoring": {
 			"when": TIMING_END_OF_OPPONENT_TURN,
+			"final_round_clause": true,
 			"conditions": [
 				{"check": "unit_outside_own_dz", "params": {}, "vp": 3},
 				{"check": "unit_outside_own_territory", "params": {}, "vp": 5},
@@ -595,7 +605,9 @@ static func _load_missions() -> void:
 		},
 		"requires_action": false,
 		"action": {},
-		"when_drawn": {},
+		# Official: "When drawn, designate one friendly unit on the battlefield
+		# (or embarked within a TRANSPORT on the battlefield) as your beacon unit."
+		"when_drawn": {"condition": "drawer_selects_unit", "details": {"purpose": "beacon"}},
 	}
 
 	_missions["outflank"] = {

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -107,6 +107,7 @@ TESTS=(
     "tests/test_iss050_fight_phase_11e.gd"
     "tests/test_iss059_attached_units_11e.gd"
     "tests/test_secondary_deck_11e.gd"
+    "tests/test_secondary_interactions_11e.gd"
     "tests/test_primary_missions_11e.gd"
     "tests/test_gdm_sourced_11e.gd"
     "tests/test_card_action_prompts_11e.gd"

--- a/40k/tests/scenarios/sp/iss063b_secondary_deck_11e.json
+++ b/40k/tests/scenarios/sp/iss063b_secondary_deck_11e.json
@@ -22,8 +22,13 @@
     },
     {
       "act": "execute_script",
-      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"deck\"].size() + SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size()",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"deck\"].size() + SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"active\"].size() + SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"discard\"].size()",
       "equals": 18
+    },
+    {
+      "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"discard\"].size() - SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"discard\"].count(\"a_grievous_blow\") - SecondaryMissionManager._player_state[str(GameState.get_active_player())][\"discard\"].count(\"bring_it_down\")",
+      "equals": 0
     },
     {
       "act": "execute_script",

--- a/40k/tests/scenarios/sp/iss065a_tempting_target_prompt_11e.json
+++ b/40k/tests/scenarios/sp/iss065a_tempting_target_prompt_11e.json
@@ -1,0 +1,66 @@
+{
+  "id": "iss065a_tempting_target_prompt_11e",
+  "covers": [
+    "rules.secondaries.a_tempting_target.opponent_prompt",
+    "autoloads.SecondaryMissionManager.pending_interactions"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "description": "THE reported bug: when the AI (P2) draws A Tempting Target, the HUMAN opponent (P1) must pick the No Man's Land objective — previously AIPlayer auto-resolved the pick randomly and no dialog ever appeared. With P2 running as a live AI, entering P2's Command phase draws the stacked card, the AI does NOT steal the choice (card stays pending, AI turn waits on the gate), the TemptingTargetDialog pops for the human, and clicking Objective NML 1 resolves the card to obj_nml_1.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script", "script": "SecondaryMissionManager.initialize_for_game()" },
+    { "act": "execute_script", "script": "SecondaryMissionManager.setup_tactical_deck(2)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"].merge({\"deck\": [\"a_tempting_target\"], \"active\": []}, true)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"deck\"].size()",
+      "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "GameState.state[\"meta\"][\"game_config\"].merge({\"player2_type\": \"AI\"}, true)" },
+    { "act": "execute_script", "script": "AIPlayer.ai_players.merge({2: true}, true)" },
+    { "act": "execute_script", "script": "AIPlayer.set(\"enabled\", true)" },
+    { "act": "execute_script", "script": "AIPlayer.is_ai_player(2)", "equals": true },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(6)" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"pending_interaction\"]",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"tempting_target_id\", \"\"))",
+      "equals": "" },
+    { "act": "execute_script",
+      "script": "AIPlayer._human_secondary_interaction_pending()",
+      "equals": true },
+
+    { "act": "expect_node_visible", "node": "/root/TemptingTargetDialog", "timeout_s": 6.0 },
+    { "act": "screenshot", "label": "01_dialog_prompts_human_opponent" },
+
+    { "act": "click_node",
+      "node": "/root/TemptingTargetDialog/MainContainer/ObjectiveScroll/ObjectiveListContainer/Pick_obj_nml_1",
+      "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"tempting_target_id\", \"\"))",
+      "equals": "obj_nml_1" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"pending_interaction\"]",
+      "equals": false },
+    { "act": "execute_script",
+      "script": "AIPlayer._human_secondary_interaction_pending()",
+      "equals": false },
+
+    { "act": "execute_script", "script": "AIPlayer.set(\"enabled\", false)" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "screenshot", "label": "02_objective_resolved_and_marked" }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss065b_plunder_action_11e.json
+++ b/40k/tests/scenarios/sp/iss065b_plunder_action_11e.json
@@ -1,0 +1,75 @@
+{
+  "id": "iss065b_plunder_action_11e",
+  "covers": [
+    "rules.secondaries.plunder.action_button",
+    "shooting.perform_secondary_action.plunder"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "11e Plunder card action UX: with Plunder active for P2 and the Warboss teleported into a low ruin wholly inside P1's half (outside P2's territory), selecting the Warboss in the Shooting phase surfaces the 'Plunder ... (5 VP)' Perform Action button. Clicking it gives up shooting, records the completed Plunder with its terrain id, refuses a second Plunder the same turn, and the Scoring phase awards the flat 5 VP.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script", "script": "SecondaryMissionManager.initialize_for_game()" },
+    { "act": "execute_script", "script": "SecondaryMissionManager.setup_tactical_deck(2)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"].merge({\"deck\": [], \"active\": [SecondaryMissionManager._create_active_mission(SecondaryMissionManager.SecondaryMissionData.get_mission_by_id(\"plunder\"))]}, true)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"id\"]",
+      "equals": "plunder" },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.apply_state_changes([{\"op\": \"set\", \"path\": \"units.U_WARBOSS_B.models.0.position\", \"value\": Vector2(500, 1000)}])" },
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.append({\"id\": \"ruins_plunder_test\", \"type\": \"ruins\", \"height_category\": \"low\", \"polygon\": PackedVector2Array([Vector2(400, 900), Vector2(600, 900), Vector2(600, 1100), Vector2(400, 1100)])})" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(8)" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance._get_secondary_action_options(\"U_WARBOSS_B\").size()",
+      "equals": 1 },
+
+    { "act": "dispatch_action", "action": { "type": "SELECT_SHOOTER", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script",
+      "script": "\"Plunder\" in main.get_node(\"HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel/PerformActionButton\").text",
+      "equals": true },
+    { "act": "expect_node_visible",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel/PerformActionButton",
+      "timeout_s": 4.0 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel/PerformActionButton\").has_meta(\"action_option\")",
+      "equals": true },
+    { "act": "screenshot", "label": "01_plunder_button_visible" },
+
+    { "act": "click_node",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel/PerformActionButton",
+      "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._active_actions[\"2\"].size()",
+      "equals": 1 },
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._active_actions[\"2\"][0][\"terrain_id\"]) != \"\"",
+      "equals": true },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.has_shot", "equals": true },
+    { "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance._get_secondary_action_options(\"U_BOYZ_E\").size()",
+      "equals": 0 },
+    { "act": "screenshot", "label": "02_plunder_performed" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(11)" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager.get_secondary_vp(2)",
+      "equals": 5 },
+    { "act": "screenshot", "label": "03_plunder_scored_5vp" }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss065c_beacon_designation_11e.json
+++ b/40k/tests/scenarios/sp/iss065c_beacon_designation_11e.json
@@ -1,0 +1,50 @@
+{
+  "id": "iss065c_beacon_designation_11e",
+  "covers": [
+    "rules.secondaries.beacon.designation_prompt",
+    "autoloads.SecondaryMissionManager.beacon_unit"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "11e Beacon designation UX: a human P2 draws Beacon in their Command phase. After closing the drawn-missions review dialog (exclusive-popup sequencing), the BeaconUnitDialog lists P2's eligible units; picking the Warboss stores mission_data.beacon_unit_id, clears the pending interaction, and sets the unit's beacon flag so the token shows the cyan beacon badge.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script", "script": "SecondaryMissionManager.initialize_for_game()" },
+    { "act": "execute_script", "script": "SecondaryMissionManager.setup_tactical_deck(2)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"].merge({\"deck\": [\"beacon\"], \"active\": []}, true)" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(6)" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"pending_interaction\"]",
+      "equals": true },
+
+    { "act": "expect_node_visible", "node": "/root/SecondaryMissionReviewDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton", "emit_pressed": true },
+
+    { "act": "expect_node_visible", "node": "/root/BeaconUnitDialog", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "01_beacon_designation_dialog" },
+
+    { "act": "click_node",
+      "node": "/root/BeaconUnitDialog/Content/UnitScroll/UnitList/Pick_U_WARBOSS_B",
+      "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"beacon_unit_id\", \"\"))",
+      "equals": "U_WARBOSS_B" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"pending_interaction\"]",
+      "equals": false },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.beacon", "equals": true },
+    { "act": "screenshot", "label": "02_beacon_designated_badge_on_token" }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss065d_guard_prompt_11e.json
+++ b/40k/tests/scenarios/sp/iss065d_guard_prompt_11e.json
@@ -1,0 +1,59 @@
+{
+  "id": "iss065d_guard_prompt_11e",
+  "covers": [
+    "rules.secondaries.burden_of_trust.guard_prompt",
+    "autoloads.SecondaryMissionManager.guards"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "11e Burden of Trust guard selection UX: with the Warboss teleported onto the centre objective, a human P2 draws Burden of Trust — guards auto-assign (Warboss guards obj_center) and, after the drawn-missions review closes, the GuardSelectionDialog offers the per-objective pickers. 'Keep Auto Picks' closes the revision window while keeping the guard map, and guarded scoring counts obj_center while controlled.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.apply_state_changes([{\"op\": \"set\", \"path\": \"units.U_WARBOSS_B.models.0.position\", \"value\": Vector2(880, 1230)}])" },
+
+    { "act": "execute_script", "script": "SecondaryMissionManager.initialize_for_game()" },
+    { "act": "execute_script", "script": "SecondaryMissionManager.setup_tactical_deck(2)" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"].merge({\"deck\": [\"burden_of_trust\"], \"active\": []}, true)" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(6)" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"guards\", {}).get(\"obj_center\", \"\"))",
+      "equals": "U_WARBOSS_B" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"guards_prompt_pending\", false)",
+      "equals": true },
+
+    { "act": "expect_node_visible", "node": "/root/SecondaryMissionReviewDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton", "emit_pressed": true },
+
+    { "act": "expect_node_visible", "node": "/root/GuardSelectionDialog", "timeout_s": 5.0 },
+    { "act": "expect_node_visible", "node": "/root/GuardSelectionDialog/Content/ObjectiveScroll/ObjectiveRows/Row_obj_center/Guard_obj_center", "timeout_s": 2.0 },
+    { "act": "screenshot", "label": "01_guard_selection_dialog" },
+
+    { "act": "click_node", "node": "/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"].get(\"guards_prompt_pending\", true)",
+      "equals": false },
+    { "act": "execute_script",
+      "script": "str(SecondaryMissionManager._player_state[\"2\"][\"active\"][0][\"mission_data\"][\"guards\"].get(\"obj_center\", \"\"))",
+      "equals": "U_WARBOSS_B" },
+
+    { "act": "execute_script", "script": "MissionManager.check_all_objectives()" },
+    { "act": "execute_script",
+      "script": "SecondaryMissionManager._count_guarded_objectives(2, {}, SecondaryMissionManager._player_state[\"2\"][\"active\"][0])",
+      "equals": 1 },
+    { "act": "screenshot", "label": "02_guards_kept_and_counting" }
+  ]
+}

--- a/40k/tests/test_secondary_deck_11e.gd
+++ b/40k/tests/test_secondary_deck_11e.gd
@@ -77,10 +77,16 @@ func _run_tests():
 	for exact in ["forward_position", "centre_ground", "outflank", "plunder", "a_grievous_blow"]:
 		_check("official card %s not flagged approximate" % exact,
 			not SecondaryMissionData.get_mission_by_id(exact).get("approximate", false))
-	# Beacon designation and Burden of Trust guard selection stay approximate.
-	_check("beacon + burden_of_trust keep approximate flag",
-		SecondaryMissionData.get_mission_by_id("beacon").get("approximate", false)
-		and SecondaryMissionData.get_mission_by_id("burden_of_trust").get("approximate", false))
+	# Beacon designation and Burden of Trust guard selection are now REAL
+	# interactions (when-drawn unit pick / per-objective guard assignment).
+	# Beacon keeps the approximate flag only for the territory-as-board-half
+	# approximation; Burden of Trust is fully modelled.
+	_check("beacon keeps approximate flag (territory approximation only)",
+		SecondaryMissionData.get_mission_by_id("beacon").get("approximate", false))
+	_check("burden_of_trust no longer approximate (real guard selection)",
+		not SecondaryMissionData.get_mission_by_id("burden_of_trust").get("approximate", false))
+	_check("beacon when-drawn requires drawer unit designation",
+		SecondaryMissionData.get_when_drawn(SecondaryMissionData.get_mission_by_id("beacon")).get("condition", "") == "drawer_selects_unit")
 
 	print("\n-- 10e deck leak fix --")
 	var deck10 = SecondaryMissionData.get_mission_ids_for_deck(false)

--- a/40k/tests/test_secondary_interactions_11e.gd
+++ b/40k/tests/test_secondary_interactions_11e.gd
@@ -1,0 +1,322 @@
+extends SceneTree
+
+# 11e secondary-mission interaction & action UX machinery (engine layer):
+#  - A Tempting Target: when the drawer's OPPONENT is human, nothing may
+#    auto-resolve; the pending interaction is exposed for the dialog and the
+#    AI wait-gate. resolve_tempting_target() completes it and fires
+#    interaction_resolved.
+#  - Beacon: when-drawn requires the DRAWER's unit designation;
+#    resolve_beacon_unit() records it, flags the unit, and scoring counts ONLY
+#    the designated unit.
+#  - Burden of Trust: guards auto-assign (one distinct unit per objective);
+#    scoring counts a guarded objective only while the guard is alive, in
+#    range, and the objective is controlled.
+#  - Plunder: ShootingPhase exposes a PERFORM_SECONDARY_ACTION option for a
+#    unit inside forward terrain, once per turn, and the completed action
+#    scores 5 VP.
+#  - Cleanse (11e): home objectives excluded; distinct objectives counted;
+#    completion requires control at end of turn.
+#  - Final-round clause: end-of-opponent-turn cards with final_round_clause
+#    also score for the ACTIVE player on the game's final turn.
+#
+# Usage: godot --headless --path . -s tests/test_secondary_interactions_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _mk_unit(gs, unit_id: String, owner: int, pos: Vector2, count: int = 3, keywords: Array = ["INFANTRY"], oc: int = 2) -> void:
+	var models = []
+	for i in range(count):
+		models.append({"id": "m%d" % i, "alive": true, "wounds": 2, "current_wounds": 2,
+			"base_mm": 32, "base_type": "circular",
+			"position": {"x": pos.x + i * 25, "y": pos.y}})
+	gs.state["units"][unit_id] = {"id": unit_id, "owner": owner,
+		"status": 2,  # UnitStatus.DEPLOYED
+		"flags": {},
+		"meta": {"name": unit_id, "keywords": keywords, "points": 100, "stats": {"objective_control": oc}},
+		"models": models}
+
+var _meas = null
+
+func _px(inches: float) -> float:
+	if _meas == null:
+		_meas = root.get_node("Measurement")
+	return _meas.inches_to_px(inches)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_secondary_interactions_11e ===\n")
+	var mgr = root.get_node_or_null("SecondaryMissionManager")
+	var gs = root.get_node_or_null("GameState")
+	var mission_mgr = root.get_node_or_null("MissionManager")
+	var ai = root.get_node_or_null("AIPlayer")
+	_check("autoloads present", mgr != null and gs != null and mission_mgr != null and ai != null)
+
+	GameConstants.edition = 11
+	gs.state["meta"]["active_player"] = 2
+	gs.state["meta"]["battle_round"] = 2
+	# P1 human, P2 AI — the shape of the reported bug (AI draws, human decides)
+	if not gs.state["meta"].has("game_config"):
+		gs.state["meta"]["game_config"] = {}
+	gs.state["meta"]["game_config"]["player1_type"] = "HUMAN"
+	gs.state["meta"]["game_config"]["player2_type"] = "AI"
+
+	# Board: 44x60, NML objectives + home objectives, simple DZs
+	gs.state["board"]["size"] = {"width": 44, "height": 60}
+	gs.state["board"]["objectives"] = [
+		{"id": "obj_home_p1", "zone": "player1", "position": Vector2(_px(22), _px(5))},
+		{"id": "obj_home_p2", "zone": "player2", "position": Vector2(_px(22), _px(55))},
+		{"id": "obj_nml_1", "zone": "no_mans_land", "position": Vector2(_px(10), _px(30))},
+		{"id": "obj_nml_2", "zone": "no_mans_land", "position": Vector2(_px(34), _px(30))},
+		{"id": "obj_nml_3", "zone": "no_mans_land", "position": Vector2(_px(22), _px(30))},
+	]
+	gs.state["board"]["deployment_zones"] = [
+		{"player": 1, "poly": [{"x": 0, "y": 0}, {"x": 44, "y": 0}, {"x": 44, "y": 12}, {"x": 0, "y": 12}]},
+		{"player": 2, "poly": [{"x": 0, "y": 48}, {"x": 44, "y": 48}, {"x": 44, "y": 60}, {"x": 0, "y": 60}]},
+	]
+	gs.state["units"] = {}
+
+	print("-- A Tempting Target: human opponent keeps the pick --")
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(2)
+	var state2 = mgr._player_state["2"]
+	# Force-draw a_tempting_target for AI P2 by stacking the deck
+	state2["deck"] = ["a_tempting_target"]
+	state2["active"] = []
+	var drawn = mgr.draw_missions_to_hand(2, 1)
+	_check("AI P2 drew A Tempting Target", drawn.size() == 1 and drawn[0]["id"] == "a_tempting_target", str(drawn))
+	var att_mission = state2["active"][0] if state2["active"].size() > 0 else {}
+	_check("card is pending interaction (NOT auto-resolved by AIPlayer)",
+		att_mission.get("pending_interaction", false) == true,
+		"pending=%s data=%s" % [str(att_mission.get("pending_interaction")), str(att_mission.get("mission_data", {}))])
+	_check("no tempting_target_id was set behind the human's back",
+		str(att_mission.get("mission_data", {}).get("tempting_target_id", "")) == "")
+	var pendings = mgr.get_pending_interactions()
+	_check("pending interaction exposed for the dialog/AI gate", pendings.size() == 1
+		and pendings[0]["mission_id"] == "a_tempting_target", str(pendings))
+	_check("responder is the human opponent P1", pendings.size() == 1 and int(pendings[0]["responder"]) == 1, str(pendings))
+	_check("AIPlayer wait-gate reports a pending human interaction",
+		ai._human_secondary_interaction_pending() == true)
+
+	# Human resolves via the manager (the dialog path dispatches RESOLVE_TEMPTING_TARGET)
+	var resolved_signal = [false]
+	mgr.interaction_resolved.connect(func(_p, _m): resolved_signal[0] = true, CONNECT_ONE_SHOT)
+	mgr.resolve_tempting_target(2, "obj_nml_2")
+	_check("resolution stores the human's objective pick",
+		str(att_mission.get("mission_data", {}).get("tempting_target_id", "")) == "obj_nml_2")
+	_check("pending flag cleared", att_mission.get("pending_interaction", true) == false)
+	_check("interaction_resolved signal fired (AI resumes)", resolved_signal[0])
+	_check("AI wait-gate releases", ai._human_secondary_interaction_pending() == false)
+
+	print("\n-- A Tempting Target: AI opponent picks (heuristic, not random) --")
+	# Reverse roles: human P1 draws, AI P2 is the opponent chooser.
+	gs.state["meta"]["game_config"]["player1_type"] = "HUMAN"
+	gs.state["meta"]["game_config"]["player2_type"] = "AI"
+	_mk_unit(gs, "U_P1_NEAR", 1, Vector2(_px(10), _px(26)))   # P1 sits near obj_nml_1
+	_mk_unit(gs, "U_P2_NEAR", 2, Vector2(_px(34), _px(33)))   # P2 sits near obj_nml_2
+	mission_mgr.objective_control_state["obj_nml_2"] = 2
+	var pick = ai._pick_tempting_target_objective(1, 2)
+	_check("AI chooser avoids the drawer's closest marker; prefers its own",
+		pick == "obj_nml_2", pick)
+	mission_mgr.objective_control_state.erase("obj_nml_2")
+
+	print("\n-- Beacon: drawer designates; scoring tracks ONLY that unit --")
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	gs.state["meta"]["active_player"] = 1
+	var state1 = mgr._player_state["1"]
+	state1["deck"] = ["beacon"]
+	state1["active"] = []
+	gs.state["units"] = {}
+	_mk_unit(gs, "U_BEACON_FWD", 1, Vector2(_px(22), _px(40)))  # forward: outside P1 DZ + territory (P1 territory = top half)
+	_mk_unit(gs, "U_HOME", 1, Vector2(_px(22), _px(5)))         # sitting in P1's DZ
+	mgr.draw_missions_to_hand(1, 1)
+	var bcn_mission = state1["active"][0] if state1["active"].size() > 0 else {}
+	_check("beacon drawn pending designation", bcn_mission.get("pending_interaction", false) == true, str(bcn_mission))
+	var eligible = mgr.get_beacon_eligible_units(1)
+	_check("both friendly units eligible for designation", eligible.size() == 2, str(eligible))
+	# Human designates the HOME unit (deliberately the bad pick)
+	mgr.resolve_beacon_unit(1, "U_HOME")
+	_check("designation stored", str(bcn_mission.get("mission_data", {}).get("beacon_unit_id", "")) == "U_HOME")
+	_check("beacon flag set for the token badge",
+		gs.state["units"]["U_HOME"].get("flags", {}).get("beacon", false) == true)
+	# Scoring: home unit is inside own DZ -> no VP even though U_BEACON_FWD is forward
+	var bcn_vp = mgr._evaluate_mission_conditions(1, bcn_mission)
+	_check("designated-at-home beacon scores 0 (forward NON-beacon unit ignored)", bcn_vp == 0, str(bcn_vp))
+	# Re-designate the forward unit: outside DZ AND outside own half -> 5 VP tier
+	bcn_mission["mission_data"]["beacon_unit_id"] = "U_BEACON_FWD"
+	bcn_vp = mgr._evaluate_mission_conditions(1, bcn_mission)
+	_check("designated forward beacon scores the 5 VP tier", bcn_vp == 5, str(bcn_vp))
+	# Dead beacon scores nothing
+	for m in gs.state["units"]["U_BEACON_FWD"]["models"]:
+		m["alive"] = false
+	bcn_vp = mgr._evaluate_mission_conditions(1, bcn_mission)
+	_check("destroyed beacon unit scores 0", bcn_vp == 0, str(bcn_vp))
+	# AI auto-pick prefers a living forward unit
+	for m in gs.state["units"]["U_BEACON_FWD"]["models"]:
+		m["alive"] = true
+	var ai_pick = ai._pick_beacon_unit(1)
+	_check("AI beacon auto-pick prefers the forward unit", ai_pick == "U_BEACON_FWD", ai_pick)
+
+	print("\n-- Burden of Trust: guards auto-assign + guarded scoring --")
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	state1 = mgr._player_state["1"]
+	state1["deck"] = ["burden_of_trust"]
+	state1["active"] = []
+	gs.state["units"] = {}
+	_mk_unit(gs, "U_G1", 1, Vector2(_px(10), _px(30)))  # on obj_nml_1
+	_mk_unit(gs, "U_G2", 1, Vector2(_px(34), _px(30)))  # on obj_nml_2
+	mission_mgr.objective_control_state.clear()
+	mission_mgr.objective_control_state["obj_nml_1"] = 1
+	mission_mgr.objective_control_state["obj_nml_2"] = 1
+	mgr.draw_missions_to_hand(1, 1)
+	var bot_mission = state1["active"][0] if state1["active"].size() > 0 else {}
+	_check("burden of trust drawn active (no blocking interaction)",
+		bot_mission.get("id", "") == "burden_of_trust" and not bot_mission.get("pending_interaction", true), str(bot_mission))
+	var guards = bot_mission.get("mission_data", {}).get("guards", {})
+	_check("guards auto-assigned to both in-range objectives",
+		guards.size() == 2 and guards.get("obj_nml_1", "") != "" and guards.get("obj_nml_2", "") != "", str(guards))
+	_check("distinct units guard distinct objectives", guards.get("obj_nml_1", "") != guards.get("obj_nml_2", ""), str(guards))
+	_check("revision window pending for the human prompt",
+		bot_mission.get("mission_data", {}).get("guards_prompt_pending", false) == true)
+	var pending_choice = mgr.get_pending_guard_choice(1)
+	_check("pending guard choice exposes eligible units per objective",
+		pending_choice.get("objectives", []).size() == 2, str(pending_choice))
+	var count_guarded = mgr._count_guarded_objectives(1, {}, bot_mission)
+	_check("both guarded objectives count while controlled + in range", count_guarded == 2, str(count_guarded))
+	# Guard dies -> its objective is no longer guarded
+	for m in gs.state["units"][guards["obj_nml_1"]]["models"]:
+		m["alive"] = false
+	count_guarded = mgr._count_guarded_objectives(1, {}, bot_mission)
+	_check("dead guard drops its objective from the count", count_guarded == 1, str(count_guarded))
+	# Losing control also drops it
+	mission_mgr.objective_control_state["obj_nml_2"] = 2
+	count_guarded = mgr._count_guarded_objectives(1, {}, bot_mission)
+	_check("lost control drops the objective from the count", count_guarded == 0, str(count_guarded))
+	# resolve_burden_guards rejects duplicate unit picks (keeps first)
+	mission_mgr.objective_control_state["obj_nml_2"] = 1
+	var res_guards = mgr.resolve_burden_guards(1, {"obj_nml_1": "U_G2", "obj_nml_2": "U_G2"})
+	_check("duplicate guard collapsed to one objective", res_guards.get("guards", {}).size() == 1, str(res_guards))
+	_check("guard prompt closed after resolution",
+		bot_mission.get("mission_data", {}).get("guards_prompt_pending", true) == false)
+
+	print("\n-- Final-round clause: active player scores opp-turn cards at game end --")
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["battle_round"] = 5
+	mission_mgr.objective_control_state["obj_nml_2"] = 1
+	for m in gs.state["units"]["U_G1"]["models"]:
+		m["alive"] = true
+	bot_mission["mission_data"]["guards"] = {"obj_nml_1": "U_G1", "obj_nml_2": "U_G2"}
+	mission_mgr.objective_control_state["obj_nml_1"] = 1
+	var normal_results = mgr.score_secondary_missions_for_player(1, false)
+	var found_bot := false
+	for r in normal_results:
+		if r["mission_id"] == "burden_of_trust":
+			found_bot = true
+	_check("no opp-turn scoring on your own turn without the clause call", not found_bot, str(normal_results))
+	var final_results = mgr.score_secondary_missions_for_player(1, true)
+	found_bot = false
+	var bot_vp := 0
+	for r in final_results:
+		if r["mission_id"] == "burden_of_trust":
+			found_bot = true
+			bot_vp = r["vp_earned"]
+	_check("final-turn call scores Burden of Trust for the active player", found_bot, str(final_results))
+	_check("2 guarded objectives = 4 VP", bot_vp == 4, str(bot_vp))
+
+	print("\n-- Plunder: shooting-phase option + once per turn + scoring --")
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["battle_round"] = 2
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	state1 = mgr._player_state["1"]
+	state1["deck"] = []
+	state1["active"] = [mgr._create_active_mission(SecondaryMissionData.get_mission_by_id("plunder"))]
+	gs.state["units"] = {}
+	# P1 territory = top half (DZ at top). Forward terrain sits in the BOTTOM half.
+	_mk_unit(gs, "U_RAIDER", 1, Vector2(_px(22), _px(43)))
+	_mk_unit(gs, "U_STAYHOME", 1, Vector2(_px(22), _px(5)))
+	var terrain_mgr = root.get_node_or_null("TerrainManager")
+	terrain_mgr.terrain_features = [
+		{"id": "ruins_fwd", "type": "ruins", "polygon": PackedVector2Array([
+			Vector2(_px(18), _px(40)), Vector2(_px(28), _px(40)), Vector2(_px(28), _px(46)), Vector2(_px(18), _px(46))])},
+		{"id": "ruins_home", "type": "ruins", "polygon": PackedVector2Array([
+			Vector2(_px(18), _px(2)), Vector2(_px(28), _px(2)), Vector2(_px(28), _px(8)), Vector2(_px(18), _px(8))])},
+	]
+	var shooting_phase = load("res://phases/ShootingPhase.gd").new()
+	root.add_child(shooting_phase)
+	shooting_phase.game_state_snapshot = gs.create_snapshot()
+	var options_fwd = shooting_phase._get_secondary_action_options("U_RAIDER")
+	_check("forward unit gets a Plunder option", options_fwd.size() == 1
+		and options_fwd[0].get("action_name", "") == "Plunder"
+		and options_fwd[0].get("vp_value", 0) == 5, str(options_fwd))
+	var options_home = shooting_phase._get_secondary_action_options("U_STAYHOME")
+	_check("unit in home-half terrain gets NO Plunder option (territory rule)",
+		options_home.is_empty(), str(options_home))
+	# Perform it
+	var pl_result = shooting_phase.process_action({"type": "PERFORM_SECONDARY_ACTION",
+		"actor_unit_id": "U_RAIDER", "payload": {"action_name": "Plunder", "location": "terrain", "mission_id": "plunder"}})
+	_check("PERFORM_SECONDARY_ACTION Plunder succeeds", pl_result.get("success", false), str(pl_result))
+	_check("plunder recorded with the terrain id",
+		mgr._active_actions["1"].size() == 1 and str(mgr._active_actions["1"][0].get("terrain_id", "")) == "ruins_fwd",
+		str(mgr._active_actions["1"]))
+	# Once per turn: the second unit inside forward terrain gets no option now
+	_mk_unit(gs, "U_RAIDER2", 1, Vector2(_px(24), _px(43)))
+	var options_second = shooting_phase._get_secondary_action_options("U_RAIDER2")
+	_check("once per turn: no second Plunder option", options_second.is_empty(), str(options_second))
+	var validate_second = shooting_phase.validate_action({"type": "PERFORM_SECONDARY_ACTION",
+		"actor_unit_id": "U_RAIDER2", "payload": {"action_name": "Plunder"}})
+	_check("validator refuses a second Plunder this turn", not validate_second.get("valid", true), str(validate_second))
+	# Scoring: flat 5 VP at end of your turn
+	var pl_mission = state1["active"][0]
+	var pl_vp = mgr._evaluate_mission_conditions(1, pl_mission)
+	_check("completed Plunder scores 5 VP", pl_vp == 5, str(pl_vp))
+
+	print("\n-- Cleanse (11e): non-home only, distinct objectives, control gate --")
+	mgr.initialize_for_game()
+	mgr.setup_tactical_deck(1)
+	state1 = mgr._player_state["1"]
+	state1["deck"] = []
+	state1["active"] = [mgr._create_active_mission(SecondaryMissionData.get_mission_by_id("cleanse"))]
+	gs.state["units"] = {}
+	_mk_unit(gs, "U_CL_HOME", 1, Vector2(_px(22), _px(5)))    # on P1 home objective
+	_mk_unit(gs, "U_CL_NML", 1, Vector2(_px(10), _px(30)))    # on obj_nml_1
+	_mk_unit(gs, "U_CL_NML2", 1, Vector2(_px(10.5), _px(30.5)))  # ALSO near obj_nml_1
+	shooting_phase.game_state_snapshot = gs.create_snapshot()
+	var cl_home_opts = shooting_phase._get_secondary_action_options("U_CL_HOME")
+	_check("home objective is NOT cleansable at 11e", cl_home_opts.is_empty(), str(cl_home_opts))
+	var cl_opts = shooting_phase._get_secondary_action_options("U_CL_NML")
+	_check("NML objective IS cleansable", cl_opts.size() == 1 and str(cl_opts[0].get("objective_id", "")) == "obj_nml_1", str(cl_opts))
+	# Two units cleanse the SAME objective -> only 1 distinct objective counts
+	mission_mgr.objective_control_state.clear()
+	mission_mgr.objective_control_state["obj_nml_1"] = 1
+	shooting_phase.process_action({"type": "PERFORM_SECONDARY_ACTION",
+		"actor_unit_id": "U_CL_NML", "payload": {"action_name": "Cleanse", "location": "objective", "mission_id": "cleanse"}})
+	# Force the second unit to record the same objective (bypass the fresh-objective steering)
+	mgr.on_action_completed(1, {"action_name": "Cleanse", "completed": true, "unit_id": "U_CL_NML2", "objective_id": "obj_nml_1"})
+	var cl_mission = state1["active"][0]
+	var cl_vp = mgr._evaluate_mission_conditions(1, cl_mission)
+	_check("duplicate-objective cleanses count once (2 VP tier)", cl_vp == 2, str(cl_vp))
+	# Losing control of the objective voids the cleanse at end of turn (11e)
+	mission_mgr.objective_control_state["obj_nml_1"] = 2
+	cl_vp = mgr._evaluate_mission_conditions(1, cl_mission)
+	_check("cleanse does not complete if the objective is lost", cl_vp == 0, str(cl_vp))
+
+	shooting_phase.queue_free()
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Summary

Sweep of all 18 11th-edition tactical secondary cards against the official launch data (40kdc). Twelve cards were already correct; the six with gaps are fixed here so every card that needs player input asks for it and every card action has a button.

### The reported bug — A Tempting Target
When the AI drew A Tempting Target, `AIPlayer._on_secondary_requires_interaction` auto-resolved the No Man's Land objective pick that belongs to the **human opponent** using `randi()`, so no dialog ever appeared. The responder is now computed per interaction type; the AI only auto-resolves when the deciding player is an AI, pauses its turn on a wait gate while a human decision is pending, and resumes via the new `interaction_resolved` signal. When the AI *is* the chooser it uses a heuristic (far from the drawer, near/held by itself) instead of a random pick. The same steal bug existed for Marked for Death alpha selection and is fixed too.

### Other cards fixed
- **Plunder** — had no action path at all (neither human nor AI could ever score it). The Shooting phase now surfaces a "Plunder &lt;terrain&gt; (5 VP)" Perform Action option for a unit within a terrain area outside its territory, once per turn.
- **Beacon** — "designate one friendly unit" is now a real when-drawn interaction: `BeaconUnitDialog` for a human drawer (embarked units listed), smart auto-pick for an AI drawer, a pulsing cyan beacon badge on the token, and scoring that tracks only the designated unit (legacy saves keep any-unit).
- **Burden of Trust** — guards are real: one distinct unit per objective, auto-assigned when drawn and at each of the holder's turn starts, with a Command-phase revision dialog; an objective only counts while its guard is alive, in range, and controlled.
- **Cleanse (11e)** — home objectives excluded, duplicate-objective cleanses count once, and completion requires still controlling the marker at end of turn.
- **Beacon / Burden of Trust / Defend Stronghold** — honour "…or the end of the fifth battle round, whichever comes first": the final player's end-of-opponent-turn cards score at the game's last turn end.

Also: TemptingTargetDialog dedup + stable node names, and secondary interaction prompts now sequence behind the drawn-missions review dialog.

## Validation
- New headless suite `tests/test_secondary_interactions_11e.gd` (44 checks) covering all of the above at the engine layer.
- Four new windowed scenarios `iss065a`–`iss065d` driven through the real UI with screenshots (opponent Tempting Target prompt during the AI's turn, the Plunder action button, the Beacon designation dialog, the Burden of Trust guard dialog).
- `iss063b` deflaked — A Grievous Blow's official discard-and-redraw made its deck-count assert nondeterministic; it now asserts conservation across deck+active+discard.
- Live `verify_delivery` gate: **PASS** on the end-to-end tempting-target flow with zero log errors.
- `version_history.json` bumped to 0.5.0 with a player-facing changelog.

## Known limitation
"Your territory" for Plunder/Beacon/Outflank remains approximated as your board half (pre-existing, documented in the data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZCPu4ZtVnhTHycXPeQYVg

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZCPu4ZtVnhTHycXPeQYVg)_