### PR TITLE
Fix 12" charge-range bubble not clearing when selecting a different unit

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.7.2",
+			"date": "2026-07-07",
+			"summary": "Fixed the 12\" charge-range bubble not disappearing when you selected a different unit in the Charge phase, so old bubbles stacked up and cluttered the board.",
+			"changes": [
+				"In the Charge phase, selecting a unit shows a dashed 12\" range bubble around it. Previously, switching to a different charging unit left the old bubble on the board and drew a new one on top, so after picking a few units the board filled up with overlapping bubbles. Now only the currently selected unit's bubble is shown — the previous one is fully cleared each time you change your selection."
+			]
+		},
+		{
 			"version": "0.7.1",
 			"date": "2026-07-07",
 			"summary": "Fixed the Game Log drawing on top of the Save & Load menu — the menu now always sits above the log and other side panels while it's open.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -3391,9 +3391,16 @@ func _show_charge_range_circle(center: Vector2) -> void:
 func _clear_charge_range_circle() -> void:
 	if not is_instance_valid(range_visual):
 		return
+	# range_visual (ChargeRangeVisual) is a dedicated container used ONLY for the
+	# 12" overlay, so free every child. We deliberately do NOT filter by
+	# name == "ChargeRangeCircle": _show_charge_range_circle() adds ~11 children
+	# (10 dash arcs + the label) all named "ChargeRangeCircle", and Godot
+	# auto-renames colliding siblings ("ChargeRangeCircle2", "ChargeRangeCircle3",
+	# …). An exact-name match therefore only removed ONE node per clear, so the
+	# rest leaked and accumulated on every unit re-selection — leaving stale
+	# bubbles cluttering the board (mirrors _clear_highlights on target_highlights).
 	for child in range_visual.get_children():
-		if child.name == "ChargeRangeCircle":
-			child.queue_free()
+		child.queue_free()
 
 # --- P3-127: Charge Trajectory Preview Management ---
 

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2445,6 +2445,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "charge.range_overlay_cleanup",
+      "description": "The 12\" charge-range overlay (ChargeRangeVisual) is fully cleared when the charging-unit selection changes, so bubbles do not accumulate across re-selections (child count stays at one bubble's worth).",
+      "scenarios": [
+        "charge_range_bubble_cleanup"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ChargeController._clear_charge_range_circle",
+      "description": "ChargeController._clear_charge_range_circle frees every child of the dedicated range_visual container, robust against Godot's auto-rename of colliding sibling names.",
+      "scenarios": [
+        "charge_range_bubble_cleanup"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/charge_range_bubble_cleanup.json
+++ b/40k/tests/scenarios/sp/charge_range_bubble_cleanup.json
@@ -1,0 +1,34 @@
+{
+  "id": "charge_range_bubble_cleanup",
+  "covers": ["charge.range_overlay_cleanup", "ChargeController._clear_charge_range_circle"],
+  "fixture": "test_charge_congestion",
+  "disable_ai": true,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "description": "Regression test for the 12-inch charge-range bubble not being cleared when the player selects a different charging unit. _show_charge_range_circle() adds ~11 child nodes (10 dash arcs + 1 label) to the dedicated ChargeRangeVisual container, all named 'ChargeRangeCircle'. Godot auto-renames colliding siblings, so the old exact-name filter in _clear_charge_range_circle() only removed one node per clear and the rest leaked, stacking a fresh bubble on top of every previous selection. After the fix the container is fully cleared each redraw, so its child count must stay at exactly 11 (one bubble) no matter how many times the selection changes. Before the fix the count grew 11 -> 21 -> 32 -> 42.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").unit_selector.get_item_count()", "equals": 3 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").range_visual.get_child_count()", "equals": 0 },
+
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\")._on_unit_selected(0)" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").range_visual.get_child_count()", "equals": 11 },
+    { "act": "screenshot", "label": "01_first_unit_selected_one_bubble" },
+
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\")._on_unit_selected(1)" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").range_visual.get_child_count()", "equals": 11 },
+    { "act": "screenshot", "label": "02_second_unit_selected_still_one_bubble" },
+
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\")._on_unit_selected(2)" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").range_visual.get_child_count()", "equals": 11 },
+
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\")._on_unit_selected(0)" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_node(\"ChargeController\").range_visual.get_child_count()", "equals": 11 },
+    { "act": "screenshot", "label": "03_reselected_first_unit_still_one_bubble" }
+  ]
+}


### PR DESCRIPTION
## Problem

In the Charge phase, selecting a charging unit draws a dashed 12" range bubble around it. Selecting a **different** unit left the old bubble on the board and drew a new one on top, so after picking a few units the board filled up with overlapping "12" charge" rings cluttering the UI.

## Root cause

`_show_charge_range_circle()` adds ~11 child nodes (10 dash arcs + 1 label) to the dedicated `ChargeRangeVisual` container, all named `"ChargeRangeCircle"`. Godot auto-renames colliding siblings (`ChargeRangeCircle2`, `ChargeRangeCircle3`, …), so the exact-name filter in `_clear_charge_range_circle()` only ever removed **one** node per clear. The rest leaked and accumulated on every re-selection.

## Fix

`_clear_charge_range_circle()` now frees **every** child of the dedicated `ChargeRangeVisual` container (mirroring `_clear_highlights()` on its `target_highlights` container), which is robust against the sibling auto-rename.

```gdscript
for child in range_visual.get_children():
    child.queue_free()
```

## Validation

- **Reproduced live** in the running game: the overlay child count grew `11 → 21 → 32 → 42` across four selections (leaking bubbles).
- **After the fix**: the count stays at exactly `11` no matter how many times the selection changes — one bubble only. No errors/warnings in the debug log.
- **Added windowed regression scenario** `charge_range_bubble_cleanup.json` that drives the real selection handler and asserts the overlay child count stays at 11. It passes on the fix (19/19) and fails on the pre-fix code (21/32/42 at the switch steps). The existing `charge_congestion` scenario still passes.

## Changes

- `40k/scripts/ChargeController.gd` — the fix
- `40k/tests/scenarios/sp/charge_range_bubble_cleanup.json` — regression scenario
- `40k/data/version_history.json` — changelog entry `0.6.8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZdQ2sEprtU7jQCBNTWWDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01YZdQ2sEprtU7jQCBNTWWDb)_