### PR TITLE
Fix MissionDiscardDialog spanning full screen height

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.4",
+			"date": "2026-07-07",
+			"summary": "Fixed the end-of-turn 'discard a Secondary Mission for CP' pop-up stretching to the full height of the screen.",
+			"changes": [
+				"The 'Discard for CP?' pop-up shown when you end your turn (offering to discard a Secondary Mission for +1 CP) used to open as a giant window spanning the whole screen, with a small amount of content at the top and a huge empty gap below it.",
+				"The window now sizes itself to its content, so it's a compact, tidy pop-up. Everything is still visible — the prompt, each Secondary Mission with its Discard button, and the 'End Turn Without Discarding' button.",
+				"When you happen to hold more Secondary Missions than fit, the mission list now scrolls inside the pop-up instead of the window growing off-screen."
+			]
+		},
+		{
 			"version": "0.6.3",
 			"date": "2026-07-07",
 			"summary": "Fixed the broken 'missing glyph' icons flanking the SHOOTING PHASE title on the phase-transition banner.",

--- a/40k/dialogs/MissionDiscardDialog.gd
+++ b/40k/dialogs/MissionDiscardDialog.gd
@@ -9,8 +9,24 @@ extends AcceptDialog
 signal mission_discard_requested(mission_index: int)
 signal end_turn_without_discard()
 
+# Max height for the mission list before it starts scrolling. Below this the
+# scroll area shrinks to hug its content so the dialog doesn't leave a gap.
+const MISSION_LIST_MAX_HEIGHT := 180.0
+
 var active_missions: Array = []
 var can_gain_cp: bool = false
+var _mission_scroll: ScrollContainer = null
+var _mission_list: VBoxContainer = null
+
+# Factory: build a ready-to-show dialog (script attached + UI built). The caller
+# connects the signals, adds it to the tree, and calls popup_centered(). Shared
+# by Main.gd and the windowed regression scenario so both exercise one path.
+static func create(p_active_missions: Array, p_can_gain_cp: bool) -> AcceptDialog:
+	var dialog := AcceptDialog.new()
+	dialog.set_script(load("res://dialogs/MissionDiscardDialog.gd"))
+	dialog.name = "MissionDiscardDialog"
+	dialog.setup(p_active_missions, p_can_gain_cp)
+	return dialog
 
 func setup(p_active_missions: Array, p_can_gain_cp: bool) -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
@@ -18,7 +34,10 @@ func setup(p_active_missions: Array, p_can_gain_cp: bool) -> void:
 	can_gain_cp = p_can_gain_cp
 
 	title = "Discard a Secondary Mission?"
-	min_size = DialogConstants.MEDIUM
+	# Keep the MEDIUM width, but let the height follow the content. The dialog is
+	# short (a prompt, a fixed-height mission list, and one button), so pinning it
+	# to the 400px MEDIUM height left a large empty gap at the bottom.
+	min_size = Vector2(DialogConstants.MEDIUM.x, 0)
 
 	# Disable default OK button - we use custom buttons
 	get_ok_button().visible = false
@@ -48,13 +67,17 @@ func _build_ui() -> void:
 	explain_label.add_theme_font_size_override("font_size", 13)
 	explain_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	explain_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	# Constrain the wrapped label's width so it reports a correct minimum HEIGHT.
+	# An autowrap Label with no width, measured while the dialog is popped up,
+	# assumes ~zero width and returns a huge minimum height; with wrap_controls
+	# that inflated the whole dialog to span the screen.
+	explain_label.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 40, 0)
 	main_container.add_child(explain_label)
 
 	main_container.add_child(HSeparator.new())
 
 	# Mission cards with discard buttons
 	var scroll = ScrollContainer.new()
-	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 180)
 	var mission_list = VBoxContainer.new()
 	mission_list.add_theme_constant_override("separation", 6)
 
@@ -63,6 +86,14 @@ func _build_ui() -> void:
 		_add_mission_option(mission_list, mission, i)
 
 	scroll.add_child(mission_list)
+	# Fit the scroll area to its content, capped so a long list scrolls instead
+	# of stretching the dialog. The previous fixed 180px height left an empty gap
+	# below the list for the common 1-2 mission case. The final fit happens in
+	# _ready() once the list is in the tree (its measured height is a few px
+	# larger there); this pre-tree estimate just seeds a sensible size.
+	_mission_scroll = scroll
+	_mission_list = mission_list
+	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, _clamped_list_height())
 	main_container.add_child(scroll)
 
 	main_container.add_child(HSeparator.new())
@@ -80,6 +111,21 @@ func _build_ui() -> void:
 	main_container.add_child(button_container)
 
 	add_child(main_container)
