### PR TITLE
Game Log: category filters + broader, clearer event coverage

### DIFF
--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -55,7 +55,8 @@ func _on_phase_changed(new_phase: GameStateData.Phase) -> void:
 	var phase_name = PHASE_NAMES.get(new_phase, "Unknown")
 	var turn = GameState.get_battle_round()
 	var player = GameState.get_active_player()
-	var header = "--- %s Phase (Round %d, P%d) ---" % [phase_name, turn, player]
+	# Clearer, spelled-out header (was "--- Movement Phase (Round 2, P1) ---")
+	var header = "--- %s Phase — Battle Round %d, Player %d's turn ---" % [phase_name, turn, player]
 	_add_entry(header, "phase_header")
 
 func _on_action_taken(action: Dictionary) -> void:
@@ -85,7 +86,21 @@ func _format_action(action: Dictionary, action_type: String, player: int) -> Str
 		"DEPLOY_UNIT":
 			if ai_desc != "":
 				return prefix + ai_desc
-			return prefix + "Deployed %s" % unit_name
+			return prefix + "Deployed %s%s" % [unit_name, _model_suffix(unit_id)]
+		"CHOOSE_DEPLOYMENT", "ROLL_OFF_DEPLOYMENT":
+			var log_text = action.get("_log_text", "")
+			if log_text != "":
+				return prefix + log_text
+			if ai_desc != "":
+				return prefix + ai_desc
+			var role = str(_af(action, "role", _af(action, "choice", "")))
+			if role != "":
+				return prefix + "Chose to deploy as %s" % role.capitalize()
+			return prefix + "Chose deployment order"
+		"DESIGNATE_WARLORD":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "Designated %s as Warlord" % unit_name
 		"BEGIN_NORMAL_MOVE", "CONFIRM_UNIT_MOVE":
 			if action_type == "CONFIRM_UNIT_MOVE":
 				if ai_desc != "":
@@ -189,11 +204,86 @@ func _format_action(action: Dictionary, action_type: String, player: int) -> Str
 			var log_text = action.get("_log_text", "")
 			if log_text != "":
 				return prefix + log_text
-			return ""
-		"FALL_BACK":
 			if ai_desc != "":
 				return prefix + ai_desc
-			return prefix + "%s fell back" % unit_name
+			return prefix + "%s Advances" % unit_name
+		"BEGIN_SURGE_MOVE":
+			var log_text = action.get("_log_text", "")
+			if log_text != "":
+				return prefix + log_text
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s makes a Surge move" % unit_name
+		"FALL_BACK", "BEGIN_FALL_BACK":
+			var log_text = action.get("_log_text", "")
+			if log_text != "":
+				return prefix + log_text
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s Falls Back" % unit_name
+		"EMBARK_UNIT", "DECLARE_TRANSPORT_EMBARKATION", "EMBARK_UNITS_DEPLOYMENT":
+			if ai_desc != "":
+				return prefix + ai_desc
+			var transport_name = _get_unit_name(str(_af(action, "transport_id", _af(action, "target_unit_id", ""))))
+			if transport_name != "Unknown" and transport_name != "":
+				return prefix + "%s embarked aboard %s" % [unit_name, transport_name]
+			return prefix + "%s embarked" % unit_name
+		"CONFIRM_DISEMBARK":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s disembarked" % unit_name
+		"DISEMBARK_UNIT":
+			# Opens the disembark dialog only; the actual move is CONFIRM_DISEMBARK.
+			return ""
+		"PLACE_REINFORCEMENT", "SCOUT_RESERVES_DEPLOY":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s arrived from Reserves (Deep Strike)%s" % [unit_name, _model_suffix(unit_id)]
+		"PLACE_RAPID_INGRESS_REINFORCEMENT":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s arrived via Rapid Ingress" % unit_name
+		"DECLARE_RESERVES", "PLACE_IN_RESERVES", "SEND_TO_STRATEGIC_RESERVES":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s placed in Strategic Reserves" % unit_name
+		"BEGIN_SCOUT_MOVE", "CONFIRM_SCOUT_MOVE":
+			if action_type == "BEGIN_SCOUT_MOVE":
+				return ""
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s made a Scout move" % unit_name
+		"SKIP_SCOUT_MOVE", "SKIP_SCOUT_UNIT":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s did not Scout" % unit_name
+		"SELECT_COMBAT_DOCTRINE":
+			if ai_desc != "":
+				return prefix + ai_desc
+			var doctrine = str(_af(action, "doctrine_key", "")).replace("_", " ")
+			if doctrine != "":
+				return prefix + "Activated the %s doctrine" % doctrine.capitalize()
+			return prefix + "Selected a Combat Doctrine"
+		"SELECT_KATAH_STANCE":
+			if ai_desc != "":
+				return prefix + ai_desc
+			var stance = str(_af(action, "stance", ""))
+			if stance == "both":
+				return prefix + "%s adopts BOTH Ka'tah stances (Master of the Stances)" % unit_name
+			elif stance != "":
+				return prefix + "%s adopts the %s Ka'tah stance" % [unit_name, stance.capitalize()]
+			return prefix + "%s selects a Ka'tah stance" % unit_name
+		"SELECT_MARTIAL_MASTERY":
+			if ai_desc != "":
+				return prefix + ai_desc
+			return prefix + "%s uses Martial Mastery" % unit_name
+		"PERFORM_SECONDARY_ACTION", "START_ACTION", "PERFORM_RITUAL_ACTION", "PERFORM_TERRAFORM_ACTION":
+			if ai_desc != "":
+				return prefix + ai_desc
+			var action_name = str(_af(action, "action_name", _af(action, "mission_name", "")))
+			if action_name != "":
+				return prefix + "%s performs action: %s" % [unit_name, action_name]
+			return prefix + "%s performs a mission action" % unit_name
 		"SWEEPING_ADVANCE":
 			if ai_desc != "":
 				return prefix + ai_desc
