### PR TITLE
Fix infantry paying a phantom 2" to move through/across ruins

### DIFF
--- a/40k/autoloads/TerrainManager.gd
+++ b/40k/autoloads/TerrainManager.gd
@@ -605,8 +605,15 @@ func calculate_charge_terrain_penalty(from_pos: Vector2, to_pos: Vector2, has_fl
 ## FLY units ignore difficult ground entirely — penalty is always 0.
 ## T3-16: Applies difficult_ground trait penalty (flat 2" per piece crossed).
 ##
+## 10e Ruins fix: a unit that can move through a terrain piece (e.g. INFANTRY
+## through a Ruin's walls/floors) is NOT slowed by it — Ruins are not Difficult
+## Ground for such a unit, so no distance is added. Only units that cannot
+## traverse the piece (e.g. VEHICLES over a low ruin) pay the flat penalty.
+## Pass the moving unit's keywords via unit_keywords to enable this exemption;
+## callers that omit it (legacy/tests) get the pre-fix "everyone pays" behaviour.
+##
 ## Returns the extra distance in inches that must be added to the movement distance.
-func calculate_movement_terrain_penalty(from_pos: Vector2, to_pos: Vector2, has_fly: bool) -> float:
+func calculate_movement_terrain_penalty(from_pos: Vector2, to_pos: Vector2, has_fly: bool, unit_keywords: Array = []) -> float:
 	# FLY units ignore difficult ground entirely during movement
 	if has_fly:
 		print("[TerrainManager] FLY unit ignores difficult ground during movement")
@@ -628,11 +635,16 @@ func calculate_movement_terrain_penalty(from_pos: Vector2, to_pos: Vector2, has_
 		# Infantry move through ruins walls freely per 10e rules.
 		print("[TerrainManager] Movement path interacts with %s: no height penalty (ground floor)" % terrain.get("id", "unknown"))
 
-		# T3-16: Difficult ground trait penalty — flat 2" per terrain piece crossed
+		# T3-16: Difficult ground trait penalty — flat 2" per terrain piece crossed.
+		# 10e Ruins fix: units that can move through this piece (INFANTRY through a
+		# Ruin) move freely and pay nothing — Ruins are not Difficult Ground for them.
 		if has_terrain_trait(terrain, "difficult_ground"):
-			total_penalty += DIFFICULT_GROUND_PENALTY_INCHES
-			print("[TerrainManager] Difficult ground penalty for %s: +%.1f\"" % [
-				terrain.get("id", "unknown"), DIFFICULT_GROUND_PENALTY_INCHES])
+			if can_unit_move_through_terrain(unit_keywords, terrain):
+				print("[TerrainManager] %s traversable by unit — no difficult ground penalty (moves through freely)" % terrain.get("id", "unknown"))
+			else:
+				total_penalty += DIFFICULT_GROUND_PENALTY_INCHES
+				print("[TerrainManager] Difficult ground penalty for %s: +%.1f\"" % [
+					terrain.get("id", "unknown"), DIFFICULT_GROUND_PENALTY_INCHES])
 
 	return total_penalty
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.4",
+			"date": "2026-07-07",
+			"summary": "Fixed Infantry being wrongly charged an extra 2\" to move through or across Ruins — including the '2\" stuck on even after you move away' bug.",
+			"changes": [
+				"Infantry (and anything that can move through a terrain feature) no longer has 2\" added to its move distance for going into, across, or through a Ruin. In 10th edition these models move through Ruins' walls and floors freely, so a Ruin costs them no extra inches — the game was treating every Ruin as 'difficult ground' for everyone.",
+				"Fixed the related 'sticky' bug: dragging a model onto a Ruin used to add the 2\" penalty and then keep it added even after you dragged the model back off the Ruin to open ground. The distance now reflects the actual path every frame, so moving away from a Ruin correctly drops the penalty.",
+				"Units that genuinely cannot move through a piece (e.g. Vehicles crossing low difficult-ground terrain) still pay the 2\", so real difficult-ground terrain still slows the models it should."
+			]
+		},
+		{
 			"version": "0.6.3",
 			"date": "2026-07-07",
 			"summary": "Fixed the broken 'missing glyph' icons flanking the SHOOTING PHASE title on the phase-transition banner.",

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -6467,7 +6467,12 @@ func _get_movement_terrain_penalty(from_pos: Vector2, to_pos: Vector2, unit_id: 
 	var penalty = 0.0
 	var terrain_manager = get_node_or_null("/root/TerrainManager")
 	if terrain_manager and terrain_manager.has_method("calculate_movement_terrain_penalty"):
-		penalty += float(terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, false))
+		# Pass the unit's keywords so INFANTRY (and anything that can move through
+		# the piece) are not charged the ruins/difficult-ground penalty — 10e: they
+		# move through walls/floors freely. FLY is already handled above.
+		var _mv_unit = get_unit(unit_id) if unit_id != "" else {}
+		var _mv_keywords = _mv_unit.get("meta", {}).get("keywords", []) if not _mv_unit.is_empty() else []
+		penalty += float(terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, false, _mv_keywords))
 	# T-103: multi-floor vertical climb cost.
 	penalty += _get_vertical_climb_cost(from_pos, to_pos, unit_id)
 	if penalty > 0.0:

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -3345,8 +3345,13 @@ func _get_terrain_penalty_for_move(from_pos: Vector2, to_pos: Vector2) -> float:
 	var terrain_manager = get_node_or_null("/root/TerrainManager")
 	if not terrain_manager or not terrain_manager.has_method("calculate_movement_terrain_penalty"):
 		return 0.0
-	var has_fly = "FLY" in _get_active_unit_keywords()
-	return terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, has_fly)
+	# Pass keywords so INFANTRY moving through a ruin are not charged the 2"
+	# difficult-ground penalty (10e: they move through walls/floors freely). This
+	# also fixes the "sticky" penalty: the live preview recomputes from keywords
+	# each frame, so an infantry model dragged onto then away from a ruin shows 0.
+	var keywords = _get_active_unit_keywords()
+	var has_fly = "FLY" in keywords
+	return terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, has_fly, keywords)
 
 func _check_position_would_overlap(position: Vector2) -> bool:
 	# Check if placing the selected model at the given position would overlap

