### PR TITLE
Make Shooting Phase weapon resolution step-by-step with Command Re-roll

### DIFF
--- a/40k/autoloads/GameManager.gd
+++ b/40k/autoloads/GameManager.gd
@@ -126,7 +126,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _delegate_to_current_phase(action)
 		"CONFIRM_TARGETS", "RESOLVE_SHOOTING", "SKIP_UNIT":
 			return _delegate_to_current_phase(action)
-		"SHOOT", "APPLY_SAVES", "RESOLVE_WEAPON_SEQUENCE", "CONTINUE_SEQUENCE":
+		"SHOOT", "APPLY_SAVES", "RESOLVE_WEAPON_SEQUENCE", "CONTINUE_SEQUENCE", \
+		"CONTINUE_TO_WOUNDS", "CONTINUE_TO_SAVES", "USE_SHOOTING_REROLL":
 			return _delegate_to_current_phase(action)
 
 		# Legacy shooting actions (kept for compatibility)

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -894,6 +894,223 @@ static func resolve_shoot_until_wounds(action: Dictionary, board: Dictionary, rn
 	return result
 
 # ==========================================
+# STAGED SHOOTING (interactive Command Re-roll between hit and wound rolls)
+# resolve_shoot_hits() rolls ONLY the hit roll for a single weapon and returns a
+# hit_context; the caller may pause (offer Command Re-roll on a hit die via
+# reroll_hit_die), then call resolve_shoot_wounds(hit_context) which rolls the
+# wound roll and prepares save data. This lets a player re-roll a hit die BEFORE
+# the wound roll is made — the whole point of the staged sequence. The composed
+# resolve_shoot_until_wounds() above stays behaviour-identical for the fast /
+# networked paths (golden tests guard it).
+# ==========================================
+
+static func resolve_shoot_hits(action: Dictionary, board: Dictionary, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var result = {"success": true, "phase": "SHOOTING", "dice": [], "log_text": "", "no_hits": true}
+	var actor_unit_id = action.get("actor_unit_id", "")
+	var assignments = action.get("payload", {}).get("assignments", [])
+	if assignments.is_empty():
+		result.success = false
+		result.log_text = "No weapon assignments provided"
+		return result
+	# Staged path resolves ONE weapon at a time.
+	var assignment = assignments[0]
+	var units = board.get("units", {})
+	var actor_unit = units.get(actor_unit_id, {})
+	if actor_unit.is_empty():
+		result.success = false
+		result.log_text = "Actor unit not found"
+		return result
+
+	var hit_res = _resolve_assignment_hits(assignment, actor_unit_id, board, rng_service)
+	result.dice = hit_res.get("dice", [])
+	result.log_text = hit_res.get("log_text", "")
+	result.no_hits = hit_res.get("no_hits", true)
+	# Always propagate hit_context (present even on a miss) so the staged path can
+	# Command Re-roll a missed die and continue to wounds if it becomes a hit.
+	result["hit_context"] = hit_res.get("hit_context", {})
+
+	# The weapon HAS fired once the hit roll is made — mirror the one-shot /
+	# hazardous bookkeeping resolve_shoot_until_wounds() performs per assignment.
+	var weapon_id = assignment.get("weapon_id", "")
+	if is_hazardous_weapon(weapon_id, board):
+		result["hazardous_weapons"] = [{
+			"weapon_id": weapon_id,
+			"models_that_fired": assignment.get("model_ids", []).size()
+		}]
+	if is_one_shot_weapon(weapon_id, board):
+		var one_shot_diffs = []
+		for model_id in assignment.get("model_ids", []):
+			one_shot_diffs.append_array(mark_one_shot_fired_diffs(actor_unit_id, actor_unit, model_id, weapon_id))
+		result["one_shot_diffs"] = one_shot_diffs
+	return result
+
+static func resolve_shoot_wounds(hit_context: Dictionary, board: Dictionary, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var w = _resolve_assignment_wounds(hit_context, board, rng_service)
+	var result = {
+		"success": true,
+		"phase": "SHOOTING",
+		"dice": w.get("dice", []),
+		"log_text": w.get("log_text", ""),
+		"no_wounds": w.get("no_wounds", false),
+		"save_data_list": []
+	}
+	if w.has("save_data") and w["save_data"].get("success", false):
+		result["save_data_list"] = [w["save_data"]]
+	if w.has("wound_context"):
+		result["wound_context"] = w["wound_context"]
+	return result
+
+# COMMAND RE-ROLL — re-roll a single hit die and recompute totals in place.
+# Only the chosen die is re-rolled; the untouched dice keep their result. A die
+# re-rolled here is not auto-re-rolled again (re-roll modifiers masked off — a
+# dice can only be re-rolled once). Returns an updated to_hit display block.
+static func reroll_hit_die(hit_context: Dictionary, die_index: int, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	if hit_context.get("is_torrent", false):
+		return {"success": false, "error": "Torrent weapons make no hit roll to re-roll"}
+	var evals = hit_context.get("hit_evals", [])
+	if die_index < 0 or die_index >= evals.size():
+		return {"success": false, "error": "Invalid hit die index %d" % die_index}
+	var old_crits = int(hit_context.get("critical_hits", 0))
+	var bs_per_attack = hit_context.get("bs_per_attack", [])
+	var attack_bs = int(bs_per_attack[die_index]) if die_index < bs_per_attack.size() else int(hit_context.get("bs", 4))
+	var mods_no_reroll = int(hit_context.get("hit_modifiers", 0)) & ~(HitModifier.REROLL_ONES | HitModifier.REROLL_FAILED)
+	var new_raw = rng_service.roll_d6(1)[0]
+	var ev = AttackSequence.evaluate_hit_roll(new_raw, attack_bs, mods_no_reroll, int(hit_context.get("critical_hit_threshold", 6)), rng_service, int(hit_context.get("hit_fail_band", 1)))
+	var old_eval = evals[die_index]
+	evals[die_index] = {"raw": new_raw, "final": ev.final_roll, "is_hit": ev.is_hit, "is_crit": ev.is_crit}
+	hit_context["hit_rolls"][die_index] = new_raw
+	hit_context["modified_rolls"][die_index] = ev.final_roll
+
+	# Re-tally from the per-die evals, then re-apply DAKKASTORM (all hits -> crits)
+	var hits = 0
+	var crits = 0
+	var regular = 0
+	for e in evals:
+		if e.get("is_hit", false):
+			hits += 1
+			if e.get("is_crit", false):
+				crits += 1
+			else:
+				regular += 1
+	if has_dakkastorm(hit_context.get("actor_unit", {})) and regular > 0:
+		crits += regular
+		regular = 0
+	hit_context["hits"] = hits
+	hit_context["critical_hits"] = crits
+	hit_context["regular_hits"] = regular
+	# Sustained bonus hits depend on the crit count — only re-roll them if the
+	# crit count actually changed, so re-rolling a plain miss->hit doesn't churn
+	# an unrelated Sustained bonus.
+	if crits != old_crits:
+		var sr = roll_sustained_hits(crits, hit_context.get("sustained_data", {"value": 0, "is_dice": false}), rng_service)
+		hit_context["sustained_bonus_hits"] = sr.bonus_hits
+	hit_context["total_hits_for_wounds"] = hits + int(hit_context.get("sustained_bonus_hits", 0))
+
+	var block = {
+		"context": "to_hit",
+		"threshold": str(hit_context.get("bs", 4)) + "+",
+		"rolls_raw": hit_context["hit_rolls"],
+		"rolls_modified": hit_context["modified_rolls"],
+		"rerolls": hit_context.get("reroll_data", []),
+		"successes": hits,
+		"critical_hits": crits,
+		"sustained_bonus_hits": int(hit_context.get("sustained_bonus_hits", 0)),
+		"total_hits_for_wounds": hit_context["total_hits_for_wounds"],
+		"command_rerolled_index": die_index
+	}
+	return {
+		"success": true,
+		"hit_context": hit_context,
+		"dice_block": block,
+		"old_value": old_eval.get("raw", 0),
+		"new_value": new_raw,
+		# Modified (post-BS-modifier) values — what the log / die buttons display.
+		"old_display": old_eval.get("final", old_eval.get("raw", 0)),
+		"new_display": ev.final_roll
+	}
+
+# COMMAND RE-ROLL — re-roll a single wound die, recompute wounds and rebuild the
+# save data (wounds_to_save / devastating crits) from the new tally.
+static func reroll_wound_die(wound_context: Dictionary, die_index: int, board: Dictionary, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var evals = wound_context.get("wound_evals", [])
+	if die_index < 0 or die_index >= evals.size():
+		return {"success": false, "error": "Invalid wound die index %d" % die_index}
+	var mods_no_reroll = int(wound_context.get("wound_modifiers", 0)) & ~(WoundModifier.REROLL_ONES | WoundModifier.REROLL_FAILED)
+	var new_raw = rng_service.roll_d6(1)[0]
+	var ev = AttackSequence.evaluate_wound_roll(new_raw, mods_no_reroll, int(wound_context.get("wound_threshold", 4)), int(wound_context.get("critical_wound_threshold", 6)), rng_service)
+	var old_eval = evals[die_index]
+	evals[die_index] = {"raw": new_raw, "is_wound": ev.is_wound, "is_crit": ev.is_crit, "auto_fail": ev.auto_fail}
+	wound_context["wound_rolls"][die_index] = new_raw
+
+	var has_dev = bool(wound_context.get("weapon_has_devastating_wounds", false))
+	var wounds_from_rolls = 0
+	var crit_wounds = 0
+	var regular_wounds = 0
+	for e in evals:
+		if e.get("auto_fail", false):
+			continue
+		if e.get("is_wound", false):
+			wounds_from_rolls += 1
+			if has_dev and e.get("is_crit", false):
+				crit_wounds += 1
+			else:
+				regular_wounds += 1
+	var auto_wounds = int(wound_context.get("auto_wounds", 0))
+	regular_wounds += auto_wounds  # Lethal Hits auto-wounds count as regular wounds
+	var wounds_caused = auto_wounds + wounds_from_rolls
+
+	var dev_data = {
+		"has_devastating_wounds": has_dev,
+		"critical_wounds": crit_wounds,
+		"regular_wounds": regular_wounds
+	}
+	var precision_data = {}
+	if bool(wound_context.get("weapon_has_precision", false)):
+		precision_data = {
+			"has_precision": true,
+			"critical_hits": int(wound_context.get("critical_hits", 0)),
+			"precision_wounds": mini(int(wound_context.get("critical_hits", 0)), wounds_caused)
+		}
+	var save_data = {}
+	if wounds_caused > 0:
+		save_data = prepare_save_resolution(
+			wounds_caused,
+			wound_context.get("target_unit_id", ""),
+			wound_context.get("actor_unit_id", ""),
+			wound_context.get("weapon_profile", {}),
+			board,
+			dev_data,
+			wound_context.get("melta_data", {}),
+			precision_data
+		)
+	var block = {
+		"context": "to_wound",
+		"threshold": str(wound_context.get("wound_threshold", 4)) + "+",
+		"rolls_raw": wound_context["wound_rolls"],
+		"successes": wounds_caused,
+		"critical_wounds": crit_wounds,
+		"regular_wounds": regular_wounds,
+		"command_rerolled_index": die_index
+	}
+	return {
+		"success": true,
+		"wound_context": wound_context,
+		"dice_block": block,
+		"wounds_caused": wounds_caused,
+		"save_data": save_data,
+		"old_value": old_eval.get("raw", 0),
+		"new_value": new_raw
+	}
+
+# ==========================================
 # OVERWATCH SHOOTING (Fire Overwatch Stratagem)
 # Only unmodified 6s hit. All other shooting mechanics (wound, save, damage) are normal.
 # ==========================================
@@ -1392,6 +1609,23 @@ static func _apply_diff_to_board(board: Dictionary, diff: Dictionary) -> void:
 # SUSTAINED HITS (PRP-011): This function is modified to handle Sustained Hits
 # BLAST (PRP-013): This function is modified to handle Blast keyword
 static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_id: String, board: Dictionary, rng: RNGService) -> Dictionary:
+	# Composed from the hit half + wound half so the staged (interactive
+	# re-roll) path can pause between them. Behaviour is identical to the
+	# original monolith (golden/replay tests guard the RNG order).
+	var h = _resolve_assignment_hits(assignment, actor_unit_id, board, rng)
+	var result = {"dice": (h.get("dice", []) as Array).duplicate(), "log_text": h.get("log_text", "")}
+	if h.get("no_hits", false):
+		return result
+	var w = _resolve_assignment_wounds(h["hit_context"], board, rng)
+	for wb in w.get("dice", []):
+		result.dice.append(wb)
+	result.log_text = w.get("log_text", result.log_text)
+	if w.has("save_data"):
+		result["save_data"] = w["save_data"]
+	return result
+
+static func _resolve_assignment_hits(assignment: Dictionary, actor_unit_id: String, board: Dictionary, rng: RNGService) -> Dictionary:
+	var hit_fail_band := 1
 	var result = {
 		"dice": [],
 		"log_text": ""
@@ -1607,6 +1841,10 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 	var hit_rolls = []
 	var modified_rolls = []
 	var reroll_data = []
+	# Per-die classification (raw/final/is_hit/is_crit), captured so a single-die
+	# Command Re-roll (staged shooting) can recompute totals without re-rolling
+	# the untouched dice. Empty for Torrent (no hit roll).
+	var hit_evals = []
 	var weapon_has_lethal_hits = false
 	var sustained_data = {"value": 0, "is_dice": false}
 	var sustained_result = {"bonus_hits": 0, "rolls": []}
@@ -1869,7 +2107,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 		# (AttackSequence.evaluate_hit_roll). INDIRECT FIRE's unmodified-1-3
 		# fail band (#371, unseen targets only) and CONVERSION's crit
 		# threshold (T4-16) are parameters.
-		var hit_fail_band = 1
+		hit_fail_band = 1
 		if is_indirect_fire and not indirect_target_visible:
 			# 11e (10.07): unmodified 1-5 fails (need a 6), unless the firing unit
 			# remained stationary AND the target is visible to a friendly unit, in
@@ -1886,6 +2124,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 			var attack_bs = bs_per_attack[i] if i < bs_per_attack.size() else bs
 			var hit_eval = AttackSequence.evaluate_hit_roll(roll, attack_bs, hit_modifiers, critical_hit_threshold, rng, hit_fail_band)
 			modified_rolls.append(hit_eval.final_roll)
+			hit_evals.append({"raw": roll, "final": hit_eval.final_roll, "is_hit": hit_eval.is_hit, "is_crit": hit_eval.is_crit})
 			if hit_eval.rerolled:
 				reroll_data.append({
 					"original": hit_eval.reroll_from,
@@ -1971,14 +2210,87 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 			"dakkastorm_active": has_dakkastorm(actor_unit)
 		})
 
+	# Build the hit context up-front so it is available even on a full miss —
+	# the staged shooting path may Command Re-roll a MISSED die (turning it into
+	# a hit), which needs the per-die evals/modifiers preserved here.
+	var hit_context = {
+		"assignment": assignment,
+		"actor_unit_id": actor_unit_id,
+		"weapon_id": weapon_id,
+		"weapon_profile": weapon_profile,
+		"actor_unit": actor_unit,
+		"target_unit": target_unit,
+		"target_unit_id": target_unit_id,
+		"model_ids": model_ids,
+		"hits": hits,
+		"critical_hits": critical_hits,
+		"regular_hits": regular_hits,
+		"sustained_bonus_hits": sustained_bonus_hits,
+		"total_hits_for_wounds": total_hits_for_wounds,
+		"weapon_has_lethal_hits": weapon_has_lethal_hits,
+		"is_torrent": is_torrent,
+		"hit_rolls": hit_rolls,
+		"modified_rolls": modified_rolls,
+		"hit_evals": hit_evals,
+		"reroll_data": reroll_data,
+		"bs": bs,
+		"bs_per_attack": bs_per_attack,
+		"total_attacks": total_attacks,
+		"heavy_bonus_applied": heavy_bonus_applied,
+		"bgnt_penalty_applied": bgnt_penalty_applied,
+		"indirect_fire_applied": indirect_fire_applied,
+		"models_in_half_range": models_in_half_range,
+		"rapid_fire_value": rapid_fire_value,
+		"hit_modifiers": hit_modifiers,
+		"critical_hit_threshold": critical_hit_threshold,
+		"hit_fail_band": hit_fail_band,
+		"sustained_data": sustained_data,
+	}
+	result["hit_context"] = hit_context
+
 	if hits == 0 and sustained_bonus_hits == 0:
 		var miss_weapon_name = weapon_profile.get("name", weapon_id)
 		var miss_log = "%s → %s with %s - No hits" % [actor_unit.get("meta", {}).get("name", actor_unit_id), target_unit.get("meta", {}).get("name", target_unit_id), miss_weapon_name]
 		if not hit_rolls.is_empty():
 			miss_log += " [%s] vs %s+" % [", ".join(hit_rolls.map(func(r): return str(r))), str(bs)]
 		result.log_text = miss_log
+		result["no_hits"] = true
 		return result
 
+	result["no_hits"] = false
+	return result
+
+static func _resolve_assignment_wounds(hit_context: Dictionary, board: Dictionary, rng: RNGService) -> Dictionary:
+	var result = {"dice": [], "log_text": ""}
+	var assignment = hit_context["assignment"]
+	var actor_unit_id = hit_context["actor_unit_id"]
+	var weapon_id = hit_context["weapon_id"]
+	var weapon_profile = hit_context["weapon_profile"]
+	var actor_unit = hit_context["actor_unit"]
+	var target_unit = hit_context["target_unit"]
+	var target_unit_id = hit_context["target_unit_id"]
+	var model_ids = hit_context["model_ids"]
+	var hits = hit_context["hits"]
+	var critical_hits = hit_context["critical_hits"]
+	var regular_hits = hit_context["regular_hits"]
+	var sustained_bonus_hits = hit_context["sustained_bonus_hits"]
+	var total_hits_for_wounds = hit_context["total_hits_for_wounds"]
+	var weapon_has_lethal_hits = hit_context["weapon_has_lethal_hits"]
+	var is_torrent = hit_context["is_torrent"]
+	var hit_rolls = hit_context["hit_rolls"]
+	var modified_rolls = hit_context["modified_rolls"]
+	var reroll_data = hit_context["reroll_data"]
+	var bs = hit_context["bs"]
+	var bs_per_attack = hit_context["bs_per_attack"]
+	var total_attacks = hit_context["total_attacks"]
+	var heavy_bonus_applied = hit_context["heavy_bonus_applied"]
+	var bgnt_penalty_applied = hit_context["bgnt_penalty_applied"]
+	var indirect_fire_applied = hit_context["indirect_fire_applied"]
+	var models_in_half_range = hit_context["models_in_half_range"]
+	var rapid_fire_value = hit_context["rapid_fire_value"]
+	var hit_modifiers = hit_context["hit_modifiers"]
+	var critical_hit_threshold = hit_context["critical_hit_threshold"]
+	var sustained_data = hit_context["sustained_data"]
 	# Roll to wound - LETHAL HITS (PRP-010) + SUSTAINED HITS (PRP-011) + DEVASTATING WOUNDS (PRP-012)
 	# TORRENT (PRP-014): Torrent weapons skip hit roll but still roll to wound normally
 	var strength = weapon_profile.get("strength", 4)
@@ -2146,6 +2458,9 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 	var critical_wound_count = 0  # Critical wounds: unmodified X+ (Anti) or 6s (default)
 	var regular_wound_count = 0   # Non-critical wounds
 	var wound_reroll_data = []  # Track twin-linked / modifier re-rolls
+	# Per-die classification, captured so a single-die Command Re-roll (staged
+	# shooting) can recompute wound totals without re-rolling untouched dice.
+	var wound_evals = []
 
 	# TORRENT (PRP-014): Since Torrent has no crits, Lethal Hits never triggers
 	# All hits must roll to wound normally
@@ -2162,6 +2477,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 			for roll in wound_rolls:
 				# ISS-012: shared per-roll evaluation (AttackSequence.evaluate_wound_roll)
 				var wound_eval = AttackSequence.evaluate_wound_roll(roll, wound_modifiers, wound_threshold, critical_wound_threshold, rng)
+				wound_evals.append({"raw": roll, "is_wound": wound_eval.is_wound, "is_crit": wound_eval.is_crit, "auto_fail": wound_eval.auto_fail})
 				if wound_eval.rerolled:
 					wound_reroll_data.append({"original": wound_eval.reroll_from, "rerolled_to": wound_eval.reroll_to})
 				if wound_eval.auto_fail:
@@ -2181,6 +2497,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 		for roll in wound_rolls:
 			# ISS-012: shared per-roll evaluation (AttackSequence.evaluate_wound_roll)
 			var wound_eval = AttackSequence.evaluate_wound_roll(roll, wound_modifiers, wound_threshold, critical_wound_threshold, rng)
+			wound_evals.append({"raw": roll, "is_wound": wound_eval.is_wound, "is_crit": wound_eval.is_crit, "auto_fail": wound_eval.auto_fail})
 			if wound_eval.rerolled:
 				wound_reroll_data.append({"original": wound_eval.reroll_from, "rerolled_to": wound_eval.reroll_to})
 			if wound_eval.auto_fail:
@@ -2242,6 +2559,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 		else:
 			no_wound_log += " - no wounds"
 		result.log_text = no_wound_log
+		result["no_wounds"] = true
 		return result
 
 	# STOP HERE - Prepare save data instead of auto-resolving
@@ -2296,6 +2614,24 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 	)
 
 	result["save_data"] = save_data
+	# Everything a single-die Command Re-roll (staged shooting) needs to re-tally
+	# wounds and rebuild save_data without re-rolling the untouched dice.
+	result["wound_context"] = {
+		"weapon_id": weapon_id,
+		"weapon_profile": weapon_profile,
+		"actor_unit_id": actor_unit_id,
+		"target_unit_id": target_unit_id,
+		"wound_rolls": wound_rolls,
+		"wound_evals": wound_evals,
+		"wound_threshold": wound_threshold,
+		"wound_modifiers": wound_modifiers,
+		"critical_wound_threshold": critical_wound_threshold,
+		"weapon_has_devastating_wounds": weapon_has_devastating_wounds,
+		"weapon_has_precision": weapon_has_precision,
+		"auto_wounds": auto_wounds,
+		"critical_hits": critical_hits,
+		"melta_data": melta_data,
+	}
 	# Build verbose log text with dice roll details
 	var int_weapon_name = weapon_profile.get("name", weapon_id)
 	var log_parts = []
@@ -2364,6 +2700,7 @@ static func _resolve_assignment_until_wounds(assignment: Dictionary, actor_unit_
 # WOUNDS] — rolling the wound preserves the critical-wound trigger (the
 # 24.23 designer's-note trade-off). assignment.lethal_hits_choice
 # ("auto"/"roll") overrides the default. 10e always auto-wounds.
+
 static func lethal_hits_auto_wound_11e(weapon_id: String, board: Dictionary, assignment: Dictionary) -> bool:
 	if GameConstants.edition < 11:
 		return true

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.7.0",
+			"date": "2026-07-07",
+			"summary": "The Shooting Phase 'Choose Weapon Order' sequence is now step-by-step and much clearer — it names each weapon, pauses after the hit roll and again after the wound roll, and lets you spend a Command Re-roll on a single die at each pause.",
+			"changes": [
+				"The resolution log is now verbose and readable. Each weapon gets its own header naming the weapon and target (e.g. 'Weapon 1 of 2 — Bolt Rifle → Ork Boyz'), and each step reads 'Rolling to Hit (need 2+): [ 5 4 4 2 ] → 3 hits, 1 miss' then 'Rolling to Wound (need 3+): [ 6 1 5 6 ] → 3 wounds' — instead of a terse summary that never said which weapon fired.",
+				"Sequential resolution now pauses after the hit roll and waits for you to click 'Roll to Wound ▶', then pauses again after the wound roll and waits for 'Continue to Saving Throws ▶'. You can read each result before moving on.",
+				"At each pause you can use the Command Re-roll stratagem (1 CP) on a single die: click a hit die (or a wound die) to re-roll it. It spends 1 CP, is limited to once per phase, and the wound roll is only made after you've finished with the hit roll — so re-rolling a hit correctly changes how many wound dice you roll.",
+				"Fixed the confusing button: after a weapon caused wounds, the only option used to be a bare 'Close' that actually took you to the defender's saving throws. It now reads 'Continue to Saving Throws ▶' so it's clear what happens next.",
+				"This staged flow applies to local/hotseat games; online multiplayer keeps the existing one-shot sequential resolution."
+			]
+		},
+		{
 			"version": "0.6.5",
 			"date": "2026-07-07",
 			"summary": "Fixed Infantry being wrongly charged an extra 2\" to move through or across Ruins — including the '2\" stuck on even after you move away' bug.",

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -15,6 +15,7 @@ signal dice_rolled(dice_data: Dictionary)
 signal saves_required(save_data_list: Array)  # For interactive save resolution
 signal weapon_order_required(assignments: Array)  # For weapon ordering when 2+ weapon types
 signal next_weapon_confirmation_required(remaining_weapons: Array, current_index: int, last_weapon_result: Dictionary)  # For sequential resolution pause
+signal shooting_stage_paused(stage: String, info: Dictionary)  # Staged sequential: "hits" or "wounds" pause reached (drives WeaponOrderDialog buttons + Command Re-roll)
 signal reactive_stratagem_opportunity(defending_player: int, available_stratagems: Array, target_unit_ids: Array)  # For opponent reactive stratagems
 signal grenade_result(result: Dictionary)  # For grenade stratagem result display
 signal command_reroll_opportunity(unit_id: String, player: int, roll_context: Dictionary)  # For Command Re-roll on save rolls (future expansion)
@@ -387,6 +388,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_apply_saves(action)
 		"CONTINUE_SEQUENCE":  # Continue to next weapon in sequential mode
 			return _validate_continue_sequence(action)
+		"CONTINUE_TO_WOUNDS", "CONTINUE_TO_SAVES", "USE_SHOOTING_REROLL":  # Staged sequential steps
+			return _validate_staged_continue(action)
 		"COMPLETE_SHOOTING_FOR_UNIT":  # Complete shooting after final weapon
 			return _validate_complete_shooting_for_unit(action)
 		"USE_REACTIVE_STRATAGEM":  # Defender uses a reactive stratagem
@@ -486,6 +489,15 @@ func process_action(action: Dictionary) -> Dictionary:
 		"CONTINUE_SEQUENCE":  # Continue to next weapon in sequential mode
 			DebugLogger.info("ShootingPhase: Matched CONTINUE_SEQUENCE")
 			return _process_continue_sequence(action)
+		"CONTINUE_TO_WOUNDS":  # Staged: roll the wound roll for the current weapon
+			DebugLogger.info("ShootingPhase: Matched CONTINUE_TO_WOUNDS")
+			return _staged_continue_to_wounds()
+		"CONTINUE_TO_SAVES":  # Staged: proceed from wound roll to saving throws
+			DebugLogger.info("ShootingPhase: Matched CONTINUE_TO_SAVES")
+			return _staged_continue_to_saves()
+		"USE_SHOOTING_REROLL":  # Staged: Command Re-roll a hit or wound die
+			DebugLogger.info("ShootingPhase: Matched USE_SHOOTING_REROLL")
+			return _process_use_shooting_reroll(action)
 		"COMPLETE_SHOOTING_FOR_UNIT":  # Complete shooting after final weapon
 			DebugLogger.info("ShootingPhase: Matched COMPLETE_SHOOTING_FOR_UNIT")
 			return _process_complete_shooting_for_unit(action)
@@ -2895,7 +2907,7 @@ func _process_resolve_weapon_sequence(action: Dictionary) -> Dictionary:
 	DebugLogger.info(str("ShootingPhase: confirmed_assignments before = ", confirmed_assignments))
 
 	# If this is a reorder during sequential resolution, update the weapon_order
-	if is_reorder and resolution_state.get("mode", "") == "sequential":
+	if is_reorder and resolution_state.get("mode", "") in ["sequential", "sequential_staged"]:
 		DebugLogger.info("ShootingPhase: Updating weapon order for remaining weapons")
 		var current_index = resolution_state.get("current_index", 0)
 		var existing_order = resolution_state.get("weapon_order", [])
@@ -2942,15 +2954,25 @@ func _process_resolve_weapon_sequence(action: Dictionary) -> Dictionary:
 		DebugLogger.info("========================================")
 		return resolve_result
 	else:
-		# Sequential resolution - resolve one weapon at a time
-		log_phase_message("Starting sequential weapon resolution")
-		DebugLogger.info("ShootingPhase: Starting sequential resolution...")
+		# Sequential resolution - resolve one weapon at a time.
+		# In non-networked play we use the STAGED variant: each weapon rolls to
+		# hit, PAUSES (so the attacker can read the result / use Command Re-roll),
+		# then rolls to wound, PAUSES again, then goes to saves. Networked games
+		# keep the original one-shot "sequential" mode (its saves ack/retry sync
+		# is unchanged) to avoid desync — mirrors how Command Re-roll is host/SP
+		# only elsewhere.
+		var seq_mode = "sequential"
+		if not NetworkManager.is_networked():
+			seq_mode = "sequential_staged"
+		log_phase_message("Starting sequential weapon resolution (%s)" % seq_mode)
+		DebugLogger.info("ShootingPhase: Starting sequential resolution... mode=%s" % seq_mode)
 		resolution_state = {
-			"mode": "sequential",
+			"mode": seq_mode,
 			"weapon_order": weapon_order,
 			"current_index": 0,
 			"completed_weapons": [],
-			"awaiting_saves": false
+			"awaiting_saves": false,
+			"stage": ""
 		}
 		DebugLogger.info(str("ShootingPhase: resolution_state = ", resolution_state))
 
@@ -3065,6 +3087,12 @@ func _resolve_next_weapon() -> Dictionary:
 
 	DebugLogger.info(str("ShootingPhase: Resolving weapon %d of %d: %s" % [current_index + 1, weapon_order.size(), weapon_id]))
 
+	# STAGED sequential resolution (non-networked): roll ONLY the hit roll now and
+	# pause. CONTINUE_TO_WOUNDS rolls the wound roll, CONTINUE_TO_SAVES emits saves.
+	# Command Re-roll can be used at each pause (USE_SHOOTING_REROLL).
+	if resolution_state.get("mode", "") == "sequential_staged":
+		return _staged_roll_hits(current_assignment, weapon_id, current_index)
+
 	# VERBOSE COMBAT LOG: Header BEFORE resolution so dice can display in real-time
 	var _seq_shooter = game_state_snapshot.get("units", {}).get(active_shooter_id, {})
 	var _seq_shooter_name = _seq_shooter.get("meta", {}).get("name", active_shooter_id)
@@ -3159,8 +3187,17 @@ func _resolve_next_weapon() -> Dictionary:
 	resolution_state.last_weapon_target_name = target_unit_name
 	resolution_state.last_weapon_target_id = current_assignment.target_unit_id
 
-	# Check if saves are needed
+	# Check if saves are needed (shared tail — see _finish_weapon_resolution)
 	var save_data_list = result.get("save_data_list", [])
+	return _finish_weapon_resolution(current_assignment, weapon_id, current_index, dice_data, hit_data, wound_data, target_unit_name, save_data_list, result.get("log_text", ""), result.get("hazardous_weapons", []))
+
+# Shared tail for sequential weapon resolution: given a fully-rolled weapon
+# (hit + wound dice already emitted), either pauses for saves (wounds) or for
+# next-weapon confirmation (no wounds). Called by _resolve_next_weapon (fast /
+# non-staged path) AND by the staged re-roll path after the wound stage.
+func _finish_weapon_resolution(current_assignment: Dictionary, weapon_id: String, current_index: int, dice_data: Array, hit_data: Dictionary, wound_data: Dictionary, target_unit_name: String, save_data_list: Array, log_text: String, hazardous_weapons: Array) -> Dictionary:
+	var weapon_order = resolution_state.get("weapon_order", [])
+	# Check if saves are needed
 	DebugLogger.info(str("ShootingPhase: save_data_list.size() = %d" % save_data_list.size()))
 
 	if save_data_list.is_empty():
@@ -3306,7 +3343,7 @@ func _resolve_next_weapon() -> Dictionary:
 
 			return create_result(true, auto_changes, "Sequential weapon resolution complete (remaining targets destroyed)", {
 				"dice": dice_data,
-				"log_text": result.get("log_text", "")
+				"log_text": log_text
 			})
 
 		# Get last weapon result for dialog display
@@ -3332,7 +3369,7 @@ func _resolve_next_weapon() -> Dictionary:
 			"remaining_weapons": remaining_weapons,
 			"last_weapon_result": last_weapon_result,
 			"dice": dice_data,
-			"log_text": result.get("log_text", "")
+			"log_text": log_text
 		})
 
 	# Store save data and trigger interactive saves
@@ -3340,7 +3377,7 @@ func _resolve_next_weapon() -> Dictionary:
 	resolution_state.awaiting_saves = true
 
 	# HAZARDOUS (T2-3): Store hazardous weapon data for post-save resolution
-	pending_hazardous_weapons = result.get("hazardous_weapons", [])
+	pending_hazardous_weapons = hazardous_weapons
 
 	# Add sequence context to save data for WoundAllocationOverlay
 	for save_data in save_data_list:
@@ -3391,8 +3428,296 @@ func _resolve_next_weapon() -> Dictionary:
 	return create_result(true, [], "Awaiting save resolution", {
 		"dice": dice_data,
 		"save_data_list": save_data_list,
-		"log_text": result.get("log_text", "")
+		"log_text": log_text
 	})
+
+
+# ==========================================================================
+# STAGED sequential resolution (non-networked): hit roll -> pause -> wound roll
+# -> pause -> saves, with Command Re-roll (USE_SHOOTING_REROLL) at each pause.
+# ==========================================================================
+
+func _shooting_reroll_available() -> bool:
+	# A staged hit/wound Command Re-roll is offered when the active player has not
+	# already used Command Re-roll this phase and can pay the CP.
+	var sm = get_node_or_null("/root/StratagemManager")
+	if sm == null or not sm.has_method("is_command_reroll_available"):
+		return false
+	var chk = sm.is_command_reroll_available(get_current_player())
+	return chk.get("available", false)
+
+func _extract_staged_hit_wound(dice_data: Array) -> Array:
+	# Pull hit/wound summary dicts out of the emitted to_hit / to_wound blocks so
+	# the completed-weapon record (and NextWeaponDialog summary) show real counts.
+	var hit_data = {}
+	var wound_data = {}
+	for db in dice_data:
+		var ctx = db.get("context", "")
+		if ctx == "to_hit" or ctx == "auto_hit":
+			hit_data = {
+				"rolls": db.get("rolls_raw", []),
+				"modified_rolls": db.get("rolls_modified", []),
+				"successes": db.get("successes", 0),
+				"total": (db.get("rolls_raw", []) as Array).size(),
+				"rerolls": db.get("rerolls", []),
+				"threshold": db.get("threshold", "")
+			}
+		elif ctx == "to_wound":
+			wound_data = {
+				"rolls": db.get("rolls_raw", []),
+				"successes": db.get("successes", 0),
+				"total": (db.get("rolls_raw", []) as Array).size(),
+				"threshold": db.get("threshold", "")
+			}
+	return [hit_data, wound_data]
+
+func _staged_roll_hits(current_assignment: Dictionary, weapon_id: String, current_index: int) -> Dictionary:
+	var weapon_order = resolution_state.get("weapon_order", [])
+	var shooter = game_state_snapshot.get("units", {}).get(active_shooter_id, {})
+	var shooter_name = shooter.get("meta", {}).get("name", active_shooter_id)
+	var weapon_profile = RulesEngine.get_weapon_profile(weapon_id)
+	var weapon_name = weapon_profile.get("name", weapon_id)
+	var target = get_unit(current_assignment.get("target_unit_id", ""))
+	var target_name = target.get("meta", {}).get("name", current_assignment.get("target_unit_id", ""))
+
+	GameEventLog.add_combat_header("P%d: %s → %s with %s (weapon %d/%d)" % [
+		get_current_player(), shooter_name, target_name, weapon_name, current_index + 1, weapon_order.size()])
+
+	# Verbose progress line that NAMES the weapon and target (Part A).
+	var progress = {
+		"context": "weapon_progress",
+		"message": "Weapon %d of %d — %s → %s" % [current_index + 1, weapon_order.size(), weapon_name, target_name],
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"current_index": current_index,
+		"total_weapons": weapon_order.size(),
+		"stage": "hits"
+	}
+	emit_signal("dice_rolled", progress)
+
+	# Roll ONLY the hit roll for this weapon.
+	var shoot_action = {"type": "SHOOT", "actor_unit_id": active_shooter_id, "payload": {"assignments": [current_assignment]}}
+	var rng = RulesEngine.make_rng()
+	var hres = RulesEngine.resolve_shoot_hits(shoot_action, game_state_snapshot, rng)
+	if not hres.get("success", false):
+		DebugLogger.info("ShootingPhase: staged hit roll FAILED: " + str(hres.get("log_text", "")))
+		return create_result(false, [], hres.get("log_text", "Hit resolution failed"))
+
+	pending_one_shot_diffs.append_array(hres.get("one_shot_diffs", []))
+
+	var dice_data = [progress]
+	for db in hres.get("dice", []):
+		dice_log.append(db)
+		emit_signal("dice_rolled", db)
+		dice_data.append(db)
+	log_phase_message(hres.get("log_text", ""))
+	_emit_verbose_combat_log(active_shooter_id, dice_data, [], 0, "sequential_hits")
+
+	# Stash everything the wound / save stages and the re-roll need.
+	resolution_state.stage = "hits_pending"
+	resolution_state.staged_hit_context = hres.get("hit_context", {})
+	resolution_state.staged_assignment = current_assignment
+	resolution_state.staged_weapon_id = weapon_id
+	resolution_state.staged_weapon_name = weapon_name
+	resolution_state.staged_target_name = target_name
+	resolution_state.staged_hazardous = hres.get("hazardous_weapons", [])
+	resolution_state.staged_dice = dice_data
+	resolution_state.staged_wound_context = {}
+	resolution_state.staged_save_data_list = []
+
+	var hc = hres.get("hit_context", {})
+	var can_reroll = _shooting_reroll_available() and not hc.get("is_torrent", false) and not (hc.get("hit_rolls", []) as Array).is_empty()
+
+	# Tell the attacker's dialog we are paused after the hit roll (show a
+	# "Roll to Wound" button + optional per-die Command Re-roll).
+	emit_signal("shooting_stage_paused", "hits", {
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"current_index": current_index,
+		"total_weapons": weapon_order.size(),
+		"reroll_available": can_reroll,
+		"hit_rolls": hc.get("hit_rolls", []),
+		"modified_rolls": hc.get("modified_rolls", []),
+		"hits": hc.get("hits", 0)
+	})
+
+	log_phase_message("Weapon %d of %d hit roll complete — awaiting attacker to continue to wound roll" % [current_index + 1, weapon_order.size()])
+	return create_result(true, [], "Weapon %d hits rolled — awaiting continue" % (current_index + 1), {
+		"staged_pause": "hits",
+		"current_weapon_index": current_index,
+		"total_weapons": weapon_order.size(),
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"reroll_available": can_reroll,
+		"hit_rolls": hc.get("hit_rolls", []),
+		"hits": hc.get("hits", 0),
+		"dice": dice_data
+	})
+
+func _staged_continue_to_wounds() -> Dictionary:
+	if resolution_state.get("stage", "") != "hits_pending":
+		return create_result(false, [], "Not awaiting continue-to-wounds")
+	var hit_context = resolution_state.get("staged_hit_context", {})
+	var current_assignment = resolution_state.get("staged_assignment", {})
+	var weapon_id = resolution_state.get("staged_weapon_id", "")
+	var target_name = resolution_state.get("staged_target_name", "")
+	var current_index = int(resolution_state.get("current_index", 0))
+	var weapon_order = resolution_state.get("weapon_order", [])
+
+	var rng = RulesEngine.make_rng()
+	var wres = RulesEngine.resolve_shoot_wounds(hit_context, game_state_snapshot, rng)
+
+	var dice_data = (resolution_state.get("staged_dice", []) as Array).duplicate()
+	for db in wres.get("dice", []):
+		dice_log.append(db)
+		emit_signal("dice_rolled", db)
+		dice_data.append(db)
+	resolution_state.staged_dice = dice_data
+	log_phase_message(wres.get("log_text", ""))
+
+	var save_data_list = wres.get("save_data_list", [])
+	resolution_state.staged_wound_context = wres.get("wound_context", {})
+	resolution_state.staged_save_data_list = save_data_list
+
+	var hw = _extract_staged_hit_wound(dice_data)
+	var hit_data = hw[0]
+	var wound_data = hw[1]
+	resolution_state.last_weapon_dice_data = dice_data
+	resolution_state.last_weapon_hit_data = hit_data
+	resolution_state.last_weapon_wound_data = wound_data
+	resolution_state.last_weapon_target_name = target_name
+	resolution_state.last_weapon_target_id = current_assignment.get("target_unit_id", "")
+
+	if save_data_list.is_empty():
+		# No wounds — go straight to the shared no-wounds / next-weapon tail.
+		resolution_state.stage = ""
+		return _finish_weapon_resolution(current_assignment, weapon_id, current_index, dice_data, hit_data, wound_data, target_name, [], wres.get("log_text", ""), resolution_state.get("staged_hazardous", []))
+
+	# Wounds caused — PAUSE so the attacker can read the wound roll / Command
+	# Re-roll a wound die before the defender makes saves.
+	resolution_state.stage = "wounds_pending"
+	var wc = resolution_state.get("staged_wound_context", {})
+	var can_reroll = _shooting_reroll_available() and not (wc.get("wound_evals", []) as Array).is_empty()
+	emit_signal("shooting_stage_paused", "wounds", {
+		"current_index": current_index,
+		"total_weapons": weapon_order.size(),
+		"reroll_available": can_reroll,
+		"wound_rolls": wc.get("wound_rolls", []),
+		"wounds": save_data_list[0].get("wounds_to_save", 0) if not save_data_list.is_empty() else 0,
+		"target_name": target_name
+	})
+	log_phase_message("Weapon %d of %d wound roll complete — awaiting attacker to continue to saving throws" % [current_index + 1, weapon_order.size()])
+	return create_result(true, [], "Weapon %d wounds rolled — awaiting continue to saves" % (current_index + 1), {
+		"staged_pause": "wounds",
+		"current_weapon_index": current_index,
+		"total_weapons": weapon_order.size(),
+		"reroll_available": can_reroll,
+		"wounds": save_data_list[0].get("wounds_to_save", 0) if not save_data_list.is_empty() else 0,
+		"dice": dice_data
+	})
+
+func _staged_continue_to_saves() -> Dictionary:
+	if resolution_state.get("stage", "") != "wounds_pending":
+		return create_result(false, [], "Not awaiting continue-to-saves")
+	var current_assignment = resolution_state.get("staged_assignment", {})
+	var weapon_id = resolution_state.get("staged_weapon_id", "")
+	var target_name = resolution_state.get("staged_target_name", "")
+	var current_index = int(resolution_state.get("current_index", 0))
+	var dice_data = resolution_state.get("staged_dice", [])
+	var save_data_list = resolution_state.get("staged_save_data_list", [])
+	var hw = _extract_staged_hit_wound(dice_data)
+	resolution_state.stage = ""
+	# Route through the shared tail — emits saves_required with sequence context.
+	return _finish_weapon_resolution(current_assignment, weapon_id, current_index, dice_data, hw[0], hw[1], target_name, save_data_list, "", resolution_state.get("staged_hazardous", []))
+
+func _replace_staged_dice_block(context: String, new_block: Dictionary) -> void:
+	var dd = resolution_state.get("staged_dice", [])
+	for i in range(dd.size()):
+		if dd[i].get("context", "") == context:
+			dd[i] = new_block
+			return
+	dd.append(new_block)
+
+func _process_use_shooting_reroll(action: Dictionary) -> Dictionary:
+	var payload = action.get("payload", {})
+	var stage = str(payload.get("stage", ""))
+	var die_index = int(payload.get("die_index", -1))
+	var expected = "hits_pending" if stage == "hits" else ("wounds_pending" if stage == "wounds" else "")
+	if expected == "" or resolution_state.get("stage", "") != expected:
+		return create_result(false, [], "No re-roll available at this stage")
+
+	# Spend the CP + record the once-per-phase Command Re-roll usage.
+	var sm = get_node_or_null("/root/StratagemManager")
+	if sm == null or not sm.has_method("execute_command_reroll"):
+		return create_result(false, [], "Command Re-roll unavailable")
+	var player = get_current_player()
+	var strat_result = sm.execute_command_reroll(player, active_shooter_id, {"roll_type": stage + "_roll"})
+	if not strat_result.get("success", false):
+		return create_result(false, [], str(strat_result.get("reason", "Cannot use Command Re-roll")))
+
+	var rng = RulesEngine.make_rng()
+	if stage == "hits":
+		var hc = resolution_state.get("staged_hit_context", {})
+		var rr = RulesEngine.reroll_hit_die(hc, die_index, rng)
+		if not rr.get("success", false):
+			return create_result(false, [], str(rr.get("error", "Re-roll failed")))
+		emit_signal("dice_rolled", {"context": "reroll_note",
+			"message": "Command Re-roll (1 CP): hit die %d → %d" % [rr.get("old_display", rr.get("old_value", 0)), rr.get("new_display", rr.get("new_value", 0))]})
+		emit_signal("dice_rolled", rr.get("dice_block", {}))
+		_replace_staged_dice_block("to_hit", rr.get("dice_block", {}))
+		var uhc = rr.get("hit_context", {})
+		emit_signal("shooting_stage_paused", "hits", {
+			"reroll_available": false,
+			"hit_rolls": uhc.get("hit_rolls", []),
+			"modified_rolls": uhc.get("modified_rolls", []),
+			"hits": uhc.get("hits", 0)
+		})
+		return create_result(true, [], "Hit die re-rolled", {
+			"staged_pause": "hits", "reroll_used": true, "reroll_available": false,
+			"dice_block": rr.get("dice_block", {}), "hits": rr.get("hit_context", {}).get("hits", 0)
+		})
+	else:
+		var wc = resolution_state.get("staged_wound_context", {})
+		var rr = RulesEngine.reroll_wound_die(wc, die_index, game_state_snapshot, rng)
+		if not rr.get("success", false):
+			return create_result(false, [], str(rr.get("error", "Re-roll failed")))
+		var new_wounds = int(rr.get("wounds_caused", 0))
+		# Rebuild the pending save list (may now have more/fewer wounds).
+		if new_wounds > 0:
+			var sd = rr.get("save_data", {})
+			# Preserve the sequence context stamped later by _finish_weapon_resolution.
+			resolution_state.staged_save_data_list = [sd]
+		else:
+			resolution_state.staged_save_data_list = []
+		emit_signal("dice_rolled", {"context": "reroll_note",
+			"message": "Command Re-roll (1 CP): wound die %d → %d" % [rr.get("old_value", 0), rr.get("new_value", 0)]})
+		emit_signal("dice_rolled", rr.get("dice_block", {}))
+		_replace_staged_dice_block("to_wound", rr.get("dice_block", {}))
+		emit_signal("shooting_stage_paused", "wounds", {
+			"reroll_available": false,
+			"wound_rolls": rr.get("wound_context", {}).get("wound_rolls", []),
+			"wounds": new_wounds
+		})
+		return create_result(true, [], "Wound die re-rolled", {
+			"staged_pause": "wounds", "reroll_used": true, "reroll_available": false,
+			"dice_block": rr.get("dice_block", {}), "wounds": new_wounds
+		})
+
+func _validate_staged_continue(action: Dictionary) -> Dictionary:
+	var t = action.get("type", "")
+	if t == "CONTINUE_TO_WOUNDS":
+		if resolution_state.get("stage", "") != "hits_pending":
+			return {"valid": false, "errors": ["Not awaiting continue-to-wounds"]}
+	elif t == "CONTINUE_TO_SAVES":
+		if resolution_state.get("stage", "") != "wounds_pending":
+			return {"valid": false, "errors": ["Not awaiting continue-to-saves"]}
+	elif t == "USE_SHOOTING_REROLL":
+		var stage = str(action.get("payload", {}).get("stage", ""))
+		var expected = "hits_pending" if stage == "hits" else ("wounds_pending" if stage == "wounds" else "")
+		if expected == "" or resolution_state.get("stage", "") != expected:
+			return {"valid": false, "errors": ["No re-roll available at this stage"]}
+	return {"valid": true, "errors": []}
+
 
 # T5-MP4-RELIABILITY: Save broadcast identity helpers
 #

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -2721,6 +2721,7 @@ func _on_weapon_order_required(assignments: Array) -> void:
 
 	# Connect to weapon_order_confirmed signal
 	dialog.weapon_order_confirmed.connect(_on_weapon_order_confirmed)
+	_connect_staged_dialog_signals(dialog)
 
 	# Add to scene tree FIRST (so _ready() runs)
 	get_tree().root.add_child(dialog)
@@ -2733,6 +2734,28 @@ func _on_weapon_order_required(assignments: Array) -> void:
 
 	print("ShootingController: WeaponOrderDialog shown and connected to phase signals")
 	print("========================================")
+
+func _connect_staged_dialog_signals(dialog) -> void:
+	# Wire the staged hit/wound pause controls (non-networked sequential mode).
+	if dialog.has_signal("staged_continue_requested") and not dialog.staged_continue_requested.is_connected(_on_staged_continue_requested):
+		dialog.staged_continue_requested.connect(_on_staged_continue_requested)
+	if dialog.has_signal("staged_reroll_requested") and not dialog.staged_reroll_requested.is_connected(_on_staged_reroll_requested):
+		dialog.staged_reroll_requested.connect(_on_staged_reroll_requested)
+
+func _on_staged_continue_requested(next_step: String) -> void:
+	# next_step: "wounds" (roll to wound) or "saves" (hand off to saving throws)
+	print("ShootingController: staged continue → %s" % next_step)
+	if next_step == "wounds":
+		emit_signal("shoot_action_requested", {"type": "CONTINUE_TO_WOUNDS"})
+	elif next_step == "saves":
+		emit_signal("shoot_action_requested", {"type": "CONTINUE_TO_SAVES"})
+
+func _on_staged_reroll_requested(stage: String, die_index: int) -> void:
+	print("ShootingController: staged Command Re-roll → stage=%s die=%d" % [stage, die_index])
+	emit_signal("shoot_action_requested", {
+		"type": "USE_SHOOTING_REROLL",
+		"payload": {"stage": stage, "die_index": die_index}
+	})
 
 func _on_weapon_order_confirmed(weapon_order: Array, fast_roll: bool) -> void:
 	"""Handle weapon order confirmation from WeaponOrderDialog"""
@@ -2975,6 +2998,7 @@ func _on_show_weapon_order_from_next_weapon_dialog(remaining_weapons: Array, fas
 
 	# Connect to weapon_order_confirmed signal
 	dialog.weapon_order_confirmed.connect(_on_next_weapon_order_confirmed)
+	_connect_staged_dialog_signals(dialog)
 
 	# Add to scene tree
 	get_tree().root.add_child(dialog)

--- a/40k/scripts/WeaponOrderDialog.gd
+++ b/40k/scripts/WeaponOrderDialog.gd
@@ -6,6 +6,10 @@ const _WhiteDwarfTheme = preload("res://scripts/WhiteDwarfTheme.gd")
 # Phase 1 MVP: Basic ordering with up/down arrows, fast roll option
 
 signal weapon_order_confirmed(weapon_order: Array, fast_roll: bool)
+# Staged sequential resolution (non-networked): the dialog stays open through the
+# hit roll and wound roll of the current weapon, driving these:
+signal staged_continue_requested(next_step: String)      # "wounds" or "saves"
+signal staged_reroll_requested(stage: String, die_index: int)  # Command Re-roll a hit/wound die
 
 # Weapon ordering data
 var weapon_assignments: Array = []  # Original assignments from shooting phase
@@ -25,8 +29,16 @@ var start_sequence_button: Button
 var close_button: Button
 var dice_log_rich_text: RichTextLabel
 
+# Staged-resolution UI
+var staged_continue_button: Button   # "Roll to Wound ▶" / "Continue to Saving Throws ▶"
+var reroll_label: Label              # "Command Re-roll available (1 CP)…"
+var reroll_row: HBoxContainer        # one button per die to re-roll
+var current_stage: String = ""       # "hits" | "wounds" while paused
+
 func _ready() -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
+	# Stable node name so windowed scenarios can address the dialog + its buttons.
+	name = "WeaponOrderDialog"
 	# Set dialog properties
 	title = "Choose Weapon Order"
 	dialog_hide_on_ok = false
@@ -90,7 +102,20 @@ func _ready() -> void:
 	WhiteDwarfTheme.apply_primary_button(start_sequence_button)
 	button_hbox.add_child(start_sequence_button)
 
+	# Staged-resolution continue button ("Roll to Wound ▶" / "Continue to Saving
+	# Throws ▶"). This REPLACES the old bare "Close" during staged resolution so
+	# the player always knows what the next step actually is.
+	staged_continue_button = Button.new()
+	staged_continue_button.name = "StagedContinueButton"
+	staged_continue_button.text = "Continue ▶"
+	staged_continue_button.pressed.connect(_on_staged_continue_pressed)
+	staged_continue_button.custom_minimum_size = Vector2(240, 42)
+	WhiteDwarfTheme.apply_primary_button(staged_continue_button)
+	button_hbox.add_child(staged_continue_button)
+	staged_continue_button.visible = false
+
 	close_button = Button.new()
+	close_button.name = "CloseButton"
 	close_button.text = "Close"
 	close_button.pressed.connect(_on_close_pressed)
 	close_button.custom_minimum_size = Vector2(100, 42)
@@ -110,6 +135,24 @@ func _ready() -> void:
 	continue_button.visible = false
 
 	_add_weapon_order_gold_separator(vbox)
+
+	# Command Re-roll affordance (staged resolution): a row of per-die buttons the
+	# attacker can click to re-roll a single hit/wound die with Command Re-roll.
+	reroll_label = Label.new()
+	reroll_label.name = "RerollLabel"
+	reroll_label.add_theme_font_size_override("font_size", 12)
+	reroll_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	reroll_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	reroll_label.visible = false
+	vbox.add_child(reroll_label)
+
+	reroll_row = HBoxContainer.new()
+	reroll_row.name = "RerollRow"
+	reroll_row.visible = false
+	var reroll_scroll = ScrollContainer.new()
+	reroll_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 44)
+	reroll_scroll.add_child(reroll_row)
+	vbox.add_child(reroll_scroll)
 
 	# Dice log section
 	var log_label = Label.new()
@@ -154,6 +197,11 @@ func setup(assignments: Array, phase = null) -> void:
 		if not current_phase.dice_rolled.is_connected(_on_dice_rolled):
 			current_phase.dice_rolled.connect(_on_dice_rolled)
 			print("║ Connected to phase dice_rolled signal")
+	# Staged sequential resolution pause signal (hit-roll / wound-roll pauses)
+	if current_phase and current_phase.has_signal("shooting_stage_paused"):
+		if not current_phase.shooting_stage_paused.is_connected(_on_stage_paused):
+			current_phase.shooting_stage_paused.connect(_on_stage_paused)
+			print("║ Connected to phase shooting_stage_paused signal")
 
 	# Group assignments by weapon type
 	var weapon_groups = {}
@@ -410,40 +458,151 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 	var context = dice_data.get("context", "")
 
 	if context == "weapon_progress":
-		# Weapon progress message
+		# Verbose weapon header — the phase now names the weapon + target.
 		var message = dice_data.get("message", "")
-		_add_to_dice_log("[b]>>> %s <<<[/b]" % message, Color.YELLOW)
+		_add_to_dice_log("", Color.WHITE)
+		_add_to_dice_log("[b]━━━ %s ━━━[/b]" % message, WhiteDwarfTheme.WH_GOLD)
 	elif context == "resolution_start":
-		# Resolution starting
 		var message = dice_data.get("message", "Beginning resolution...")
 		_add_to_dice_log(message, Color.CYAN)
+	elif context == "reroll_note":
+		_add_to_dice_log("[b][color=orange]↻ %s[/color][/b]" % dice_data.get("message", "Re-roll"), Color.ORANGE)
+	elif context == "auto_hit":
+		# Torrent: automatic hits, no roll.
+		var total = dice_data.get("total_attacks", dice_data.get("successes", 0))
+		_add_to_dice_log("[b]Rolling to Hit:[/b] [color=cyan]Torrent — %d automatic hits[/color]" % total, Color.WHITE)
+	elif context == "to_hit" or context == "to_wound":
+		_add_to_dice_log(_format_roll_line(context, dice_data), Color.WHITE)
 	else:
-		# Dice roll results
+		# Fallback for any other dice block.
 		var rolls_raw = dice_data.get("rolls_raw", [])
 		var rolls_modified = dice_data.get("rolls_modified", [])
-		var rerolls = dice_data.get("rerolls", [])
-		var successes = dice_data.get("successes", -1)
-		var threshold = dice_data.get("threshold", "")
-
-		# Format the display text
-		var log_text = "[b]%s[/b] (need %s): " % [context.capitalize().replace("_", " "), threshold]
-
-		# Show re-rolls if any
-		if not rerolls.is_empty():
-			log_text += "[color=orange]Re-rolled:[/color] "
-			for reroll in rerolls:
-				log_text += "[s]%d[/s]→%d " % [reroll.original, reroll.rerolled_to]
-			log_text += "| "
-
-		# Show rolls
 		var display_rolls = rolls_modified if not rolls_modified.is_empty() else rolls_raw
-		log_text += "Rolls: %s" % str(display_rolls)
-
-		# Show successes
+		var successes = dice_data.get("successes", -1)
+		var line = "[b]%s[/b] (need %s): Rolls: %s" % [context.capitalize().replace("_", " "), dice_data.get("threshold", ""), _dice_str(display_rolls)]
 		if successes >= 0:
-			log_text += " → [b][color=green]%d successes[/color][/b]" % successes
+			line += " → [b][color=green]%d successes[/color][/b]" % successes
+		_add_to_dice_log(line, Color.WHITE)
 
-		_add_to_dice_log(log_text, Color.WHITE)
+func _format_roll_line(context: String, dice_data: Dictionary) -> String:
+	# Verbose, human-readable hit / wound line.
+	var threshold = str(dice_data.get("threshold", ""))
+	var rolls_raw = dice_data.get("rolls_raw", [])
+	var rolls_modified = dice_data.get("rolls_modified", [])
+	var display_rolls = rolls_modified if not rolls_modified.is_empty() else rolls_raw
+	var total = (display_rolls as Array).size()
+	var successes = int(dice_data.get("successes", 0))
+	var rerolls = dice_data.get("rerolls", [])
+
+	var label = "Rolling to Hit" if context == "to_hit" else "Rolling to Wound"
+	var noun = "hit" if context == "to_hit" else "wound"
+	var line = "[b]%s[/b] (need %s): %s" % [label, threshold, _dice_str(display_rolls)]
+	if not (rerolls as Array).is_empty():
+		line += "  [color=orange]("
+		for rr in rerolls:
+			line += "%d→%d " % [rr.get("original", 0), rr.get("rerolled_to", 0)]
+		line = line.strip_edges() + ")[/color]"
+	# "→ 4 hits, 1 miss" (or wounds)
+	var fails = max(0, total - successes)
+	var success_word = noun if successes == 1 else noun + "s"
+	line += " → [b][color=green]%d %s[/color][/b]" % [successes, success_word]
+	if context == "to_hit" and total > 0:
+		var miss_word = "miss" if fails == 1 else "misses"
+		line += "[color=gray], %d %s[/color]" % [fails, miss_word]
+	# Crit / sustained annotations
+	var crits = int(dice_data.get("critical_hits", dice_data.get("critical_wounds", 0)))
+	if crits > 0:
+		var crit_kind = "critical hit" if context == "to_hit" else "critical wound"
+		line += "  [color=#c8a24a](%d %s%s)[/color]" % [crits, crit_kind, "" if crits == 1 else "s"]
+	var sustained = int(dice_data.get("sustained_bonus_hits", 0))
+	if context == "to_hit" and sustained > 0:
+		line += "  [color=#c8a24a](+%d Sustained)[/color]" % sustained
+	return line
+
+func _dice_str(rolls: Array) -> String:
+	# Render dice as spaced values, highlighting 6s (gold) and 1s (red).
+	if rolls.is_empty():
+		return "[color=gray]—[/color]"
+	var parts = []
+	for r in rolls:
+		var v = int(r)
+		if v == 6:
+			parts.append("[color=#d4af37]6[/color]")
+		elif v == 1:
+			parts.append("[color=#a04040]1[/color]")
+		else:
+			parts.append(str(v))
+	return "[ " + " ".join(parts) + " ]"
+
+# --- Staged sequential resolution (hit pause / wound pause) -------------------
+
+func _on_stage_paused(stage: String, info: Dictionary) -> void:
+	current_stage = stage
+	var reroll_available = bool(info.get("reroll_available", false))
+	if stage == "hits":
+		staged_continue_button.text = "Roll to Wound ▶"
+		staged_continue_button.tooltip_text = "Proceed to the wound roll for this weapon"
+	elif stage == "wounds":
+		staged_continue_button.text = "Continue to Saving Throws ▶"
+		staged_continue_button.tooltip_text = "Hand off to the defender to make saving throws"
+	staged_continue_button.visible = true
+	close_button.visible = false
+	# Command Re-roll affordance
+	if reroll_available:
+		var rolls = info.get("modified_rolls", [])
+		if (rolls as Array).is_empty():
+			rolls = info.get("hit_rolls", info.get("wound_rolls", []))
+		_populate_reroll_row(stage, rolls, info.get("threshold", ""))
+	else:
+		reroll_label.visible = false
+		reroll_row.visible = false
+		_clear_reroll_row()
+
+func _populate_reroll_row(stage: String, rolls: Array, _threshold: String) -> void:
+	_clear_reroll_row()
+	if rolls.is_empty():
+		reroll_label.visible = false
+		reroll_row.visible = false
+		return
+	reroll_label.text = "Command Re-roll (1 CP) — click a %s die to re-roll it (once per phase):" % ("hit" if stage == "hits" else "wound")
+	reroll_label.visible = true
+	reroll_row.visible = true
+	for i in range(rolls.size()):
+		var die_btn = Button.new()
+		die_btn.text = str(int(rolls[i]))
+		die_btn.custom_minimum_size = Vector2(38, 38)
+		die_btn.tooltip_text = "Re-roll this die with Command Re-roll (1 CP)"
+		_WhiteDwarfTheme.apply_to_button(die_btn)
+		die_btn.pressed.connect(_on_reroll_die_pressed.bind(i))
+		reroll_row.add_child(die_btn)
+
+func _clear_reroll_row() -> void:
+	if not reroll_row:
+		return
+	for child in reroll_row.get_children():
+		child.queue_free()
+
+func _on_reroll_die_pressed(die_index: int) -> void:
+	print("WeaponOrderDialog: re-roll %s die %d requested" % [current_stage, die_index])
+	# Disable further clicks immediately (once per phase); the phase will confirm.
+	reroll_label.visible = false
+	reroll_row.visible = false
+	_clear_reroll_row()
+	emit_signal("staged_reroll_requested", current_stage, die_index)
+
+func _on_staged_continue_pressed() -> void:
+	staged_continue_button.visible = false
+	reroll_label.visible = false
+	reroll_row.visible = false
+	_clear_reroll_row()
+	if current_stage == "hits":
+		emit_signal("staged_continue_requested", "wounds")
+	elif current_stage == "wounds":
+		# Hand off to the defender's saving throws — free the dialog so the
+		# wound-allocation overlay underneath becomes interactive.
+		emit_signal("staged_continue_requested", "saves")
+		hide()
+		queue_free()
 
 func _add_to_dice_log(text: String, color: Color) -> void:
 	"""Add colored text to dice log"""
@@ -453,11 +612,11 @@ func _add_to_dice_log(text: String, color: Color) -> void:
 	var color_hex = color.to_html(false)
 	dice_log_rich_text.append_text("[color=#%s]%s[/color]\n" % [color_hex, text])
 
-	# Check if sequence is complete (ShootingPhase will emit shooting_resolved or saves_required)
-	# For now, we'll show the close button after the first weapon progress
-	# A more robust solution would be to connect to shooting_resolved signal
-	if is_resolving and not close_button.visible:
-		# Show close button after first dice roll (user can close anytime during resolution)
+	# The staged flow drives progression via the staged continue button (shown by
+	# _on_stage_paused), so we no longer surface a bare "Close" mid-resolution.
+	# Fallback: if we are resolving but no stage pause ever arrives (e.g. the
+	# networked one-shot path), reveal Close so the player is never stuck.
+	if is_resolving and current_stage == "" and not close_button.visible and not staged_continue_button.visible:
 		close_button.visible = true
 
 

--- a/40k/tests/scenarios/sp/staged_shooting_reroll_ui.json
+++ b/40k/tests/scenarios/sp/staged_shooting_reroll_ui.json
@@ -1,0 +1,116 @@
+{
+  "id": "staged_shooting_reroll_ui",
+  "covers": [
+    "ui.shooting.staged_hit_wound_pause",
+    "ui.shooting.command_reroll",
+    "ui.shooting.continue_buttons"
+  ],
+  "fixture": "shooting_phase",
+  "rng_seed": 7,
+  "transition_to_phase": 8,
+  "description": "Drives the non-networked STAGED shooting sequence through the real WeaponOrderDialog: Start Sequence -> hit roll pause ('Roll to Wound' + per-die Command Re-roll) -> wound roll pause ('Continue to Saving Throws' + wound re-roll) -> wound-allocation overlay. Verifies the verbose log and that the bare 'Close' button is gone.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "execute_script",
+      "script": "var main = tree.root.get_node(\"Main\")\nvar sc = main.shooting_controller\nvar phase = sc.current_phase\nvar ap = GameState.get_active_player()\n# Find an active-player unit with 2+ distinct ranged weapon types.\nvar shooter_id = \"\"\nvar wtypes = []\nfor uid in GameState.state.units:\n\tvar u = GameState.state.units[uid]\n\tif u.get(\"owner\", 0) != ap:\n\t\tcontinue\n\tif u.get(\"models\", []).is_empty():\n\t\tcontinue\n\tvar wl = RulesEngine.get_unit_weapons(uid)\n\tvar seen = {}\n\tfor mid in wl:\n\t\tfor w in wl[mid]:\n\t\t\tseen[w] = true\n\tif seen.size() >= 2:\n\t\tshooter_id = uid\n\t\twtypes = seen.keys()\n\t\tbreak\nif shooter_id == \"\":\n\treturn \"ERR no 2-weapon shooter\"\nvar target_id = \"\"\nfor uid in GameState.state.units:\n\tvar u = GameState.state.units[uid]\n\tif u.get(\"owner\", 0) != ap and not u.get(\"models\", []).is_empty():\n\t\ttarget_id = uid\n\t\tbreak\nif target_id == \"\":\n\treturn \"ERR no target\"\nvar shooter = GameState.state.units[shooter_id]\nvar target = GameState.state.units[target_id]\nvar bx = 880.0\nvar by = 1000.0\nvar si = 0\nfor m in shooter.models:\n\tm.position = {\"x\": bx, \"y\": by + si * 34}\n\tm.alive = true\n\tm[\"status\"] = 2\n\tsi += 1\nshooter[\"status\"] = 2\nvar ti = 0\nfor m in target.models:\n\tm.position = {\"x\": bx + 80, \"y\": by + ti * 34}\n\tm.alive = true\n\tti += 1\nGameState.state[\"players\"][str(ap)][\"cp\"] = 5\nvar mids = []\nfor m in shooter.models:\n\tmids.append(m.id)\nvar m0 = mids[0]\nvar assigns = [\n\t{\"weapon_id\": wtypes[0], \"target_unit_id\": target_id, \"model_ids\": [m0]},\n\t{\"weapon_id\": wtypes[1], \"target_unit_id\": target_id, \"model_ids\": [m0]},\n]\nphase.active_shooter_id = shooter_id\nphase.confirmed_assignments = assigns.duplicate(true)\nsc.current_phase = phase\nsc.call(\"_on_weapon_order_required\", assigns)\nreturn \"OK shooter=\" + shooter_id + \" target=\" + target_id + \" cp=\" + str(GameState.state.players[str(ap)].cp)\n",
+      "multiline": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 4
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node_or_null(\"WeaponOrderDialog\") != null",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "01_weapon_order_dialog"
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node_or_null(\"WeaponOrderDialog\")._on_start_sequence_pressed()",
+      "multiline": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 6
+    },
+    {
+      "act": "execute_script",
+      "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nreturn d.staged_continue_button.visible and d.staged_continue_button.text.begins_with(\"Roll to Wound\")",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "not tree.root.get_node_or_null(\"WeaponOrderDialog\").close_button.visible",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node_or_null(\"WeaponOrderDialog\").reroll_row.visible",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var t=tree.root.get_node_or_null(\"WeaponOrderDialog\").dice_log_rich_text.get_parsed_text()\nreturn t.contains(\"Rolling to Hit\")",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "02_hits_pause"
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node_or_null(\"WeaponOrderDialog\")._on_staged_continue_pressed()",
+      "multiline": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 6
+    },
+    {
+      "act": "execute_script",
+      "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nreturn d == null or d.staged_continue_button.text.begins_with(\"Continue to Saving Throws\")",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "03_wounds_pause"
+    },
+    {
+      "act": "execute_script",
+      "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nif d != null and d.reroll_row.visible and d.reroll_row.get_child_count() > 0:\n\td._on_reroll_die_pressed(0)\n\treturn \"wound reroll used\"\nreturn \"no wound reroll (already used or no wounds)\"",
+      "multiline": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 6
+    },
+    {
+      "act": "screenshot",
+      "label": "04_after_wound_reroll"
+    },
+    {
+      "act": "execute_script",
+      "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nif d != null:\n\td._on_staged_continue_pressed()\n\treturn \"continued to saves\"\nreturn \"dialog already closed\"",
+      "multiline": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "screenshot",
+      "label": "05_after_continue"
+    }
+  ]
+}

--- a/40k/tests/test_shooting_sequential_pause.gd
+++ b/40k/tests/test_shooting_sequential_pause.gd
@@ -1,0 +1,189 @@
+extends SceneTree
+
+# Anchor for the sequential-resolution tail refactor (_resolve_next_weapon).
+# Drives ShootingPhase._resolve_next_weapon() directly for:
+#   - a wounds case  -> result carries save_data_list, resolution_state.awaiting_saves
+#   - a no-wounds/miss case -> result carries sequential_pause, completed_weapons grows
+# These structural invariants must hold identically before and after extracting
+# the shared tail helper. RNG is not seeded here; we assert on shape, not values.
+#
+# Usage: godot --headless --path . -s tests/test_shooting_sequential_pause.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run"))
+	create_timer(0.1).timeout.connect(_run)
+
+func _board(target_toughness: int, target_save: int, attacks: int) -> Dictionary:
+	var sm = []
+	for i in range(3):
+		sm.append({"id": "ms%d" % i, "position": {"x": 0, "y": float(i*35)}, "base_mm": 32,
+			"base_type": "circular", "alive": true, "wounds": 2, "current_wounds": 2})
+	var tm = []
+	for i in range(8):
+		tm.append({"id": "mt%d" % i, "position": {"x": 40, "y": float(i*35)}, "base_mm": 32,
+			"base_type": "circular", "alive": true, "wounds": 1, "current_wounds": 1,
+			"stats": {"toughness": target_toughness, "save": target_save}})
+	return {
+		"meta": {"active_player": 1, "turn_number": 1},
+		"players": {"1": {"cp": 5}, "2": {"cp": 5}},
+		"units": {
+			"U_S": {"id": "U_S", "owner": 1, "meta": {"name": "Shooters", "keywords": ["INFANTRY"],
+				"stats": {"toughness": 4, "save": 3}}, "models": sm, "flags": {}},
+			"U_T": {"id": "U_T", "owner": 2, "meta": {"name": "Targets", "keywords": ["INFANTRY"],
+				"stats": {"toughness": target_toughness, "save": target_save}}, "models": tm, "flags": {}}
+		}
+	}
+
+func _assign(attacks: int) -> Dictionary:
+	return {"weapon_id": "bolt_rifle", "target_unit_id": "U_T",
+		"model_ids": ["ms0", "ms1", "ms2"], "attacks_override": attacks}
+
+func _new_phase(board: Dictionary, order: Array):
+	var ShootingPhaseScript = load("res://phases/ShootingPhase.gd")
+	var phase = ShootingPhaseScript.new()
+	# game_state_snapshot is a read-only property backed by GameState.state, so we
+	# must load the board into the GameState autoload for get_unit() to see it.
+	root.get_node("GameState").state = board
+	# Add to the tree so the phase's get_node_or_null("/root/StratagemManager") etc. resolve.
+	get_root().add_child(phase)
+	phase.active_shooter_id = "U_S"
+	phase.confirmed_assignments = order.duplicate(true)
+	phase.resolution_state = {
+		"mode": "sequential",
+		"weapon_order": order.duplicate(true),
+		"current_index": 0,
+		"completed_weapons": [],
+		"awaiting_saves": false
+	}
+	return phase
+
+func _has_ctx(dice: Array, ctx: String) -> bool:
+	for d in dice:
+		if d.get("context", "") == ctx:
+			return true
+	return false
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_shooting_sequential_pause ===\n")
+	if root.get_node_or_null("RulesEngine") == null:
+		_check("RulesEngine autoload reachable", false)
+		_finish(); return
+
+	# --- Wounds case: T1 Sv6 vs 30 attacks -> guaranteed wounds -> saves pause ---
+	var wounds_ok := false
+	for attempt in range(3):
+		var board = _board(1, 6, 40)
+		var order = [_assign(40), _assign(40)]  # two weapons
+		var phase = _new_phase(board, order)
+		var res = phase._resolve_next_weapon()
+		var sdl = res.get("save_data_list", [])
+		if not sdl.is_empty():
+			wounds_ok = true
+			_check("wounds: result.success", res.get("success", false))
+			_check("wounds: save_data_list present", not sdl.is_empty())
+			_check("wounds: awaiting_saves set", phase.resolution_state.get("awaiting_saves", false))
+			_check("wounds: dice has to_hit", _has_ctx(res.get("dice", []), "to_hit"))
+			_check("wounds: dice has to_wound", _has_ctx(res.get("dice", []), "to_wound"))
+			_check("wounds: sequence_context stamped on save_data",
+				sdl[0].has("sequence_context") and sdl[0]["sequence_context"].get("total_weapons", 0) == 2)
+			phase.queue_free()
+			break
+		phase.queue_free()
+	_check("wounds: reached a wounds result within 3 attempts", wounds_ok)
+
+	# --- No-wounds case: T12 Sv2 vs 1 attack -> likely miss/no-wound -> sequential_pause ---
+	var miss_ok := false
+	for attempt in range(6):
+		var board2 = _board(12, 2, 1)
+		var order2 = [_assign(1), _assign(1)]
+		var phase2 = _new_phase(board2, order2)
+		var res2 = phase2._resolve_next_weapon()
+		if res2.get("sequential_pause", false):
+			miss_ok = true
+			_check("no-wounds: result.success", res2.get("success", false))
+			_check("no-wounds: sequential_pause=true", res2.get("sequential_pause", false))
+			_check("no-wounds: completed_weapons grew", phase2.resolution_state.get("completed_weapons", []).size() >= 1)
+			_check("no-wounds: current_index advanced", int(phase2.resolution_state.get("current_index", 0)) == 1)
+			_check("no-wounds: remaining_weapons present", res2.has("remaining_weapons"))
+			phase2.queue_free()
+			break
+		phase2.queue_free()
+	_check("no-wounds: reached a sequential_pause within 6 attempts", miss_ok)
+
+	# --- Staged progression: hits pause -> wounds pause -> saves ---
+	var staged_ok := false
+	for attempt in range(4):
+		var board = _board(1, 6, 40)
+		var order = [_assign(40)]  # single weapon so the tail leads to saves
+		var phase = _new_phase(board, order)
+		phase.resolution_state["mode"] = "sequential_staged"
+		var r1 = phase._resolve_next_weapon()  # -> _staged_roll_hits
+		if r1.get("staged_pause", "") != "hits":
+			phase.queue_free(); continue
+		_check("staged: first result is a hits pause", r1.get("staged_pause", "") == "hits")
+		_check("staged: stage == hits_pending", phase.resolution_state.get("stage", "") == "hits_pending")
+		_check("staged: to_hit emitted, no to_wound yet", _has_ctx(r1.get("dice", []), "to_hit") and not _has_ctx(r1.get("dice", []), "to_wound"))
+		_check("staged: progress message names the weapon",
+			str(r1.get("weapon_name", "")).length() > 0)
+		var r2 = phase.process_action({"type": "CONTINUE_TO_WOUNDS"})
+		# T1/Sv6 vs 40 attacks -> almost certainly wounds -> wounds pause
+		if r2.get("staged_pause", "") == "wounds":
+			staged_ok = true
+			_check("staged: second result is a wounds pause", r2.get("staged_pause", "") == "wounds")
+			_check("staged: stage == wounds_pending", phase.resolution_state.get("stage", "") == "wounds_pending")
+			_check("staged: to_wound now present", _has_ctx(phase.resolution_state.get("staged_dice", []), "to_wound"))
+			var r3 = phase.process_action({"type": "CONTINUE_TO_SAVES"})
+			_check("staged: continue-to-saves yields save_data_list", not (r3.get("save_data_list", []) as Array).is_empty())
+			_check("staged: awaiting_saves set after saves stage", phase.resolution_state.get("awaiting_saves", false))
+			phase.queue_free()
+			break
+		phase.queue_free()
+	_check("staged: reached hits->wounds->saves progression", staged_ok)
+
+	# --- Staged Command Re-roll at the hit stage: spends CP, updates the roll ---
+	var rr_board = _board(1, 6, 20)
+	var rr_phase = _new_phase(rr_board, [_assign(20)])
+	rr_phase.resolution_state["mode"] = "sequential_staged"
+	var rr1 = rr_phase._resolve_next_weapon()
+	var cp_before = root.get_node("StratagemManager").get_player_cp(1)
+	if rr1.get("staged_pause", "") == "hits" and cp_before > 0:
+		var rr_res = rr_phase.process_action({"type": "USE_SHOOTING_REROLL", "payload": {"stage": "hits", "die_index": 0}})
+		_check("reroll: USE_SHOOTING_REROLL succeeded", rr_res.get("success", false), str(rr_res.get("error", "")))
+		if rr_res.get("success", false):
+			_check("reroll: CP was spent (1 CP)", root.get_node("StratagemManager").get_player_cp(1) == cp_before - 1,
+				"before=%d after=%d" % [cp_before, root.get_node("StratagemManager").get_player_cp(1)])
+			_check("reroll: a second re-roll is now unavailable (once per phase)",
+				not rr_phase._shooting_reroll_available())
+			var rr_res2 = rr_phase.process_action({"type": "USE_SHOOTING_REROLL", "payload": {"stage": "hits", "die_index": 1}})
+			_check("reroll: second re-roll rejected (once per phase)", not rr_res2.get("success", true))
+	else:
+		print("    (reroll test skipped — no hits pause or no CP)")
+	rr_phase.queue_free()
+
+	# --- Staged guards: wrong-stage actions are rejected ---
+	var gboard = _board(1, 6, 40)
+	var gphase = _new_phase(gboard, [_assign(40)])
+	gphase.resolution_state["mode"] = "sequential_staged"
+	gphase._resolve_next_weapon()  # now at hits_pending
+	var bad = gphase.process_action({"type": "CONTINUE_TO_SAVES"})  # illegal before wounds
+	_check("staged: CONTINUE_TO_SAVES rejected at hits stage", not bad.get("success", true))
+	gphase.queue_free()
+
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit()

--- a/40k/tests/test_staged_shooting_reroll.gd
+++ b/40k/tests/test_staged_shooting_reroll.gd
@@ -1,0 +1,185 @@
+extends SceneTree
+
+# Staged shooting resolution + Command Re-roll (RulesEngine).
+#
+# Proves:
+#   A) resolve_shoot_hits() + resolve_shoot_wounds() driven with the SAME rng
+#      as resolve_shoot_until_wounds() consumes dice in the identical order and
+#      produces identical to_hit / to_wound dice records (the split is a pure
+#      re-shape of the monolith).
+#   B) resolve_shoot_hits() returns ONLY the hit roll (no wound record) + a
+#      hit_context; resolve_shoot_wounds(hit_context) returns the wound record.
+#   C) reroll_hit_die() re-rolls exactly one die, recomputes hits and
+#      total_hits_for_wounds, and leaves the untouched dice unchanged.
+#   D) reroll_wound_die() re-rolls one die and rebuilds wounds_caused + save_data.
+#
+# Usage: godot --headless --path . -s tests/test_staged_shooting_reroll.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run"))
+	create_timer(0.1).timeout.connect(_run)
+
+func _make_board() -> Dictionary:
+	var shooter_models = []
+	for i in range(5):
+		shooter_models.append({
+			"id": "ms%d" % i,
+			"position": {"x": 0, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1
+		})
+	var target_models = []
+	for i in range(10):
+		target_models.append({
+			"id": "mt%d" % i,
+			"position": {"x": 40, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1,
+			"stats": {"toughness": 4, "save": 4}
+		})
+	return {
+		"units": {
+			"U_SHOOTER": {
+				"id": "U_SHOOTER", "owner": 1,
+				"meta": {"name": "Shooters", "keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 3}},
+				"models": shooter_models, "flags": {}
+			},
+			"U_TARGET": {
+				"id": "U_TARGET", "owner": 2,
+				"meta": {"name": "Targets", "keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 4}},
+				"models": target_models, "flags": {}
+			}
+		}
+	}
+
+func _action() -> Dictionary:
+	return {
+		"type": "SHOOT",
+		"actor_unit_id": "U_SHOOTER",
+		"payload": {"assignments": [{
+			"weapon_id": "bolt_rifle",
+			"target_unit_id": "U_TARGET",
+			"model_ids": ["ms0", "ms1", "ms2", "ms3", "ms4"],
+			"attacks_override": 12
+		}]}
+	}
+
+func _find(dice: Array, ctx: String) -> Dictionary:
+	for d in dice:
+		if d.get("context", "") == ctx:
+			return d
+	return {}
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_staged_shooting_reroll ===\n")
+	var rules = root.get_node_or_null("RulesEngine")
+	if rules == null:
+		_check("RulesEngine autoload reachable", false)
+		_finish()
+		return
+
+	var SEED := 424242
+
+	# --- A) Equivalence: monolith vs staged with the same seed ---
+	var mono = rules.resolve_shoot_until_wounds(_action(), _make_board(), rules.RNGService.new(SEED))
+	var mono_hit = _find(mono.get("dice", []), "to_hit")
+	var mono_wound = _find(mono.get("dice", []), "to_wound")
+
+	var staged_rng = rules.RNGService.new(SEED)
+	var board2 = _make_board()
+	var hits_res = rules.resolve_shoot_hits(_action(), board2, staged_rng)
+	var wounds_res = rules.resolve_shoot_wounds(hits_res.get("hit_context", {}), board2, staged_rng)
+	var staged_hit = _find(hits_res.get("dice", []), "to_hit")
+	var staged_wound = _find(wounds_res.get("dice", []), "to_wound")
+
+	_check("A: monolith produced a to_hit record", not mono_hit.is_empty())
+	_check("A: monolith produced a to_wound record", not mono_wound.is_empty())
+	_check("A: staged hit rolls == monolith hit rolls",
+		str(staged_hit.get("rolls_raw", [])) == str(mono_hit.get("rolls_raw", [])),
+		"staged=%s mono=%s" % [str(staged_hit.get("rolls_raw", [])), str(mono_hit.get("rolls_raw", []))])
+	_check("A: staged hit successes == monolith",
+		staged_hit.get("successes", -1) == mono_hit.get("successes", -2))
+	_check("A: staged wound rolls == monolith wound rolls",
+		str(staged_wound.get("rolls_raw", [])) == str(mono_wound.get("rolls_raw", [])),
+		"staged=%s mono=%s" % [str(staged_wound.get("rolls_raw", [])), str(mono_wound.get("rolls_raw", []))])
+	_check("A: staged wound successes == monolith",
+		staged_wound.get("successes", -1) == mono_wound.get("successes", -2))
+
+	# --- B) hits stage returns ONLY the hit roll + a hit_context ---
+	var hits_only = rules.resolve_shoot_hits(_action(), _make_board(), rules.RNGService.new(SEED))
+	_check("B: hits stage has to_hit record", not _find(hits_only.get("dice", []), "to_hit").is_empty())
+	_check("B: hits stage has NO to_wound record", _find(hits_only.get("dice", []), "to_wound").is_empty())
+	_check("B: hits stage returns a hit_context", hits_only.has("hit_context") and not hits_only.hit_context.is_empty())
+
+	# --- C) reroll_hit_die: one die changes, totals recompute, others stable ---
+	var hc = hits_only.get("hit_context", {})
+	var evals_before = (hc.get("hit_evals", []) as Array).duplicate(true)
+	var hits_before = int(hc.get("hits", 0))
+	var idx := 0  # pick a failed die if present, else 0
+	for i in range(evals_before.size()):
+		if not evals_before[i].get("is_hit", false):
+			idx = i
+			break
+	var rr = rules.reroll_hit_die(hc, idx, rules.RNGService.new(99))
+	_check("C: reroll_hit_die succeeded", rr.get("success", false), str(rr.get("error", "")))
+	_check("C: exactly one hit die changed",
+		_count_diff(evals_before, hc.get("hit_evals", [])) == 1,
+		"diffs=%d" % _count_diff(evals_before, hc.get("hit_evals", [])))
+	_check("C: total_hits_for_wounds == hits + sustained",
+		int(hc.get("total_hits_for_wounds", -1)) == int(hc.get("hits", 0)) + int(hc.get("sustained_bonus_hits", 0)))
+	_check("C: hits recomputed consistently with evals",
+		int(hc.get("hits", -1)) == _count_hits(hc.get("hit_evals", [])),
+		"hits=%d evals_hits=%d" % [int(hc.get("hits", -1)), _count_hits(hc.get("hit_evals", []))])
+	print("    (hits %d -> %d after re-rolling die %d)" % [hits_before, int(hc.get("hits", 0)), idx])
+
+	# --- D) reroll_wound_die: rebuild wounds + save_data ---
+	# Fresh resolve to a wound stage with wounds present.
+	var d_rng = rules.RNGService.new(SEED)
+	var d_board = _make_board()
+	var d_hits = rules.resolve_shoot_hits(_action(), d_board, d_rng)
+	var d_wounds = rules.resolve_shoot_wounds(d_hits.get("hit_context", {}), d_board, d_rng)
+	if d_wounds.has("wound_context") and not d_wounds.get("save_data_list", []).is_empty():
+		var wc = d_wounds.get("wound_context", {})
+		var wev_before = (wc.get("wound_evals", []) as Array).duplicate(true)
+		var w_rr = rules.reroll_wound_die(wc, 0, d_board, rules.RNGService.new(7))
+		_check("D: reroll_wound_die succeeded", w_rr.get("success", false), str(w_rr.get("error", "")))
+		_check("D: exactly one wound die changed",
+			_count_diff(wev_before, wc.get("wound_evals", [])) == 1)
+		_check("D: rebuilt save_data has wounds_to_save == wounds_caused",
+			int(w_rr.get("save_data", {}).get("wounds_to_save", -1)) == int(w_rr.get("wounds_caused", -2))
+				or int(w_rr.get("wounds_caused", 0)) == 0)
+	else:
+		print("    (no wounds this seed — D skipped, not a failure)")
+
+	_finish()
+
+func _count_diff(a: Array, b: Array) -> int:
+	var n = 0
+	for i in range(min(a.size(), b.size())):
+		if str(a[i]) != str(b[i]):
+			n += 1
+	return n
+
+func _count_hits(evals: Array) -> int:
+	var n = 0
+	for e in evals:
+		if e.get("is_hit", false):
+			n += 1
+	return n
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit()


### PR DESCRIPTION
## Summary

The Shooting Phase "Choose Weapon Order" sequence was terse and confusing: after **Start Sequence** it never said which weapon fired, and the only button was a bare **"Close"** that actually advanced to the defender's saving throws.

Local/hotseat sequential resolution is now **staged**: roll to hit → pause → roll to wound → pause → saves, and at each pause the attacker can spend a **Command Re-roll (1 CP)** on a single die. Because the wound roll is only made *after* the hit pause, re-rolling a hit correctly changes how many wound dice are rolled — the whole point of the staged flow.

### Player-facing changes
- **Verbose log** that names the weapon + target and reads `Rolling to Hit (need 2+): [ 5 4 4 2 ] → 3 hits, 1 miss` / `Rolling to Wound (need 3+): [ 6 1 5 6 ] → 3 wounds`.
- **Pauses** after the hit roll (`Roll to Wound ▶`) and after the wound roll (`Continue to Saving Throws ▶`) so you can read each result before moving on.
- **Command Re-roll** at each pause: click a hit die (or a wound die) to re-roll it — spends 1 CP, once per phase.
- The misleading bare **"Close"** button is replaced by **"Continue to Saving Throws ▶"** so it's clear what happens next.
- Applies to local/hotseat games; online multiplayer keeps the existing one-shot sequential resolution.

## Implementation

**RulesEngine**
- Split the ranged `_resolve_assignment_until_wounds` monolith into `_resolve_assignment_hits` (returns a `hit_context`) + `_resolve_assignment_wounds` (consumes it). The original entry point is now a pure composition of the two halves, so behaviour and RNG order are **unchanged** (golden/replay tests guard this). `hit_context` is packed even on a miss so a missed die can be re-rolled.
- Added `resolve_shoot_hits` / `resolve_shoot_wounds` staged wrappers, plus `reroll_hit_die` / `reroll_wound_die` which re-roll **one** die and recompute totals (and rebuild save data) without disturbing the untouched dice. Per-die evals are captured in both roll loops to make that recompute exact.

**ShootingPhase**
- Sequential resolution picks `sequential_staged` mode when not networked; the shared post-wound tail is extracted into `_finish_weapon_resolution` and reused by both the staged and non-staged paths.
- New actions `CONTINUE_TO_WOUNDS` / `CONTINUE_TO_SAVES` / `USE_SHOOTING_REROLL` and a `shooting_stage_paused` signal drive the dialog. Command Re-roll spends CP and is once-per-phase via `StratagemManager`. Networked games keep the original one-shot sequential path (with its saves ack/retry) to avoid desync.

**WeaponOrderDialog**
- Verbose resolution log + a Command Re-roll die row, and context buttons replacing the bare "Close".

## Testing
- **Headless: 181 assertions pass**, including split-equivalence (byte-identical dice vs the monolith at the same seed), the staged hits→wounds→saves progression, per-die re-roll recompute, CP spend + once-per-phase, and wrong-stage guards. New tests: `tests/test_staged_shooting_reroll.gd`, `tests/test_shooting_sequential_pause.gd`.
- **Windowed (real UI):** drove the full flow via the in-game bridge — verbose named log, `Roll to Wound ▶`, per-die Command Re-roll (CP 5→4), `Continue to Saving Throws ▶`, and the wound-allocation overlay; `verify_delivery` returned **PASS**. Added windowed scenario `tests/scenarios/sp/staged_shooting_reroll_ui.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjHZ3JAEbKSESdrXA7Jeh3

---
_Generated by [Claude Code](https://claude.ai/code/session_01LjHZ3JAEbKSESdrXA7Jeh3)_