### PR TITLE
Fix false 'charge failed' near ruins and a batch of charge-phase bugs

### DIFF
--- a/40k/autoloads/TerrainManager.gd
+++ b/40k/autoloads/TerrainManager.gd
@@ -552,10 +552,16 @@ func calculate_charge_terrain_penalty(from_pos: Vector2, to_pos: Vector2, has_fl
 		if is_infantry and can_move_through.get("INFANTRY", false):
 			unit_can_traverse = true
 
+		# A segment wholly inside one footprint crosses no wall — ground-floor
+		# movement within the same ruin pays no climb (matches movement phase).
+		var wholly_inside = starts_inside and ends_inside and not crosses_edge
+
 		# Units that can move through terrain at ground level (e.g. Infantry through ruins)
 		# don't pay height climbing penalties — same as movement phase rules.
 		if unit_can_traverse:
 			print("[TerrainManager] Charge: %s traversable by INFANTRY — no height penalty (ground floor)" % terrain.get("id", "unknown"))
+		elif wholly_inside:
+			print("[TerrainManager] Charge segment wholly inside %s: no height penalty (ground floor)" % terrain.get("id", "unknown"))
 		else:
 			var from_inside = not polygon.is_empty() and starts_inside
 			var to_inside = not polygon.is_empty() and ends_inside

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,21 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.1",
+			"date": "2026-07-07",
+			"summary": "Charge phase overhaul: no more false 'charge failed' verdicts near ruins, plus a batch of charge bug fixes.",
+			"changes": [
+				"Fixed the false [INSUFFICIENT_ROLL] failure: a charge roll big enough to reach the target (e.g. rolling 6\" against a target 2.5\" away) no longer fails just because a ruin clips the straight line — the check now knows models stop at engagement range and can move around terrain, matching what the charge move actually allows.",
+				"Failure messages and tooltips now show the real 11th-edition 2\" engagement range (they hardcoded 1\"), and the orange engagement rings + 'charge needed' preview around targets are sized to 2\" as well.",
+				"Command Re-rolls and +N charge bonuses now count: the list of chargeable targets is recomputed from your FINAL roll total, so a re-rolled charge no longer fails against the stale first-roll list (your CP is no longer wasted).",
+				"A rejected charge confirm now tells you why (toast + dice log) and lets you re-position and try again — previously it silently reset the UI and left tokens displayed in the wrong place.",
+				"11e target selection is completed with the move: confirming a charge now declares the enemy units you actually moved into engagement with, so charges whose pre-declared target was dropped by the roll can still be completed against a nearer unit.",
+				"Fire Overwatch is usable by human players again in 10e mode (the confirm button dispatched a format the rules engine rejected; only the AI could ever fire it).",
+				"Fixed a crash in the AI's multi-target charge evaluation that fired every time the AI weighed charging two or more units.",
+				"Rules tightening: charge dice can no longer be re-rolled by re-declaring the charge; unit coherency is checked for the whole unit (a single model can no longer be dragged away from its squad); moving inside one ruin at ground level no longer pays a phantom climb penalty; Heroic Intervention counter-charges evaluate base-contact from the defender's perspective; units in Reserves no longer block charges as phantom 'units at the board corner'."
+			]
+		},
+		{
 			"version": "0.6.0",
 			"date": "2026-07-07",
 			"summary": "The Game Log is clearer, covers more of what happens, and now has per-category filter toggles so you can focus on the events you care about.",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -85,11 +85,12 @@ const FAIL_MUST_END_CLOSER = "MUST_END_CLOSER"
 const FAIL_WALL = "WALL"
 
 # Human-readable explanations for each failure category (teaches players the rules)
+# "{er}" is substituted with the edition's engagement range by get_failure_category_tooltip.
 const FAIL_CATEGORY_TOOLTIPS = {
-	FAIL_INSUFFICIENT_ROLL: "The 2D6 charge roll was too low for any model to reach engagement range (1\") of the declared targets. Try charging closer targets or units with fewer declared targets.",
+	FAIL_INSUFFICIENT_ROLL: "The 2D6 charge roll was too low for any model to reach engagement range ({er}) of the declared targets. Try charging closer targets or units with fewer declared targets.",
 	FAIL_DISTANCE: "A model's movement path exceeded the rolled charge distance. Each model can move at most the rolled distance in inches during a charge move.",
-	FAIL_ENGAGEMENT: "The charging unit must end its move with at least one model within engagement range (1\") of EVERY declared target. If you declared multiple targets, you must reach all of them.",
-	FAIL_NON_TARGET_ER: "No charging model may end within engagement range (1\") of an enemy unit that was NOT declared as a charge target. Plan your movement to avoid non-target enemies.",
+	FAIL_ENGAGEMENT: "The charging unit must end its move with at least one model within engagement range ({er}) of EVERY declared target. If you declared multiple targets, you must reach all of them.",
+	FAIL_NON_TARGET_ER: "No charging model may end within engagement range ({er}) of an enemy unit that was NOT declared as a charge target. Plan your movement to avoid non-target enemies.",
 	FAIL_COHERENCY: "All models in the unit must maintain unit coherency (within 2\" horizontally and 5\" vertically of at least one other model) after the charge move completes.",
 	FAIL_OVERLAP: "Models cannot end their charge movement overlapping with other models (friendly or enemy). Reposition to avoid base overlaps.",
 	FAIL_BASE_CONTACT: "If a charging model CAN make base-to-base contact with an enemy model while still satisfying all other charge conditions, it MUST do so (10e core rule).",
@@ -340,6 +341,16 @@ func _validate_declare_charge(action: Dictionary) -> Dictionary:
 	if unit_id in completed_charges:
 		return {"valid": false, "errors": ["Unit has already charged this phase"]}
 
+	# A unit whose 2D6 are already rolled must resolve that charge (move or
+	# skip) — re-declaring would grant a free re-roll of the charge dice.
+	if pending_charges.has(unit_id) and pending_charges[unit_id].has("distance"):
+		return {"valid": false, "errors": ["Charge roll already made — complete the charge move or skip the unit"]}
+
+	# No new declarations while a Fire Overwatch decision is pending (it would
+	# clobber the overwatch bookkeeping for the charge that triggered it).
+	if awaiting_fire_overwatch:
+		return {"valid": false, "errors": ["Awaiting Fire Overwatch decision"]}
+
 	# T2-9: Check if charging unit has FLY keyword (needed to charge AIRCRAFT targets)
 	var charger_keywords = unit.get("meta", {}).get("keywords", [])
 	var charger_has_fly = "FLY" in charger_keywords
@@ -366,13 +377,24 @@ func _validate_declare_charge(action: Dictionary) -> Dictionary:
 
 func _validate_charge_roll(action: Dictionary) -> Dictionary:
 	var unit_id = action.get("actor_unit_id", "")
-	
+
 	if unit_id == "":
 		return {"valid": false, "errors": ["Missing actor_unit_id"]}
-	
+
 	if not pending_charges.has(unit_id):
 		return {"valid": false, "errors": ["No charge declared for unit"]}
-	
+
+	# Reaction windows pause the flow — no rolling while a decision is pending.
+	if awaiting_ability_reroll or awaiting_reroll_decision:
+		return {"valid": false, "errors": ["Awaiting re-roll decision"]}
+	if awaiting_fire_overwatch:
+		return {"valid": false, "errors": ["Awaiting Fire Overwatch decision"]}
+
+	# The 2D6 are rolled once per declared charge — a repeat CHARGE_ROLL would
+	# grant a free re-roll (only Command Re-roll / abilities may re-roll).
+	if pending_charges[unit_id].has("distance"):
+		return {"valid": false, "errors": ["Charge roll already made for this unit"]}
+
 	return {"valid": true, "errors": []}
 
 func _validate_apply_charge_move(action: Dictionary) -> Dictionary:
@@ -472,9 +494,12 @@ func _process_declare_charge(action: Dictionary) -> Dictionary:
 	var unit_id = action.get("actor_unit_id", "")
 	var target_ids = action.get("payload", {}).get("target_unit_ids", [])
 
-	# Store charge declaration
+	# Store charge declaration. declared_targets preserves the original
+	# declaration so the 11e roll-resolution can re-filter it against the
+	# FINAL roll total (after re-rolls / +N bonuses), not the first raw 2D6.
 	pending_charges[unit_id] = {
 		"targets": target_ids,
+		"declared_targets": target_ids.duplicate(),
 		"declared_at": Time.get_unix_time_from_system()
 	}
 
@@ -575,24 +600,15 @@ func _process_charge_roll(action: Dictionary) -> Dictionary:
 	charge_data.distance = total_distance
 	charge_data.dice_rolls = rolls
 
-	# ISS-049 step 2 (11e 11.02): the roll IS the maximum distance —
-	# targets are selected after the roll, from enemies within 12" AND
-	# within the roll (the pg-37 example). Pre-declared targets that the
-	# roll cannot reach are dropped.
+	# ISS-049 step 2 (11e 11.02): the roll IS the maximum distance — targets
+	# are selected after the roll, from enemies within 12" AND within the
+	# roll (the pg-37 example). This list is PROVISIONAL so paused re-roll
+	# flows can introspect it; _resolve_charge_roll recomputes it from the
+	# FINAL total (after re-rolls / +N charge bonuses) — resolving from the
+	# raw first 2D6 made re-rolled/bonused charges fail against a stale list.
 	if GameConstants.edition >= 11:
 		var tmpl_11e = MoveTypes.get_type("charge")
-		var selectable: Array = tmpl_11e._targets_within(unit_id, GameState.state, min(12.0, float(total_distance)))
-		charge_data["selectable_targets"] = selectable
-		if not charge_data.targets.is_empty():
-			var kept: Array = []
-			for tid in charge_data.targets:
-				if tid in selectable:
-					kept.append(tid)
-				else:
-					log_phase_message("[11e] Charge target %s beyond the roll (%d\") — dropped" % [tid, total_distance])
-			charge_data.targets = kept
-		log_phase_message("[11e] Selectable charge targets after roll of %d: %s" % [total_distance, str(selectable)])
-		emit_signal("charge_targets_available", unit_id, selectable)
+		charge_data["selectable_targets"] = tmpl_11e._targets_within(unit_id, GameState.state, min(12.0, float(total_distance)))
 
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 	var target_ids = charge_data.targets
@@ -714,6 +730,28 @@ func _resolve_charge_roll(unit_id: String) -> Dictionary:
 			unit_name, charge_data.dice_rolls[0] + charge_data.dice_rolls[1], charge_bonus, total_distance
 		]))
 