@@ -228,6 +318,37 @@ func _get_unit_name(unit_id: String) -> String:
 	if name != "":
 		return name
 	return unit_id
+
+func _af(action: Dictionary, key: String, default = ""):
+	"""Read a field from an action, checking the top level first and then the
+	nested `payload` dict — action shapes vary (some carry fields at the top,
+	others under payload)."""
+	if action.has(key):
+		return action[key]
+	var payload = action.get("payload", {})
+	if typeof(payload) == TYPE_DICTIONARY and payload.has(key):
+		return payload[key]
+	return default
+
+func _get_alive_model_count(unit_id: String) -> int:
+	"""Number of models in a unit that are still alive (for verbose log detail)."""
+	if unit_id == "":
+		return 0
+	var unit = GameState.state.get("units", {}).get(unit_id, {})
+	var models = unit.get("models", [])
+	var n := 0
+	for m in models:
+		if m.get("alive", true):
+			n += 1
+	return n
+
+func _model_suffix(unit_id: String) -> String:
+	"""' (N models)' suffix, or '' when the count is unknown/singular-agnostic."""
+	var n = _get_alive_model_count(unit_id)
+	if n <= 0:
+		return ""
+	var label = "model" if n == 1 else "models"
+	return " (%d %s)" % [n, label]
 
 func _add_entry(text: String, entry_type: String) -> void:
 	entries.append({"text": text, "type": entry_type})

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.0",
+			"date": "2026-07-07",
+			"summary": "The Game Log is clearer, covers more of what happens, and now has per-category filter toggles so you can focus on the events you care about.",
+			"changes": [
+				"New: a 'Filters' button on the Game Log opens a row of toggle chips — Phase, Move, Shoot, Fight, Charge, Overwatch, VP, Info and AI. Click one to hide/show that kind of event; 'All' and 'None' bulk-toggle. Each entry is colour-coded to match its filter.",
+				"More events now appear in the log: units Falling Back, embarking/disembarking transports, arriving from Reserves / Deep Strike, Combat Doctrine and Ka'tah stance selections, mission (secondary) actions, Warlord designation, Advance and Surge moves, and Scout moves — many of these were previously silent.",
+				"Existing entries read more clearly: phase headers now spell out 'Movement Phase — Battle Round 2, Player 1's turn', and deployed / reinforcing units show their model count.",
+				"The AI-thinking quick-toggle in the header still works and now stays in sync with the AI filter chip."
+			]
+		},
+		{
 			"version": "0.5.2",
 			"date": "2026-07-07",
 			"summary": "The Shooting phase's wound-allocation window now matches the weapon-order window — one consistent gothic look across both.",

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -60,6 +60,46 @@ const ICON_CHARS = {
 	EntryCategory.COMBAT: "X",
 }
 
+# --- Filters ---
+# Categories exposed as filter chips, in the order they appear in the filter bar.
+# COMBAT is intentionally absent: combat cards are tagged SHOOTING or MELEE so
+# they filter alongside the matching phase.
+const FILTER_ORDER = [
+	EntryCategory.PHASE,
+	EntryCategory.MOVEMENT,
+	EntryCategory.SHOOTING,
+	EntryCategory.MELEE,
+	EntryCategory.CHARGE,
+	EntryCategory.OVERWATCH,
+	EntryCategory.SCORING,
+	EntryCategory.INFO,
+	EntryCategory.AI_THINKING,
+]
+# Short chip labels (the icon badge already carries the letter).
+const FILTER_LABELS = {
+	EntryCategory.PHASE: "Phase",
+	EntryCategory.MOVEMENT: "Move",
+	EntryCategory.SHOOTING: "Shoot",
+	EntryCategory.MELEE: "Fight",
+	EntryCategory.CHARGE: "Charge",
+	EntryCategory.OVERWATCH: "Overwatch",
+	EntryCategory.SCORING: "VP",
+	EntryCategory.INFO: "Info",
+	EntryCategory.AI_THINKING: "AI",
+}
+# Stable string keys for tests / external callers to name a category.
+const FILTER_KEYS = {
+	EntryCategory.PHASE: "phase",
+	EntryCategory.MOVEMENT: "move",
+	EntryCategory.SHOOTING: "shoot",
+	EntryCategory.MELEE: "fight",
+	EntryCategory.CHARGE: "charge",
+	EntryCategory.OVERWATCH: "overwatch",
+	EntryCategory.SCORING: "vp",
+	EntryCategory.INFO: "info",
+	EntryCategory.AI_THINKING: "ai",
+}
+
 # --- State ---
 var _scroll: ScrollContainer
 var _card_container: VBoxContainer
@@ -68,6 +108,14 @@ var _collapse_button: Button
 var _ai_filter_button: Button
 var _show_ai_thinking: bool = true
 var _ai_cards: Array[PanelContainer] = []
+
+# --- Filter state ---
+# category (EntryCategory) -> bool. Missing key means visible (default on).
+var _category_visible: Dictionary = {}
+var _filter_button: Button = null       # header button that expands/collapses the chip bar
+var _filter_bar: HFlowContainer = null  # holds the per-category toggle chips
+var _filter_chips: Dictionary = {}      # category:int -> Button
+var _filters_expanded: bool = false
 # Board-linked thinking cards (carry ai_link_context metadata) + pin state
 var _linked_ai_cards: Array[PanelContainer] = []
 var _pinned_link_card: PanelContainer = null
@@ -93,6 +141,9 @@ func _ready() -> void:
 	_dice_regex.compile("\\[([0-9, ]+)\\]")
 	_threshold_regex = RegEx.new()
 	_threshold_regex.compile("(?:needed |Save |Pain |vs )(\\d+)\\+")
+	# Every filterable category starts visible.
+	for cat in FILTER_ORDER:
+		_category_visible[cat] = true
 
 func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 105.0, offset_bottom: float = 0.0) -> void:
 	name = "GameLogPanel"