--- a/40k/tests/scenarios/sp/infantry_ruin_no_move_penalty.json
+++ b/40k/tests/scenarios/sp/infantry_ruin_no_move_penalty.json
@@ -1,0 +1,71 @@
+{
+  "id": "infantry_ruin_no_move_penalty",
+  "covers": [
+    "movement.terrain.infantry_difficult_ground_exemption",
+    "terrain.difficult_ground.traversable_exemption",
+    "TerrainManager.calculate_movement_terrain_penalty"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "10e Ruins fix: INFANTRY move through a Ruin's walls/floors freely, so a difficult_ground ruin adds NO distance to their movement. A difficult_ground ruin is injected straddling U_CUSTODIAN_GUARD_B m1's downward lane. (1) Live math: calculate_movement_terrain_penalty across the ruin returns 0\" for INFANTRY, 2\" for a non-traversing VEHICLE, and 2\" with no keywords (legacy). (2) Sticky-bug proof: a segment starting INSIDE the ruin and ending in open ground still returns 0\" for INFANTRY — no residual penalty when moving away. (3) Player path: m1 makes a real 5\" Normal Move straight through the ruin. Pre-fix this cost 5\"+2\"=7\" > the 6\" cap and was silently rejected; post-fix it succeeds and the tracked per-model distance is exactly the 5\" geometry.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.append({\"id\": \"dg_ruin_test\", \"type\": \"ruins\", \"polygon\": PackedVector2Array([Vector2(150,180),Vector2(250,180),Vector2(250,220),Vector2(150,220)]), \"height_category\": \"low\", \"position\": Vector2(200,200), \"size\": Vector2(100,40), \"rotation\": 0.0, \"can_move_through\": {\"INFANTRY\": true, \"VEHICLE\": false, \"MONSTER\": false}, \"traits\": [\"obscuring\", \"difficult_ground\"]})"
+    },
+    { "act": "screenshot", "label": "01_difficult_ground_ruin_injected" },
+
+    { "act": "execute_script",
+      "script": "TerrainManager.calculate_movement_terrain_penalty(Vector2(200,100), Vector2(200,300), false, [\"INFANTRY\"])",
+      "equals": 0.0
+    },
+    { "act": "execute_script",
+      "script": "TerrainManager.calculate_movement_terrain_penalty(Vector2(200,100), Vector2(200,300), false, [\"VEHICLE\"])",
+      "equals": 2.0
+    },
+    { "act": "execute_script",
+      "script": "TerrainManager.calculate_movement_terrain_penalty(Vector2(200,100), Vector2(200,300), false)",
+      "equals": 2.0
+    },
+    { "act": "execute_script",
+      "script": "TerrainManager.calculate_movement_terrain_penalty(Vector2(200,200), Vector2(200,400), false, [\"INFANTRY\"])",
+      "equals": 0.0
+    },
+
+    { "act": "dispatch_action", "action": {
+      "type": "BEGIN_NORMAL_MOVE",
+      "actor_unit_id": "U_CUSTODIAN_GUARD_B",
+      "payload": {}
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().active_moves[\"U_CUSTODIAN_GUARD_B\"][\"move_cap_inches\"]",
+      "equals": 6.0
+    },
+
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_CUSTODIAN_GUARD_B",
+      "payload": {
+        "model_id": "m1",
+        "dest": [200, 300],
+        "rotation": 0.0
+      }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "abs(PhaseManager.get_current_phase_instance().active_moves[\"U_CUSTODIAN_GUARD_B\"][\"model_distances\"][\"U_CUSTODIAN_GUARD_B:m1\"] - 5.0) < 0.01",
+      "equals": true
+    },
+    { "act": "screenshot", "label": "02_infantry_moved_across_ruin_no_penalty" },
+
+    { "act": "execute_script", "script": "TerrainManager.terrain_features.pop_back()" }
+  ]
+}

