### PR TITLE
Fix pop-up windows overflowing off-screen (Burden of Trust + systemic)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.2",
+			"date": "2026-07-07",
+			"summary": "Fixed the Burden of Trust guard-assignment window overflowing off the bottom of the screen so its Confirm / Keep buttons were unreachable.",
+			"changes": [
+				"Burden of Trust (secondary mission): the 'Assign Guards' window no longer stretches thousands of pixels tall and off the bottom of the screen. The dialog is now capped to fit within the view, the objective list scrolls inside it, and the 'Confirm Guards' and 'Keep Auto Picks' buttons stay pinned and visible so you can actually confirm which unit guards which objective."
+			]
+		},
+		{
 			"version": "0.6.1",
 			"date": "2026-07-07",
 			"summary": "Charge phase overhaul: no more false 'charge failed' verdicts near ruins, plus a batch of charge bug fixes.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.3",
+			"date": "2026-07-07",
+			"summary": "Fixed a whole family of pop-up windows that could stretch off the bottom of the screen and hide their buttons — the same bug as the Burden of Trust window, across many other prompts.",
+			"changes": [
+				"Several pop-up windows could balloon far taller than the screen (a long description line inside them was mis-measured), pushing their action buttons off the bottom where you couldn't click them. Fixed the secondary-mission prompts (A Tempting Target, Marked for Death, Beacon, Extract Relic, Condemn), the 'Deploy Unit in Transport' window, the out-of-coherency model-removal prompt, the shooting action prompt, the transport firing-deck picker, and more.",
+				"Added a global safety net so ANY pop-up window is automatically kept within the screen and re-centered if it would ever open too tall — its confirm/cancel buttons can no longer end up unreachable. Windows that already fit are left exactly as they were."
+			]
+		},
+		{
 			"version": "0.6.2",
 			"date": "2026-07-07",
 			"summary": "Fixed the Burden of Trust guard-assignment window overflowing off the bottom of the screen so its Confirm / Keep buttons were unreachable.",

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -4444,7 +4444,9 @@ func _show_firing_deck_dialog(transport_id: String) -> void:
 	dialog.models_selected.connect(_on_firing_deck_models_selected.bind(transport_id))
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Cap to the viewport so the firing-deck instructions can't push the
+	# Confirm button off-screen (see DialogUtils.popup_centered_capped).
+	DialogUtils.popup_centered_capped(dialog)
 
 func _on_firing_deck_models_selected(selected_weapons: Array, transport_id: String) -> void:
 	"""Handle selection of weapons from embarked units for firing deck"""

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -1771,7 +1771,11 @@ func _show_guard_dialog(pending: Dictionary, player: int) -> void:
 
 	var scroll = ScrollContainer.new()
 	scroll.name = "ObjectiveScroll"
-	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 220)
+	# Keep a modest minimum so the objective list can shrink (and the fixed
+	# Confirm / Keep buttons stay on-screen) when the dialog is capped to a
+	# small viewport; SIZE_EXPAND_FILL still grows it on roomier screens.
+	scroll.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 160)
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	var rows = VBoxContainer.new()
 	rows.name = "ObjectiveRows"