@@ -128,6 +179,7 @@ func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 1
 
 	# --- Header row ---
 	var header = HBoxContainer.new()
+	header.name = "HeaderRow"
 	header.custom_minimum_size = Vector2(0, 28)
 	vbox.add_child(header)
 
@@ -138,7 +190,17 @@ func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 1
 	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	header.add_child(title)
 
-	# AI filter toggle
+	# Filters toggle — expands/collapses the per-category chip bar below.
+	_filter_button = Button.new()
+	_filter_button.name = "FilterToggle"
+	_filter_button.text = "Filters"
+	_filter_button.tooltip_text = "Show/hide the event-type filter chips"
+	_filter_button.custom_minimum_size = Vector2(54, 24)
+	_filter_button.add_theme_font_size_override("font_size", 10)
+	_filter_button.pressed.connect(_on_filter_button_pressed)
+	header.add_child(_filter_button)
+
+	# AI filter toggle (quick-access shortcut; also present as a chip in the bar)
 	_ai_filter_button = Button.new()
 	_ai_filter_button.text = "AI"
 	_ai_filter_button.tooltip_text = "Toggle AI thinking entries"
@@ -162,6 +224,9 @@ func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 1
 	sep.color = Color(COLOR_GOLD.r, COLOR_GOLD.g, COLOR_GOLD.b, 0.4)
 	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	vbox.add_child(sep)
+
+	# --- Filter chip bar (collapsible) ---
+	_build_filter_bar(vbox)
 
 	# --- Scroll area with card container ---
 	_scroll = ScrollContainer.new()
