### PR TITLE
Fix Fight-phase Pile In / Consolidate step windows opening blacked-out

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.6.8",
+			"date": "2026-07-07",
+			"summary": "Fixed the Fight phase 'Pile In' and 'Consolidate' step windows opening as a giant blacked-out box instead of showing the unit picker.",
+			"changes": [
+				"When the Fight phase opened, the 'Pile In Step' pop-up (and the end-of-phase 'Consolidate Step' pop-up) could appear as a huge, mostly-black window that filled the screen with no visible content. The window was being stretched to roughly 5,500 pixels tall — far bigger than the screen — because a long description line inside it was mis-measured, and an off-screen-sized window renders as a black rectangle.",
+				"Both windows now size to their content: a compact picker showing the banner, the instructions, the list of eligible units to pile in / consolidate (each as a button), and the 'End Pile In' / 'End Consolidation' button — all visible and clickable."
+			]
+		},
+		{
 			"version": "0.6.7",
 			"date": "2026-07-07",
 			"summary": "Fixed a whole family of pop-up windows that could stretch off the bottom of the screen and hide their buttons — the same bug as the Burden of Trust window, across many other prompts.",

--- a/40k/dialogs/ConsolidationStepDialog.gd
+++ b/40k/dialogs/ConsolidationStepDialog.gd
@@ -18,6 +18,17 @@ signal end_consolidation(player: int)
 var dialog_data: Dictionary = {}
 var phase_reference = null
 
+# Factory: build a ready-to-show dialog (script attached + UI built). The caller
+# connects the signals, adds it to the tree, and calls popup_centered(). Shared
+# by FightController and the windowed regression scenario so both exercise one
+# construction path (and the autowrap-Label height guard in _build_ui).
+static func create(data: Dictionary, phase) -> AcceptDialog:
+	var dialog := AcceptDialog.new()
+	dialog.set_script(load("res://dialogs/ConsolidationStepDialog.gd"))
+	dialog.name = "ConsolidationStepDialog"
+	dialog.setup(data, phase)
+	return dialog
+
 func setup(data: Dictionary, phase) -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
 	dialog_data = data
@@ -47,6 +58,12 @@ func _build_ui() -> void:
 	var instructions = Label.new()
 	instructions.text = "All fighting is resolved. Pick a unit to make its consolidation move (up to 3\"), or end your consolidation. Consolidating is optional — units you don't pick simply stay put."
 	instructions.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	# Constrain the wrapped label's width so it reports a correct minimum HEIGHT.
+	# An autowrap Label with no bounded width is measured at ~zero width while the
+	# dialog pops up and returns a towering minimum height (~5500px), which inflates
+	# the whole AcceptDialog to span/overflow the screen — the oversized embedded
+	# window then renders as a black rectangle for the player.
+	instructions.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 40, 0)
 	instructions.add_theme_color_override("font_color", Color.YELLOW)
 	content.add_child(instructions)
 	content.add_child(HSeparator.new())

--- a/40k/dialogs/PileInStepDialog.gd
+++ b/40k/dialogs/PileInStepDialog.gd
@@ -18,6 +18,17 @@ signal end_pile_in(player: int)
 var dialog_data: Dictionary = {}
 var phase_reference = null
 
+# Factory: build a ready-to-show dialog (script attached + UI built). The caller
+# connects the signals, adds it to the tree, and calls popup_centered(). Shared
+# by FightController and the windowed regression scenario so both exercise one
+# construction path (and the autowrap-Label height guard in _build_ui).
+static func create(data: Dictionary, phase) -> AcceptDialog:
+	var dialog := AcceptDialog.new()
+	dialog.set_script(load("res://dialogs/PileInStepDialog.gd"))
+	dialog.name = "PileInStepDialog"
+	dialog.setup(data, phase)
+	return dialog
+
 func setup(data: Dictionary, phase) -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
 	dialog_data = data
@@ -47,6 +58,12 @@ func _build_ui() -> void:
 	var instructions = Label.new()
 	instructions.text = "The Fight phase opens with pile-ins. Pick a unit to make its pile-in move (up to 3\", each model closer to its pile-in target), or end your pile-in. Piling in is optional — units you don't pick simply stay put."
 	instructions.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	# Constrain the wrapped label's width so it reports a correct minimum HEIGHT.
+	# An autowrap Label with no bounded width is measured at ~zero width while the
+	# dialog pops up and returns a towering minimum height (~5500px), which inflates
+	# the whole AcceptDialog to span/overflow the screen — the oversized embedded
+	# window then renders as a black rectangle for the player.
+	instructions.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 40, 0)
 	instructions.add_theme_color_override("font_color", Color.YELLOW)
 	content.add_child(instructions)
 	content.add_child(HSeparator.new())

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -2022,10 +2022,7 @@ func _on_pile_in_step_required(data: Dictionary) -> void:
 		push_error("Failed to load PileInStepDialog.gd")
 		return
 
-	var dialog = AcceptDialog.new()
-	dialog.set_script(dialog_script)
-	dialog.name = "PileInStepDialog"
-	dialog.setup(data, current_phase)
+	var dialog = dialog_script.create(data, current_phase)
 	dialog.pile_in_unit_chosen.connect(_on_pile_in_step_unit_chosen)
 	dialog.end_pile_in.connect(_on_end_pile_in)
 	get_tree().root.add_child(dialog)
@@ -2085,10 +2082,7 @@ func _on_consolidation_step_required(data: Dictionary) -> void:
 		push_error("Failed to load ConsolidationStepDialog.gd")
 		return
 
