### PR TITLE
Movement: auto-confirm a moved-but-unconfirmed unit on unit switch / end phase

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.5.1",
+			"date": "2026-07-07",
+			"summary": "Movement phase no longer nags you to click 'Confirm Move' — moving on auto-confirms.",
+			"changes": [
+				"In the Movement phase, if you move a unit's models but forget to click 'Confirm Move', the move is now confirmed automatically the moment you select a different unit or end the phase. No more 'There are active moves that need to be confirmed or reset' blocking you.",
+				"Auto-confirm runs the same checks as the button (coherency, Fall Back engagement range, Fire Overwatch), so an illegal position still won't be silently committed."
+			]
+		},
+		{
 			"version": "0.5.0",
 			"date": "2026-07-06",
 			"summary": "11th-edition secondary missions are now fully playable: every card that needs your input asks for it, and every card action has a button.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -8847,6 +8847,16 @@ func _on_phase_action_pressed() -> void:
 					return
 			action = {"type": "END_COMMAND", "player": active_player}
 		GameStateData.Phase.MOVEMENT:
+			# QoL: auto-confirm any unit the player moved but never clicked
+			# "Confirm Move" for, so ending the phase doesn't get blocked by
+			# "active moves that need to be confirmed or reset" (and, in
+			# single-player, so the staged move is committed instead of being
+			# discarded by the local-advance fallback below). Mirrors the Scout
+			# phase's end-of-phase commit. In single-player the confirm routes
+			# synchronously, so the move is committed before END_MOVEMENT validates.
+			if movement_controller and is_instance_valid(movement_controller) \
+					and movement_controller.has_method("_auto_confirm_all_pending_moves"):
+				movement_controller._auto_confirm_all_pending_moves()
 			action = {"type": "END_MOVEMENT", "player": active_player}
 		GameStateData.Phase.SHOOTING:
 			# T5-UX9: Show end-of-phase shooting summary dialog (skipped for AI)

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -100,6 +100,12 @@ var advance_roll_label: Label
 # Flag to prevent duplicate actions when programmatically setting radio buttons
 var setting_radio_programmatically: bool = false
 
+# QoL: when the player has moved models for a unit but never clicked "Confirm
+# Move", treat that move as confirmed the moment they end the phase or switch to
+# another unit. This guard prevents re-entrancy while the auto-dispatched
+# CONFIRM_UNIT_MOVE runs (it fires unit_move_confirmed → _auto_select_next_unmoved).
+var _auto_confirming_pending_move: bool = false
+
 # OA-24: PopupMenu for special movement actions (e.g. Kunnin' Infiltrator)
 var _movement_action_popup: PopupMenu = null
 var _popup_pending_unit_id: String = ""  # Unit awaiting action choice from popup
@@ -914,6 +920,12 @@ func _on_unit_selected(index: int) -> void:
 	if not unit:
 		return
 
+	# QoL: switching to a different unit auto-confirms the previously selected
+	# unit's moved-but-unconfirmed move (same as clicking "Confirm Move"). Do this
+	# before we repoint active_unit_id so the pending unit is the one confirmed.
+	if unit_id != active_unit_id:
+		_auto_confirm_pending_move(active_unit_id)
+
 	# Route reserve units to Main's reinforcement placement flow
 	if unit.get("status", 0) == GameStateData.UnitStatus.IN_RESERVES:
 		print("MovementController: Reserve unit %s selected — routing to Main for reinforcement placement" % unit_id)
@@ -987,6 +999,20 @@ func _on_unit_selected(index: int) -> void:
 	emit_signal("ui_update_requested")
 
 # This function has been moved below to avoid duplication
+
+func _select_unit_in_list_by_id(unit_id: String) -> bool:
+	"""Select `unit_id` in the unit list exactly as clicking its row would
+	(emits item_selected → _on_unit_selected). Unlike begin_unit_movement it does
+	NOT pre-set active_unit_id, so switching from a previously moved unit still
+	triggers that unit's auto-confirm. Returns false if the unit is not listed."""
+	if not unit_list or not is_instance_valid(unit_list):
+		return false
+	for i in range(unit_list.get_item_count()):
+		if unit_list.get_item_metadata(i) == unit_id:
+			unit_list.select(i)
+			unit_list.emit_signal("item_selected", i)
+			return true
+	return false
 
 func begin_unit_movement(unit_id: String) -> void:
 	"""Begin movement for a unit (called after disembark if transport hasn't moved)"""
@@ -1183,10 +1209,50 @@ func _on_reset_unit_pressed() -> void:
 	}
 	emit_signal("move_action_requested", action)
 