@@ -581,8 +646,10 @@ func _start_combat_card(header_text: String, animate: bool) -> void:
 
 	_card_container.add_child(card)
 	_card_count += 1
+	# Combat cards filter alongside their phase (Shoot / Fight).
+	_register_card(card, category)
 
-	if animate:
+	if animate and card.visible:
 		_animate_card_in(card)
 
 func _append_combat_detail(text: String, animate: bool) -> void:
@@ -597,7 +664,8 @@ func _append_combat_detail(text: String, animate: bool) -> void:
 		var card = _make_simple_entry_card(text, "combat_detail", EntryCategory.COMBAT)
 		_card_container.add_child(card)
 		_card_count += 1
-		if animate:
+		_register_card(card, _combat_category_from_text(text))
+		if animate and card.visible:
 			_animate_card_in(card)
 
 func _build_combat_detail_line(text: String) -> Control:
@@ -675,7 +743,8 @@ func _finalize_combat_card(text: String, animate: bool) -> void:
 		var card = _make_combat_result_card(text)
 		_card_container.add_child(card)
 		_card_count += 1
-		if animate:
+		_register_card(card, _combat_category_from_text(text))
+		if animate and card.visible:
 			_animate_card_in(card)
 
 # ==========================================================================
@@ -688,14 +757,18 @@ func _create_simple_card(text: String, entry_type: String, animate: bool) -> voi
 	category = _refine_category_from_text(text, category)
 
 	var card: PanelContainer
+	var final_category = category
 
 	match entry_type:
 		"phase_header":
 			card = _make_phase_card(text)
+			final_category = EntryCategory.PHASE
 		"overwatch":
 			card = _make_simple_entry_card(text, entry_type, EntryCategory.OVERWATCH)
+			final_category = EntryCategory.OVERWATCH
 		"ai_thinking":
 			card = _make_simple_entry_card(text, entry_type, EntryCategory.AI_THINKING)
+			final_category = EntryCategory.AI_THINKING
 		"ai_thinking_block":
 			# Board-link context (unit + candidate positions) travels alongside
 			# the entry — read it synchronously from the emitting autoload.
@@ -704,18 +777,21 @@ func _create_simple_card(text: String, entry_type: String, animate: bool) -> voi
 			if gel and gel.has_method("get_last_entry_context"):
 				block_context = gel.get_last_entry_context()
 			card = _make_ai_thinking_block_card(text, block_context)
+			final_category = EntryCategory.AI_THINKING
 		_:
 			card = _make_simple_entry_card(text, entry_type, category)
+			final_category = category
 
 	_card_container.add_child(card)
 	_card_count += 1
+	# Tag with its category + apply the current filter (also sets AI-card visibility).
+	_register_card(card, final_category)
 
 	# Track AI cards for filtering
 	if entry_type == "ai_thinking" or entry_type == "ai_thinking_block":
 		_ai_cards.append(card)
-		card.visible = _show_ai_thinking
 
-	if animate:
+	if animate and card.visible:
 		_animate_card_in(card)
 
 # ==========================================================================
@@ -1105,21 +1181,50 @@ func _categorize_entry_type(entry_type: String) -> int:
 			return EntryCategory.INFO
 
 func _refine_category_from_text(text: String, current_category: int) -> int:
-	if current_category != EntryCategory.MOVEMENT:
+	# Only loosely-typed player actions (MOVEMENT base) and general info lines
+	# (INFO base) get content-based routing; already-specific categories
+	# (phase, overwatch, ai, combat…) pass straight through.
+	if current_category != EntryCategory.MOVEMENT and current_category != EntryCategory.INFO:
 		return current_category
 
-	var lower_text = text.to_lower()
-	if "shot" in lower_text or "shoots" in lower_text or "shooting" in lower_text:
-		return EntryCategory.SHOOTING
-	elif "fought" in lower_text or "fights" in lower_text or "fight" in lower_text:
-		return EntryCategory.MELEE
-	elif "charged" in lower_text or "charge" in lower_text or "pile" in lower_text or "consolidat" in lower_text:
-		return EntryCategory.CHARGE
-	elif "score" in lower_text or "vp" in lower_text or "point" in lower_text:
-		return EntryCategory.SCORING
-	elif "overwatch" in lower_text:
+	var t = text.to_lower()
+
+	# Distinctive reactions / events first.
+	if "overwatch" in t:
 		return EntryCategory.OVERWATCH
