### PR TITLE
Unify Shooting-phase wound-allocation window with the weapon-order window

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.5.2",
+			"date": "2026-07-07",
+			"summary": "The Shooting phase's wound-allocation window now matches the weapon-order window — one consistent gothic look across both.",
+			"changes": [
+				"The 'Allocate Attacks' window (where you order allocation groups before saves are rolled) now wears the same White Dwarf gold-and-red theme as the 'Choose Weapon Order' window: gold-bordered panel, gold section headers, gold-outlined arrow reorder buttons, and a red primary action button.",
+				"Added an 'ALLOCATION ORDER' heading and gold section dividers so the wound window reads the same way the weapon-order window does.",
+				"No behaviour change — only the styling was unified so the two Shooting-phase ordering windows feel like the same UI."
+			]
+		},
+		{
 			"version": "0.5.1",
 			"date": "2026-07-07",
 			"summary": "Movement phase no longer nags you to click 'Confirm Move' — moving on auto-confirms.",

--- a/40k/scripts/AllocationGroupOverlay.gd
+++ b/40k/scripts/AllocationGroupOverlay.gd
@@ -1,6 +1,8 @@
 extends Control
 class_name AllocationGroupOverlay
 
+const _WhiteDwarfTheme = preload("res://scripts/WhiteDwarfTheme.gd")
+
 ## ISS-045 — the 11e defender allocation UI (core rules 05.03-05.04).
 ## Replaces WoundAllocationOverlay's per-wound click loop at edition ≥ 11:
 ## the defender divides the target into allocation groups ONCE per attack
@@ -77,6 +79,12 @@ func _build_ui() -> void:
 	z_index = 2000  # above the phase banner / HUD (UI_MODAL_Z)
 	mouse_filter = Control.MOUSE_FILTER_STOP
 
+	# UI-CONSISTENCY: share the White Dwarf chrome with WeaponOrderDialog and
+	# the other shooting dialogs. The theme cascades to every Button / Label /
+	# OptionButton descendant (including the reorder rows rebuilt later), so the
+	# wound-allocation window reads as the same UI as the weapon-order window.
+	_WhiteDwarfTheme.apply_to_control_theme(self)
+
 	dim = ColorRect.new()
 	dim.name = "Dim"
 	dim.color = Color(0, 0, 0, 0.55)
@@ -91,6 +99,13 @@ func _build_ui() -> void:
 	panel = PanelContainer.new()
 	panel.name = "Panel"
 	panel.custom_minimum_size = Vector2(560, 0)
+	# Gothic gold-bordered parchment-dark panel + inner padding. Content margins
+	# live on the stylebox (not a wrapper node) so the scenario node paths
+	# Panel/VBox/... stay intact.
+	var panel_style = _WhiteDwarfTheme.create_panel_style()
+	panel_style.bg_color = Color(0.1, 0.09, 0.07, 0.97)
+	panel_style.set_content_margin_all(14)
+	panel.add_theme_stylebox_override("panel", panel_style)
 	center.add_child(panel)
 
 	var vbox = VBoxContainer.new()
@@ -102,7 +117,11 @@ func _build_ui() -> void:
 	title.name = "Title"
 	title.text = "Allocate Attacks — %s" % str(save_data.get("target_unit_name", save_data.get("target_unit_id", "")))
 	title.add_theme_font_size_override("font_size", 22)
+	title.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_GOLD)
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(title)
+
+	_WhiteDwarfTheme.add_gold_separator(vbox)
 
 	var info = Label.new()
 	info.name = "Info"
@@ -114,6 +133,8 @@ func _build_ui() -> void:
 		int(save_data.get("wounds_to_save", 0)), dev_txt,
 		int(save_data.get("ap", 0)),
 		str(save_data.get("damage_raw", save_data.get("damage", 1)))]
+	info.add_theme_font_size_override("font_size", 14)
+	info.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_GOLD)
 	vbox.add_child(info)
 
 	var hint = Label.new()
@@ -121,6 +142,7 @@ func _build_ui() -> void:
 	hint.text = "Declare the allocation order (05.03). Damage is applied lowest save roll → highest against the current group."
 	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	hint.add_theme_font_size_override("font_size", 13)
+	hint.add_theme_color_override("font_color", Color(0.7, 0.7, 0.8))
 	vbox.add_child(hint)
 
 	# 24.28 [PRECISION]: attacker's promotion choice (visibility-gated).