@@ -1874,8 +1878,26 @@ func _show_guard_dialog(pending: Dictionary, player: int) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
-	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives)" % [player, objectives.size()])
+
+	# Cap the dialog to the viewport so the Confirm / Keep buttons can never be
+	# pushed off the bottom of the screen. The autowrap description Label reports
+	# a very tall minimum height during the initial popup_centered() (before it
+	# has been laid out to a width), which previously sized the AcceptDialog
+	# window to thousands of pixels tall and scrolled the action buttons
+	# off-screen — the player could see the objective pickers but had no way to
+	# confirm. Forcing the window size (min == max) makes the inner
+	# ObjectiveScroll absorb any overflow instead. Height grows with the
+	# objective count but never past 90% of the viewport, and the MEDIUM floor
+	# keeps the fixed chrome (buttons) on-screen on normal displays.
+	var vp := get_viewport()
+	var vp_h: float = vp.get_visible_rect().size.y if vp else DialogConstants.MEDIUM.y
+	var desired_h: float = 230.0 + float(objectives.size()) * 40.0
+	var cap_w: int = int(DialogConstants.MEDIUM.x)
+	var cap_h: int = int(clamp(desired_h, DialogConstants.MEDIUM.y, vp_h * 0.9))
+	dialog.min_size = Vector2i(cap_w, cap_h)
+	dialog.max_size = Vector2i(cap_w, cap_h)
+	dialog.popup_centered(Vector2i(cap_w, cap_h))
+	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives), dialog size %dx%d (vp_h=%d)" % [player, objectives.size(), cap_w, cap_h, int(vp_h)])
 
 
 # T-096: compute command phase sub-step progress (1/3 → 3/3)

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -1294,7 +1294,9 @@ func _show_condemn_dialog(pending: Dictionary, player: int) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Cap to the viewport so the dynamic Punishment description can't push the
+	# confirm/skip buttons off-screen (see DialogUtils.popup_centered_capped).
+	DialogUtils.popup_centered_capped(dialog)
 
 # ============================================================================
 # 11e GDM EXTRACT RELIC / LOCATE AND DENY — MARKER SETUP CHOICE
@@ -1449,7 +1451,9 @@ func _show_relic_setup_dialog(pending: Dictionary, player: int) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Cap to the viewport so the relic description can't push the confirm/skip
+	# buttons off-screen (see DialogUtils.popup_centered_capped).
+	DialogUtils.popup_centered_capped(dialog)
 
 func _on_mission_drawn(player: int, mission_id: String) -> void:
 	"""Handle SecondaryMissionManager mission_drawn signal — rebuild the secondary missions UI."""
@@ -1522,7 +1526,7 @@ func _show_marked_for_death_dialog(drawing_player: int, opponent: int, details: 
 	dialog.setup(drawing_player, opponent, opponent_units, details)
 	dialog.marked_for_death_resolved.connect(_on_marked_for_death_resolved.bind(drawing_player))
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 	print("CommandController: Marked for Death dialog shown — P%d (opponent) selects Alpha, P%d (card holder) selects Gamma" % [opponent, drawing_player])
 
 func _on_marked_for_death_resolved(alpha_targets: Array, gamma_target: String, drawing_player: int) -> void:
@@ -1571,7 +1575,7 @@ func _on_ai_alpha_targets_selected(drawing_player: int, alpha_targets: Array, el
 	dialog.setup_gamma_only(drawing_player, opponent, all_opponent_units, alpha_targets)
 	dialog.marked_for_death_resolved.connect(_on_marked_for_death_resolved.bind(drawing_player))
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 	print("CommandController: Marked for Death gamma-only dialog shown for P%d (card holder)" % drawing_player)
 
 func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: Dictionary) -> void:
@@ -1603,7 +1607,7 @@ func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: D
 	dialog.setup(opponent, nml_objectives)
 	dialog.tempting_target_resolved.connect(_on_tempting_target_resolved.bind(drawing_player))
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 	print("CommandController: A Tempting Target dialog shown for player %d to select objective" % opponent)
 
 func _on_tempting_target_resolved(objective_id: String, drawing_player: int) -> void:
@@ -1703,7 +1707,7 @@ func _show_beacon_dialog(drawing_player: int) -> void:
 	# and the prompt reopens on the next Command phase entry.
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 	print("CommandController: Beacon designation dialog shown for player %d (%d eligible units)" % [drawing_player, eligible.size()])
 
 # ============================================================================
@@ -1885,19 +1889,10 @@ func _show_guard_dialog(pending: Dictionary, player: int) -> void:
 	# has been laid out to a width), which previously sized the AcceptDialog
 	# window to thousands of pixels tall and scrolled the action buttons
 	# off-screen — the player could see the objective pickers but had no way to
-	# confirm. Forcing the window size (min == max) makes the inner
-	# ObjectiveScroll absorb any overflow instead. Height grows with the
-	# objective count but never past 90% of the viewport, and the MEDIUM floor
-	# keeps the fixed chrome (buttons) on-screen on normal displays.
-	var vp := get_viewport()
-	var vp_h: float = vp.get_visible_rect().size.y if vp else DialogConstants.MEDIUM.y
-	var desired_h: float = 230.0 + float(objectives.size()) * 40.0
-	var cap_w: int = int(DialogConstants.MEDIUM.x)
-	var cap_h: int = int(clamp(desired_h, DialogConstants.MEDIUM.y, vp_h * 0.9))
-	dialog.min_size = Vector2i(cap_w, cap_h)
-	dialog.max_size = Vector2i(cap_w, cap_h)
-	dialog.popup_centered(Vector2i(cap_w, cap_h))
-	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives), dialog size %dx%d (vp_h=%d)" % [player, objectives.size(), cap_w, cap_h, int(vp_h)])
+	# confirm. Height grows with the objective count but never past 90% of the
+	# viewport; the inner ObjectiveScroll absorbs any overflow.
+	DialogUtils.popup_centered_capped(dialog, DialogConstants.MEDIUM, 230.0 + float(objectives.size()) * 40.0)
+	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives)" % [player, objectives.size()])
 
 
 # T-096: compute command phase sub-step progress (1/3 → 3/3)