--- a/40k/tests/unit/test_difficult_ground_terrain.gd
+++ b/40k/tests/unit/test_difficult_ground_terrain.gd
@@ -250,6 +250,73 @@ func test_difficult_ground_charge_fly_ignores():
 	assert_eq(penalty, 0.0, "FLY unit should ignore difficult ground penalty during charges")
 
 # ==========================================
+# 10e Ruins fix: units that move through the piece pay no difficult ground
+# ==========================================
+
+## Add a ruin-style difficult_ground piece: INFANTRY can move through it (walls),
+## VEHICLE/MONSTER cannot. This mirrors how the real layouts tag ruins.
+func _add_difficult_ground_ruin(id: String, position: Vector2, size: Vector2, height_category: String = "tall") -> void:
+	var half_size = size * 0.5
+	var polygon = PackedVector2Array([
+		position + Vector2(-half_size.x, -half_size.y),
+		position + Vector2(half_size.x, -half_size.y),
+		position + Vector2(half_size.x, half_size.y),
+		position + Vector2(-half_size.x, half_size.y)
+	])
+	terrain_manager.terrain_features.append({
+		"id": id,
+		"type": "ruins",
+		"polygon": polygon,
+		"height_category": height_category,
+		"position": position,
+		"size": size,
+		"rotation": 0.0,
+		"can_move_through": {"INFANTRY": true, "VEHICLE": false, "MONSTER": false},
+		"traits": ["obscuring", "difficult_ground"]
+	})
+
+func test_infantry_through_ruin_no_difficult_ground_penalty():
+	# 10e: INFANTRY move through Ruins walls/floors freely — no 2" penalty.
+	_add_difficult_ground_ruin("ruin_1", Vector2(200, 0), Vector2(80, 80))
+
+	var from_pos = Vector2(0, 0)
+	var to_pos = Vector2(400, 0)
+
+	var penalty = terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, false, ["INFANTRY"])
+	assert_eq(penalty, 0.0, "INFANTRY crossing a ruin should pay NO difficult ground penalty")
+
+func test_vehicle_through_ruin_still_pays_difficult_ground():
+	# A unit that CANNOT move through the piece (e.g. VEHICLE) is still slowed.
+	_add_difficult_ground_ruin("ruin_1", Vector2(200, 0), Vector2(80, 80))
+
+	var from_pos = Vector2(0, 0)
+	var to_pos = Vector2(400, 0)
+
+	var penalty = terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, false, ["VEHICLE"])
+	assert_eq(penalty, 2.0, "VEHICLE that cannot move through the ruin should still pay 2\"")
+
+func test_no_keywords_preserves_legacy_penalty():
+	# Backward compatibility: omitting keywords keeps the pre-fix "everyone pays".
+	_add_difficult_ground_ruin("ruin_1", Vector2(200, 0), Vector2(80, 80))
+
+	var from_pos = Vector2(0, 0)
+	var to_pos = Vector2(400, 0)
+
+	var penalty = terrain_manager.calculate_movement_terrain_penalty(from_pos, to_pos, false)
+	assert_eq(penalty, 2.0, "No keywords → legacy behaviour (2\" penalty) preserved for callers/tests")
+
+func test_infantry_leaving_ruin_no_sticky_penalty():
+	# The reported "sticky" bug: a model standing INSIDE a ruin that moves OUT to
+	# open ground must not keep the 2". For INFANTRY the penalty is always 0.
+	_add_difficult_ground_ruin("ruin_1", Vector2(0, 0), Vector2(160, 160))
+
+	var inside_pos = Vector2(0, 0)      # starts inside the ruin footprint
+	var open_ground = Vector2(400, 0)   # ends well outside, clear of the ruin
+
+	var penalty = terrain_manager.calculate_movement_terrain_penalty(inside_pos, open_ground, false, ["INFANTRY"])
+	assert_eq(penalty, 0.0, "INFANTRY leaving a ruin must not retain a difficult ground penalty")
+
+# ==========================================
 # DIFFICULT_GROUND_PENALTY_INCHES constant
 # ==========================================
 