+	if "charge" in t or "charged" in t:
+		return EntryCategory.CHARGE
+	if "shot" in t or "shoot" in t or "fires at" in t or "firing" in t:
+		return EntryCategory.SHOOTING
+	if "fought" in t or "fights" in t or "fight " in t or "melee" in t \
+		or "pile in" in t or "piled in" in t or "consolidat" in t:
+		return EntryCategory.MELEE
+	if "scored" in t or "score " in t or "vp" in t or "victory point" in t:
+		return EntryCategory.SCORING
+
+	# Command / abilities / stratagems / mission bookkeeping → Info.
+	if "stratagem" in t or "waaagh" in t or "oath" in t or "doctrine" in t or "stance" in t \
+		or "banner" in t or "warlord" in t or "secondar" in t or "mission" in t \
+		or "battle-shock" in t or "battle shock" in t or "command re-roll" in t \
+		or " cp" in t or "cp " in t or "objective" in t or "ability" in t:
+		return EntryCategory.INFO
+
+	# Movement-family verbs → Move (also covers deploy / reserves / transport).
+	if "moved" in t or "moves" in t or " move" in t or "advanc" in t \
+		or "fall back" in t or "falls back" in t or "fell back" in t \
+		or "deploy" in t or "embark" in t or "disembark" in t or "reserve" in t \
+		or "deep strike" in t or "ingress" in t or "stationary" in t or "scout" in t \
+		or "surge" in t:
+		return EntryCategory.MOVEMENT
+
 	return current_category
+
+func _combat_category_from_text(text: String) -> int:
+	"""Map an orphaned combat line to Fight or Shoot by its wording."""
+	var t = text.to_lower()
+	if "fight" in t or "fought" in t or "melee" in t or "pile in" in t or "consolidat" in t:
+		return EntryCategory.MELEE
+	return EntryCategory.SHOOTING
 
 # ==========================================================================
 # Combat detail styling (dice rolls, keywords)
@@ -1218,15 +1323,119 @@ func _trim_old_cards(count: int) -> void:
 		_card_count -= 1
 
 # ==========================================================================
-# Filter & visibility (AI toggle from xBfRG)
+# Filter & visibility — per-category toggle chips + AI quick-toggle
 # ==========================================================================
 
-func _on_ai_filter_pressed() -> void:
-	_show_ai_thinking = !_show_ai_thinking
-	for card in _ai_cards:
-		if is_instance_valid(card):
-			card.visible = _show_ai_thinking
+func _build_filter_bar(parent: VBoxContainer) -> void:
+	"""Build the collapsible bar of per-category toggle chips. Hidden until the
+	'Filters' header button is pressed so it costs no vertical space by default."""
+	_filter_bar = HFlowContainer.new()
+	_filter_bar.name = "FilterBar"
+	_filter_bar.add_theme_constant_override("h_separation", 3)
+	_filter_bar.add_theme_constant_override("v_separation", 3)
+	_filter_bar.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_filter_bar.visible = false
+	parent.add_child(_filter_bar)
+
+	# A tiny "all/none" pair keeps bulk toggling one click away.
+	var all_btn = Button.new()
+	all_btn.text = "All"
+	all_btn.tooltip_text = "Show every event type"
+	all_btn.custom_minimum_size = Vector2(30, 22)
+	all_btn.add_theme_font_size_override("font_size", 9)
+	all_btn.pressed.connect(func(): _set_all_categories_visible(true))
+	_filter_bar.add_child(all_btn)
+
+	var none_btn = Button.new()
+	none_btn.text = "None"
+	none_btn.tooltip_text = "Hide every event type"
+	none_btn.custom_minimum_size = Vector2(38, 22)
+	none_btn.add_theme_font_size_override("font_size", 9)
+	none_btn.pressed.connect(func(): _set_all_categories_visible(false))
+	_filter_bar.add_child(none_btn)
+
+	for cat in FILTER_ORDER:
+		var chip = _make_filter_chip(cat)
+		_filter_chips[cat] = chip
+		_filter_bar.add_child(chip)
+		_update_chip_visual(cat)
+
+func _make_filter_chip(category: int) -> Button:
+	var chip = Button.new()
+	chip.name = "Chip_%s" % FILTER_KEYS.get(category, str(category))
+	chip.text = FILTER_LABELS.get(category, "?")
+	chip.toggle_mode = false  # we drive the on/off look ourselves via modulate
+	chip.custom_minimum_size = Vector2(0, 22)
+	chip.add_theme_font_size_override("font_size", 9)
+	chip.tooltip_text = "Toggle %s events" % FILTER_LABELS.get(category, "")
+	# Tint the chip with the category's accent so it reads like the cards it controls.
+	var accent = BORDER_COLORS.get(category, Color.GRAY)
+	chip.add_theme_color_override("font_color", accent)
+	chip.add_theme_color_override("font_hover_color", accent.lightened(0.3))
+	chip.pressed.connect(func(): _toggle_category(category))
+	return chip
+
+func _toggle_category(category: int) -> void:
+	_set_category_visible(category, not _category_visible.get(category, true))
+
+func _set_category_visible(category: int, visible_flag: bool) -> void:
+	_category_visible[category] = visible_flag
+	# Keep the AI quick-toggle + legacy bool in sync with the AI chip.
+	if category == EntryCategory.AI_THINKING:
+		_show_ai_thinking = visible_flag
+		_update_ai_filter_button()
+	_apply_filters()
+	_update_chip_visual(category)
+
+func _set_all_categories_visible(visible_flag: bool) -> void:
+	for cat in FILTER_ORDER:
+		_category_visible[cat] = visible_flag
+		_update_chip_visual(cat)
+	_show_ai_thinking = visible_flag
 	_update_ai_filter_button()