+	# ISS-049 step 2 (11e 11.02): targets are selected after the roll, from
+	# enemies within 12" AND within the roll. Computed HERE — from the FINAL
+	# total (after re-rolls and +N bonuses) — and the original declaration is
+	# re-filtered against it. Pre-declared targets the roll cannot reach are
+	# dropped; ones a re-roll newly reaches come back.
+	if GameConstants.edition >= 11:
+		var tmpl_11e = MoveTypes.get_type("charge")
+		var selectable: Array = tmpl_11e._targets_within(unit_id, GameState.state, min(12.0, float(total_distance)))
+		charge_data["selectable_targets"] = selectable
+		var declared: Array = charge_data.get("declared_targets", charge_data.targets)
+		if not declared.is_empty():
+			var kept: Array = []
+			for tid in declared:
+				if tid in selectable:
+					kept.append(tid)
+				else:
+					log_phase_message("[11e] Charge target %s beyond the roll (%d\") — dropped" % [tid, total_distance])
+			charge_data.targets = kept
+			target_ids = kept
+		log_phase_message("[11e] Selectable charge targets after roll of %d: %s" % [total_distance, str(selectable)])
+		emit_signal("charge_targets_available", unit_id, selectable)
+
 	# Server-side feasibility check: can any model reach engagement range?
 	var roll_sufficient = _is_charge_roll_sufficient(unit_id, total_distance)
 	var min_distance = _get_min_distance_to_any_target(unit_id, target_ids)
@@ -725,7 +763,13 @@ func _resolve_charge_roll(unit_id: String) -> Dictionary:
 	if GameConstants.edition >= 11 and target_ids.is_empty():
 		var selectable_11e: Array = charge_data.get("selectable_targets", [])
 		roll_sufficient = not selectable_11e.is_empty()
-		min_distance = _get_min_distance_to_any_target(unit_id, selectable_11e)
+		# For the log/failure record, measure against something meaningful:
+		# the selectable list, or (if the roll reached nothing) the original
+		# declaration — an empty list read as "nearest target is inf\" away".
+		var md_ids: Array = selectable_11e
+		if md_ids.is_empty():
+			md_ids = charge_data.get("declared_targets", [])
+		min_distance = _get_min_distance_to_any_target(unit_id, md_ids)
 		log_phase_message("[11e] No pre-declared targets — charge %s (selectable: %s)" % [
 			"continues, select targets with the move" if roll_sufficient else "FAILED (nothing reachable)",
 			str(selectable_11e)])