-	var dialog = AcceptDialog.new()
-	dialog.set_script(dialog_script)
-	dialog.name = "ConsolidationStepDialog"
-	dialog.setup(data, current_phase)
+	var dialog = dialog_script.create(data, current_phase)
 	dialog.consolidate_unit_chosen.connect(_on_consolidation_unit_chosen)
 	dialog.end_consolidation.connect(_on_end_consolidation)
 	get_tree().root.add_child(dialog)

--- a/40k/tests/scenarios/sp/fight_step_dialogs_height.json
+++ b/40k/tests/scenarios/sp/fight_step_dialogs_height.json
@@ -1,0 +1,64 @@
+{
+  "id": "fight_step_dialogs_height",
+  "covers": [
+    "ui.layout.PileInStepDialog_fits_content",
+    "ui.layout.ConsolidationStepDialog_fits_content"
+  ],
+  "fixture": "co_pretrigger",
+  "disable_ai": true,
+  "description": "The Fight-phase Pile In / Consolidate step pickers (PileInStepDialog, ConsolidationStepDialog) must size to their content, not span the screen. Regression guard for the autowrap-Label minimum-height blowup: the instructions Label had no bounded width, so when the AcceptDialog was measured it assumed ~zero width and reported a towering minimum height (~5517px), inflating the window past the viewport. The oversized embedded window then renders as a black rectangle for the player ('Pile In' window blacked out). Instantiates each real dialog via its create() factory (the same path FightController uses), pops it up, and asserts the RAW popup height (measured in the same frame as popup_centered, BEFORE the deferred overflow guard can re-fit it — the guard masks the bug on fast machines) stays well under the viewport. With the bug the raw height is ~5517px; fixed it is ~477px. Then lets it settle a few frames and screenshots the rendered picker.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.add_child(ResourceLoader.load('res://dialogs/PileInStepDialog.gd').create({'piling_in_player': 1, 'eligible_units': {'U_A': {'name': 'Vertus Praetors', 'engaged': true}, 'U_B': {'name': 'Telemon Heavy Dreadnought', 'engaged': false}}}, null))" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').popup_centered()" },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').size.y",
+      "expect_max": 900 },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').size.y",
+      "expect_min": 300 },
+
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_pile_in_step_dialog" },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').visible",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').size.y < main.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('PileInStepDialog').free()" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.add_child(ResourceLoader.load('res://dialogs/ConsolidationStepDialog.gd').create({'consolidating_player': 1, 'eligible_units': {'U_A': {'name': 'Vertus Praetors', 'mode': 'ongoing'}, 'U_B': {'name': 'Telemon Heavy Dreadnought', 'mode': 'engaging'}}}, null))" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').popup_centered()" },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').size.y",
+      "expect_max": 900 },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').size.y",
+      "expect_min": 300 },
+
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "02_consolidation_step_dialog" },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').visible",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').size.y < main.get_viewport().get_visible_rect().size.y",
+      "equals": true },
+
+    { "act": "execute_script",
+      "script": "main.get_tree().root.get_node('ConsolidationStepDialog').free()" }
+  ]
+}


### PR DESCRIPTION
## Summary

When the Fight phase opened, the **Pile In Step** picker (and the end-of-phase **Consolidate Step** picker) appeared as a giant, mostly-black box filling the screen with no usable content — the window titled "Pile In" was blacked out.

## Root cause

Both dialogs build their instructions text as an autowrap `Label` with **no bounded width**. When the `AcceptDialog` is measured during `popup_centered()`, that Label is measured at ~zero width and reports a *towering* minimum height, so the window opens at **550 × 5517 px** (measured) — roughly 5× the screen height. An embedded `Window` that many times taller than its host viewport renders as a solid black rectangle on GPU hardware.

The existing `DialogUtils` overflow guard is a deferred, race-prone band-aid: it only re-fits the window if the Label has re-wrapped by the frame it runs. On a real machine it loses that race, so the window stays oversized and black with its content stranded thousands of pixels down.

## Fix

- **Bound the instructions Label width** via `custom_minimum_size.x` in `PileInStepDialog.gd` and `ConsolidationStepDialog.gd` — the exact pattern already used to fix `MissionDiscardDialog`. The dialog now opens at ~477 px and shows its banner, instructions, eligible-unit buttons, and End button.
- Add a static `create()` factory to both dialogs and route `FightController` through it, so the real controller path and the windowed regression scenario share one construction path.

## Validation (windowed, against the running game)

- New scenario `tests/scenarios/sp/fight_step_dialogs_height.json` asserts the **raw popup height** (measured in the same frame as `popup_centered()`, before the deferred guard can mask it). It **FAILS at 5517 px without the fix** and **PASSES at 477 px with it** — a real regression guard, not a pin test.
- Existing fight scenarios still pass, exercising the `FightController` factory path:
  - `iss066_pile_in_consolidate_11e` — 27/0
  - `global_consolidation_step_11e` — 83/0
  - `iss050_fight_11e` — 21/0
- Zero `ERROR` / `SCRIPT ERROR` lines in the debug log during the runs.

Changelog bumped to **0.6.8**.

## Player-facing changelog

- The Fight-phase "Pile In Step" and "Consolidate Step" pop-ups no longer open as a huge blacked-out box. They now size to their content: a compact picker showing the banner, instructions, the list of eligible units (each a button), and the End button — all visible and clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SzQuG7R8tQ528r7GF34rbv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzQuG7R8tQ528r7GF34rbv)_