@@ -141,6 +163,17 @@ func _build_ui() -> void:
 		precision_picker.selected = 1  # default: promote the first eligible group
 		vbox.add_child(precision_picker)
 
+	_WhiteDwarfTheme.add_gold_separator(vbox)
+
+	# Section label so the ordered rows read as "FIRING ORDER" does in the
+	# weapon-order window.
+	var order_label = Label.new()
+	order_label.name = "OrderLabel"
+	order_label.text = "ALLOCATION ORDER"
+	order_label.add_theme_font_size_override("font_size", 13)
+	order_label.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_GOLD)
+	vbox.add_child(order_label)
+
 	group_list = VBoxContainer.new()
 	group_list.name = "GroupList"
 	group_list.add_theme_constant_override("separation", 4)
@@ -148,19 +181,24 @@ func _build_ui() -> void:
 
 	error_label = Label.new()
 	error_label.name = "ErrorLabel"
-	error_label.add_theme_color_override("font_color", Color(1.0, 0.4, 0.4))
+	error_label.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_RED)
 	error_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	error_label.text = ""
 	vbox.add_child(error_label)
 
+	_WhiteDwarfTheme.add_gold_separator(vbox)
+
 	confirm_button = Button.new()
 	confirm_button.name = "ConfirmButton"
 	confirm_button.text = "Confirm Order & Roll Saves"
+	confirm_button.custom_minimum_size = Vector2(0, 42)
 	confirm_button.pressed.connect(_on_confirm_pressed)
+	_WhiteDwarfTheme.apply_primary_button(confirm_button)
 	vbox.add_child(confirm_button)
 
 	result_panel = VBoxContainer.new()
 	result_panel.name = "ResultPanel"
+	result_panel.add_theme_constant_override("separation", 8)
 	result_panel.visible = false
 	vbox.add_child(result_panel)
 
@@ -169,12 +207,15 @@ func _build_ui() -> void:
 	result_label.bbcode_enabled = false
 	result_label.fit_content = true
 	result_label.custom_minimum_size = Vector2(520, 0)
+	result_label.add_theme_color_override("default_color", _WhiteDwarfTheme.WH_PARCHMENT)
 	result_panel.add_child(result_label)
 
 	done_button = Button.new()
 	done_button.name = "DoneButton"
 	done_button.text = "Done"
+	done_button.custom_minimum_size = Vector2(0, 42)
 	done_button.pressed.connect(_on_done_pressed)
+	_WhiteDwarfTheme.apply_primary_button(done_button)
 	result_panel.add_child(done_button)
 
 

--- a/40k/scripts/WhiteDwarfTheme.gd
+++ b/40k/scripts/WhiteDwarfTheme.gd
@@ -138,21 +138,11 @@ static func apply_to_item_list(item_list: ItemList) -> void:
 	item_list.add_theme_stylebox_override("selected", selected_style)
 	item_list.add_theme_stylebox_override("selected_focus", selected_style)
 
-static func apply_to_dialog(dialog: Window) -> void:
-	if not dialog:
-		return
-	# Style the dialog window background and chrome
-	var theme = Theme.new()
-	# Window panel background
-	var panel_style = StyleBoxFlat.new()
-	panel_style.bg_color = Color(0.1, 0.09, 0.07, 0.97)
-	panel_style.border_color = WH_GOLD
-	panel_style.set_border_width_all(2)
-	panel_style.set_corner_radius_all(4)
-	panel_style.set_content_margin_all(10)
-	theme.set_stylebox("embedded_border", "Window", panel_style)
-	# Title font color
-	theme.set_color("title_color", "Window", WH_GOLD)
+# Populate the shared White Dwarf control chrome (buttons, labels, option
+# buttons, separators, item lists) into a Theme. Used by both apply_to_dialog
+# (Window-based AcceptDialogs) and apply_to_control_theme (Control-based
+# overlays) so every modal shares one visual language.
+static func _apply_common_theme_entries(theme: Theme) -> void:
 	# Button styles for dialog buttons (OK, Cancel, etc.)
 	theme.set_stylebox("normal", "Button", create_button_normal())
 	theme.set_stylebox("hover", "Button", create_button_hover())
@@ -192,7 +182,36 @@ static func apply_to_dialog(dialog: Window) -> void:
 	item_selected_style.set_corner_radius_all(2)
 	theme.set_stylebox("selected", "ItemList", item_selected_style)
 	theme.set_stylebox("selected_focus", "ItemList", item_selected_style)