+func _has_pending_unconfirmed_move(unit_id: String) -> bool:
+	"""True when `unit_id` has an active move with at least one moved model that
+	has NOT yet been confirmed (the player dragged models but skipped the
+	"Confirm Move" button). Fall Back / Remain Stationary that never moved a
+	model, and already-completed moves, return false."""
+	if unit_id == "":
+		return false
+	if not current_phase or not current_phase.has_method("get_active_move_data"):
+		return false
+	var move_data = current_phase.get_active_move_data(unit_id)
+	if move_data.is_empty():
+		return false
+	if move_data.get("completed", false):
+		return false
+	# Staged (drag flow) or committed-but-unconfirmed (direct-set flow) moves both count.
+	var has_staged = not move_data.get("staged_moves", []).is_empty()
+	var has_committed = not move_data.get("model_moves", []).is_empty()
+	return has_staged or has_committed
+
+func _auto_confirm_pending_move(unit_id: String) -> bool:
+	"""If `unit_id` moved models but was never confirmed, dispatch the same
+	CONFIRM_UNIT_MOVE the "Confirm Move" button sends so the player does not have
+	to click it before ending the phase or moving a different unit. Returns true
+	if a confirm was dispatched. Reuses the full action pipeline, so coherency
+	checks, Fire Overwatch, network sync, etc. behave exactly as a manual confirm."""
+	if _auto_confirming_pending_move:
+		return false
+	if not _has_pending_unconfirmed_move(unit_id):
+		return false
+	print("MovementController: Auto-confirming pending move for %s (player did not click Confirm Move)" % unit_id)
+	DebugLogger.info(str("[MovementController] Auto-confirming pending move for ", unit_id, " (no explicit Confirm Move)"))
+	_auto_confirming_pending_move = true
+	emit_signal("move_action_requested", {
+		"type": "CONFIRM_UNIT_MOVE",
+		"actor_unit_id": unit_id,
+		"payload": {}
+	})
+	_auto_confirming_pending_move = false
+	return true
+
 func _on_confirm_move_pressed() -> void:
 	if active_unit_id == "":
 		return
-	
+
 	var action = {
 		"type": "CONFIRM_UNIT_MOVE",
 		"actor_unit_id": active_unit_id,
@@ -1195,11 +1261,27 @@ func _on_confirm_move_pressed() -> void:
 	emit_signal("move_action_requested", action)
 
 func _on_end_phase_pressed() -> void:
+	# NOTE: The live "End Phase" button in the Movement phase is wired to
+	# Main._on_phase_action_pressed (which auto-confirms via
+	# _auto_confirm_all_pending_moves before dispatching END_MOVEMENT), not to
+	# this handler. This is kept for parity and any legacy/local wiring.
+	_auto_confirm_all_pending_moves()
+
 	var action = {
 		"type": "END_MOVEMENT",
 		"payload": {}
 	}
 	emit_signal("move_action_requested", action)
+
+func _auto_confirm_all_pending_moves() -> void:
+	"""Auto-confirm every unit that moved models but was never confirmed. Used
+	when ending the phase so no stray staged move blocks END_MOVEMENT."""
+	if not current_phase or not "active_moves" in current_phase:
+		return
+	# Copy the keys — confirming flips each move's `completed` flag as we go.
+	var unit_ids: Array = current_phase.active_moves.keys()
+	for uid in unit_ids:
+		_auto_confirm_pending_move(uid)
 
 func _on_confirm_mode_pressed() -> void:
 	if not active_unit_id:
@@ -1590,8 +1672,12 @@ func _on_unit_move_confirmed(unit_id: String, result_summary: Dictionary) -> voi
 	_refresh_unit_list()
 	emit_signal("ui_update_requested")
 
-	# T-094: auto-select next unmoved unit in the list
-	_auto_select_next_unmoved()
+	# T-094: auto-select next unmoved unit in the list.
+	# Skip when this confirm was auto-triggered by the player switching units or
+	# ending the phase — they already chose what happens next, and re-selecting
+	# here would fight that choice (and could spawn a stray active move).
+	if not _auto_confirming_pending_move:
+		_auto_select_next_unmoved()
 
 
 func _auto_select_next_unmoved() -> void:

--- a/40k/tests/scenarios/sp/movement_auto_confirm.json
+++ b/40k/tests/scenarios/sp/movement_auto_confirm.json
@@ -1,0 +1,73 @@
+{
+  "id": "movement_auto_confirm",
+  "covers": [
+    "movement.auto_confirm_on_unit_switch",
+    "movement.auto_confirm_on_end_phase"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Movement phase QoL: a unit whose models were moved but never explicitly confirmed is auto-confirmed when the player selects a different unit (unit-switch trigger) or ends the phase (end-phase trigger). Drives the real controller/Main UI handlers, not a direct CONFIRM_UNIT_MOVE dispatch.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "screenshot", "label": "01_movement_loaded" },
+
+    { "act": "execute_script",
+      "script": "main.movement_controller._select_unit_in_list_by_id(\"U_BLADE_CHAMPION_A\")",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.movement_controller.active_unit_id",
+      "equals": "U_BLADE_CHAMPION_A" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_BLADE_CHAMPION_A",
+      "payload": { "model_id": "m1", "dest": [120, 320], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"flags\", {}).get(\"moved\", false)",
+      "equals": false },
+    { "act": "screenshot", "label": "02_blade_champion_staged_not_confirmed" },
+
+    { "act": "execute_script",
+      "script": "main.movement_controller._select_unit_in_list_by_id(\"U_SHIELD_CAPTAIN_A\")",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"flags\", {}).get(\"moved\", false)",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))",
+      "equals": 320 },
+    { "act": "execute_script",
+      "script": "main.movement_controller.active_unit_id",
+      "equals": "U_SHIELD_CAPTAIN_A" },
+    { "act": "screenshot", "label": "03_blade_champion_auto_confirmed_on_switch" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_SHIELD_CAPTAIN_A",
+      "payload": { "model_id": "m1", "dest": [50, 280], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"flags\", {}).get(\"moved\", false)",
+      "equals": false },
+    { "act": "screenshot", "label": "04_shield_captain_staged_not_confirmed" },
+
+    { "act": "execute_script",
+      "script": "main.phase_action_button.emit_signal(\"pressed\")" },
+
+    { "act": "execute_script",
+      "script": "GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"flags\", {}).get(\"moved\", false)",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))",
+      "equals": 280 },
+    { "act": "screenshot", "label": "05_shield_captain_auto_confirmed_on_end_phase" }
+  ]
+}