### PR DESCRIPTION
## Problem

When moving INFANTRY into or across Ruins, the game added **2" to their move distance**. Per the 10th-edition core rules, INFANTRY move through Ruins' walls and floors *freely* — a Ruin adds no distance for them. The "Difficult Ground" trait that legitimately subtracts 2" belongs on Woods/Craters, not Ruins, and even then does not exempt a unit that moves through the piece.

The game tags every ruin with `traits: ["obscuring", "difficult_ground"]`, and `TerrainManager.calculate_movement_terrain_penalty()` applied the flat 2" to **every non-FLY unit**, infantry included.

### Two symptoms, one root cause
The penalty fires whenever the move path *starts inside*, *ends inside*, or *crosses* a ruin. So:
1. Moving infantry into/across a ruin wrongly cost +2".
2. Once a model sat on a ruin, moving it **away** still "started inside difficult ground", so the +2" stuck even when the final path no longer touched the ruin.

For infantry there should never have been a penalty at all, which fixes both.

## Fix

Infantry — anything that can move through the piece — no longer pays the ruin penalty. This mirrors the existing vertical-climb-cost exemption (`_get_vertical_climb_cost`).

- `TerrainManager.calculate_movement_terrain_penalty()` gains an optional `unit_keywords` arg and skips the `difficult_ground` penalty for pieces the unit can traverse (`can_unit_move_through_terrain`). Omitting keywords preserves the legacy "everyone pays" behaviour for existing callers/tests.
- `MovementPhase._get_movement_terrain_penalty()` and `MovementController._get_terrain_penalty_for_move()` now pass the moving unit's keywords through. The live-drag preview recomputes from keywords every frame, so the "sticky" 2" is gone.
- Units that genuinely cannot traverse a piece (e.g. a Vehicle over low difficult ground) **still** pay 2".

## Validation

- `test_difficult_ground_terrain.gd`: **21/21** (4 new — infantry=0", vehicle=2", legacy no-keywords=2", leaving-a-ruin sticky-case=0").
- `test_fly_movement_terrain.gd`: **15/15** (no regression).
- Windowed scenario `infantry_ruin_no_move_penalty.json`: **17/17**. Drives a real 5" infantry Normal Move straight through a difficult_ground ruin — pre-fix that was 5"+2"=7" > the 6" cap and was silently rejected; it now succeeds and the tracked per-model distance is exactly 5.0". No ERROR lines in the debug log; screenshot confirms the unit moving in-phase.

## Scope note

The Charge phase has the same latent behaviour (`calculate_charge_terrain_penalty` still adds 2" to infantry charging through a ruin). This PR is scoped to **movement** as requested; charge can be addressed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fddm47KkCt69MNK8EJtQap

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fddm47KkCt69MNK8EJtQap)_