### PR TITLE
Fix missing-glyph icons on the Shooting Phase transition banner

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.2",
+			"date": "2026-07-07",
+			"summary": "Fixed the broken 'missing glyph' icons flanking the SHOOTING PHASE title on the phase-transition banner.",
+			"changes": [
+				"The two icons on either side of 'SHOOTING PHASE' on the phase banner (shown when you End the Movement Phase) rendered as empty boxes containing a code number ('2316') instead of a real symbol. The crosshair character they used isn't included in any of the game's bundled fonts, so it only ever showed up if your operating system happened to provide it — most players saw the missing-glyph box.",
+				"They now use a bundled bullseye/target icon that ships with the game, so the Shooting Phase banner renders correctly everywhere, matching the other phases (Charge, Scoring, etc.)."
+			]
+		},
+		{
 			"version": "0.6.1",
 			"date": "2026-07-07",
 			"summary": "Charge phase overhaul: no more false 'charge failed' verdicts near ruins, plus a batch of charge bug fixes.",

--- a/40k/scripts/PhaseTransitionBanner.gd
+++ b/40k/scripts/PhaseTransitionBanner.gd
@@ -25,7 +25,12 @@ static func _get_phase_display(phase: GameStateData.Phase) -> Dictionary:
 		GameStateData.Phase.FIRST_TURN_ROLLOFF: return {"name": "DETERMINE FIRST TURN", "icon": "\u2684"}
 		GameStateData.Phase.COMMAND: return {"name": "COMMAND PHASE", "icon": "\u2655"}
 		GameStateData.Phase.MOVEMENT: return {"name": "MOVEMENT PHASE", "icon": "\u21C4"}
-		GameStateData.Phase.SHOOTING: return {"name": "SHOOTING PHASE", "icon": "\u2316"}
+		# Icon must exist in a BUNDLED font (Rajdhani + DejaVuSans + NotoColorEmoji).
+		# Do NOT use U+2316 (position indicator): it is in NONE of the bundled fonts
+		# and only renders through an OS system-font fallback, so a player whose OS
+		# lacks it sees a .notdef box (a rectangle showing "2316"). U+25CE (BULLSEYE)
+		# is covered by the bundled DejaVuSans and reads as a target for the shooting phase.
+		GameStateData.Phase.SHOOTING: return {"name": "SHOOTING PHASE", "icon": "\u25ce"}
 		GameStateData.Phase.CHARGE: return {"name": "CHARGE PHASE", "icon": "\u2694"}
 		GameStateData.Phase.FIGHT: return {"name": "FIGHT PHASE", "icon": "\u2620"}
 		GameStateData.Phase.SCORING: return {"name": "SCORING PHASE", "icon": "\u2605"}
@@ -136,6 +141,8 @@ func _ready() -> void:
 
 	# Phase name label (centered, large) — top portion
 	_phase_label = Label.new()
+	# Stable node name so windowed scenarios can assert the rendered title/icons.
+	_phase_label.name = "PhaseNameLabel"
 	_phase_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_phase_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
 	_phase_label.anchor_left = 0.0

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -54,6 +54,7 @@ TESTS=(
     "tests/test_shooting_visual_broadcast.gd"
     "tests/test_shooting_phase_summary.gd"
     "tests/test_shooting_phase_shortcuts.gd"
+    "tests/test_phase_banner_icons.gd"
     "tests/test_wound_allocation_priority_pulse.gd"
     "tests/test_test_mode_handler_shooting.gd"
     "tests/test_test_mode_handler_command_dedupe.gd"

--- a/40k/tests/scenarios/sp/shooting_phase_banner_icon.json
+++ b/40k/tests/scenarios/sp/shooting_phase_banner_icon.json
@@ -1,0 +1,11 @@
+{
+  "id": "shooting_phase_banner_icon",
+  "covers": ["ui.phase_banner.shooting_icon"],
+  "fixture": "shooting_phase",
+  "transition_to_phase": 8,
+  "description": "Regression for the SHOOTING PHASE transition banner icons. The banner used to flank the title with U+2316 (position indicator / crosshair), which is present in NONE of the bundled fonts (Rajdhani, DejaVuSans, NotoColorEmoji) and rendered as a .notdef 'missing glyph' box (a rectangle showing '2316') on any machine whose OS did not happen to supply that glyph. It now uses U+25CE (BULLSEYE), covered by the bundled DejaVuSans, so it renders for every player. This drives the real PhaseManager phase_changed -> Main._on_phase_changed -> show_phase_banner path and asserts the banner is shown with the bundled bullseye icon.",
+  "steps": [
+    { "act": "expect_node_visible", "node": "/root/Main/PhaseTransitionBanner", "timeout_s": 3.0 },
+    { "act": "expect_node_property", "node": "/root/Main/PhaseTransitionBanner/PhaseNameLabel", "property": "text", "equals": "◎  SHOOTING PHASE  ◎" }
+  ]
+}

--- a/40k/tests/test_charge_phase_fixes.gd.uid
+++ b/40k/tests/test_charge_phase_fixes.gd.uid
@@ -1,0 +1,1 @@
+uid://bq5rckogidkjg

--- a/40k/tests/test_phase_banner_icons.gd
+++ b/40k/tests/test_phase_banner_icons.gd
@@ -1,0 +1,118 @@
+extends SceneTree
+
+# Regression: every PhaseTransitionBanner phase icon must be a glyph that ships
+# in a BUNDLED font (Rajdhani-Bold, DejaVuSans, or NotoColorEmoji).
+#
+# The SHOOTING PHASE banner shipped with U+2316 (POSITION INDICATOR / crosshair)
+# flanking the title. That codepoint is in NONE of the bundled fonts, so it only
+# rendered when the player's OS happened to supply the glyph via system-font
+# fallback; everyone else saw a .notdef "missing glyph" box (a rectangle showing
+# "2316"). The other phase icons all live in the bundled DejaVuSans, which is why
+# only the shooting banner was broken.
+#
+# `Font.has_char()` checks the font resource and its explicit `.fallbacks` only —
+# it deliberately does NOT consult the OS system-font fallback. That is exactly
+# the property we want: the glyph must ship with the game, not depend on whatever
+# fonts a given machine has installed.
+#
+# The test parses the phase->icon map straight out of PhaseTransitionBanner.gd
+# source (rather than instantiating the class, which pulls in autoload globals
+# that a `-s` SceneTree run cannot resolve) and loads the fonts directly, so it
+# has no autoload dependencies. It auto-discovers every phase icon, guarding all
+# phases (present + future) from regressing to a non-bundled glyph.
+#
+# Usage: godot --headless --path . -s tests/test_phase_banner_icons.gd
+
+const BANNER_SRC := "res://scripts/PhaseTransitionBanner.gd"
+const BUNDLED_FONTS := [
+	"res://fonts/Rajdhani-Bold.ttf",
+	"res://fonts/DejaVuSans.ttf",
+	"res://fonts/NotoColorEmoji.ttf",
+]
+
+var passed := 0
+var failed := 0
+var _fonts: Array = []
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run_tests)
+
+# True if the codepoint is drawable from a font that ships with the game.
+func _bundled_has(cp: int) -> bool:
+	for f in _fonts:
+		if f != null and f.has_char(cp):
+			return true
+	return false
+
+# Decode a GDScript string-literal body (as it appears in source) into its
+# codepoints, expanding \uXXXX escapes and passing literal chars through.
+func _codepoints_of(raw: String) -> Array:
+	var cps: Array = []
+	var i := 0
+	while i < raw.length():
+		if raw[i] == "\\" and i + 6 <= raw.length() and raw[i + 1] == "u":
+			cps.append(raw.substr(i + 2, 4).hex_to_int())
+			i += 6
+		else:
+			cps.append(raw.unicode_at(i))
+			i += 1
+	return cps
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_phase_banner_icons ===\n")
+
+	for path in BUNDLED_FONTS:
+		_fonts.append(load(path))
+	_check("bundled fonts loaded", _fonts.size() == 3 and not _fonts.has(null))
+
+	# Pull every `"icon": "..."` value out of the banner source.
+	var f := FileAccess.open(BANNER_SRC, FileAccess.READ)
+	_check("banner source readable", f != null)
+	if f == null:
+		_finish()
+		return
+	var src := f.get_as_text()
+	f.close()
+
+	var re := RegEx.new()
+	re.compile('"icon"\\s*:\\s*"([^"]+)"')
+	var matches := re.search_all(src)
+	_check("found phase icons in source (>= 10)", matches.size() >= 10,
+		"only found %d" % matches.size())
+
+	var saw_bullseye := false
+	for m in matches:
+		var raw: String = m.get_string(1)
+		for cp in _codepoints_of(raw):
+			if cp == 0x25CE:
+				saw_bullseye = true
+			# ASCII (e.g. the "?" default) is always drawable; only assert on
+			# the symbol glyphs that actually depend on font coverage.
+			if cp < 0x80:
+				continue
+			_check("icon U+%04X is in a bundled font" % cp, _bundled_has(cp),
+				"absent from Rajdhani/DejaVuSans/NotoColorEmoji -> renders as a .notdef box")
+
+	# The shooting fix specifically: the bundled bullseye (U+25CE) is now used...
+	_check("SHOOTING banner uses bundled U+25CE (BULLSEYE)", saw_bullseye,
+		"expected the shooting icon to be U+25CE")
+	# ...and the old crosshair U+2316 is genuinely NOT bundled, documenting the
+	# root cause (the per-icon loop above already fails if any icon uses it).
+	_check("old crosshair U+2316 is NOT in any bundled font (why it tofu'd)",
+		not _bundled_has(0x2316))
+
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_phase_banner_icons.gd.uid
+++ b/40k/tests/test_phase_banner_icons.gd.uid
@@ -1,0 +1,1 @@
+uid://fmis1r006agk


### PR DESCRIPTION
## Problem

When the game transitions to the Shooting Phase, the two icons flanking the **SHOOTING PHASE** banner title rendered as `.notdef` "missing glyph" boxes — a rectangle showing `2316` — instead of a symbol. The Charge and Scoring banners were fine.

## Root cause

`PhaseTransitionBanner._get_phase_display()` maps each phase to a Unicode icon. Shooting used **`⌖` ⌖ (POSITION INDICATOR)**, which lives in the Miscellaneous Technical block. The game bundles three fonts and chains them as fallbacks (Rajdhani → DejaVuSans → NotoColorEmoji). Verified with fontTools **and** live in‑game `Font.has_char()` that **`⌖` is present in none of them**. Every other phase icon (⚔ ★ ☠ ⚓ …) lives in the bundled DejaVuSans, which is why only shooting broke.

Because `⌖` isn't bundled, it only rendered on machines whose OS happened to supply the glyph via system‑font fallback — a UI icon shouldn't depend on that.

## Fix

Switch the shooting icon to **`◎` ◎ (BULLSEYE)**, which the bundled DejaVuSans covers, so it renders identically for every player and reads as a target. One‑character change plus a comment so the constraint isn't reintroduced.

## Validation (ran the real game)

- **Reproduced** the exact `2316` box and confirmed the fix using bundled fonts only (before/after).
- **Drove the real production banner** into the Shooting Phase and captured it rendering `◎ SHOOTING PHASE ◎`, no errors in the debug log.
- **Windowed scenario** (`tests/scenarios/sp/shooting_phase_banner_icon.json`) — transitions into the Shooting phase and asserts the banner shows with the bundled icon: **2/2 pass**.
- **Headless regression test** (`tests/test_phase_banner_icons.gd`) — parses the phase→icon map from source and asserts *every* phase icon is in a bundled font (would have caught this; guards all phases): **18/18 pass**.

## Changes

- `40k/scripts/PhaseTransitionBanner.gd` — `⌖` → `◎`; name the title label `PhaseNameLabel` so scenarios can assert it.
- `40k/tests/test_phase_banner_icons.gd` (+ `.uid`) — new headless regression test, registered in `run_pretrigger_tests.sh`.
- `40k/tests/scenarios/sp/shooting_phase_banner_icon.json` — new windowed scenario.
- `40k/data/version_history.json` — `0.6.2` changelog entry.
- `40k/tests/test_charge_phase_fixes.gd.uid` — backfill a missing generated UID file (unrelated pre-existing gap surfaced by import).

## Note (out of scope)

The Fight Phase state banner uses `⌛` ⌛, also absent from the bundled DejaVuSans but rescued by NotoColorEmoji, so it renders as a color emoji rather than tofu. Left as‑is; can convert to a monochrome bundled glyph for consistency if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016now5fUXYV4ur3z4BKMCkp

---
_Generated by [Claude Code](https://claude.ai/code/session_016now5fUXYV4ur3z4BKMCkp)_