--- a/40k/tests/test_secondary_interactions_11e.gd.uid
+++ b/40k/tests/test_secondary_interactions_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://qgadu4lu6mv5


### PR DESCRIPTION
## Summary

In the Movement phase, if a player drags a unit's models but never clicks **"Confirm Move"**, the pending move is now confirmed automatically the moment they:
- **select a different unit** in the unit list, or
- **end the Movement phase**.

Previously that unit sat in a "moved but unconfirmed" state: ending the phase was blocked by *"There are active moves that need to be confirmed or reset"*, and in single-player the local-advance fallback silently **discarded** the staged move (the model snapped back to its deployed spot).

## Approach

Mirrors the existing **Scout-phase** end-of-phase commit pattern, and reuses the real `CONFIRM_UNIT_MOVE` action pipeline so coherency checks, Fall Back engagement-range checks, Fire Overwatch, and network sync behave exactly like a manual confirm. An illegal layout still fails validation and is **not** silently committed.

- `MovementController._auto_confirm_pending_move()` — dispatches the same `CONFIRM_UNIT_MOVE` the button sends; `_has_pending_unconfirmed_move()` gates it to units that actually moved models (staged or committed-but-unconfirmed).
- `_on_unit_selected` — auto-confirms the previously selected unit before switching, guarded against the `unit_move_confirmed → _auto_select_next_unmoved` re-entrancy.
- `Main._on_phase_action_pressed` (the live **End Phase** button, which routes here — not through the controller's unwired `_on_end_phase_pressed`) — auto-confirms all pending moves before dispatching `END_MOVEMENT`.

## Testing

New windowed scenario `40k/tests/scenarios/sp/movement_auto_confirm.json` drives **both triggers through the real controller/Main UI handlers** — **22/22 steps pass**, no script errors. Screenshot evidence shows `Blade Champion [COMPLETED MOVING]` after switching units, and the Game Log reading `P1 Ended Movement Phase → Shooting Phase` after clicking End Phase (with `END_MOVEMENT VALIDATION PASSED`, which previously FAILED).

No regressions in existing movement scenarios: `51_confirm_movement_mode` (11/0), `ri_offer_at_end_of_movement` (17/0), `horde_movement` (3/0), `iss040_movement_11e` (52/0). Version history bumped to 0.5.1.

Note: this covers the human UI paths (unit-list switch and the End Phase button/Enter). The AI auto-confirms its own moves, so it never leaves a pending move — no change needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aq9grSg38WDuphRAQaukp1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aq9grSg38WDuphRAQaukp1)_