### PR TITLE
Fix AI advancing "toward the enemy" but not actually moving

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -1238,8 +1238,19 @@ func _execute_pending_advance_move(player: int, decision: Dictionary, unit_id: S
 		var enemies = _get_enemies_for_recompute(player, snapshot)
 		var objectives = snapshot.get("board", {}).get("objectives", [])
 
-		# Find the target position from the original decision description
-		var target_pos = _get_target_pos_for_unit(unit, snapshot, objectives)
+		# BUGFIX (orc-waagh-movement-bug): recompute toward the SAME heading the AI
+		# originally chose for this advance — derived from the pre-roll per-model
+		# destinations — NOT the nearest objective. The old _get_target_pos_for_unit()
+		# snapped every advance to the closest objective, which at the start of the
+		# game is the unit's OWN home objective sitting directly behind it. That turned
+		# "advance toward the enemy" into a ~1" shuffle backward that collided with the
+		# unit's own tightly-packed models, so a Boyz blob barely moved (or, when boxed
+		# in, remained stationary) even though the log said it was advancing.
+		var target_pos = _advance_heading_target(unit, decision.get("_ai_model_destinations", {}), actual_move_cap)
+		if target_pos == Vector2.INF:
+			# No usable heading from the original destinations — fall back to the
+			# previous behaviour so a degenerate case still produces some move.
+			target_pos = _get_target_pos_for_unit(unit, snapshot, objectives)
 
 		var new_destinations = AIDecisionMaker._compute_movement_toward_target(
 			unit, unit_id, target_pos, actual_move_cap, snapshot, enemies,
@@ -1274,6 +1285,37 @@ func _get_target_pos_for_unit(unit: Dictionary, snapshot: Dictionary, objectives
 	if parsed_objectives.is_empty():
 		return Vector2.INF
 	return AIDecisionMaker._nearest_objective_pos(centroid, parsed_objectives)
+
+func _advance_heading_target(unit: Dictionary, orig_destinations: Dictionary, move_cap_inches: float) -> Vector2:
+	"""Project a target point far along the heading the AI originally picked for a
+	move, taken from its pre-roll per-model destinations. Recomputing a move toward
+	THIS keeps the unit heading where the AI intended (the enemy it chose to advance
+	on, the objective it was grabbing, or away from danger for a fall back) at the
+	real move cap — instead of snapping to the nearest objective, which is often the
+	unit's own home objective directly behind it. Returns Vector2.INF when no usable
+	heading can be derived so callers can fall back to their previous target."""
+	if orig_destinations.is_empty():
+		return Vector2.INF
+	var origin_centroid = AIDecisionMaker._get_unit_centroid(unit)
+	if origin_centroid == Vector2.INF:
+		return Vector2.INF
+	# Centroid of the original (pre-roll) destinations encodes the intended heading.
+	var dest_sum = Vector2.ZERO
+	var counted = 0
+	for mid in orig_destinations:
+		var d = orig_destinations[mid]
+		if d is Array and d.size() >= 2:
+			dest_sum += Vector2(float(d[0]), float(d[1]))
+			counted += 1
+	if counted == 0:
+		return Vector2.INF
+	var heading = (dest_sum / counted) - origin_centroid
+	if heading.length() < 1.0:
+		return Vector2.INF
+	# Project past the cap so _compute_movement_toward_target uses the full distance
+	# (it clamps the move to min(cap, distance-to-target)).
+	var reach_px = Measurement.inches_to_px(move_cap_inches) + Measurement.inches_to_px(6.0)
+	return origin_centroid + heading.normalized() * reach_px
 
 # --- Submit reactive action ---
 
@@ -1873,7 +1915,13 @@ func _execute_ai_movement(player: int, decision: Dictionary) -> void:
 		var snapshot = GameState.create_snapshot()
 		var enemies = _get_enemies_for_recompute(player, snapshot)
 		var parsed_objectives = AIDecisionMaker._get_objectives(snapshot)
-		var target_pos = _get_target_pos_for_unit(unit_fresh, snapshot, parsed_objectives)
+		# Head toward the AI's originally chosen target (from the pre-scale
+		# destinations), not the nearest objective — same fix as the pending-advance
+		# recompute above. Otherwise a failed staging retry drifts the unit toward its
+		# own home objective instead of the enemy/objective it was told to move to.
+		var target_pos = _advance_heading_target(unit_fresh, decision.get("_ai_model_destinations", {}), move_stat)
+		if target_pos == Vector2.INF:
+			target_pos = _get_target_pos_for_unit(unit_fresh, snapshot, parsed_objectives)
 		var scaled_move = move_stat * recompute_scale
 
 		var new_dests = AIDecisionMaker._compute_movement_toward_target(

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.2",
+			"date": "2026-07-07",
+			"summary": "Fixed the AI advancing 'aggressively toward the enemy' but not actually moving — Ork mobs (and any advancing AI unit) now cover ground instead of shuffling in place.",
+			"changes": [
+				"Fixed a bug where an AI unit that Advanced — often an Ork mob after calling a WAAAGH! — would announce it was advancing toward your army, roll the Advance, then barely move (or stay put entirely). After the Advance roll came in, the AI was recomputing its move toward the nearest objective (usually its own home objective, sitting right behind the unit) instead of toward the enemy it had chosen, so a packed mob just collided with itself and never left its deployment.",
+				"AI Advances (and the retry path for any move that gets boxed in) now keep heading in the direction the AI originally picked — toward the enemy, the objective it was grabbing, or away from danger for a Fall Back — and use the full Advance distance rolled.",
+				"This only affected the AI; your own units were never impacted."
+			]
+		},
+		{
 			"version": "0.6.1",
 			"date": "2026-07-07",
 			"summary": "Charge phase overhaul: no more false 'charge failed' verdicts near ruins, plus a batch of charge bug fixes.",

--- a/40k/tests/test_charge_phase_fixes.gd.uid
+++ b/40k/tests/test_charge_phase_fixes.gd.uid
@@ -1,0 +1,1 @@
+uid://6ongwgbucd3q

--- a/40k/tests/unit/test_ai_advance_heading.gd
+++ b/40k/tests/unit/test_ai_advance_heading.gd
@@ -1,0 +1,111 @@
+extends SceneTree
+
+# Regression test for the "orc WAAAGH movement" bug.
+#
+# Symptom: the AI would announce "Boyz advances aggressively toward <enemy>",
+# roll the advance, then barely move (or stay put entirely). Root cause:
+# after the advance roll resolved, AIPlayer._execute_pending_advance_move()
+# recomputed the per-model destinations toward the NEAREST OBJECTIVE instead of
+# the enemy the AI had chosen. At the start of a game the nearest objective is
+# the unit's own home objective — sitting directly behind it — so "advance 9\"
+# toward the enemy" became a ~1\" shuffle backward that collided with the unit's
+# own packed models and never landed.
+#
+# The fix: recompute toward the heading the AI originally chose, derived from the
+# pre-roll per-model destinations, via AIPlayer._advance_heading_target().
+# These tests pin that helper: it must return a point ALONG the original heading
+# (toward the enemy), far enough to use the full move cap — never snap to a
+# position behind the unit.
+#
+# Uses the live AIPlayer autoload (do NOT preload it — the script references other
+# autoloads that only resolve once the project is running).
+#
+# Run with: godot --headless --script tests/unit/test_ai_advance_heading.gd
+
+var _pass_count: int = 0
+var _fail_count: int = 0
+const PPI: float = 40.0  # AIDecisionMaker.PIXELS_PER_INCH
+
+func _init():
+	print("\n=== AI Advance Heading Tests ===\n")
+	# Defer so autoloads (AIPlayer, Measurement, AIDecisionMaker) are ready.
+	call_deferred("_run_tests")
+
+func _assert(condition: bool, message: String) -> void:
+	if condition:
+		_pass_count += 1
+		print("PASS: %s" % message)
+	else:
+		_fail_count += 1
+		print("FAIL: %s" % message)
+
+func _make_unit(centroid: Vector2) -> Dictionary:
+	# 4 models arranged in a small square around `centroid`.
+	var models = []
+	var offs = [Vector2(-27, -27), Vector2(27, -27), Vector2(-27, 27), Vector2(27, 27)]
+	for i in range(offs.size()):
+		var p = centroid + offs[i]
+		models.append({
+			"id": "m%d" % (i + 1),
+			"alive": true,
+			"base_mm": 32.0,
+			"position": {"x": p.x, "y": p.y},
+		})
+	return {"id": "U_TEST", "owner": 2, "meta": {"stats": {"move": 6}}, "models": models}
+
+func _dests_toward(centroid: Vector2, direction: Vector2, inches: float) -> Dictionary:
+	# Per-model destinations shifted `inches` along `direction` (an advance heading).
+	var shift = direction.normalized() * inches * PPI
+	var dests = {}
+	var offs = [Vector2(-27, -27), Vector2(27, -27), Vector2(-27, 27), Vector2(27, 27)]
+	for i in range(offs.size()):
+		var d = centroid + offs[i] + shift
+		dests["m%d" % (i + 1)] = [d.x, d.y]
+	return dests
+
+func _run_tests():
+	var ai = root.get_node_or_null("/root/AIPlayer")
+	if ai == null:
+		print("FAIL: AIPlayer autoload not found")
+		quit(1)
+		return
+
+	# --- Case 1: the reported bug. Unit is deployed at the bottom of the board;
+	# the enemy it chose to advance on is NORTH (lower Y). The original
+	# destinations point north. The recompute target MUST stay north. ---
+	var centroid = Vector2(880, 2200)
+	var north_enemy = Vector2(0, -1)  # toward lower Y = the enemy
+	var dests_north = _dests_toward(centroid, north_enemy, 7.0)
+	var target = ai._advance_heading_target(_make_unit(centroid), dests_north, 7.0)
+
+	_assert(target != Vector2.INF, "heading target derived from non-empty destinations")
+	_assert(target.y < centroid.y,
+		"advance heads toward the enemy (north, y<%.0f), got y=%.0f — NOT back toward the home objective" % [centroid.y, target.y])
+	# The projected point must be at least the cap away so the recompute can use
+	# the full advance distance (the old estimate under-shot on high rolls).
+	_assert(centroid.distance_to(target) >= 7.0 * PPI,
+		"target projected at least the full move cap (%.0fpx) away, got %.0fpx" % [7.0 * PPI, centroid.distance_to(target)])
+
+	# --- Case 2: heading is preserved for any direction, not just north.
+	# A unit chasing an enemy to the EAST must get an eastward target. ---
+	var east = Vector2(1, 0)
+	var dests_east = _dests_toward(centroid, east, 9.0)
+	var target_e = ai._advance_heading_target(_make_unit(centroid), dests_east, 9.0)
+	_assert(target_e != Vector2.INF and target_e.x > centroid.x and abs(target_e.y - centroid.y) < 40.0,
+		"eastward advance yields an eastward target (x>%.0f), got (%.0f,%.0f)" % [centroid.x, target_e.x, target_e.y])
+
+	# --- Case 3: empty destinations -> INF so callers fall back safely. ---
+	_assert(ai._advance_heading_target(_make_unit(centroid), {}, 7.0) == Vector2.INF,
+		"empty destinations return Vector2.INF (caller falls back)")
+
+	# --- Case 4: a degenerate zero-length heading (destinations == origin) -> INF. ---
+	var dests_zero = _dests_toward(centroid, north_enemy, 0.0)
+	_assert(ai._advance_heading_target(_make_unit(centroid), dests_zero, 7.0) == Vector2.INF,
+		"zero-length heading returns Vector2.INF")
+
+	print("\n=== Results: %d passed, %d failed ===" % [_pass_count, _fail_count])
+	if _fail_count > 0:
+		print("SOME TESTS FAILED")
+	else:
+		print("ALL TESTS PASSED")
+	quit(1 if _fail_count > 0 else 0)

--- a/40k/tests/unit/test_ai_advance_heading.gd.uid
+++ b/40k/tests/unit/test_ai_advance_heading.gd.uid
@@ -1,0 +1,1 @@
+uid://b0cju4feqd8qa


### PR DESCRIPTION
## Problem

An AI unit that **Advanced** — most visibly an Ork mob after calling a **WAAAGH!** — would announce "advances aggressively toward &lt;enemy&gt;", roll the Advance, then barely move or stay put entirely, leaving the mob sitting in its deployment zone. (Reported: the Orks call a Waaagh and claim to advance aggressively, but the models don't move at all.)

## Root cause

When a player has CP, `BEGIN_ADVANCE` pauses for a Command Re-roll decision, so the real model move is deferred until the roll resolves. When it resolved, `AIPlayer._execute_pending_advance_move()` recomputed the per-model destinations toward `_get_target_pos_for_unit()` — the **nearest objective** — instead of the enemy the AI had chosen at decision time.

At the start of a game the nearest objective is the unit's **own home objective, sitting directly behind it**, so a 7–12" advance toward the foe became a **~1" shuffle backward** that collided with the mob's own tightly-packed models. Staging then failed for most/all models and the unit remained stationary. This fired on any advance roll ≠ M+2 (i.e. almost always) whenever a re-roll was available. The identical latent bug lived in the staging-retry loop in `_execute_ai_movement()`.

## Fix

Derive the intended heading from the pre-roll per-model destinations (new `_advance_heading_target` helper) and recompute along **that**, projected past the cap so the full Advance distance is used. This keeps advances aimed at the enemy, objective-grabs aimed at the objective, and fall backs aimed away from danger, for every move type — with a safe fallback to the old nearest-objective target when no heading can be derived. Player units were never affected.

## Validation

- **Headless AI-vs-AI benchmark** on the Custodes-vs-Orks baseline fixture: the recompute target flipped from the home objective `(880,2240)` to the enemy `(880,1680)`/`(880,1227)`; the Boyz mob went from **7/20 → 19–20/20 models moving**, centroid advancing 2200 → 1947 toward the foe.
- **Windowed against the running UI**: the Boyz mob visibly advances toward the Custodian Guard with movement trails (`Boyz [COMPLETED MOVING]`, "20 models staged"), zero errors from the fix path.
- Added a headless regression test (`test_ai_advance_heading.gd`, 6/6 passing) pinning `_advance_heading_target`.

## Changes

- `40k/autoloads/AIPlayer.gd` — the fix + new `_advance_heading_target` helper (applied to both the pending-advance recompute and the staging-retry fallback)
- `40k/tests/unit/test_ai_advance_heading.gd` (+`.uid`) — regression test
- `40k/data/version_history.json` — changelog entry (v0.6.2)
- `40k/tests/test_charge_phase_fixes.gd.uid` — missing tracked UID sidecar regenerated by the editor import

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mu66QvxPYkL7RBERvz5VGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mu66QvxPYkL7RBERvz5VGv)_