+	_apply_filters()
+
+func _apply_filters() -> void:
+	"""Walk every card and set its visibility from its tagged category."""
+	if _card_container == null:
+		return
+	for card in _card_container.get_children():
+		if not is_instance_valid(card):
+			continue
+		var cat = card.get_meta("log_category", EntryCategory.INFO)
+		card.visible = _category_visible.get(cat, true)
+
+func _update_chip_visual(category: int) -> void:
+	var chip = _filter_chips.get(category, null)
+	if chip == null or not is_instance_valid(chip):
+		return
+	var on = _category_visible.get(category, true)
+	if on:
+		chip.modulate = Color(1, 1, 1, 1)
+		chip.text = "%s" % FILTER_LABELS.get(category, "?")
+	else:
+		# Dim + strike-through style cue when a category is hidden.
+		chip.modulate = Color(1, 1, 1, 0.4)
+		chip.text = "%s ✕" % FILTER_LABELS.get(category, "?")
+
+func _on_filter_button_pressed() -> void:
+	_filters_expanded = not _filters_expanded
+	if _filter_bar:
+		_filter_bar.visible = _filters_expanded
+	if _filter_button:
+		_filter_button.modulate = Color(1, 1, 1, 1.0) if _filters_expanded else Color(1, 1, 1, 0.7)
+
+func _register_card(card: Control, category: int) -> void:
+	"""Tag a freshly-created card with its category and apply the current filter
+	so it appears/hides consistently with cards already in the log."""
+	if card == null:
+		return
+	card.set_meta("log_category", category)
+	card.visible = _category_visible.get(category, true)
+
+func _on_ai_filter_pressed() -> void:
+	# The header 'AI' shortcut drives the same state as the AI chip.
+	_set_category_visible(EntryCategory.AI_THINKING, not _category_visible.get(EntryCategory.AI_THINKING, true))
 
 func _update_ai_filter_button() -> void:
 	if _ai_filter_button:
@@ -1236,6 +1445,69 @@ func _update_ai_filter_button() -> void:
 		else:
 			_ai_filter_button.modulate = Color(1, 1, 1, 0.4)
 			_ai_filter_button.tooltip_text = "AI thinking hidden - click to show"
+
+# --- Introspection helpers (windowed scenarios) ---
+
+func is_category_visible(category_key: String) -> bool:
+	"""True if the named category ('phase','move','shoot','fight','charge',
+	'overwatch','vp','info','ai') is currently shown."""
+	var cat = _category_from_key(category_key)
+	if cat < 0:
+		return true
+	return _category_visible.get(cat, true)
+
+func set_category_filter(category_key: String, visible_flag: bool) -> bool:
+	"""Programmatic toggle by name — same code path as clicking a chip."""
+	var cat = _category_from_key(category_key)
+	if cat < 0:
+		return false
+	_set_category_visible(cat, visible_flag)
+	return true
+
+func toggle_filter_bar(expand = null) -> void:
+	"""Show/hide the chip bar. Pass true/false to force a state."""
+	if expand == null:
+		_on_filter_button_pressed()
+		return
+	_filters_expanded = bool(expand)
+	if _filter_bar:
+		_filter_bar.visible = _filters_expanded
+
+func is_filter_bar_expanded() -> bool:
+	return _filters_expanded
+
+func count_visible_cards_in_category(category_key: String) -> int:
+	"""How many cards of the named category are currently visible. Used by
+	scenarios to assert a filter actually hid/showed the right rows."""
+	var cat = _category_from_key(category_key)
+	if _card_container == null:
+		return 0
+	var n := 0
+	for card in _card_container.get_children():
+		if not is_instance_valid(card):
+			continue
+		if card.get_meta("log_category", EntryCategory.INFO) == cat and card.visible:
+			n += 1
+	return n
+
+func count_cards_in_category(category_key: String) -> int:
+	"""Total cards of the named category regardless of visibility."""
+	var cat = _category_from_key(category_key)
+	if _card_container == null:
+		return 0
+	var n := 0
+	for card in _card_container.get_children():
+		if not is_instance_valid(card):
+			continue
+		if card.get_meta("log_category", EntryCategory.INFO) == cat:
+			n += 1
+	return n
+
+func _category_from_key(category_key: String) -> int:
+	for cat in FILTER_KEYS:
+		if FILTER_KEYS[cat] == category_key:
+			return cat
+	return -1
 
 func _on_collapse_pressed() -> void:
 	_is_visible = false