@@ -1808,6 +1852,9 @@ func _validate_engagement_range_constraints(unit_id: String, per_model_paths: Di
 		if enemy_unit_id in target_ids:
 			continue  # Skip declared targets
 
+		if not _is_unit_on_board(enemy_unit):
+			continue  # Issue #320: Reserves units have no board position — they'd read as (0,0)
+
 		# Check if any charging model ends in ER of this non-target
 		for model_id in per_model_paths:
 			var path = per_model_paths[model_id]
@@ -1841,13 +1888,31 @@ func _validate_unit_coherency_for_charge(unit_id: String, per_model_paths: Dicti
 
 	# Build model dicts with final positions for shape-aware distance checks
 	var final_models = []
+	var moved_ids := {}
 	for model_id in per_model_paths:
 		var path = per_model_paths[model_id]
 		if path is Array and path.size() > 0:
+			moved_ids[model_id] = true
 			var model = _get_model_in_unit(unit_id, model_id)
 			var model_at_final = model.duplicate()
 			model_at_final["position"] = Vector2(path[-1][0], path[-1][1])
 			final_models.append(model_at_final)
+
+	# Coherency is a whole-unit condition: include the UNMOVED alive models at
+	# their current positions. Checking only the moved subset let a single
+	# dragged model legally break away from the rest of its unit.
+	var unit = get_unit(unit_id)
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		if model.get("position") == null:
+			continue
+		var mid = model.get("id", "")
+		if moved_ids.has(mid):
+			continue
+		var model_at_current = model.duplicate()
+		model_at_current["position"] = _get_model_position(model)
+		final_models.append(model_at_current)
 
 	if final_models.size() < 2:
 		return {"valid": true, "errors": []}  # Single model or no movement
@@ -1874,7 +1939,10 @@ func _validate_base_to_base_possible(unit_id: String, per_model_paths: Dictionar
 	# with an enemy model while satisfying all other constraints, it MUST.
 	var errors = []
 	var all_units = game_state_snapshot.get("units", {})
-	var current_player = get_current_player()
+	# "Friendly" is relative to the CHARGING UNIT's owner, not the active
+	# player — a Heroic Intervention charge is made by the DEFENDER (same
+	# fix as _validate_engagement_range_constraints).
+	var charging_owner = int(get_unit(unit_id).get("owner", get_current_player()))
 
 	# Threshold for considering models in base-to-base contact (inches)
 	# Accounts for floating-point imprecision in shape-aware distance calculations
@@ -1978,10 +2046,12 @@ func _validate_base_to_base_possible(unit_id: String, per_model_paths: Dictionar
 			var non_target_er_ok = true
 			for enemy_unit_id in all_units:
 				var enemy_unit = all_units[enemy_unit_id]
-				if enemy_unit.get("owner", 0) == current_player:
+				if int(enemy_unit.get("owner", 0)) == charging_owner:
 					continue
 				if enemy_unit_id in target_ids:
 					continue
+				if not _is_unit_on_board(enemy_unit):
+					continue  # Issue #320: Reserves units have no board position
 
 				for enemy_model in enemy_unit.get("models", []):
 					if not enemy_model.get("alive", true):
@@ -2554,11 +2624,13 @@ func get_failed_charge_attempts() -> Array:
 	return failed_charge_attempts
 
 func get_failure_category_tooltip(category: String) -> String:
-	return FAIL_CATEGORY_TOOLTIPS.get(category, "Charge failed due to an unknown constraint.")
+	var text: String = FAIL_CATEGORY_TOOLTIPS.get(category, "Charge failed due to an unknown constraint.")
+	return text.replace("{er}", "%.0f\"" % GameConstants.engagement_range_inches())
 
 func record_insufficient_roll_failure(unit_id: String, rolled_distance: int, dice: Array, target_ids: Array, min_distance: float) -> void:
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
-	var detail = "Rolled %d\" but nearest target is %.1f\" away (need to close to within 1\" engagement range)" % [rolled_distance, min_distance]
+	var er_in = GameConstants.engagement_range_inches()
+	var detail = "Rolled %d\" but nearest target is %.1f\" away (need to close to within %.0f\" engagement range)" % [rolled_distance, min_distance, er_in]
 	var failure_record = {
 		"unit_id": unit_id,
 		"unit_name": unit_name,
@@ -2578,9 +2650,21 @@ func has_pending_charge(unit_id: String) -> bool:
 
 func _is_charge_roll_sufficient(unit_id: String, rolled_distance: int) -> bool:
 	"""Check if the rolled distance is sufficient for at least one model to reach
-	engagement range (1") of at least one target model in any declared target unit.
+	engagement range of at least one target model in any declared target unit.
 	This is the server-side feasibility check performed immediately after the roll.
-	T2-8: Now accounts for terrain vertical distance penalties along the charge path."""
+	T2-8: Accounts for terrain vertical distance penalties along the charge path.
+
+	Charge-fix (false INSUFFICIENT_ROLL): the old check penalized the full
+	straight line from model centre to target centre. But (a) a charging model
+	stops as soon as it reaches engagement range — terrain beyond that point is
+	never crossed — and (b) the real charge move validator scores the PLAYER'S
+	drawn path, which may legally go around terrain. Both made this pre-check
+	strictly harsher than the move it gates, failing makeable charges (e.g. a
+	6\" roll vs a target 2.5\" away with a ruin corner clipping the line).
+	Now: cost = distance travelled to the ER stop point + penalties on that
+	travelled portion, and if the straight approach pays a penalty we also try
+	detour paths around the offending terrain, mirroring what
+	_validate_charge_movement_constraints would accept."""
 	var unit = get_unit(unit_id)
 	if unit.is_empty():
 		return false
@@ -2596,11 +2680,13 @@ func _is_charge_roll_sufficient(unit_id: String, rolled_distance: int) -> bool:
 	var unit_keywords = unit.get("meta", {}).get("keywords", [])
 	var has_fly = "FLY" in unit_keywords
 
+	# Pass 1 (cheap): straight approach, stopping at engagement range.
+	# Collect pairs whose raw distance fits the roll but whose straight
+	# approach pays a terrain penalty — those get the detour pass.
+	var detour_candidates: Array = []
 	for model in unit.get("models", []):
 		if not model.get("alive", true):
 			continue
-
-		var model_pos = _get_model_position(model)
 
 		for target_id in target_ids:
 			var target_unit = get_unit(target_id)
@@ -2611,22 +2697,90 @@ func _is_charge_roll_sufficient(unit_id: String, rolled_distance: int) -> bool:
 				if not target_model.get("alive", true):
 					continue
 
-				# Edge-to-edge distance in inches, minus engagement range
-				var distance_inches = Measurement.model_to_model_distance_inches(model, target_model)
-				# T3-9: Use barricade-aware engagement range
-				var target_pos = _get_model_position(target_model)
-				var effective_er = _get_effective_engagement_range(model_pos, target_pos)
-				var distance_to_close = distance_inches - effective_er
-
-				# T2-8: Add terrain penalty for the straight-line path
-				var terrain_penalty = _calculate_path_terrain_penalty(
-					[model_pos, target_pos], has_fly, unit_keywords)
-				var effective_distance = distance_to_close + terrain_penalty
-
-				if effective_distance <= rolled_distance:
+				var direct = _direct_charge_cost(model, target_model, has_fly, unit_keywords)
+				if direct.cost <= float(rolled_distance) + MOVEMENT_CAP_EPSILON:
 					return true
+				# Any path is at least `required` long, so only pairs whose raw
+				# required distance fits the roll can be saved by a detour.
+				if direct.required <= float(rolled_distance) + MOVEMENT_CAP_EPSILON:
+					detour_candidates.append({
+						"model": model, "target_model": target_model,
+						"required": direct.required,
+					})
+
+	# Pass 2: try paths around the penalizing terrain for the closest few pairs.
+	detour_candidates.sort_custom(func(a, b): return a.required < b.required)
+	var tried := 0
+	for cand in detour_candidates:
+		if tried >= 4:
+			break
+		tried += 1
+		var around_cost = _detour_charge_cost(cand.model, cand.target_model, has_fly, unit_keywords, float(rolled_distance))
+		DebugLogger.info(str("ChargePhase: charge feasibility detour cost %.2f\" (roll %d\", required %.2f\")" % [around_cost, rolled_distance, cand.required]))
+		if around_cost <= float(rolled_distance) + MOVEMENT_CAP_EPSILON:
+			return true
 
 	return false
+
+func _direct_charge_cost(model: Dictionary, target_model: Dictionary, has_fly: bool, unit_keywords: Array) -> Dictionary:
+	"""Effective cost (inches) for `model` to charge straight at `target_model`,
+	stopping as soon as its base reaches engagement range. Returns
+	{required: raw distance to close, cost: required + terrain penalties on the
+	travelled portion of the line}."""
+	var a = _get_model_position(model)
+	var b = _get_model_position(target_model)
+	var edge_dist_in = Measurement.model_to_model_distance_inches(model, target_model)
+	var er_in = _get_effective_engagement_range(a, b)
+	var required_in = maxf(0.0, edge_dist_in - er_in)
+	if required_in <= 0.0:
+		return {"required": 0.0, "cost": 0.0}
+	var dir = b - a
+	if dir.length() < 0.001:
+		return {"required": required_in, "cost": required_in}
+	# Penalties only accrue on the portion of the line actually travelled.
+	var stop_pt = a + dir.normalized() * Measurement.inches_to_px(required_in)
+	var penalty = _calculate_path_terrain_penalty([a, stop_pt], has_fly, unit_keywords)
+	return {"required": required_in, "cost": required_in + penalty}
+
+func _detour_charge_cost(model: Dictionary, target_model: Dictionary, has_fly: bool, unit_keywords: Array, budget_inches: float) -> float:
+	"""Cheapest cost (inches, straight-drag length + terrain penalties) over
+	candidate FINAL positions sampled on the engagement ring around
+	`target_model`. Both the drag UI and the AI submit 2-point paths
+	(origin -> final), so this is exactly the cost model
+	_validate_charge_movement_constraints will apply — a sample within the
+	budget means a confirmable move exists (e.g. angling around a ruin corner
+	instead of over it)."""
+	var a = _get_model_position(model)
+	var b = _get_model_position(target_model)
+	var edge_dist_in = Measurement.model_to_model_distance_inches(model, target_model)
+	var er_in = _get_effective_engagement_range(a, b)
+	var required_in = maxf(0.0, edge_dist_in - er_in)
+	if required_in <= 0.0:
+		return 0.0
+	var center_dist_px = a.distance_to(b)
+	# Centre distance at which the bases are exactly ER apart along this
+	# bearing (base-shape allowance baked in) — the "stop ring" around b.
+	var ring_px = maxf(0.0, center_dist_px - Measurement.inches_to_px(required_in))
+	if ring_px <= 0.0:
+		return required_in + _calculate_path_terrain_penalty([a, b], has_fly, unit_keywords)
+	var budget_px = Measurement.inches_to_px(budget_inches)
+
+	var best := INF
+	const RING_SAMPLES := 24
+	for i in range(RING_SAMPLES):
+		var ang = TAU * float(i) / float(RING_SAMPLES)
+		var final_pos = b + Vector2(cos(ang), sin(ang)) * ring_px
+		# Cheap lower-bound cull before the terrain-penalty sweep
+		if a.distance_to(final_pos) > budget_px + 1.0:
+			continue
+		var cost = _charge_segment_cost(a, final_pos, has_fly, unit_keywords)
+		best = minf(best, cost)
+		if best <= budget_inches:
+			break
+	return best
+
+func _charge_segment_cost(p: Vector2, q: Vector2, has_fly: bool, unit_keywords: Array) -> float:
+	return Measurement.px_to_inches(p.distance_to(q)) + _calculate_path_terrain_penalty([p, q], has_fly, unit_keywords)
 
 func _get_charge_reroll_ability_name(unit_id: String) -> String:
 	"""OA-23: Determine which ability granted the charge reroll flag for display purposes."""
@@ -2672,7 +2826,10 @@ func get_charge_distance(unit_id: String) -> int:
 
 func _validate_use_fire_overwatch(action: Dictionary) -> Dictionary:
 	var errors = []
-	var unit_id = action.get("unit_id", "")
+	# The overwatching unit arrives as `unit_id` from the AI but as
+	# `actor_unit_id` from the human dialog / get_available_actions — accept
+	# both (reading only `unit_id` made human Fire Overwatch always reject).
+	var unit_id = action.get("unit_id", action.get("actor_unit_id", ""))
 	var player = action.get("player", fire_overwatch_player)
 
 	if not awaiting_fire_overwatch:
@@ -2715,7 +2872,7 @@ func _validate_decline_fire_overwatch(action: Dictionary) -> Dictionary:
 	return {"valid": true, "errors": []}
 
 func _process_use_fire_overwatch(action: Dictionary) -> Dictionary:
-	var unit_id = action.get("unit_id", "")
+	var unit_id = action.get("unit_id", action.get("actor_unit_id", ""))
 	var player = action.get("player", fire_overwatch_player)
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 	var enemy_unit_id = fire_overwatch_enemy_unit_id

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -11386,10 +11386,11 @@ static func _score_multi_target_combo(
 	# A model can reach ~base_radius + 1" ER in each direction, so targets must be
 	# within about charger_diameter + 2" of each other (plus target base sizes).
 	var charger_base_mm = charger.get("meta", {}).get("base_mm", 32)
-	var charger_models = charger.get("models", {})
+	# `models` is an Array of model dicts — indexing it with the loop variable
+	# (a dict) crashed every multi-target combo evaluation the AI attempted.
+	var charger_models = charger.get("models", [])
 	var num_charger_models = 0
-	for _mid in charger_models:
-		var m = charger_models[_mid]
+	for m in charger_models:
 		if m.get("current_wounds", 1) > 0 and m.get("position") != null:
 			num_charger_models += 1
 	var charger_reach_inches = (float(charger_base_mm) / 25.4) + 2.0

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -24,6 +24,7 @@ var awaiting_roll: bool = false
 var awaiting_movement: bool = false
 var last_processed_charge_roll: Dictionary = {}  # Tracks last processed roll to prevent duplicates
 var _pending_complete_unit_id: String = ""  # Unit awaiting COMPLETE_UNIT_CHARGE after charge_resolved
+var _last_apply_rejection: Dictionary = {}  # Set by Main via on_charge_move_rejected when APPLY_CHARGE_MOVE fails validation
 
 # Charge movement tracking
 var models_to_move: Array = []  # Models that still need to move
@@ -967,9 +968,9 @@ func _is_charge_successful(unit_id: String, rolled_distance: int, target_ids: Ar
 				if target_pos == null:
 					continue
 
-				# Edge-to-edge distance in inches, minus engagement range (1")
+				# Edge-to-edge distance in inches, minus the edition's engagement range
 				var distance_inches = Measurement.model_to_model_distance_inches(model, target_model)
-				var distance_to_close = distance_inches - 1.0  # 1" engagement range
+				var distance_to_close = distance_inches - GameConstants.engagement_range_inches()
 
 				# T2-8: Add terrain penalty for straight-line path
 				var terrain_penalty = _calculate_terrain_penalty_for_path(model_pos, target_pos)
@@ -1105,7 +1106,7 @@ func _show_target_engagement_visuals(unit_id: String) -> void:
 			var er_visual = preload("res://scripts/EngagementRangeVisual.gd").new()
 			var base_mm = target_model.get("base_mm", 32)
 			var base_radius_px = Measurement.base_radius_px(base_mm)
-			var er_px = Measurement.inches_to_px(1.0)  # 1" engagement range
+			var er_px = Measurement.inches_to_px(GameConstants.engagement_range_inches())  # edition-aware ER
 			er_visual.setup_engagement_range(base_radius_px + er_px, Color(1.0, 0.5, 0.0, 0.5))
 			er_visual.position = target_pos
 			board_root.add_child(er_visual)
@@ -1867,8 +1868,37 @@ func _on_confirm_charge_moves() -> void:
 		}
 	}
 
+	# ISS-049 (11e 11.02): targets are SELECTED WITH THE MOVE — send the enemy
+	# units the final positions actually engage. Without this the server keeps
+	# whatever survived the pre-roll declaration; if the roll dropped them all,
+	# the confirm was rejected ("No charge targets selected") with no UI to fix it.
+	if GameConstants.edition >= 11 and not is_hi_move:
+		var inferred_targets = _infer_11e_targets_from_moves(per_model_paths)
+		if not inferred_targets.is_empty():
+			action.payload["target_unit_ids"] = inferred_targets
+			print("ChargeController: [11e] targets selected with the move: ", inferred_targets)
+
 	print("Requesting apply charge move: ", action)
+	_last_apply_rejection = {}
 	charge_action_requested.emit(action)
+
+	# Single-player processes the action synchronously — if the server rejected
+	# the move (Main calls on_charge_move_rejected), the charge and its roll are
+	# still pending: keep movement mode alive so the player can re-position,
+	# instead of silently pretending the charge concluded.
+	if not _last_apply_rejection.is_empty():
+		_last_apply_rejection = {}
+		moved_models.clear()
+		_moved_model_order.clear()
+		# Token visuals are re-synced to GameState (pre-drag origins) by
+		# Main.update_after_charge_action(); drag ghosts/lines are stale now.
+		_clear_movement_visuals()
+		awaiting_movement = true
+		_pending_complete_unit_id = ""
+		if is_instance_valid(confirm_button):
+			confirm_button.visible = true
+		_update_button_states()
+		return
 
 	# Clear the movement state
 	moved_models.clear()
@@ -1882,6 +1912,71 @@ func _on_confirm_charge_moves() -> void:
 
 	# Update UI for next charge selection
 	_update_ui_for_next_charge()
+
+func on_charge_move_rejected(action: Dictionary, result: Dictionary) -> void:
+	"""Called by Main when the server rejects APPLY_CHARGE_MOVE validation.
+	Records the rejection (consumed by _on_confirm_charge_moves to keep the
+	movement mode alive) and tells the player why in the dice log."""
+	_last_apply_rejection = {"action": action, "result": result}
+	var errs: Array = result.get("errors", [])
+	var msg: String = str(errs[0]) if not errs.is_empty() else str(result.get("error", "move does not satisfy charge constraints"))
+	if is_instance_valid(dice_log_display):
+		dice_log_display.append_text("[color=red]Charge move rejected:[/color] %s — re-position the models and confirm again.\n" % msg)
+	if is_instance_valid(charge_info_label):
+		charge_info_label.text = "Move rejected: %s" % msg
+	print("ChargeController: charge move rejected — %s" % msg)
+
+func _infer_11e_targets_from_moves(per_model_paths: Dictionary) -> Array:
+	"""11e 11.02: the charge targets are the enemy units the unit actually ends
+	engaged with. Derive them from the final model positions; when the phase's
+	selectable list is available (host), filter to it so an accidental brush
+	against a non-selectable unit still surfaces as a non-target-ER error."""
+	var unit = GameState.get_unit(active_unit_id)
+	if unit.is_empty():
+		return []
+
+	# Final-position model dicts for the shape-aware ER test
+	var final_models: Array = []
+	for model_id in per_model_paths:
+		var path = per_model_paths[model_id]
+		if path is Array and path.size() > 0:
+			for model in unit.get("models", []):
+				if model.get("id", "") == model_id:
+					var at_final = model.duplicate()
+					at_final["position"] = Vector2(path[-1][0], path[-1][1])
+					final_models.append(at_final)
+					break
+	if final_models.is_empty():
+		return []
+
+	var selectable: Array = []
+	if current_phase != null and current_phase.has_method("get_pending_charges"):
+		var pending = current_phase.get_pending_charges()
+		if pending.has(active_unit_id):
+			selectable = pending[active_unit_id].get("selectable_targets", [])
+
+	var my_owner = int(unit.get("owner", 0))
+	var out: Array = []
+	var er_inches = GameConstants.engagement_range_inches()
+	for enemy_id in GameState.state.get("units", {}):
+		var enemy = GameState.state.units[enemy_id]
+		if int(enemy.get("owner", 0)) == my_owner:
+			continue
+		if not selectable.is_empty() and not (enemy_id in selectable):
+			continue
+		var engaged := false
+		for fm in final_models:
+			for em in enemy.get("models", []):
+				if not em.get("alive", true) or em.get("position") == null:
+					continue
+				if Measurement.is_in_engagement_range_shape_aware(fm, em, er_inches):
+					engaged = true
+					break
+			if engaged:
+				break
+		if engaged:
+			out.append(enemy_id)
+	return out
 
 func _on_declare_charge_pressed() -> void:
 	if active_unit_id == "" or selected_targets.is_empty():
@@ -2382,12 +2477,13 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 		# Server determined charge roll insufficient — show failure, let charge_resolved
 		# (re-emitted by NetworkManager) handle the full UI update.
 		awaiting_movement = false
-		var needed = max(0.0, min_distance - 1.0)
+		var er_inches = GameConstants.engagement_range_inches()
+		var needed = max(0.0, min_distance - er_inches)
 
 		if is_instance_valid(charge_info_label):
 			charge_info_label.text = "Failed! Rolled %d\" but needed ~%.1f\" to reach engagement range" % [total, needed]
 		if is_instance_valid(dice_log_display):
-			dice_log_display.append_text("[color=red][INSUFFICIENT_ROLL] Charge failed![/color] Rolled %d\" but nearest target is %.1f\" away (need ~%.1f\" to reach 1\" engagement range).\n" % [total, min_distance, needed])
+			dice_log_display.append_text("[color=red][INSUFFICIENT_ROLL] Charge failed![/color] Rolled %d\" but nearest target is %.1f\" away (need ~%.1f\" to reach %.0f\" engagement range).\n" % [total, min_distance, needed, er_inches])
 
 		# T7-58: Update arrows with failure result
 		_update_charge_arrow_roll_results(total, false)
@@ -3345,8 +3441,8 @@ func _update_charge_trajectory_preview(unit: Dictionary, unit_center: Vector2) -
 					closest_target_pos = target_pos
 
 		if closest_target_pos != Vector2.ZERO and closest_dist_inches < INF:
-			# Distance needed = edge-to-edge minus 1" engagement range
-			var charge_distance_needed = maxf(closest_dist_inches - 1.0, 0.0)
+			# Distance needed = edge-to-edge minus the edition's engagement range
+			var charge_distance_needed = maxf(closest_dist_inches - GameConstants.engagement_range_inches(), 0.0)
 
 			# Add terrain penalty for straight-line path
 			var terrain_penalty = _calculate_terrain_penalty_for_path(model_pos, closest_target_pos)

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -9354,8 +9354,27 @@ func _on_charge_action_requested(action: Dictionary) -> void:
 				# Update UI after successful action (state changes applied by BasePhase)
 				update_after_charge_action()
 		else:
-			print("Main: Charge action failed: ", result.get("error", "Unknown error"))
+			# BasePhase validation failures carry `errors` (array); processing
+			# failures carry `error` (string) — surface whichever exists.
+			var charge_errs: Array = result.get("errors", [])
+			var charge_error_msg: String = str(result.get("error", ""))
+			if charge_error_msg == "" and not charge_errs.is_empty():
+				charge_error_msg = str(charge_errs[0])
+			if charge_error_msg == "":
+				charge_error_msg = "Unknown error"
+			print("Main: Charge action failed: ", charge_error_msg)
 			print("Main: Full charge action result: ", result)
+			var charge_action_type = action.get("type", "")
+			if charge_action_type == "APPLY_CHARGE_MOVE" or charge_action_type == "APPLY_HEROIC_INTERVENTION_MOVE":
+				# A rejected charge move previously vanished silently: no toast,
+				# and the dragged token visuals stayed at the drop spots while
+				# GameState kept the origins. Tell the player why and re-sync.
+				ToastManager.show_error("Charge move rejected: %s" % charge_error_msg)
+				update_after_charge_action()
+				if charge_controller and charge_controller.has_method("on_charge_move_rejected"):
+					charge_controller.on_charge_move_rejected(action, result)
+			else:
+				ToastManager.show_error("Charge action failed: %s" % charge_error_msg)
 	else:
 		print("Main: Unexpected result from charge action")
 

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -100,6 +100,7 @@ TESTS=(
     "tests/test_iss057_actions_11e.gd"
     "tests/test_iss058_disembark_11e.gd"
     "tests/test_iss049_charge_11e.gd"
+    "tests/test_charge_phase_fixes.gd"
     "tests/test_iss041b_resolution_11e.gd"
     "tests/test_iss016_modifier_stack.gd"
     "tests/test_iss045_allocation_overlay.gd"

--- a/40k/tests/scenarios/sp/charge_over_ruin_corner_succeeds.json
+++ b/40k/tests/scenarios/sp/charge_over_ruin_corner_succeeds.json
@@ -1,0 +1,77 @@
+{
+  "id": "charge_over_ruin_corner_succeeds",
+  "covers": ["charge.bug.false_insufficient_roll", "charge.terrain.stop_at_engagement_range", "charge.terrain.path_around_corner"],
+  "fixture": "audit_372_charge_modifier",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Regression for the false [INSUFFICIENT_ROLL] failure: a Battlewagon (VEHICLE, non-INFANTRY) sits 2.5\" edge-to-edge from a Blade Champion with an injected 6\"-tall ruin strip clipping the straight centre-to-centre line (straight-line climb penalty 12\"). Before the fix, a charge roll of 6 was declared failed ('Rolled 6\" but nearest target is 2.5\" away') even though the model only needs ~0.5\" of movement to reach the 11e 2\" engagement range and never touches the ruin. After the fix the roll succeeds and the charge completes into base contact.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_BATTLEWAGON_G\"].models[0].merge({\"position\": {\"x\": 700.0, \"y\": 2150.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].merge({\"position\": {\"x\": 973.0, \"y\": 2150.0}}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.append({\"id\": \"repro_tall_ruin\", \"type\": \"ruins\", \"polygon\": PackedVector2Array([Vector2(900, 2060), Vector2(940, 2060), Vector2(940, 2155), Vector2(900, 2155)]), \"height_category\": \"tall\", \"position\": Vector2(920, 2107), \"size\": Vector2(40, 95), \"rotation\": 0.0, \"can_move_through\": {\"INFANTRY\": true, \"VEHICLE\": false, \"MONSTER\": false}})" },
+
+    { "act": "execute_script",
+      "script": "Measurement.model_to_model_distance_inches(GameState.state.units[\"U_BATTLEWAGON_G\"].models[0], GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0])",
+      "expect_max": 2.6 },
+    { "act": "execute_script",
+      "script": "TerrainManager.calculate_charge_terrain_penalty(Vector2(700, 2150), Vector2(973, 2150), false, [\"VEHICLE\"])",
+      "expect_min": 12.0 },
+    { "act": "screenshot", "label": "01_setup_ruin_between" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DECLARE_CHARGE",
+      "actor_unit_id": "U_BATTLEWAGON_G",
+      "payload": { "target_unit_ids": ["U_BLADE_CHAMPION_A"] }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "CHARGE_ROLL",
+      "actor_unit_id": "U_BATTLEWAGON_G",
+      "payload": { "rng_seed": 15 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_action_result", "path": "charge_failed", "equals": false },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().has_pending_charge(\"U_BATTLEWAGON_G\")",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().get_failed_charge_attempts().size()",
+      "equals": 0 },
+    { "act": "screenshot", "label": "02_roll_of_6_succeeded" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "APPLY_CHARGE_MOVE",
+      "actor_unit_id": "U_BATTLEWAGON_G",
+      "payload": {
+        "per_model_paths": { "m1": [[700.0, 2150.0], [799.7716, 2150.0]] },
+        "per_model_rotations": {}
+      }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.U_BATTLEWAGON_G.flags.charged_this_turn", "equals": true },
+    { "act": "expect_state", "path": "units.U_BATTLEWAGON_G.flags.fights_first", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "COMPLETE_UNIT_CHARGE",
+      "actor_unit_id": "U_BATTLEWAGON_G"
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_token_visible", "unit_id": "U_BATTLEWAGON_G" },
+    { "act": "screenshot", "label": "03_charge_completed_base_contact" }
+  ]
+}

--- a/40k/tests/test_charge_phase_fixes.gd
+++ b/40k/tests/test_charge_phase_fixes.gd
@@ -1,0 +1,333 @@
+extends SceneTree
+
+# Charge-phase bug-fix regression suite (charge-phase-bugs branch).
+# Pins the fixes for:
+#   1. False INSUFFICIENT_ROLL: the pre-roll feasibility check penalized the
+#      full straight centre-to-centre line — a 6" roll vs a target 2.5" away
+#      behind a ruin corner was declared failed. Now the model stops at
+#      engagement range and may angle around terrain (ring sampling that
+#      mirrors the 2-point paths the drag UI / AI actually submit).
+#   2. TerrainManager: a segment wholly inside one footprint (no wall crossed)
+#      paid a phantom climb penalty.
+#   3. 11e selectable_targets recomputed from the FINAL total (after Command
+#      Re-roll / +N bonuses), not the raw first 2D6.
+#   4. Double CHARGE_ROLL / re-DECLARE after a roll are rejected.
+#   5. USE_FIRE_OVERWATCH accepts actor_unit_id (human dialog format).
+#   6. _validate_base_to_base_possible judges friend/foe from the CHARGING
+#      unit's owner (Heroic Intervention correctness).
+#   7. Unit coherency for charges includes UNMOVED models.
+#   8. Non-target ER check skips Reserves units (they read as (0,0)).
+#
+# Usage: godot --headless --path . -s tests/test_charge_phase_fixes.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.2).timeout.connect(_run_tests)
+
+func _make_unit(id: String, owner: int, keywords: Array, positions: Array, base_mm: int = 32) -> Dictionary:
+	var models = []
+	for i in range(positions.size()):
+		var pos = positions[i]
+		models.append({
+			"id": "m%d" % (i + 1),
+			"alive": true,
+			"current_wounds": 4,
+			"wounds": 4,
+			"base_mm": base_mm,
+			"base_type": "circular",
+			"position": ({"x": pos.x, "y": pos.y} if pos != null else null),
+		})
+	return {
+		"id": id, "squad_id": id, "owner": owner,
+		"status": GameStateData.UnitStatus.DEPLOYED,
+		"flags": {},
+		"meta": {"name": id, "keywords": keywords, "stats": {"move": 6, "toughness": 4, "save": 4, "wounds": 4}},
+		"models": models,
+		"embarked_in": null,
+	}
+
+func _tall_ruin(id: String, x0: float, y0: float, x1: float, y1: float) -> Dictionary:
+	return {
+		"id": id, "type": "ruins",
+		"polygon": PackedVector2Array([Vector2(x0, y0), Vector2(x1, y0), Vector2(x1, y1), Vector2(x0, y1)]),
+		"height_category": "tall",
+		"position": Vector2((x0 + x1) / 2.0, (y0 + y1) / 2.0),
+		"size": Vector2(x1 - x0, y1 - y0), "rotation": 0.0,
+		"can_move_through": {"INFANTRY": true, "VEHICLE": false, "MONSTER": false},
+	}
+
+func _setup_state(units: Dictionary, active_player: int = 2) -> void:
+	var gs = root.get_node("GameState")
+	gs.state = {
+		"meta": {"phase": GameStateData.Phase.CHARGE, "active_player": active_player, "battle_round": 1, "turn_number": 1, "game_id": "test"},
+		"units": units,
+		"players": {"1": {"cp": 0, "vp": 0}, "2": {"cp": 0, "vp": 0}},
+		"board": {"terrain": []},
+		"phase_log": [],
+	}
+
+func _new_phase() -> Node:
+	var phase = load("res://phases/ChargePhase.gd").new()
+	root.add_child(phase)
+	phase._on_phase_enter()
+	return phase
+
+func _tm() -> Node:
+	return root.get_node("TerrainManager")
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_charge_phase_fixes ===")
+	var prev_edition = GameConstants.edition
+
+	_test_feasibility_around_ruin_corner()
+	_test_feasibility_stops_at_er()
+	_test_feasibility_genuinely_blocked()
+	_test_wholly_inside_no_penalty()
+	_test_11e_selectable_recomputed_after_reroll()
+	_test_roll_and_declare_guards()
+	_test_fire_overwatch_actor_unit_id()
+	_test_b2b_owner_perspective()
+	_test_coherency_includes_unmoved()
+	_test_reserves_not_at_origin()
+
+	GameConstants.edition = prev_edition
+	print("\n=== %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)
+
+# -- 1a. The reported bug: roll 6, target ~2.5" away, tall ruin corner clips the line --
+func _test_feasibility_around_ruin_corner() -> void:
+	print("\n-- feasibility: path around a ruin corner (reported bug) --")
+	GameConstants.edition = 11
+	# Rect-based charger like the live repro (Battlewagon geometry): edge gap 2.49"
+	var charger = _make_unit("U_CHG", 2, ["VEHICLE"], [Vector2(700, 2150)])
+	charger.models[0]["base_type"] = "rectangular"
+	charger.models[0]["base_mm"] = 180
+	charger.models[0]["base_dimensions"] = {"length": 180, "width": 110}
+	charger.models[0]["rotation"] = 0.0
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(973, 2150)], 40)
+	_setup_state({"U_CHG": charger, "U_TGT": target})
+	_tm().terrain_features.clear()
+	_tm().terrain_features.append(_tall_ruin("corner_ruin", 900, 2060, 940, 2155))
+
+	var phase = _new_phase()
+	phase.pending_charges["U_CHG"] = {"targets": ["U_TGT"], "declared_targets": ["U_TGT"]}
+	var straight_penalty = _tm().calculate_charge_terrain_penalty(Vector2(700, 2150), Vector2(973, 2150), false, ["VEHICLE"])
+	_check("straight line pays the climb penalty (12\")", straight_penalty >= 12.0, "penalty=%.1f" % straight_penalty)
+	_check("roll of 6 IS sufficient (stops at ER / angles around)", phase._is_charge_roll_sufficient("U_CHG", 6))
+	_check("roll of 2 IS sufficient (only ~0.5\" needed)", phase._is_charge_roll_sufficient("U_CHG", 2))
+
+	# FLY charger (the user's Vertus Praetors case) — same geometry
+	var gs = root.get_node("GameState")
+	gs.state.units["U_CHG"].meta.keywords = ["MOUNTED", "FLY"]
+	_check("FLY charger: roll of 6 sufficient", phase._is_charge_roll_sufficient("U_CHG", 6))
+	phase.queue_free()
+	_tm().terrain_features.clear()
+
+# -- 1b. Penalty only accrues on the travelled portion of the line --
+func _test_feasibility_stops_at_er() -> void:
+	print("\n-- feasibility: model stops at engagement range before the terrain --")
+	GameConstants.edition = 11
+	# 32mm charger 5.6" (edge) from target; ruin sits BEHIND the stop point.
+	var charger = _make_unit("U_CHG", 2, ["VEHICLE"], [Vector2(700, 2150)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(973, 2150)])
+	_setup_state({"U_CHG": charger, "U_TGT": target})
+	_tm().terrain_features.clear()
+	# Ruin hugging the target: straight full line crosses it, travelled part does not
+	_tm().terrain_features.append(_tall_ruin("behind_stop", 930, 2060, 960, 2250))
+
+	var phase = _new_phase()
+	phase.pending_charges["U_CHG"] = {"targets": ["U_TGT"], "declared_targets": ["U_TGT"]}
+	var full_line_penalty = _tm().calculate_charge_terrain_penalty(Vector2(700, 2150), Vector2(973, 2150), false, ["VEHICLE"])
+	_check("full line would pay a penalty", full_line_penalty > 0.0, "penalty=%.1f" % full_line_penalty)
+	_check("roll of 6 sufficient (stop point is before the ruin)", phase._is_charge_roll_sufficient("U_CHG", 6))
+	phase.queue_free()
+	_tm().terrain_features.clear()
+
+# -- 1c. A genuinely blocked charge still fails; INFANTRY passes freely --
+func _test_feasibility_genuinely_blocked() -> void:
+	print("\n-- feasibility: genuinely blocked stays infeasible --")
+	GameConstants.edition = 11
+	var charger = _make_unit("U_CHG", 2, ["VEHICLE"], [Vector2(700, 2150)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(973, 2150)])
+	_setup_state({"U_CHG": charger, "U_TGT": target})
+	_tm().terrain_features.clear()
+	# A 20"-long tall wall between them: every reachable final position's
+	# straight drag line crosses it -> 12" climb applies on every candidate.
+	_tm().terrain_features.append(_tall_ruin("long_wall", 800, 1750, 840, 2550))
+
+	var phase = _new_phase()
+	phase.pending_charges["U_CHG"] = {"targets": ["U_TGT"], "declared_targets": ["U_TGT"]}
+	_check("VEHICLE roll 6 infeasible over 6\"-tall wall", not phase._is_charge_roll_sufficient("U_CHG", 6))
+	_check("VEHICLE roll 12 still infeasible (needed + 12\" climb > 12)", not phase._is_charge_roll_sufficient("U_CHG", 12))
+	var gs = root.get_node("GameState")
+	gs.state.units["U_CHG"].meta.keywords = ["INFANTRY"]
+	_check("INFANTRY same geometry: roll 6 sufficient (walks through)", phase._is_charge_roll_sufficient("U_CHG", 6))
+	# Too-far case, no terrain involved at all
+	_tm().terrain_features.clear()
+	gs.state.units["U_TGT"].models[0].position = {"x": 700.0 + 8.0 * 40.0 + 50.4, "y": 2150.0}
+	_check("8\" away with roll 2: infeasible", not phase._is_charge_roll_sufficient("U_CHG", 2))
+	phase.queue_free()
+
+# -- 2. Wholly-inside segment pays no climb --
+func _test_wholly_inside_no_penalty() -> void:
+	print("\n-- TerrainManager: segment wholly inside one footprint --")
+	_tm().terrain_features.clear()
+	_tm().terrain_features.append(_tall_ruin("big_ruin", 400, 400, 1200, 1200))
+	var pen_vehicle = _tm().calculate_charge_terrain_penalty(Vector2(500, 800), Vector2(1100, 800), false, ["VEHICLE"])
+	var pen_fly = _tm().calculate_charge_terrain_penalty(Vector2(500, 800), Vector2(1100, 800), true, ["FLY"])
+	_check("ground-floor move inside a ruin: no climb (non-FLY)", pen_vehicle == 0.0, "penalty=%.2f" % pen_vehicle)
+	_check("ground-floor move inside a ruin: no climb (FLY)", pen_fly == 0.0, "penalty=%.2f" % pen_fly)
+	var pen_crossing = _tm().calculate_charge_terrain_penalty(Vector2(300, 800), Vector2(1100, 800), false, ["VEHICLE"])
+	_check("crossing INTO the ruin still pays the climb", pen_crossing > 0.0, "penalty=%.2f" % pen_crossing)
+	# difficult_ground trait must keep applying — including wholly inside
+	_tm().terrain_features[0]["traits"] = ["difficult_ground"]
+	var pen_dg_inside = _tm().calculate_charge_terrain_penalty(Vector2(500, 800), Vector2(1100, 800), false, ["VEHICLE"])
+	_check("difficult ground still applies wholly inside", pen_dg_inside == 2.0, "penalty=%.2f" % pen_dg_inside)
+	# On LOW terrain (no climb component) the trait is the whole penalty:
+	# non-FLY pays exactly 2", FLY ignores it entirely.
+	_tm().terrain_features[0]["height_category"] = "low"
+	var pen_dg_low = _tm().calculate_charge_terrain_penalty(Vector2(300, 800), Vector2(1100, 800), false, ["VEHICLE"])
+	_check("difficult ground costs 2\" crossing low terrain", pen_dg_low == 2.0, "penalty=%.2f" % pen_dg_low)
+	var pen_dg_fly = _tm().calculate_charge_terrain_penalty(Vector2(300, 800), Vector2(1100, 800), true, ["FLY"])
+	_check("FLY ignores difficult ground", pen_dg_fly == 0.0, "penalty=%.2f" % pen_dg_fly)
+	_tm().terrain_features.clear()
+
+# -- 3. 11e selectable recomputed after Command Re-roll --
+func _test_11e_selectable_recomputed_after_reroll() -> void:
+	print("\n-- 11e: selectable targets recomputed from the re-rolled total --")
+	GameConstants.edition = 11
+	# Target 7" (edge) away: raw roll of 2 reaches nothing; re-roll of 9 does.
+	var charger = _make_unit("U_CHG", 2, ["INFANTRY"], [Vector2(400, 400)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(400 + 7.0 * 40.0 + 50.4, 400)])
+	_setup_state({"U_CHG": charger, "U_TGT": target})
+	root.get_node("GameState").state.players["2"]["cp"] = 1
+	_tm().terrain_features.clear()
+
+	var phase = _new_phase()
+	var r1 = phase.execute_action({"type": "DECLARE_CHARGE", "actor_unit_id": "U_CHG", "payload": {"target_unit_ids": []}})
+	_check("11e declare with no targets ok", r1.get("success", false), str(r1.get("errors", [])))
+	# seed 3 -> [1,1] = 2 (verified against RNGService)
+	var r2 = phase.execute_action({"type": "CHARGE_ROLL", "actor_unit_id": "U_CHG", "payload": {"rng_seed": 3}})
+	_check("roll of 2 pauses for Command Re-roll", phase.awaiting_reroll_decision, str(r2))
+	# seed 2 -> [5,4] = 9
+	var r3 = phase.execute_action({"type": "USE_COMMAND_REROLL", "actor_unit_id": "U_CHG", "payload": {"rng_seed": 2}})
+	_check("re-roll action succeeded", r3.get("success", false), str(r3.get("errors", [])))
+	var pend = phase.get_pending_charges().get("U_CHG", {})
+	_check("re-rolled total is 9", int(pend.get("distance", 0)) == 9, "distance=%s" % str(pend.get("distance")))
+	_check("selectable recomputed from re-rolled total", "U_TGT" in pend.get("selectable_targets", []),
+		"selectable=%s" % str(pend.get("selectable_targets", [])))
+	_check("charge did NOT fail after re-roll", phase.get_failed_charge_attempts().is_empty(),
+		str(phase.get_failed_charge_attempts()))
+	phase.queue_free()
+
+# -- 4. Double-roll / re-declare guards --
+func _test_roll_and_declare_guards() -> void:
+	print("\n-- guards: one 2D6 per declared charge --")
+	GameConstants.edition = 11
+	var charger = _make_unit("U_CHG", 2, ["INFANTRY"], [Vector2(400, 400)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(400 + 5.0 * 40.0 + 50.4, 400)])
+	_setup_state({"U_CHG": charger, "U_TGT": target})
+	_tm().terrain_features.clear()
+
+	var phase = _new_phase()
+	phase.execute_action({"type": "DECLARE_CHARGE", "actor_unit_id": "U_CHG", "payload": {"target_unit_ids": ["U_TGT"]}})
+	var roll1 = phase.execute_action({"type": "CHARGE_ROLL", "actor_unit_id": "U_CHG", "payload": {"rng_seed": 2}})
+	_check("first roll ok", roll1.get("success", false))
+	var roll2 = phase.execute_action({"type": "CHARGE_ROLL", "actor_unit_id": "U_CHG", "payload": {"rng_seed": 23}})
+	_check("second CHARGE_ROLL rejected", not roll2.get("success", true), str(roll2.get("errors", [])))
+	var redeclare = phase.execute_action({"type": "DECLARE_CHARGE", "actor_unit_id": "U_CHG", "payload": {"target_unit_ids": ["U_TGT"]}})
+	_check("re-DECLARE after roll rejected", not redeclare.get("success", true), str(redeclare.get("errors", [])))
+	phase.queue_free()
+
+# -- 5. Fire Overwatch accepts actor_unit_id --
+func _test_fire_overwatch_actor_unit_id() -> void:
+	print("\n-- Fire Overwatch: actor_unit_id accepted (human dialog format) --")
+	GameConstants.edition = 10  # 11e moved Fire Overwatch to end of Movement phase
+	var charger = _make_unit("U_CHG", 2, ["INFANTRY"], [Vector2(400, 400)])
+	var ow_unit = _make_unit("U_OW", 1, ["INFANTRY"], [Vector2(800, 400)])
+	_setup_state({"U_CHG": charger, "U_OW": ow_unit})
+	root.get_node("GameState").state.players["1"]["cp"] = 1
+
+	var phase = _new_phase()
+	phase.awaiting_fire_overwatch = true
+	phase.fire_overwatch_player = 1
+	phase.fire_overwatch_enemy_unit_id = "U_CHG"
+	phase.fire_overwatch_eligible_units = ["U_OW"]
+	var v_actor = phase._validate_use_fire_overwatch({"type": "USE_FIRE_OVERWATCH", "actor_unit_id": "U_OW", "player": 1})
+	_check("actor_unit_id accepted", v_actor.get("valid", false), str(v_actor.get("errors", [])))
+	var v_unit = phase._validate_use_fire_overwatch({"type": "USE_FIRE_OVERWATCH", "unit_id": "U_OW", "player": 1})
+	_check("unit_id (AI format) still accepted", v_unit.get("valid", false), str(v_unit.get("errors", [])))
+	var v_none = phase._validate_use_fire_overwatch({"type": "USE_FIRE_OVERWATCH", "player": 1})
+	_check("missing unit still rejected", not v_none.get("valid", true))
+	phase.queue_free()
+	GameConstants.edition = 11
+
+# -- 6. B2B constraint judged from the charging unit's owner --
+func _test_b2b_owner_perspective() -> void:
+	print("\n-- base-to-base: friend/foe from the charging unit's owner (HI) --")
+	GameConstants.edition = 10  # 1" ER keeps the geometry tight
+	# Heroic Intervention shape: ACTIVE player is 1, the DEFENDER (owner 2) charges.
+	# U_BLOCK (owner 1, NOT a target) sits right behind the b2b spot, so making
+	# base contact would enter its ER — b2b is not cleanly achievable, and the
+	# 1.9"-short final position must therefore be accepted.
+	var hi_charger = _make_unit("U_DEF", 2, ["INFANTRY"], [Vector2(400, 400)])
+	var atk_target = _make_unit("U_ATK", 1, ["INFANTRY"], [Vector2(400 + 3.0 * 40.0 + 50.4, 400)])
+	var atk_blocker = _make_unit("U_BLOCK", 1, ["INFANTRY"], [Vector2(400 + 3.0 * 40.0 + 50.4 + 60.0, 400)])
+	_setup_state({"U_DEF": hi_charger, "U_ATK": atk_target, "U_BLOCK": atk_blocker}, 1)
+
+	var phase = _new_phase()
+	# Final position 0.9" short of contact: within 1" ER of target, outside ER of blocker.
+	var final_x = 400.0 + (3.0 - 0.9) * 40.0
+	var paths = {"m1": [[400.0, 400.0], [final_x, 400.0]]}
+	var result = phase._validate_base_to_base_possible("U_DEF", paths, ["U_ATK"], 12)
+	_check("no false FAIL_BASE_CONTACT for defender charge", result.get("valid", false), str(result.get("errors", [])))
+	phase.queue_free()
+	GameConstants.edition = 11
+
+# -- 7. Coherency includes unmoved models --
+func _test_coherency_includes_unmoved() -> void:
+	print("\n-- coherency: whole unit, not just the moved subset --")
+	GameConstants.edition = 11
+	var unit = _make_unit("U_CHG", 2, ["INFANTRY"], [Vector2(400, 400), Vector2(440, 400)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(800, 400)])
+	_setup_state({"U_CHG": unit, "U_TGT": target})
+
+	var phase = _new_phase()
+	# Move ONLY m1 6" away from unmoved m2 -> unit broken
+	var broken = phase._validate_unit_coherency_for_charge("U_CHG", {"m1": [[400.0, 400.0], [400.0 + 240.0, 400.0]]})
+	_check("dragging one model away breaks coherency", not broken.get("valid", true))
+	# Move m1 to 1.5" from unmoved m2 -> fine
+	var ok = phase._validate_unit_coherency_for_charge("U_CHG", {"m1": [[400.0, 400.0], [440.0 + 60.0, 400.0]]})
+	_check("moved model within 2\" of unmoved mate is coherent", ok.get("valid", false), str(ok.get("errors", [])))
+	phase.queue_free()
+
+# -- 8. Reserves units are not phantom (0,0) non-targets --
+func _test_reserves_not_at_origin() -> void:
+	print("\n-- non-target ER: Reserves units are skipped --")
+	GameConstants.edition = 11
+	var charger = _make_unit("U_CHG", 2, ["INFANTRY"], [Vector2(120, 120)])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [Vector2(120 + 3.0 * 40.0 + 50.4, 120)])
+	var reserves = _make_unit("U_RSV", 1, ["INFANTRY"], [null])
+	reserves["status"] = GameStateData.UnitStatus.IN_RESERVES
+	_setup_state({"U_CHG": charger, "U_TGT": target, "U_RSV": reserves})
+
+	var phase = _new_phase()
+	# Charge to base contact near the board origin — pre-fix the Reserves unit
+	# "at (0,0)" produced a false non-target-ER rejection.
+	var final_x = 120.0 + 3.0 * 40.0
+	var result = phase._validate_engagement_range_constraints("U_CHG", {"m1": [[120.0, 120.0], [final_x, 120.0]]}, ["U_TGT"])
+	_check("no phantom ER violation from a Reserves unit", result.get("valid", false), str(result.get("errors", [])))
+	phase.queue_free()


### PR DESCRIPTION
## The reported bug

A unit rolling **6"** on 2D6 against a target **2.5"** away got `[INSUFFICIENT_ROLL] Charge failed`. Reproduced live in the running game before fixing.

**Cause:** `_is_charge_roll_sufficient` penalized the **full straight centre-to-centre line** with terrain climb penalties (12" for a tall ruin; ~5–6" for FLY units). But a charging model *stops at engagement range* — it may never reach the ruin — and the real charge move lets you angle *around* terrain. The pre-roll gate was strictly harsher than the move it was gating, killing trivially-makeable charges.

**Fix:** feasibility now costs the straight approach only up to the ER stop point, then falls back to sampling final positions on the engagement ring around each target (the exact cost model the move validator applies to the 2-point paths the drag UI / AI submit). Genuinely blocked charges still fail correctly.

## Other charge-phase bugs found and fixed during the test pass

- **Wasted Command Re-rolls (11e):** the chargeable-target list was computed from the *first* roll and never updated — re-rolling 2 into 11 still reported "charge failed". Now recomputed from the final total (re-rolls + `+N` bonuses).
- **Silently rejected charge confirms:** an illegal confirm gave no feedback and stranded token visuals. Now surfaces an error toast + dice-log entry, re-syncs visuals, and keeps movement mode alive to retry.
- **11e target selection incomplete:** if the roll dropped your pre-declared target, the charge could never be confirmed. Confirm now declares the units you actually moved into engagement with.
- **Fire Overwatch unusable by humans (10e):** the dialog dispatched `actor_unit_id` but the phase only read `unit_id`; now accepts both.
- **AI crash:** `_score_multi_target_combo` indexed the models Array as a Dictionary, crashing every AI multi-target charge evaluation (30 script errors → 0).
- **Free re-roll exploit:** re-declaring a charge after rolling re-rolled the 2D6; now blocked, along with rolling during re-roll/overwatch decision windows.
- **Rules tightening:** whole-unit coherency (a model could be dragged away from its squad), phantom climb penalty for moving inside one ruin at ground level, Heroic Intervention base-contact judged from the wrong player, Reserves units acting as phantom blockers at (0,0), and 1"-vs-2" engagement-range hardcodes in failure text, tooltips, target rings, and the charge-needed preview.

## Files

| Area | Change |
|---|---|
| `phases/ChargePhase.gd` | feasibility rewrite, 11e selectable recompute, ER hardcodes, guards, owner-perspective B2B, whole-unit coherency, Reserves skip |
| `autoloads/TerrainManager.gd` | no phantom climb for a segment wholly inside one footprint |
| `scripts/ChargeController.gd` | rejection recovery, 11e target inference, ER hardcodes |
| `scripts/Main.gd` | surface APPLY_CHARGE_MOVE rejection + re-sync |
| `scripts/AIDecisionMaker.gd` | fix multi-target charge crash |

## Validation

- **New windowed scenario** `tests/scenarios/sp/charge_over_ruin_corner_succeeds.json` (27 steps) drives the reported geometry end-to-end: declare → seeded roll of 6 → **succeeds** → move to base contact → Fights First granted.
- **New headless suite** `tests/test_charge_phase_fixes.gd` (32 checks), wired into `run_pretrigger_tests.sh`.
- All existing charge scenarios green: `charge_infantry_through_ruins`, `372_ere_we_go_charge_modifier`, `charge_cannot_end_on_wall`, `charge_congestion`, `iss049_charge_11e`, `hi_offer_after_charge_into_engagement`, `co_offer_after_charge`, `T30_charge_dashed_rings`.

Version bumped to **0.5.1** in `version_history.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LGyFUPbgiB2iXUmXNZVs3n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LGyFUPbgiB2iXUmXNZVs3n)_