### PR TITLE
Move version + What's New section to the bottom of the main menu

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.5.3",
+			"date": "2026-07-07",
+			"summary": "The version + 'What's New' box now sits at the bottom of the main menu, so the menu leads with army and mission setup.",
+			"changes": [
+				"Moved the version badge and the 'What's New' changelog panel from just under the title to the very bottom of the main menu, below the Start/Load/Quit buttons.",
+				"No behaviour change — the same version info is shown, just relocated so the game-setup options are the first thing you see."
+			]
+		},
+		{
 			"version": "0.5.2",
 			"date": "2026-07-07",
 			"summary": "The Shooting phase's wound-allocation window now matches the weapon-order window — one consistent gothic look across both.",

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -223,25 +223,24 @@ func _create_data_attribution_credit() -> void:
 	print("MainMenu: 40kdc data attribution credit added")
 
 func _create_version_display() -> void:
-	"""Show the game version + a summary of the most recent changes near the top
+	"""Show the game version + a summary of the most recent changes at the bottom
 	of the menu. Data comes from res://data/version_history.json via VersionInfo
 	so it can be told at a glance which build is running (e.g. itch.io vs GitHub)."""
 	var menu_container := $ScrollContainer/MenuContainer as VBoxContainer
 	if menu_container == null:
 		return
 
-	var title_idx := _get_child_index(menu_container, "TitleLabel")
-
-	# --- Compact version badge directly under the title ---
+	# --- Compact version badge at the bottom of the menu ---
 	var badge := Label.new()
 	badge.name = "VersionBadge"
 	badge.text = VersionInfo.get_version_badge()
 	badge.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	badge.add_theme_font_size_override("font_size", 13)
 	badge.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_GOLD)
+	# add_child appends to the end of the VBox. Since _create_version_display()
+	# is the last step of _ready(), the version info lands below the
+	# Start/Load/Quit button section, at the very bottom of the menu.
 	menu_container.add_child(badge)
-	if title_idx >= 0:
-		menu_container.move_child(badge, title_idx + 1)
 
 	# --- "What's New" panel listing the latest release summary + changes ---
 	var changes := VersionInfo.get_latest_changes()
@@ -290,13 +289,11 @@ func _create_version_display() -> void:
 		change_label.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
 		vbox.add_child(change_label)
 
+	# Appended after the badge, so the "What's New" panel is the very last
+	# element in the menu, directly below the version badge.
 	menu_container.add_child(panel)
-	# Place the panel just below the version badge, above the first separator.
-	var badge_idx := _get_child_index(menu_container, "VersionBadge")
-	if badge_idx >= 0:
-		menu_container.move_child(panel, badge_idx + 1)
 
-	print("MainMenu: Version display added (%s, %d changes)" % [VersionInfo.get_version(), changes.size()])
+	print("MainMenu: Version display added at bottom (%s, %d changes)" % [VersionInfo.get_version(), changes.size()])
 
 func _apply_theme_to_dynamic_elements() -> void:
 	# Style dynamically created dropdowns and buttons

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2321,6 +2321,15 @@
       "status": "covered"
     },
     {
+      "id": "ui.main_menu.version_display_bottom",
+      "description": "Main menu version badge + 'What's New' panel are appended at the bottom of the menu VBox (below the Start/Load/Quit ButtonSection), with the panel as the very last child.",
+      "scenarios": [
+        "version_display_at_bottom"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "formations.warlord.supreme_commander",
       "description": "Supreme Commander forces Ghazghkull to be the Warlord: designating a plain Warboss is rejected, Ghazghkull is accepted.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/version_display_at_bottom.json
+++ b/40k/tests/scenarios/sp/version_display_at_bottom.json
@@ -1,0 +1,45 @@
+{
+  "id": "version_display_at_bottom",
+  "covers": ["ui.main_menu.version_display_bottom"],
+  "description": "Boots the MainMenu scene (no fixture) and asserts the version badge + 'What's New' panel are appended at the BOTTOM of the menu VBox — below the Start/Load/Quit ButtonSection — with the What's New panel as the very last child. Drives the live scene root created by MainMenu._create_version_display().",
+
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "execute_script",
+      "script": "main.get_script().resource_path",
+      "equals": "res://scripts/MainMenu.gd" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ScrollContainer/MenuContainer/VersionBadge\").is_visible_in_tree()",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ScrollContainer/MenuContainer/WhatsNewPanel\").is_visible_in_tree()",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"VersionBadge\") > main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"ButtonSection\")",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"WhatsNewPanel\") > main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"ButtonSection\")",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"WhatsNewPanel\") == main.get_node(\"ScrollContainer/MenuContainer\").get_child_count() - 1",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"WhatsNewPanel\") == main._get_child_index(main.get_node(\"ScrollContainer/MenuContainer\"), \"VersionBadge\") + 1",
+      "equals": true },
+
+    { "act": "screenshot", "label": "top_no_version" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ScrollContainer\").set_deferred(\"scroll_vertical\", 100000)" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "version_at_bottom" }
+  ]
+}


### PR DESCRIPTION
## Summary

The version badge and "What's New" changelog panel were placed directly under the title at the top of the main menu. This moves the whole version section to the very bottom of the menu (below the Start/Load/Quit button section) so the menu leads with the army and mission setup a player actually configures.

`MainMenu._create_version_display()` no longer moves the badge/panel up under the title. Since it is the last step of `_ready()`, `add_child` leaves both appended at the end of the `MenuContainer` VBox — the badge first, then the "What's New" panel as the last child.

## Changes

- **`40k/scripts/MainMenu.gd`** — removed the two upward `move_child` calls in `_create_version_display()`; updated docstring/comments.
- **`40k/data/version_history.json`** — prepended a `v0.5.3` entry describing the relocation.
- **`40k/tests/coverage.json`** — added the `ui.main_menu.version_display_bottom` coverage tile.
- **`40k/tests/scenarios/sp/version_display_at_bottom.json`** — new windowed scenario.

## Validation

Ran the game windowed (Xvfb + software rendering) and drove the real MainMenu scene:

- New windowed scenario `version_display_at_bottom` — **12/12 steps passed**. Asserts both elements are below the `ButtonSection`, that the "What's New" panel is the last child, and that the badge sits directly above it.
- Screenshots confirm the effect: the top of the menu now goes straight from the title into "Army Selection", and the bottom shows `v0.5.3 · 2026-07-07` followed by the "What's New" panel, right under the Quit button.

No behaviour change — the same version info is shown, just relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNkxnduGKZaXD7avsFmBEF)_