--- a/40k/tests/scenarios/sp/game_log_clarity_filters.json
+++ b/40k/tests/scenarios/sp/game_log_clarity_filters.json
@@ -1,0 +1,90 @@
+{
+  "id": "game_log_clarity_filters",
+  "covers": [
+    "ui.GameLogPanel.category_filters",
+    "ui.GameLogPanel.filter_toggle",
+    "log.coverage.fall_back",
+    "log.coverage.transport_embark",
+    "log.coverage.reserves_arrival",
+    "log.coverage.katah_stance",
+    "log.coverage.secondary_action",
+    "log.coverage.designate_warlord"
+  ],
+  "fixture": "audit_367_warlord",
+  "transition_to_phase": 0,
+  "description": "Game-log clarity + filters. Part A drives the new category toggle filters in the left GameLogPanel: injects one entry per category via the real GameEventLog API, expands the filter bar with a real click on the 'Filters' button, then hides/shows categories and asserts exactly the right cards become (in)visible — including a real chip click and that the legacy AI shortcut stays in sync. Part B validates newly-covered events (Fall Back, embark, Deep Strike arrival, Ka'tah stance, secondary action) produce verbose log text, and that a real DESIGNATE_WARLORD dispatch reaches the log end-to-end.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 0 },
+
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, 'Intercessor Squad shot at Ork Boyz')" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, 'Rhino moved 6 inches up the flank')" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(2, 'Warboss charged the Intercessor Squad')" },
+    { "act": "execute_script", "script": "GameEventLog.add_info_entry('CP generated — P1: 3 CP, P2: 3 CP')" },
+    { "act": "execute_script", "script": "GameEventLog.add_info_entry('VP Totals — P1: 5 (Pri 5 + Sec 0) | P2: 3 (Pri 3 + Sec 0)')" },
+    { "act": "execute_script", "script": "GameEventLog.add_ai_thinking_entry(2, 'Weighing charge targets for the Warboss')" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "screenshot", "label": "01_all_categories_visible", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('shoot')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('move')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('charge')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('info')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('vp')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('ai')", "expect_min": 1 },
+
+    { "act": "click_node", "node": "/root/Main/GameLogPanel/VBox/HeaderRow/FilterToggle", "emit_pressed": true },
+    { "act": "execute_script", "script": "main.game_log_panel.is_filter_bar_expanded()", "equals": true },
+    { "act": "expect_node_visible", "node": "/root/Main/GameLogPanel/VBox/FilterBar", "timeout_s": 2.0 },
+    { "act": "screenshot", "label": "02_filter_bar_open", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('info', false)" },
+    { "act": "execute_script", "script": "main.game_log_panel.is_category_visible('info')", "equals": false },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('info')", "equals": 0 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('shoot')", "expect_min": 1 },
+    { "act": "screenshot", "label": "03_info_hidden", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('info', true)" },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('info')", "expect_min": 1 },
+
+    { "act": "click_node", "node": "/root/Main/GameLogPanel/VBox/FilterBar/Chip_shoot", "emit_pressed": true },
+    { "act": "execute_script", "script": "main.game_log_panel.is_category_visible('shoot')", "equals": false },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('shoot')", "equals": 0 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('charge')", "expect_min": 1 },
+    { "act": "screenshot", "label": "04_shoot_hidden_via_chip", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('ai', false)" },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('ai')", "equals": 0 },
+    { "act": "execute_script", "script": "main.game_log_panel._show_ai_thinking", "equals": false },
+    { "act": "execute_script", "script": "main.game_log_panel.get_ai_card_count()", "expect_min": 1 },
+
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('shoot', true)" },
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('ai', true)" },
+    { "act": "screenshot", "label": "05_all_restored", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "GameEventLog._on_action_taken({'type':'BEGIN_FALL_BACK','player':1,'unit_id':'U_SHIELD_CAPTAIN_A'})" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('Falls Back')", "equals": true },
+
+    { "act": "execute_script", "script": "GameEventLog._on_action_taken({'type':'EMBARK_UNIT','player':1,'actor_unit_id':'U_SHIELD_CAPTAIN_A','payload':{'transport_id':'U_BLADE_CHAMPION_A'}})" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('embarked')", "equals": true },
+
+    { "act": "execute_script", "script": "GameEventLog._on_action_taken({'type':'PLACE_REINFORCEMENT','player':1,'unit_id':'U_SHIELD_CAPTAIN_A'})" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('Reserves')", "equals": true },
+
+    { "act": "execute_script", "script": "GameEventLog._on_action_taken({'type':'SELECT_KATAH_STANCE','player':1,'unit_id':'U_SHIELD_CAPTAIN_A','stance':'aggressive'})" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('Ka')", "equals": true },
+
+    { "act": "execute_script", "script": "GameEventLog._on_action_taken({'type':'PERFORM_SECONDARY_ACTION','player':1,'actor_unit_id':'U_SHIELD_CAPTAIN_A','payload':{'action_name':'Cleanse'}})" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('Cleanse')", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "screenshot", "label": "06_new_event_coverage", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "dispatch_action", "action": { "type": "DESIGNATE_WARLORD", "unit_id": "U_SHIELD_CAPTAIN_A" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('text','')).contains('Warlord')", "equals": true },
+    { "act": "screenshot", "label": "07_designate_warlord_logged", "region": [0, 100, 360, 760] }
+  ]
+}


### PR DESCRIPTION
## What & why

The in-game **Game Log** (left panel) missed many events, and there was no way to focus on the ones you care about. This adds per-category **toggle filters**, widens what the log narrates, and makes existing entries read more clearly.

## Toggle filters (headline feature)

- New **"Filters"** header button expands a collapsible chip bar with one toggle per category — **Phase, Move, Shoot, Fight, Charge, Overwatch, VP, Info, AI** — plus **All / None** bulk toggles.
- Clicking a chip hides/shows every card of that category; the chip dims and shows a ✕ when off. Each chip is tinted to match the cards it controls.
- Every card is tagged with its category (`set_meta`) and filtered through a single `_apply_filters` pass. Categorization is now more thorough (movement/deploy/transport/reserves → Move; abilities/stratagems/mission → Info; VP → Scoring; etc.).
- The existing **AI** quick-toggle in the header still works and now stays in sync with the AI filter chip.

## Broader event coverage

Previously-silent events now appear in the log, each honouring any AI/phase-supplied text first so nothing double-logs:

- **Fall Back** — the old `FALL_BACK` handler was dead code; the real action is `BEGIN_FALL_BACK`.
- Transport **embark / disembark**, **Deep Strike / Reserves arrival**, **Rapid Ingress**.
- **Combat Doctrine** and **Ka'tah stance** selection, **Martial Mastery**.
- **Secondary / mission actions**, **Warlord designation**, deployment-order choice.
- **Advance / Surge / Scout** moves.

## Clearer, more verbose entries

- Phase headers spelled out: *"Movement Phase — Battle Round 2, Player 1's turn"* (was *"(Round 2, P1)"*).
- Model counts on deploy and reserve arrival.

## Validation

Windowed scenario `tests/scenarios/sp/game_log_clarity_filters.json` drives the real UI — clicks the Filters button and a chip live, asserts the right cards hide/show, and confirms the new events produce verbose text end-to-end (including a real `DESIGNATE_WARLORD` dispatch): **57/57 steps, 0 errors**. The existing `ai_vp_thought_links` scenario still passes (18/0), confirming no regression to the AI-thinking cards / board-links.

Version bumped to **0.6.0** with a "What's New" entry.

## Files

- `40k/scripts/GameLogPanel.gd` — filter system, card tagging, introspection helpers
- `40k/autoloads/GameEventLog.gd` — new event coverage + verbosity
- `40k/tests/scenarios/sp/game_log_clarity_filters.json` — windowed validation
- `40k/data/version_history.json` — changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WfMRSHG9cTcW4C6XuYQXiQ)_