+
+func _ready() -> void:
+	# Re-fit the scroll to the list's real (in-tree) height, which is a few px
+	# taller than the pre-tree estimate used while building. Runs before the
+	# caller's popup_centered(), so the dialog sizes correctly the first time and
+	# short lists don't show a spurious scrollbar.
+	if _mission_scroll and _mission_list:
+		_mission_scroll.custom_minimum_size.y = _clamped_list_height()
+
+func _clamped_list_height() -> float:
+	# Mission list content height, capped so long lists scroll instead of growing
+	# the dialog past the screen.
+	if not _mission_list:
+		return MISSION_LIST_MAX_HEIGHT
+	return min(_mission_list.get_combined_minimum_size().y, MISSION_LIST_MAX_HEIGHT)
 
 func _add_mission_option(parent: VBoxContainer, mission: Dictionary, index: int) -> void:
 	var card = PanelContainer.new()

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -9522,9 +9522,7 @@ func _show_mission_discard_dialog(active_missions: Array, active_player: int) ->
 		return
 
 	var can_gain_cp = GameState.can_gain_bonus_cp(active_player)
-	var dialog = AcceptDialog.new()
-	dialog.set_script(dialog_script)
-	dialog.setup(active_missions, can_gain_cp)
+	var dialog = dialog_script.create(active_missions, can_gain_cp)
 	dialog.mission_discard_requested.connect(_on_mission_discard_from_dialog.bind(active_player))
 	dialog.end_turn_without_discard.connect(_on_end_scoring_without_discard.bind(active_player))
 	get_tree().root.add_child(dialog)

--- a/40k/tests/scenarios/sp/mission_discard_dialog_height.json
+++ b/40k/tests/scenarios/sp/mission_discard_dialog_height.json
@@ -1,0 +1,38 @@
+{
+  "id": "mission_discard_dialog_height",
+  "covers": ["ui.layout.MissionDiscardDialog_fits_content"],
+  "fixture": "co_pretrigger",
+  "disable_ai": true,
+  "description": "The end-of-turn 'Discard for CP?' pop-up (MissionDiscardDialog) must size to its content, not span the screen. Regression guard for the autowrap-Label minimum-height blowup that inflated the dialog to ~2762px tall. Instantiates the real dialog via its create() factory with two secondary missions, pops it up, and asserts the window height stays well under the viewport (would be ~2762px if the bug returns) while remaining tall enough to show its content and staying visible.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.add_child(ResourceLoader.load('res://dialogs/MissionDiscardDialog.gd').create([{'name': 'Storm Hostile Objective', 'category': 'tactical'}, {'name': 'Behind Enemy Lines', 'category': 'tactical'}], true))" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').popup_centered()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_discard_dialog" },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').visible",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').size.y",
+      "expect_max": 500 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').size.y",
+      "expect_min": 150 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').size.y < main.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('MissionDiscardDialog').free()" }
+  ]
+}


### PR DESCRIPTION
## Problem

The end-of-turn **"Discard for CP?"** pop-up (offering to discard a Secondary Mission for +1 CP) opened as a window that spanned the **full height of the screen (~2762px)** — a small block of content at the top and a huge empty gap below it.

## Root cause

The wrapped explanation `Label` had no width constraint. When `AcceptDialog` measured its contents during `popup_centered()`, the autowrap `Label` was measured at ~zero width and reported an enormous minimum height. Because `wrap_controls` is on, the dialog grew to fit that bogus height and never shrank back.

## Fix (`MissionDiscardDialog.gd`)

- **Root cause:** constrain the autowrap label's width so it reports a correct minimum height — this alone drops the dialog from ~2762px to a normal size.
- **Padding:** remove the fixed 400px `MEDIUM` height floor; keep the `MEDIUM` width and let the height follow the content so there's no empty gap at the bottom.
- **Scroll area:** size the mission-list scroll to its content (capped at 180px) instead of a fixed 180px, re-fitting in `_ready()` with the accurate in-tree height — so short lists (the common 1–2 mission case) hug their content, long lists scroll instead of growing off-screen, and there's no spurious scrollbar on the exact-fit case.
- Add a small static `create()` factory shared by `Main.gd` and the new windowed regression scenario.

## Validation

Ran the real game (windowed) and drove the actual dialog for 1–4 missions — everything visible, button reachable, no full-screen stretch:

| Missions | Before | After |
|---|---|---|
| 1 | ~2762px | 215px |
| 2 (common) | ~2762px | 269px, no scrollbar |
| 3 | ~2762px | 323px |
| 4 | ~2762px | 347px, scrolls |

- Screenshots confirm the compact layout in-game; `verify_delivery` → **PASS**, zero errors/warnings.
- Confirmed the Discard and "End Turn Without Discarding" buttons still fire their signals correctly.
- Added a committed windowed regression scenario (`tests/scenarios/sp/mission_discard_dialog_height.json`) that asserts the dialog height stays well under the viewport. **Proved it fails (dialog ~2684px) when the fix is reverted and passes (11/11) with it.**
- Version bumped to 0.6.4 with a player-facing changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VUC3uRjFUVZuyWen4WdRe

---
_Generated by [Claude Code](https://claude.ai/code/session_019VUC3uRjFUVZuyWen4WdRe)_