+
+static func apply_to_dialog(dialog: Window) -> void:
+	if not dialog:
+		return
+	# Style the dialog window background and chrome
+	var theme = Theme.new()
+	# Window panel background
+	var panel_style = StyleBoxFlat.new()
+	panel_style.bg_color = Color(0.1, 0.09, 0.07, 0.97)
+	panel_style.border_color = WH_GOLD
+	panel_style.set_border_width_all(2)
+	panel_style.set_corner_radius_all(4)
+	panel_style.set_content_margin_all(10)
+	theme.set_stylebox("embedded_border", "Window", panel_style)
+	# Title font color
+	theme.set_color("title_color", "Window", WH_GOLD)
+	_apply_common_theme_entries(theme)
 	dialog.theme = theme
+
+# Apply the White Dwarf chrome to a Control-based overlay (not a Window).
+# Cascades to every Button / Label / OptionButton / ItemList descendant so a
+# hand-built overlay matches the AcceptDialog-based dialogs without theming
+# each widget individually. Per-widget overrides still win where an accent is
+# wanted (gold headers, primary/red action buttons).
+static func apply_to_control_theme(control: Control) -> void:
+	if not control:
+		return
+	var theme = Theme.new()
+	_apply_common_theme_entries(theme)
+	control.theme = theme
 
 static func apply_to_overlay_panel(panel: PanelContainer) -> void:
 	if not panel:
@@ -200,6 +219,18 @@ static func apply_to_overlay_panel(panel: PanelContainer) -> void:
 	var style = create_panel_style()
 	style.bg_color = Color(0.1, 0.09, 0.07, 0.97)
 	panel.add_theme_stylebox_override("panel", style)
+
+# Shared gold accent separator — a thin translucent-gold bar between sections.
+# Matches the divider used across the shooting dialogs so every modal breaks
+# its sections up the same way.
+static func add_gold_separator(parent: Control) -> void:
+	if not parent:
+		return
+	var sep = ColorRect.new()
+	sep.custom_minimum_size = Vector2(0, 2)
+	sep.color = Color(WH_GOLD.r, WH_GOLD.g, WH_GOLD.b, 0.4)
+	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(sep)
 
 # ── Color Helpers for BBCode ─────────────────────────────────────────
 # Hex color strings for use in RichTextLabel BBCode


### PR DESCRIPTION
## Summary

The two Shooting-phase "order these, then confirm" windows looked completely different. The **weapon-order** window (`WeaponOrderDialog`) and ~36 other dialogs use the **White Dwarf** gold/red gothic chrome, but the 11th-edition **wound-allocation** window (`AllocationGroupOverlay`) was rendered in Godot's default gray theme — it was the lone unthemed outlier in the shooting flow. This PR gives the wound-allocation window the same design language so the two windows read as one UI.

## What changed

**`WhiteDwarfTheme.gd`**
- Extracted the shared button / label / option-button / separator / item-list theme entries into a private `_apply_common_theme_entries()` helper. `apply_to_dialog()` now calls it — behaviour is unchanged (still used by all the AcceptDialog-based dialogs).
- Added `apply_to_control_theme(control)` — cascades the shared chrome to a **Control-based** overlay (the Window-only `apply_to_dialog` can't target `AllocationGroupOverlay`, which is a `Control`, not a `Window`).
- Added `add_gold_separator(parent)` — the shared thin translucent-gold divider used across the shooting windows.

**`AllocationGroupOverlay.gd`**
- Applies the White Dwarf chrome: gold-bordered, padded panel; gold centered title; gold info line; muted hint; a new **"ALLOCATION ORDER"** gold section header; gold dividers; **red primary** Confirm/Done buttons; parchment result text; red error text.
- All existing node names are preserved (content margins live on the panel stylebox, not a new wrapper node), so the windowed scenario's node paths keep working.

**`version_history.json`** — new `0.5.1` entry (player-facing styling change).

## Validation (windowed)

- `iss045_allocation_groups` windowed scenario passes **31/31** — node paths intact, damage still applied lowest→highest save roll, CHARACTER group still resolved last. No `ERROR` lines fired.
- Captured live screenshots of **both** windows: they now share the same gold-bordered panel, gold section headers, gold-outlined ▲▼ reorder buttons, and red primary action buttons.

No behaviour change — styling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MXQZUmMmPUZ27ThkwYxqB

---
_Generated by [Claude Code](https://claude.ai/code/session_013MXQZUmMmPUZ27ThkwYxqB)_