--- a/40k/scripts/DeploymentTransportDialog.gd
+++ b/40k/scripts/DeploymentTransportDialog.gd
@@ -80,8 +80,8 @@ func show_for_unit(unit_id_: String, deployment_controller: Node) -> void:
 			transport_list.add_item(text)
 			transport_list.set_item_metadata(transport_list.get_item_count() - 1, transport.id)
 
-	# Show dialog
-	popup_centered()
+	# Show dialog (capped to the viewport so the Deploy buttons stay on-screen)
+	DialogUtils.popup_centered_capped(self)
 
 func _on_transport_selected(index: int) -> void:
 	selected_transport_id = transport_list.get_item_metadata(index)

--- a/40k/scripts/DialogUtils.gd
+++ b/40k/scripts/DialogUtils.gd
@@ -1,0 +1,114 @@
+class_name DialogUtils
+
+## Shared helpers for showing dialogs safely.
+
+## Show `dialog` centered, clamped so it can never exceed the viewport, then
+## snugly re-fit to its real content on the next frame.
+##
+## This fixes a recurring layout bug: an autowrap `Label` placed directly in a
+## dialog's content reports a towering *minimum height* during the initial
+## `popup_centered()` — before it has been laid out to a width it wraps to
+## roughly one character per line. `AcceptDialog` then sizes its window to
+## thousands of pixels tall and never shrinks it, scrolling the confirm/cancel
+## buttons off the bottom of the screen where the player can't reach them.
+##
+## Fix in two steps:
+##   1. `max_size` hard-caps the window to the viewport up front, so it can
+##      never open off-screen no matter how tall the transient minimum is.
+##   2. One frame later — once the content has been laid out to the capped width
+##      and the autowrap Labels have re-wrapped to their real height — the window
+##      is re-measured to its genuine content size, re-clamped to the viewport,
+##      and re-centered. Dialogs with an inner ScrollContainer keep their scroll;
+##      short dialogs shrink to fit their content.
+##
+## `base_size` is the dialog's intended size (defaults to the MEDIUM tier);
+## `desired_height` optionally requests a taller initial height (still capped to
+## 90% of the viewport).
+static func popup_centered_capped(dialog: Window, base_size: Vector2 = DialogConstants.MEDIUM, desired_height: float = -1.0) -> void:
+	if dialog == null:
+		return
+	if not dialog.is_inside_tree():
+		# Can't resolve the screen size before the dialog is in the tree; fall
+		# back to a plain centered popup rather than doing nothing.
+		dialog.popup_centered(Vector2i(int(base_size.x), int(base_size.y)))
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var max_w: int = int(vp_size.x * 0.95)
+	var max_h: int = int(vp_size.y * 0.9)
+	# Hard ceiling so the window can never exceed the viewport.
+	dialog.max_size = Vector2i(max_w, max_h)
+	var want_h: float = desired_height if desired_height > 0.0 else base_size.y
+	dialog.popup_centered(Vector2i(
+		int(min(base_size.x, float(max_w))),
+		int(min(want_h, float(max_h)))))
+	# Re-fit once the content has been laid out (autowrap Labels have wrapped).
+	var t := dialog.get_tree()
+	if t != null:
+		t.process_frame.connect(DialogUtils._refit_to_viewport.bind(dialog), CONNECT_ONE_SHOT)
+
+
+static func _refit_to_viewport(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var max_w: int = int(vp_size.x * 0.95)
+	var max_h: int = int(vp_size.y * 0.9)
+	# Snap to the real content size (Labels have wrapped by now), clamp to the
+	# viewport, then re-center via popup_centered so it can't spill off-screen.
+	dialog.reset_size()
+	var w: int = min(int(dialog.size.x), max_w)
+	var h: int = min(int(dialog.size.y), max_h)
+	dialog.popup_centered(Vector2i(w, h))
+
+
+## The size of the screen/root viewport the `dialog` popup is embedded in.
+## NOTE: a Window is itself a Viewport, so `dialog.get_viewport()` returns the
+## dialog, not the screen — use the SceneTree root viewport instead.
+static func _screen_size(dialog: Window) -> Vector2:
+	var t := dialog.get_tree()
+	if t != null and t.root != null:
+		return t.root.get_visible_rect().size
+	return DialogConstants.LARGE
+
+
+## Arm a safety net on `dialog`: whenever it becomes visible, if it has opened
+## larger than the viewport (e.g. a tall autowrap Label ballooned its minimum
+## height and pushed the action buttons off-screen), clamp it back on-screen.
+## Only fires on ACTUAL overflow, so correctly-sized dialogs are never touched.
+## Wired into WhiteDwarfTheme.apply_to_dialog() so every themed dialog is covered
+## without each having to opt in.
+static func arm_overflow_guard(dialog: Window) -> void:
+	if dialog == null:
+		return
+	if not dialog.visibility_changed.is_connected(DialogUtils._on_guarded_visibility.bind(dialog)):
+		dialog.visibility_changed.connect(DialogUtils._on_guarded_visibility.bind(dialog))
+
+
+static func _on_guarded_visibility(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	# Defer so the content has been laid out (autowrap Labels have wrapped) before
+	# we decide whether the window overflows.
+	var t := dialog.get_tree()
+	if t != null:
+		t.process_frame.connect(DialogUtils._cap_if_overflowing.bind(dialog), CONNECT_ONE_SHOT)
+
+
+static func _cap_if_overflowing(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var overflows: bool = (
+		dialog.size.x > vp_size.x or dialog.size.y > vp_size.y
+		or dialog.position.x < 0 or dialog.position.y < 0
+		or dialog.position.x + dialog.size.x > vp_size.x
+		or dialog.position.y + dialog.size.y > vp_size.y)
+	if not overflows:
+		return  # fits on-screen — leave well-sized dialogs alone
+	var max_w: int = int(vp_size.x * 0.95)
+	var max_h: int = int(vp_size.y * 0.9)
+	dialog.max_size = Vector2i(max_w, max_h)
+	dialog.reset_size()
+	var w: int = min(int(dialog.size.x), max_w)
+	var h: int = min(int(dialog.size.y), max_h)
+	dialog.popup_centered(Vector2i(w, h))

--- a/40k/scripts/DialogUtils.gd.uid
+++ b/40k/scripts/DialogUtils.gd.uid
@@ -1,0 +1,1 @@
+uid://du6wvc6uvcbyq

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -705,7 +705,7 @@ func _show_coherency_removal_dialog(pending: Array) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 
 func _recheck_coherency_removal() -> void:
 	# After each removal: re-open the dialog while units remain incoherent;
@@ -859,7 +859,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 
 func _recheck_card_action() -> void:
 	# After resolve/skip the gate should be down — finish the turn the player
@@ -972,7 +972,7 @@ func _on_acrobatic_escape_vanish_available(unit_id: String, unit_name: String, p
 	dialog.add_child(content)
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 
 	# 60-second countdown timer
 	var time_remaining = [60.0]
@@ -1088,7 +1088,7 @@ func _on_end_turn_redeploy_available(unit_id: String, unit_name: String, player:
 	dialog.add_child(content)
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_centered_capped(dialog)
 
 	var time_remaining = [60.0]
 	var countdown_timer = Timer.new()

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -3794,7 +3794,9 @@ func _show_action_choice_dialog(options: Array) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Cap to the viewport so the action's description can't push the buttons
+	# off-screen (see DialogUtils.popup_centered_capped).
+	DialogUtils.popup_centered_capped(dialog)
 
 func _update_burn_objective_button() -> void:
 	"""Show/hide the Burn Objective button for Scorched Earth mission."""

--- a/40k/scripts/WhiteDwarfTheme.gd
+++ b/40k/scripts/WhiteDwarfTheme.gd
@@ -201,6 +201,12 @@ static func apply_to_dialog(dialog: Window) -> void:
 	_apply_common_theme_entries(theme)
 	dialog.theme = theme
 
+	# Safety net: if this dialog ever opens larger than the viewport (e.g. a tall
+	# autowrap Label ballooned its minimum height), clamp it back on-screen so its
+	# action buttons can never end up unreachable. Only fires on actual overflow,
+	# so correctly-sized dialogs are untouched.
+	DialogUtils.arm_overflow_guard(dialog)
+
 # Apply the White Dwarf chrome to a Control-based overlay (not a Window).
 # Cascades to every Button / Label / OptionButton / ItemList descendant so a
 # hand-built overlay matches the AcceptDialog-based dialogs without theming

--- a/40k/tests/scenarios/sp/iss065a_tempting_target_prompt_11e.json
+++ b/40k/tests/scenarios/sp/iss065a_tempting_target_prompt_11e.json
@@ -42,6 +42,11 @@
       "equals": true },
 
     { "act": "expect_node_visible", "node": "/root/TemptingTargetDialog", "timeout_s": 6.0 },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"TemptingTargetDialog\").position.y >= 0 and (get_tree().root.get_node(\"TemptingTargetDialog\").position.y + get_tree().root.get_node(\"TemptingTargetDialog\").size.y) <= get_tree().root.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
     { "act": "screenshot", "label": "01_dialog_prompts_human_opponent" },
 
     { "act": "click_node",

--- a/40k/tests/scenarios/sp/iss065c_beacon_designation_11e.json
+++ b/40k/tests/scenarios/sp/iss065c_beacon_designation_11e.json
@@ -31,6 +31,11 @@
     { "act": "click_node", "node": "/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton", "emit_pressed": true },
 
     { "act": "expect_node_visible", "node": "/root/BeaconUnitDialog", "timeout_s": 5.0 },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"BeaconUnitDialog\").position.y >= 0 and (get_tree().root.get_node(\"BeaconUnitDialog\").position.y + get_tree().root.get_node(\"BeaconUnitDialog\").size.y) <= get_tree().root.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
     { "act": "screenshot", "label": "01_beacon_designation_dialog" },
 
     { "act": "click_node",

--- a/40k/tests/scenarios/sp/iss065d_guard_prompt_11e.json
+++ b/40k/tests/scenarios/sp/iss065d_guard_prompt_11e.json
@@ -8,7 +8,7 @@
   "edition": 11,
   "rng_seed": 42,
   "disable_ai": true,
-  "description": "11e Burden of Trust guard selection UX: with the Warboss teleported onto the centre objective, a human P2 draws Burden of Trust — guards auto-assign (Warboss guards obj_center) and, after the drawn-missions review closes, the GuardSelectionDialog offers the per-objective pickers. 'Keep Auto Picks' closes the revision window while keeping the guard map, and guarded scoring counts obj_center while controlled.",
+  "description": "11e Burden of Trust guard selection UX: with the Warboss teleported onto the centre objective, a human P2 draws Burden of Trust — guards auto-assign (Warboss guards obj_center) and, after the drawn-missions review closes, the GuardSelectionDialog offers the per-objective pickers. The dialog must fit fully within the viewport so the Confirm / Keep action buttons are reachable (regression guard: the AcceptDialog previously blew up to thousands of pixels tall from the autowrap description Label's minimum size, pushing the buttons off-screen so selections could not be confirmed). 'Keep Auto Picks' closes the revision window while keeping the guard map, and guarded scoring counts obj_center while controlled.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.6 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
@@ -38,6 +38,14 @@
 
     { "act": "expect_node_visible", "node": "/root/GuardSelectionDialog", "timeout_s": 5.0 },
     { "act": "expect_node_visible", "node": "/root/GuardSelectionDialog/Content/ObjectiveScroll/ObjectiveRows/Row_obj_center/Guard_obj_center", "timeout_s": 2.0 },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"GuardSelectionDialog\").position.y >= 0 and (get_tree().root.get_node(\"GuardSelectionDialog\").position.y + get_tree().root.get_node(\"GuardSelectionDialog\").size.y) <= get_tree().root.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "(get_tree().root.get_node(\"GuardSelectionDialog\").position.y + get_tree().root.get_node(\"GuardSelectionDialog/Content/Actions/ConfirmGuards\").global_position.y + get_tree().root.get_node(\"GuardSelectionDialog/Content/Actions/ConfirmGuards\").size.y) <= get_tree().root.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
     { "act": "screenshot", "label": "01_guard_selection_dialog" },
 
     { "act": "click_node", "node": "/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards", "emit_pressed": true },

--- a/40k/tests/test_charge_phase_fixes.gd.uid
+++ b/40k/tests/test_charge_phase_fixes.gd.uid
@@ -1,0 +1,1 @@
+uid://ct7s2hkt16yqw


### PR DESCRIPTION
## Summary

Fixes the reported bug where the **Burden of Trust** guard-assignment window overflowed off the bottom of the screen, hiding its Confirm / Keep Auto Picks buttons — then extends the fix to the whole family of dialogs that share the same defect.

### Root cause
When an autowrap `Label` is placed directly in a dialog's content, it reports a towering *minimum height* during the initial `popup_centered()` (before it has been laid out to a width it wraps to ~1 character per line). `AcceptDialog` then sizes its window thousands of pixels tall and never shrinks it, scrolling the action buttons off the bottom of the screen. This was independent of content count — even a single-objective guard prompt ballooned to ~3078px on a 1080p viewport.

### Other menus affected (this was systemic)
Measured live on a 1080p viewport before the fix:
- **A Tempting Target** — 2584px
- **Marked for Death** — 2558px
- **Deploy Unit in Transport** — 1320px

Static audit flagged the same structure in **Beacon, Condemn, Extract Relic, out-of-coherency model removal, the shooting action prompt, the transport firing-deck picker**, and several other prompts.

## Changes
- **`DialogUtils.gd`** (new) — `popup_centered_capped()` shows a dialog centered but hard-capped to the viewport (`max_size`), then snugly re-fits to real content once autowrap Labels have wrapped. Applied to the confirmed dialogs (guard, condemn, relic, marked-for-death ×2, tempting-target, beacon, deploy-transport, 4 ScoringController prompts, shooting action-choice, firing-deck).
- **`WhiteDwarfTheme.apply_to_dialog()`** — now arms a global overflow guard on every themed dialog (~49 of them) that clamps it back on-screen **only if it ever opens larger than the viewport**. Correctly-sized dialogs are left untouched. This covers dialogs not individually converted.
- Refactored the original inline guard-dialog fix to use the shared helper.
- Windowed-scenario viewport-fit assertions added to the guard, tempting-target, and beacon flows.
- Changelog bumped to 0.6.3.

## Validation
- **Windowed (MCP bridge):** Tempting / Marked / Deploy / a tall 8-row coherency dialog / the real `KatahStanceDialog` (fixed by the net alone) all measured fully on-screen with nothing clipped; a healthy small dialog is left untouched; zero errors in the debug log.
- **Scenarios:** `iss065d_guard_prompt` (26 passed), `iss065a_tempting_target` (28), `iss065c_beacon_designation` (21), `iss064f_condemn` (30), `iss064i_relic_setup` (31), `iss063b_secondary_deck` (14) — all green with the net active.
- The new guard-scenario assertions were confirmed to **fail** against the pre-fix code and **pass** after, proving they catch the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hym8b3QoYPTj1hkPm14DF

---
_Generated by [Claude Code](https://claude.ai/code/session_018hym8b3QoYPTj1hkPm14DF)_