### PR TITLE
Multiplayer 1.0 hardening: fix LAN roll-off softlock, phase desyncs, and online game-code play

### DIFF
--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -33,7 +33,11 @@ const FILTERED_ACTIONS = [
 ]
 
 const PHASE_NAMES = {
+	GameStateData.Phase.FORMATIONS: "Battle Formations",
 	GameStateData.Phase.DEPLOYMENT: "Deployment",
+	GameStateData.Phase.REDEPLOYMENT: "Redeployment",
+	GameStateData.Phase.SCOUT: "Scout",
+	GameStateData.Phase.SCOUT_MOVES: "Scout Moves",
 	GameStateData.Phase.ROLL_OFF: "Roll-Off",
 	GameStateData.Phase.FIRST_TURN_ROLLOFF: "First-Turn Roll-Off",
 	GameStateData.Phase.COMMAND: "Command",

--- a/40k/autoloads/GameManager.gd
+++ b/40k/autoloads/GameManager.gd
@@ -230,7 +230,15 @@ func process_action(action: Dictionary) -> Dictionary:
 			return process_debug_move(action)
 
 		_:
-			return {"success": false, "error": "Unknown action type: " + str(action.get("type", "UNKNOWN"))}
+			# Not handled directly by GameManager — delegate to the current
+			# phase. Phases own many phase-local action types (END_SCOUT_PHASE,
+			# redeployment ops, katah stances, ...) that single-player reaches
+			# via phase.execute_action directly; the MULTIPLAYER path routes
+			# every action through here and used to hard-fail on them with
+			# "Unknown action type". The phase's own validate/process still
+			# rejects genuinely unknown types, so nothing becomes laxer.
+			print("GameManager: '%s' not handled directly — delegating to current phase" % str(action.get("type", "UNKNOWN")))
+			return _delegate_to_current_phase(action)
 
 func _get_pos_xy(pos) -> Dictionary:
 	"""Extract x,y from a position that may be Vector2 or Dictionary (from JSON relay)."""

--- a/40k/autoloads/NetworkManager.gd
+++ b/40k/autoloads/NetworkManager.gd
@@ -1080,6 +1080,10 @@ func _send_action_to_host(action: Dictionary) -> void:
 
 		# Broadcast the result to all clients (but not back to host since it already applied)
 		print("NetworkManager: Host broadcasting client action result to all clients")
+		# ISS-015: client-submitted actions get the same post-action state hash
+		# host-submitted ones do — previously only host actions were checked,
+		# leaving half the action stream uncovered by the desync detector.
+		result["_state_hash"] = compute_state_hash()
 		_broadcast_result.rpc(result)
 	else:
 		print("NetworkManager: GameManager returned failure: ", result.get("error", "Unknown"))
@@ -1155,6 +1159,43 @@ func _emit_client_visual_updates(result: Dictionary) -> void:
 				var dest_vec = Vector2(dest[0], dest[1])
 				print("NetworkManager: Client emitting model_drop_committed for ", unit_id, "/", model_id, " at ", dest_vec, " rotation: ", rotation)
 				phase.emit_signal("model_drop_committed", unit_id, model_id, dest_vec, rotation)
+
+	# ====================================================================
+	# ROLL-OFF PHASES — sync client phase-internal state + re-emit result
+	# ====================================================================
+	# The host's RollOffPhase/FirstTurnRollOffPhase processed the action and
+	# emitted roll_off_result locally. The client only applied meta diffs, so
+	# its phase instance still thinks the roll is pending — sync the internal
+	# fields (otherwise get_available_actions/validation diverge) and re-emit
+	# the signal so the client's dialog animates the result.
+	if action_type == "ROLL_OFF_DEPLOYMENT" or action_type == "ROLL_OFF_FIRST_TURN":
+		var ro_p1 = int(result.get("player1_roll", 0))
+		var ro_p2 = int(result.get("player2_roll", 0))
+		var ro_tied = result.get("tied", false)
+		var ro_winner = int(result.get("winner", 0))
+		if "_player1_roll" in phase:
+			phase._player1_roll = ro_p1
+			phase._player2_roll = ro_p2
+		if not ro_tied:
+			if "_roll_complete" in phase:
+				phase._roll_complete = true
+			if action_type == "ROLL_OFF_DEPLOYMENT" and "_roll_off_winner" in phase:
+				phase._roll_off_winner = ro_winner
+			if action_type == "ROLL_OFF_FIRST_TURN" and "_first_turn_player" in phase:
+				phase._first_turn_player = ro_winner
+		if phase.has_signal("roll_off_result"):
+			print("NetworkManager: Client re-emitting roll_off_result (p1=%d, p2=%d, winner=%d, tied=%s)" % [ro_p1, ro_p2, ro_winner, str(ro_tied)])
+			phase.emit_signal("roll_off_result", ro_p1, ro_p2, ro_winner, ro_tied)
+
+	# CHOOSE_DEPLOYMENT / CONFIRM_FIRST_TURN — keep the client's phase-internal
+	# completion flags in lockstep so a duplicate submission from this client
+	# validates the same way it would on the host.
+	if action_type == "CHOOSE_DEPLOYMENT":
+		if "_choice_made" in phase:
+			phase._choice_made = true
+	if action_type == "CONFIRM_FIRST_TURN":
+		if "_confirmed" in phase:
+			phase._confirmed = true
 
 	# Handle shooting phase SELECT_SHOOTER visual updates
 	if action_type == "SELECT_SHOOTER":
@@ -1387,6 +1428,17 @@ func _emit_client_visual_updates(result: Dictionary) -> void:
 		else:
 			print("NetworkManager: ⚠️ Missing fight_selection_data or phase doesn't support signal")
 
+	# Handle epic_challenge_opportunity (after SELECT_FIGHTER of a CHARACTER).
+	# The phase stamped the trigger metadata for exactly this purpose but it
+	# was never re-emitted client-side — the prompt only ever appeared on the
+	# host, so a remote player's Epic Challenge decision was unreachable.
+	if result.get("trigger_epic_challenge", false):
+		var ec_unit_id = result.get("epic_challenge_unit_id", "")
+		var ec_player = int(result.get("epic_challenge_player", 0))
+		if ec_unit_id != "" and ec_player > 0 and phase.has_signal("epic_challenge_opportunity"):
+			print("NetworkManager: Client re-emitting epic_challenge_opportunity for %s (player %d)" % [ec_unit_id, ec_player])
+			phase.emit_signal("epic_challenge_opportunity", ec_unit_id, ec_player)
+
 	# Handle pile_in_required signal (after SELECT_FIGHTER)
 	# Handle katah_stance_required signal (Martial Ka'tah, after SELECT_FIGHTER)
 	if result.get("trigger_katah_stance", false):
@@ -1497,6 +1549,17 @@ func _emit_client_visual_updates(result: Dictionary) -> void:
 		var unit_id = action_data.get("actor_unit_id", "")
 		var target_ids = action_data.get("payload", {}).get("target_unit_ids", [])
 		if unit_id != "" and not target_ids.is_empty():
+			# Mirror the host's pending-charge record into the client's phase.
+			# The client never processes DECLARE_CHARGE itself, so without this
+			# its ChargeController later sees an empty pending_charges and
+			# misreads the subsequent CHARGE_ROLL as an already-failed charge.
+			if "pending_charges" in phase:
+				phase.pending_charges[unit_id] = {
+					"targets": target_ids.duplicate(),
+					"declared_targets": target_ids.duplicate(),
+					"selectable_targets": target_ids.duplicate(),
+				}
+				print("NetworkManager: Client mirrored pending charge for %s (targets: %s)" % [unit_id, str(target_ids)])
 			if phase.has_signal("targets_declared"):
 				print("NetworkManager: Client re-emitting targets_declared for %s with %d targets" % [unit_id, target_ids.size()])
 				phase.emit_signal("targets_declared", unit_id, target_ids)
@@ -1552,7 +1615,11 @@ func _emit_client_visual_updates(result: Dictionary) -> void:
 						if "current_charging_unit" in phase:
 							phase.current_charging_unit = null
 					else:
-						# Charge roll sufficient — enable movement tools
+						# Charge roll sufficient — sync the roll into the client's
+						# mirrored pending-charge record and enable movement tools
+						if "pending_charges" in phase and phase.pending_charges.has(unit_id):
+							phase.pending_charges[unit_id]["distance"] = total
+							phase.pending_charges[unit_id]["dice_rolls"] = rolls
 						if phase.has_signal("charge_path_tools_enabled"):
 							print("NetworkManager: Client re-emitting charge_path_tools_enabled for %s (distance=%d)" % [unit_id, total])
 							phase.emit_signal("charge_path_tools_enabled", unit_id, total)
@@ -2115,6 +2182,10 @@ func validate_action(action: Dictionary, peer_id: int) -> Dictionary:
 		"EMBARK_UNITS_DEPLOYMENT",
 		"PLACE_IN_RESERVES",  # Part of deployment alternation flow
 		"APPLY_SAVES",  # Reactive action - defender responds during attacker's turn
+		# Roll-off completions: the roll-off WINNER acts, who is often not the
+		# active player (RollOffPhase validates the winner server-side).
+		"CHOOSE_DEPLOYMENT",
+		"CONFIRM_FIRST_TURN",
 		"APPLY_MELEE_SAVES",  # P0-58: Reactive action - defender allocates melee wounds
 		# Formations actions - both players declare simultaneously
 		"DECLARE_LEADER_ATTACHMENT",
@@ -2142,7 +2213,19 @@ func validate_action(action: Dictionary, peer_id: int) -> Dictionary:
 		"DECLINE_HEROIC_INTERVENTION",
 		"HEROIC_INTERVENTION_CHARGE_ROLL",
 		"APPLY_HEROIC_INTERVENTION_MOVE",
-		"END_FIGHT"
+		"END_FIGHT",
+		# Reactive stratagem windows — the deciding player is frequently NOT
+		# the active player (opponent's fight activation, opponent's charge),
+		# so these must skip turn validation like APPLY_SAVES does. Authority
+		# (claimed player == sending peer) is still enforced.
+		"USE_EPIC_CHALLENGE",
+		"DECLINE_EPIC_CHALLENGE",
+		"USE_COUNTER_OFFENSIVE",
+		"DECLINE_COUNTER_OFFENSIVE",
+		"USE_FIRE_OVERWATCH",
+		"DECLINE_FIRE_OVERWATCH",
+		"USE_COMMAND_REROLL",
+		"DECLINE_COMMAND_REROLL"
 	]
 	var is_exempt = action_type in exempt_actions
 
@@ -2462,11 +2545,34 @@ func _on_phase_changed(new_phase: GameStateData.Phase) -> void:
 # PHASE 4: DETERMINISTIC RNG - Seed Generation
 # ============================================================================
 
-## ISS-015: canonical hash of the full game state. JSON.stringify sorts
+## ISS-015: canonical hash of the game state. JSON.stringify sorts
 ## dictionary keys by default, so insertion-order differences between host
 ## and client do not produce false positives.
+##
+## Hash only the action-mutated gameplay subset, NOT the full state:
+## - create_snapshot() enriches snapshots with manager keys (mission_manager,
+##   secondary_missions, stratagem_manager, ...) that exist only on peers that
+##   loaded a snapshot (clients), never in the host's live state — hashing the
+##   full state guaranteed a false DESYNC on every check after the first sync.
+## - history / phase_log / unit_visuals evolve locally per peer.
+## - board.terrain is static after load and its typed values serialize
+##   differently depending on load path.
+const _HASH_META_EXCLUDE := ["created_at", "game_id", "version"]
+
 func compute_state_hash() -> int:
-	return JSON.stringify(game_state.state).hash()
+	var s = game_state.state
+	var meta_canon := {}
+	for k in s.get("meta", {}):
+		if k in _HASH_META_EXCLUDE:
+			continue
+		meta_canon[k] = s.meta[k]
+	var canon := {
+		"units": s.get("units", {}),
+		"players": s.get("players", {}),
+		"factions": s.get("factions", {}),
+		"meta": meta_canon,
+	}
+	return JSON.stringify(canon).hash()
 
 func get_next_rng_seed() -> int:
 	if not is_networked():
@@ -2587,6 +2693,13 @@ func _receive_phase_change(new_phase: GameStateData.Phase) -> void:
 	# Get PhaseManager and trigger transition on client
 	var phase_manager = get_node_or_null("/root/PhaseManager")
 	if phase_manager:
+		# Dedup: the same transition can also arrive as a meta.phase diff in a
+		# broadcast result (Main._on_network_result_applied transitions from
+		# that). Re-transitioning would create a second phase instance.
+		var inst = phase_manager.current_phase_instance
+		if inst != null and "phase_type" in inst and inst.phase_type == new_phase:
+			print("NetworkManager: Client already in phase %s — skipping duplicate transition" % GameStateData.Phase.keys()[new_phase])
+			return
 		print("NetworkManager: Transitioning client to phase: ", GameStateData.Phase.keys()[new_phase])
 		phase_manager.transition_to_phase(new_phase)
 	else:

--- a/40k/autoloads/NetworkManager.gd
+++ b/40k/autoloads/NetworkManager.gd
@@ -535,11 +535,20 @@ func _handle_relayed_action(action: Dictionary) -> void:
 		print("NetworkManager: Ignoring relayed action - not host")
 		return
 
+	# The relay is JSON: _sanitize_for_json turned every Vector2 in the guest's
+	# action into an {x, y} dict. Phase handlers take typed Vector2 parameters
+	# (e.g. DeploymentPhase._validate_model_position), which hard-crash on the
+	# dict — validation died mid-call, no rejection was sent, and the guest
+	# kept its optimistic apply forever (permanent desync). Restore Vector2s
+	# before the phase sees the action. (ENet never hits this: Godot RPCs
+	# serialize Variants natively.)
+	action = _desanitize_from_json(action)
+
 	# Validate the action (use player 2's ID since it came from the guest)
 	var peer_id = 2
 	var validation = validate_action(action, peer_id)
 
-	if not validation.valid:
+	if not validation.get("valid", false):
 		var reason = validation.get("reason", "Validation failed")
 		if reason == "Validation failed" and validation.has("errors") and validation.errors.size() > 0:
 			reason = validation.errors[0]
@@ -657,6 +666,28 @@ func _send_via_relay(data: Dictionary) -> void:
 	# Sanitize data for JSON serialization (Vector2/Vector3 etc. are not JSON-safe)
 	var safe_data = _sanitize_for_json(data)
 	web_relay.send_game_data(safe_data)
+
+func _desanitize_from_json(value) -> Variant:
+	"""Inverse of _sanitize_for_json: convert {x, y} dicts (produced from
+	Vector2 when crossing the JSON relay) back into Vector2, recursively.
+	Only dicts with EXACTLY the numeric keys x and y are converted — that
+	shape is only ever produced by the sanitizer."""
+	if value is Dictionary:
+		if value.size() == 2 and value.has("x") and value.has("y") \
+				and (value.x is float or value.x is int) \
+				and (value.y is float or value.y is int):
+			return Vector2(value.x, value.y)
+		var result = {}
+		for key in value:
+			result[key] = _desanitize_from_json(value[key])
+		return result
+	elif value is Array:
+		var result = []
+		for item in value:
+			result.append(_desanitize_from_json(item))
+		return result
+	else:
+		return value
 
 func _sanitize_for_json(value) -> Variant:
 	"""Recursively convert Godot types (Vector2, Vector3, etc.) to JSON-safe types."""
@@ -865,7 +896,7 @@ func submit_action(action: Dictionary) -> void:
 		var peer_id = 1  # Host's own peer ID
 		var validation = validate_action(action, peer_id)
 
-		if not validation.valid:
+		if not validation.get("valid", false):
 			# Get error message from either "reason" or first "errors" entry
 			var error_msg = validation.get("reason", "Validation failed")
 			if error_msg == "Validation failed" and validation.has("errors") and validation.errors.size() > 0:
@@ -918,7 +949,7 @@ func _submit_action_via_relay(action: Dictionary) -> void:
 		var peer_id = 1  # Host's own player ID
 		var validation = validate_action(action, peer_id)
 
-		if not validation.valid:
+		if not validation.get("valid", false):
 			var error_msg = validation.get("reason", "Validation failed")
 			if error_msg == "Validation failed" and validation.has("errors") and validation.errors.size() > 0:
 				error_msg = validation.errors[0]
@@ -952,7 +983,7 @@ func _submit_action_via_relay(action: Dictionary) -> void:
 
 			# Step 1: Validate locally (as player 2)
 			var validation = validate_action(action, 2)
-			if not validation.valid:
+			if not validation.get("valid", false):
 				var error_msg = validation.get("reason", "Validation failed")
 				if error_msg == "Validation failed" and validation.has("errors") and validation.errors.size() > 0:
 					error_msg = validation.errors[0]
@@ -1022,7 +1053,7 @@ func _send_action_to_host(action: Dictionary) -> void:
 	var validation = validate_action(action, peer_id)
 	print("NetworkManager: Validation result: ", validation)
 
-	if not validation.valid:
+	if not validation.get("valid", false):
 		# Get reason from either "reason" field or first error in "errors" array
 		var reason = validation.get("reason", "Unknown validation error")
 		if reason == "Unknown validation error" and validation.has("errors") and validation.errors.size() > 0:

--- a/40k/autoloads/PhaseManager.gd
+++ b/40k/autoloads/PhaseManager.gd
@@ -114,6 +114,15 @@ func transition_to_phase(new_phase: GameStateData.Phase) -> void:
 	# Exit current phase if one exists
 	if current_phase_instance != null:
 		print("[PhaseManager] Exiting current phase: ", current_phase_instance.get_class())
+		# Sever signals BEFORE queue_free: the node stays alive until end of
+		# frame, so a deferred phase_completed from the outgoing instance (e.g.
+		# RedeploymentPhase's auto-skip call_deferred) would otherwise fire
+		# _on_phase_completed against the NEW phase and silently skip it.
+		# This is how FIRST_TURN_ROLLOFF got skipped in multiplayer games.
+		if current_phase_instance.has_signal("phase_completed") and current_phase_instance.phase_completed.is_connected(_on_phase_completed):
+			current_phase_instance.phase_completed.disconnect(_on_phase_completed)
+		if current_phase_instance.has_signal("action_taken") and current_phase_instance.action_taken.is_connected(_on_phase_action_taken):
+			current_phase_instance.action_taken.disconnect(_on_phase_action_taken)
 		current_phase_instance.exit_phase()
 		current_phase_instance.queue_free()
 		current_phase_instance = null
@@ -321,6 +330,16 @@ func _get_next_phase(current: GameStateData.Phase) -> GameStateData.Phase:
 
 func _on_phase_completed() -> void:
 	if game_ended:
+		return
+
+	# Multiplayer: only the HOST advances phases. A phase instance on a client
+	# can auto-complete locally (Redeployment/Scout with nothing to do) but the
+	# client must wait for the host's phase-change RPC / broadcast diffs —
+	# otherwise the client free-runs ahead of the host (observed: client raced
+	# through COMMAND→MOVEMENT→SHOOTING→CHARGE while the host sat in SCOUT).
+	var network_mgr = get_node_or_null("/root/NetworkManager")
+	if network_mgr and network_mgr.is_networked() and not network_mgr.is_host():
+		print("PhaseManager: phase_completed on CLIENT — waiting for host to advance")
 		return
 
 	var completed_phase = get_current_phase()

--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -82,6 +82,21 @@ func _run_scenario() -> void:
 		if save_mgr == null or game_state == null:
 			_fail_and_quit("autoloads missing (SaveLoadManager / GameState)")
 			return
+		# SaveLoadManager only resolves res://saves/. The committed fixtures
+		# live in res://tests/saves/, so on a fresh clone (CI, containers)
+		# every fixture scenario failed with "Save file not found". Stage the
+		# fixture into saves/ when it's only present in tests/saves/.
+		var fixture_file = fixture if fixture.ends_with(".w40ksave") else fixture + ".w40ksave"
+		var saves_path = "res://saves/" + fixture_file
+		var tests_path = "res://tests/saves/" + fixture_file
+		if not FileAccess.file_exists(saves_path) and FileAccess.file_exists(tests_path):
+			var dir = DirAccess.open("res://")
+			if dir:
+				dir.copy(tests_path, saves_path)
+				var meta_src = tests_path.replace(".w40ksave", ".meta")
+				if FileAccess.file_exists(meta_src):
+					dir.copy(meta_src, saves_path.replace(".w40ksave", ".meta"))
+				print("[ScenarioRunner] staged fixture from tests/saves: %s" % fixture_file)
 		var ok = save_mgr.load_game(fixture)
 		if not ok:
 			_fail_and_quit("fixture load failed: %s" % fixture)

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.7.4",
+			"date": "2026-07-08",
+			"summary": "Fixed online (game-code) multiplayer: joining with a code and deploying your first unit permanently desynced the two players. Online games now play through correctly.",
+			"changes": [
+				"Fixed the #1 online multiplayer bug: in an online game (host shares a code, opponent joins with it), the moment the joining player deployed their first unit the two games silently fell out of sync forever — the unit showed up for the joiner but never for the host. Online play sends moves as text (JSON), which turned every board position into a plain object; the host then crashed while checking the move and never told the joiner it failed, so the joiner kept a move the host never accepted. Positions are now converted back correctly before the host processes an online move, and a failed check is reported instead of silently dropped.",
+				"Fixed the same empty-battlefield terrain bug as the LAN fix, but for online games: the host of an online game was judging movement and line-of-sight against a board with no terrain on it.",
+				"Hardened online move handling so a single malformed message can no longer take down the host's processing of the rest of the game."
+			]
+		},
+		{
 			"version": "0.7.3",
 			"date": "2026-07-08",
 			"summary": "Major multiplayer hardening pass: LAN games no longer soft-lock at the pre-deployment roll-off, phases no longer get skipped or run ahead on one player's screen, and a large family of actions (stratagems, reactions, phase steps) that silently failed online now work.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,23 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.7.3",
+			"date": "2026-07-08",
+			"summary": "Major multiplayer hardening pass: LAN games no longer soft-lock at the pre-deployment roll-off, phases no longer get skipped or run ahead on one player's screen, and a large family of actions (stratagems, reactions, phase steps) that silently failed online now work.",
+			"changes": [
+				"Fixed every LAN multiplayer game soft-locking at the 'Who Deploys First?' roll-off: the dice result and the winner's 'deploy first / deploy second' choice now appear on BOTH players' screens, and the winner (not the player who happened to click Roll) makes the choice. The same fix covers the 'Determine First Turn' roll-off after deployment.",
+				"Fixed multiplayer phase desyncs: the 'Determine First Turn' step could be skipped entirely on the host, while the other player's game raced ahead through Command → Movement → Shooting → Charge on its own. Phases now advance exactly once, on both screens, in lockstep.",
+				"Fixed a large family of actions that hard-failed with 'Unknown action type' ONLY in multiplayer: ending the Scout phase, declining/using a Command Re-roll, Counter-Offensive, Fire Overwatch, Epic Challenge, the Fight phase's End Pile In / End Consolidation buttons, warlord designation, secondary-mission steps (e.g. Beacon), and more.",
+				"Reactive decisions are now shown to the right player: the Epic Challenge prompt used to appear on the OTHER player's screen (where it could only be mis-clicked and rejected) — it now opens for the player whose decision it is. Stratagem windows that belong to the non-active player (Counter-Offensive, Overwatch, re-rolls) are no longer rejected as 'not your turn'.",
+				"Clicking your opponent's buttons no longer half-works: the phase button and roll-off dice are turn-gated with a friendly 'It's Player N's turn' message instead of firing actions that get rejected after the UI already reacted.",
+				"Fixed the host adjudicating terrain rules against an EMPTY battlefield in multiplayer (walls/ruins existed visually but not in the host's rules state — the joining player had the real list).",
+				"Fixed the multiplayer desync detector crying wolf: it compared incompatible views of the game state, so it reported a desync after nearly every action; it now compares the actual gameplay state on both sides (and also covers actions submitted by the joining player, which were previously unchecked).",
+				"Fixed the charge phase forgetting a declared charge on the opponent's screen, and a broken signal that dropped the post-roll target list update.",
+				"The game log now names the Battle Formations / Redeployment / Scout phases instead of showing 'Unknown Phase'.",
+				"Test infrastructure: scenario fixtures now load on fresh checkouts (CI/containers), and a new regression test pins all of the multiplayer contracts above."
+			]
+		},
+		{
 			"version": "0.7.2",
 			"date": "2026-07-07",
 			"summary": "Fixed the 12\" charge-range bubble not disappearing when you selected a different unit in the Charge phase, so old bubbles stacked up and cluttered the board.",
@@ -36,8 +53,7 @@
 			"changes": [
 				"When you shot a weapon, the Game Log entry summarising the attack (e.g. 'Telemon Heavy Dreadnought → Boyz … Hit: 7/9 … Wound: 0/7 …') could balloon to nearly the entire height of the log, with the dice icons floating far out to the right and a huge empty gap. The trailing part of the line was being squeezed into a one-character-wide column and wrapped down the whole card.",
 				"These log lines now flow naturally like a sentence — the text wraps across a few lines and the dice icons sit inline exactly where the rolls happened, so the entry is a tidy, compact card.",
-				"Both sets of dice on a combined hit-and-wound line now render as icons (previously only the hit dice became icons and the wound dice stayed as raw '[2, 2, 3, …]' numbers), each coloured against its own target — the hit dice vs the hit roll needed and the wound dice vs the wound roll needed."
-			]
+				"Both sets of dice on a combined hit-and-wound line now render as icons (previously only the hit dice became icons and the wound dice stayed as raw '[2, 2, 3, …]' numbers), each coloured against its own target — the hit dice vs the hit roll needed and the wound dice vs the wound roll needed."			]
 		},
 		{
 			"version": "0.6.8",

--- a/40k/dialogs/FightSelectionDialog.gd
+++ b/40k/dialogs/FightSelectionDialog.gd
@@ -133,16 +133,31 @@ func _add_subphase_units(container: VBoxContainer, subphase_name: String, units_
 				" (Fought)" if has_fought else ""
 			]
 
+			# Multiplayer: this dialog is shown on BOTH peers for visibility,
+			# but only the selecting player may pick. Without this gate the
+			# other player saw enabled buttons whose clicks were then rejected
+			# by the host ("Player ID mismatch") — confusing dead UI.
+			var is_local_players_pick = true
+			# NOTE: setup() runs before this dialog enters the tree, so
+			# get_node_or_null("/root/...") would return null — resolve the
+			# autoload through the main loop instead.
+			var nm = Engine.get_main_loop().root.get_node_or_null("NetworkManager")
+			if nm and nm.is_networked():
+				is_local_players_pick = (nm.get_local_player() == int(dialog_data.selecting_player))
+
 			# Style based on state
 			if has_fought:
 				unit_button.disabled = true
 				unit_button.modulate = Color.GRAY
 			elif not is_eligible:
 				unit_button.disabled = true
+			elif not is_local_players_pick:
+				unit_button.disabled = true
+				unit_button.tooltip_text = "Player %d is selecting" % int(dialog_data.selecting_player)
 			elif is_current:
 				unit_button.modulate = Color.LIGHT_GREEN
 
-			if is_eligible and not has_fought:
+			if is_eligible and not has_fought and is_local_players_pick:
 				unit_button.pressed.connect(_on_unit_selected.bind(unit_id))
 
 			container.add_child(unit_button)

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -750,7 +750,16 @@ func _resolve_charge_roll(unit_id: String) -> Dictionary:
 			charge_data.targets = kept
 			target_ids = kept
 		log_phase_message("[11e] Selectable charge targets after roll of %d: %s" % [total_distance, str(selectable)])
-		emit_signal("charge_targets_available", unit_id, selectable)
+		# charge_targets_available carries a Dictionary (target_id -> data) —
+		# passing the raw `selectable` Array made Godot drop the signal call
+		# ("Cannot convert argument 2 from Array to Dictionary") on every
+		# post-roll re-target, so the controller never saw the filtered list.
+		var selectable_dict = {}
+		var all_eligible_after_roll = _get_eligible_targets_for_unit(unit_id)
+		for tid in selectable:
+			if all_eligible_after_roll.has(tid):
+				selectable_dict[tid] = all_eligible_after_roll[tid]
+		emit_signal("charge_targets_available", unit_id, selectable_dict)
 
 	# Server-side feasibility check: can any model reach engagement range?
 	var roll_sufficient = _is_charge_roll_sufficient(unit_id, total_distance)

--- a/40k/phases/FirstTurnRollOffPhase.gd
+++ b/40k/phases/FirstTurnRollOffPhase.gd
@@ -21,6 +21,10 @@ const BasePhase = preload("res://phases/BasePhase.gd")
 # Placed between REDEPLOYMENT and SCOUT so the first-turn player is known
 # before pre-game Scout moves (which are made in first-turn order).
 
+# Same contract as RollOffPhase.roll_off_result — the single UI-facing channel
+# for roll results (works identically in single-player and multiplayer).
+signal roll_off_result(p1_roll: int, p2_roll: int, winner: int, tied: bool)
+
 var _rng  # RulesEngine.RNGService — honours static test_mode_seed
 var _player1_roll: int = 0
 var _player2_roll: int = 0
@@ -121,6 +125,7 @@ func _handle_roll_off(action: Dictionary) -> Dictionary:
 		_player1_roll = 0
 		_player2_roll = 0
 		_roll_complete = false
+		emit_signal("roll_off_result", p1_roll, p2_roll, 0, true)
 		return {
 			"success": true,
 			"player1_roll": p1_roll,
@@ -146,6 +151,7 @@ func _handle_roll_off(action: Dictionary) -> Dictionary:
 		{"op": "set", "path": "meta.active_player", "value": _first_turn_player}
 	]
 
+	emit_signal("roll_off_result", p1_roll, p2_roll, _first_turn_player, false)
 	return {
 		"success": true,
 		"changes": changes,

--- a/40k/phases/RollOffPhase.gd
+++ b/40k/phases/RollOffPhase.gd
@@ -19,6 +19,13 @@ const BasePhase = preload("res://phases/BasePhase.gd")
 #
 # If the dice tie, players must re-roll (per the core rules).
 
+# Emitted whenever a roll-off resolves (win or tie). This is the ONLY channel
+# the UI listens on — in multiplayer the submitting peer gets {pending:true}
+# back from route_action, so reading roll results from the return value never
+# worked networked. The host emits during processing; NetworkManager re-emits
+# on clients from the broadcast result.
+signal roll_off_result(p1_roll: int, p2_roll: int, winner: int, tied: bool)
+
 var _rng  # RulesEngine.RNGService — picks up test_mode_seed via PR #346
 var _player1_roll: int = 0
 var _player2_roll: int = 0
@@ -92,6 +99,14 @@ func validate_action(action: Dictionary) -> Dictionary:
 				errors.append("Roll-off has not been completed yet")
 			if _choice_made:
 				errors.append("Deployment choice has already been made")
+			# Only the roll-off winner may pick the deploy order. Without this,
+			# any peer could submit the choice (it bypasses turn validation as
+			# an exempt reactive action). Only enforced when the action claims
+			# a player: the networked path always injects one (NetworkIntegration
+			# stamps the local player), while direct SP/test dispatches may omit it.
+			var choosing_player = action.get("player", -1)
+			if _roll_off_winner > 0 and choosing_player != -1 and choosing_player != _roll_off_winner:
+				errors.append("Only Player %d (roll-off winner) may choose the deployment order" % _roll_off_winner)
 			var choice = action.get("choice", "")
 			if choice != "first" and choice != "second":
 				errors.append("Invalid choice: must be 'first' (deploy first) or 'second' (deploy second)")
@@ -140,6 +155,7 @@ func _handle_roll_off(action: Dictionary) -> Dictionary:
 		_player2_roll = 0
 		_roll_complete = false
 
+		emit_signal("roll_off_result", p1_roll, p2_roll, 0, true)
 		return {
 			"success": true,
 			"player1_roll": p1_roll,
@@ -166,6 +182,7 @@ func _handle_roll_off(action: Dictionary) -> Dictionary:
 		{"op": "set", "path": "meta.roll_off_winner", "value": _roll_off_winner}
 	]
 
+	emit_signal("roll_off_result", p1_roll, p2_roll, _roll_off_winner, false)
 	return {
 		"success": true,
 		"changes": changes,

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -789,13 +789,15 @@ func _on_select_fighter_pressed(unit_id: String) -> void:
 		"type": "SELECT_FIGHTER",
 		"unit_id": unit_id
 	}
-	
-	# Send the action to the phase
-	if current_phase and current_phase.has_method("execute_action"):
-		print("DEBUG: Executing SELECT_FIGHTER action: %s" % str(action))
-		var result = current_phase.execute_action(action)
+
+	# Route through NetworkIntegration: in multiplayer a direct
+	# current_phase.execute_action() ran only on the clicking peer — the host
+	# never validated or broadcast it, desyncing the fight sequence.
+	if current_phase:
+		print("DEBUG: Routing SELECT_FIGHTER action: %s" % str(action))
+		var result = NetworkIntegration.route_action(action)
 		print("DEBUG: SELECT_FIGHTER result: %s" % str(result))
-		
+
 		# Refresh the UI after executing action
 		_refresh_available_actions()
 	else:
@@ -811,13 +813,13 @@ func _on_select_melee_weapon_pressed(unit_id: String, weapon_id: String) -> void
 		"unit_id": unit_id,
 		"weapon_id": weapon_id
 	}
-	
-	# Send the action to the phase
-	if current_phase and current_phase.has_method("execute_action"):
-		print("DEBUG: Executing SELECT_MELEE_WEAPON action: %s" % str(action))
-		var result = current_phase.execute_action(action)
+
+	# Route through NetworkIntegration (see _on_select_fighter_pressed).
+	if current_phase:
+		print("DEBUG: Routing SELECT_MELEE_WEAPON action: %s" % str(action))
+		var result = NetworkIntegration.route_action(action)
 		print("DEBUG: SELECT_MELEE_WEAPON result: %s" % str(result))
-		
+
 		# Refresh the UI after executing action
 		_refresh_available_actions()
 	else:
@@ -1573,6 +1575,14 @@ func _on_fighter_selected_from_dialog(unit_id: String) -> void:
 func _on_epic_challenge_opportunity(unit_id: String, player: int) -> void:
 	"""Show Epic Challenge dialog when a CHARACTER unit is selected to fight"""
 	print("[FightController] Epic Challenge opportunity for unit %s (player %d)" % [unit_id, player])
+
+	# Multiplayer: the decision belongs to `player` — only THEIR peer shows the
+	# dialog. The phase runs on the host, so without this gate the host showed
+	# (and could only fail to answer) the remote player's stratagem prompt.
+	var nm = get_node_or_null("/root/NetworkManager")
+	if nm and nm.is_networked() and nm.get_local_player() != player:
+		print("[FightController] Epic Challenge decision belongs to remote player %d — not showing dialog here" % player)
+		return
 
 	# Skip dialog for AI players — AIPlayer handles via signal
 	var ai_player_node = get_node_or_null("/root/AIPlayer")

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7214,6 +7214,17 @@ func _show_roll_off_dialog(local_player: int) -> void:
 	roll_off_dialog.popup_centered()
 	print("Main: Showed %s roll-off dialog for Player %d" % [_roll_off_context(), local_player])
 
+	# The roll RESULT arrives via the phase's roll_off_result signal — emitted
+	# synchronously in single-player, and re-emitted by NetworkManager on the
+	# peer that didn't process the action in multiplayer. The route_action
+	# return value carries no roll data in MP ({success, pending}), so this
+	# signal is the only correct display driver on BOTH peers.
+	var roll_phase_inst = PhaseManager.get_current_phase_instance()
+	if roll_phase_inst and roll_phase_inst.has_signal("roll_off_result"):
+		if not roll_phase_inst.roll_off_result.is_connected(_on_roll_off_result):
+			roll_phase_inst.roll_off_result.connect(_on_roll_off_result)
+			print("Main: Connected to %s.roll_off_result" % roll_phase_inst.get_class())
+
 func _roll_off_context() -> String:
 	# "first_turn" for the post-deployment "who goes first" roll-off,
 	# "deploy" for the pre-deployment "who deploys first" roll-off.
@@ -7223,6 +7234,12 @@ func _roll_off_context() -> String:
 
 func _on_roll_off_roll_pressed() -> void:
 	print("Main: Roll-off dialog — Roll pressed")
+	# In multiplayer only the active player may submit the roll. Give the other
+	# player feedback instead of sending an action that will be rejected (it
+	# would go out stamped with the ACTIVE player's id — a spoof).
+	if NetworkManager.is_networked() and not NetworkManager.is_local_player_turn():
+		_show_toast("Waiting for Player %d to roll..." % GameState.get_active_player(), 2.0)
+		return
 	var is_first_turn := _roll_off_context() == "first_turn"
 	var action := {
 		"type": "ROLL_OFF_FIRST_TURN" if is_first_turn else "ROLL_OFF_DEPLOYMENT",
@@ -7231,17 +7248,22 @@ func _on_roll_off_roll_pressed() -> void:
 	var result = NetworkIntegration.route_action(action)
 	if not result.get("success", false):
 		print("Main: Roll-off failed: ", result.get("error", "unknown"))
-		return
-	# The phase emitted result fields p1/p2 rolls + winner OR tied=true.
-	# Update the dialog to show what happened.
+	# Display is driven by the phase's roll_off_result signal (see
+	# _on_roll_off_result) — NOT by this return value, which in multiplayer is
+	# just {success:true, pending:true} with no roll data.
+
+func _on_roll_off_result(p1: int, p2: int, winner: int, tied: bool) -> void:
+	# Single handler for roll-off results on every peer (SP: synchronous emit
+	# during route_action; MP host: emit while processing; MP client: re-emit
+	# from the broadcast result via NetworkManager).
+	print("Main: roll_off_result received — p1=%d p2=%d winner=%d tied=%s" % [p1, p2, winner, str(tied)])
 	if not (roll_off_dialog and is_instance_valid(roll_off_dialog)):
+		print("Main: roll_off_result with no dialog — ignoring")
 		return
-	var p1: int = int(result.get("player1_roll", 0))
-	var p2: int = int(result.get("player2_roll", 0))
-	if result.get("tied", false):
+	if tied:
 		roll_off_dialog.show_tie(p1, p2)
 		return
-	var winner: int = int(result.get("winner", 0))
+	var is_first_turn := _roll_off_context() == "first_turn"
 	# Decide what the local human does at the result screen:
 	#   "choose"      — (deploy roll-off only) they won and pick deploy order
 	#   "acknowledge" — they must click Continue to proceed: the first-turn
@@ -7261,27 +7283,40 @@ func _on_roll_off_roll_pressed() -> void:
 	else:
 		local_action = "choose"
 	roll_off_dialog.show_result(p1, p2, winner, local_action)
+	# Keep the top-bar button consistent on both peers (it may still read
+	# "[Enter] Roll the dice" on the peer that didn't submit).
+	if phase_action_button:
+		phase_action_button.text = "[Enter] Continue"
 
 func _on_roll_off_acknowledged() -> void:
 	# The human dismissed a result that needed no choice from them.
 	if _roll_off_context() == "first_turn":
-		# Confirm the first turn and start the battle.
+		# Confirm the first turn and start the battle. Stamp the LOCAL player in
+		# multiplayer — CONFIRM_FIRST_TURN is turn-exempt but still authority-
+		# checked (claimed player must match the sending peer).
 		print("Main: First-turn roll-off — human acknowledged; confirming first turn")
+		var confirming_player = NetworkManager.get_local_player() if NetworkManager.is_networked() else GameState.get_active_player()
 		_dispatch_roll_off_completion({"type": "CONFIRM_FIRST_TURN",
-			"player": GameState.get_active_player()})
+			"player": confirming_player})
 	else:
 		# Deploy roll-off, AI won: apply the AI's choice (it deploys second / Attacker).
+		# The choice is made BY the winner — stamp the winner, not the active player.
 		print("Main: Deploy roll-off — human acknowledged AI result; AI deploys second")
+		var ai_winner = int(GameState.state.get("meta", {}).get("roll_off_winner", GameState.get_active_player()))
 		_dispatch_roll_off_completion({"type": "CHOOSE_DEPLOYMENT", "choice": "second",
-			"player": GameState.get_active_player()})
+			"player": ai_winner})
 
 func _on_roll_off_choice_made(choice: String) -> void:
 	# Deploy roll-off only: the winning human picked their deploy role.
 	#   choice "first"  = deploy first  (Defender)
 	#   choice "second" = deploy second (Attacker)
+	# The action is stamped with the WINNER: the phase rejects a choice from
+	# anyone else, and in multiplayer the winner is frequently not the active
+	# player (the active player merely triggered the roll).
 	print("Main: Deploy roll-off — choice=%s" % choice)
+	var choosing_player = int(GameState.state.get("meta", {}).get("roll_off_winner", GameState.get_active_player()))
 	_dispatch_roll_off_completion({"type": "CHOOSE_DEPLOYMENT", "choice": choice,
-		"player": GameState.get_active_player()})
+		"player": choosing_player})
 
 func _dispatch_roll_off_completion(action: Dictionary) -> void:
 	var result = NetworkIntegration.route_action(action)
@@ -8129,10 +8164,18 @@ func _on_network_result_applied(result: Dictionary) -> void:
 		print("Main: Phase changed via network to: ", new_phase)
 		current_phase = new_phase
 
-		# Transition PhaseManager to new phase
+		# Transition PhaseManager to new phase — but only if it isn't already
+		# there. PhaseManager transitions itself on the host (phase_completed →
+		# advance_to_next_phase) and on clients (host phase-change RPC); doing
+		# it again here created a SECOND phase instance whose deferred
+		# auto-complete then skipped the following phase in multiplayer.
 		if PhaseManager and PhaseManager.has_method("transition_to_phase"):
-			print("Main: Transitioning PhaseManager to phase: ", new_phase)
-			PhaseManager.transition_to_phase(new_phase)
+			var inst = PhaseManager.current_phase_instance
+			if inst != null and "phase_type" in inst and inst.phase_type == new_phase:
+				print("Main: PhaseManager already in phase %s — skipping duplicate transition" % str(new_phase))
+			else:
+				print("Main: Transitioning PhaseManager to phase: ", new_phase)
+				PhaseManager.transition_to_phase(new_phase)
 
 		# Wait for phase transition
 		await get_tree().process_frame
@@ -8817,6 +8860,17 @@ func _on_phase_action_pressed() -> void:
 		"timestamp": Time.get_ticks_msec()
 	})
 
+	# Multiplayer: the phase-driving button belongs to the ACTIVE player. The
+	# waiting overlay covers the board but never blocked this button, so the
+	# non-active player could fire phase actions stamped with the opponent's
+	# player id (host rejected them, but only AFTER local UI already reacted).
+	# FORMATIONS is exempt — both players confirm their own formations dialog.
+	if NetworkManager.is_networked() and current_phase != GameStateData.Phase.FORMATIONS:
+		if not NetworkManager.is_local_player_turn():
+			_show_toast("It's Player %d's turn" % GameState.get_active_player(), 2.0)
+			print("Main: Phase action button blocked — not local player's turn")
+			return
+
 	# For multiplayer sync, we need to route phase end actions through the network system
 	var action = {}
 	var active_player = GameState.get_active_player()
@@ -8841,8 +8895,19 @@ func _on_phase_action_pressed() -> void:
 		GameStateData.Phase.SCOUT_MOVES:
 			action = {"type": "END_SCOUT_MOVES", "player": active_player}
 		GameStateData.Phase.ROLL_OFF:
+			# Post-roll this button reads "Continue" — reopen the dialog (the
+			# choice/acknowledgement lives there); re-submitting the roll would
+			# just be rejected as already completed.
+			if int(GameState.state.get("meta", {}).get("roll_off_winner", 0)) > 0:
+				if roll_off_dialog and is_instance_valid(roll_off_dialog):
+					roll_off_dialog.popup_centered()
+				return
 			action = {"type": "ROLL_OFF_DEPLOYMENT", "player": active_player}
 		GameStateData.Phase.FIRST_TURN_ROLLOFF:
+			if int(GameState.state.get("meta", {}).get("first_turn_player", 0)) > 0:
+				if roll_off_dialog and is_instance_valid(roll_off_dialog):
+					roll_off_dialog.popup_centered()
+				return
 			action = {"type": "ROLL_OFF_FIRST_TURN", "player": active_player}
 		GameStateData.Phase.COMMAND:
 			# P3-94: Check for untested battle-shock units and show confirmation dialog
@@ -8926,16 +8991,24 @@ func _on_phase_action_pressed() -> void:
 		if not NetworkManager.is_networked():
 			print("Main: Falling back to local phase advance")
 			PhaseManager.advance_to_next_phase()
-	else:
-		# Update button text after a successful roll-off (no longer need to roll)
-		if action.get("type") == "ROLL_OFF_DEPLOYMENT" or action.get("type") == "ROLL_OFF_FIRST_TURN":
-			if not result.get("tied", false):
-				phase_action_button.text = "[Enter] Continue"
-				print("Main: Roll-off complete, button text updated to 'Continue'")
+	# NOTE: the roll-off "Continue" button text is set by _on_roll_off_result
+	# (signal-driven, fires on both peers). It must NOT be set here: in
+	# multiplayer route_action returns {success:true, pending:true} BEFORE
+	# validation, so flipping the text here showed "Continue" on a peer whose
+	# roll was subsequently rejected.
 
 func update_ui_for_phase() -> void:
 	# Clear any phase-specific UI artifacts first
 	_clear_phase_ui_artifacts()
+
+	# Tear down a stale roll-off dialog when leaving the roll-off phases. The
+	# submitting peer closes it in _dispatch_roll_off_completion, but the OTHER
+	# peer (multiplayer) only learns about the completion via the phase change.
+	if current_phase != GameStateData.Phase.ROLL_OFF and current_phase != GameStateData.Phase.FIRST_TURN_ROLLOFF:
+		if roll_off_dialog and is_instance_valid(roll_off_dialog):
+			print("Main: Closing stale roll-off dialog on phase change")
+			roll_off_dialog.queue_free()
+			roll_off_dialog = null
 
 	print("Main: ========== UPDATE UI FOR PHASE ==========")
 	print("Main: Current phase: ", GameStateData.Phase.keys()[current_phase])

--- a/40k/scripts/MultiplayerLobby.gd
+++ b/40k/scripts/MultiplayerLobby.gd
@@ -248,6 +248,17 @@ func _do_start_game() -> void:
 		# Re-initialize with selected deployment type if state already exists
 		GameState.initialize_default_state(selected_deployment)
 
+	# Re-mirror terrain into the fresh state on the HOST. initialize_default_state
+	# wipes board.terrain; clients rebuild theirs in load_from_snapshot (the
+	# snapshot carries terrain_layout), but nothing reloaded it host-side — so the
+	# host adjudicated terrain rules (movement through ruins walls etc.) against
+	# an EMPTY terrain list while the client saw 14 pieces.
+	var terrain_mgr = get_node_or_null("/root/TerrainManager")
+	if terrain_mgr and terrain_mgr.current_layout != "":
+		terrain_mgr.load_terrain_layout(terrain_mgr.current_layout)
+		print("MultiplayerLobby: Reloaded terrain layout '%s' into fresh game state (%d pieces)" % [
+			terrain_mgr.current_layout, terrain_mgr.terrain_features.size()])
+
 	# Clear existing units
 	GameState.state.units.clear()
 

--- a/40k/scripts/WebLobby.gd
+++ b/40k/scripts/WebLobby.gd
@@ -488,6 +488,17 @@ func _start_game() -> void:
 	else:
 		GameState.initialize_default_state(selected_deployment)
 
+	# Re-mirror terrain into the fresh state. initialize_default_state wipes
+	# board.terrain and nothing reloads it here — the HOST then adjudicates
+	# terrain rules against an empty list while the guest gets the real one
+	# via the initial_state snapshot (same bug as the LAN lobby, fixed there
+	# in _do_start_game).
+	var terrain_mgr = get_node_or_null("/root/TerrainManager")
+	if terrain_mgr and terrain_mgr.current_layout != "":
+		terrain_mgr.load_terrain_layout(terrain_mgr.current_layout)
+		print("WebLobby: Reloaded terrain layout '%s' into fresh game state (%d pieces)" % [
+			terrain_mgr.current_layout, terrain_mgr.terrain_features.size()])
+
 	# Load selected armies for both host and client
 	# (Client receives army selections from host via start_game message)
 	print("WebLobby: Loading selected armies - P1: ", selected_player1_army, ", P2: ", selected_player2_army)

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -73,6 +73,8 @@ TESTS=(
     "tests/test_iss013_signal_registry.gd"
     "tests/test_iss014_shared_ai_math.gd"
     "tests/test_iss015_mp_seed_sync.gd"
+    "tests/test_mp_v1_launch_fixes.gd"
+    "tests/test_mp_relay_json_roundtrip.gd"
     "tests/test_iss020_public_api.gd"
     "tests/test_iss017_state_schema.gd"
     "tests/test_iss021_action_replay.gd"

--- a/40k/tests/test_iss015_mp_seed_sync.gd
+++ b/40k/tests/test_iss015_mp_seed_sync.gd
@@ -47,15 +47,23 @@ func _run_tests():
 		src.find('if not action.get("payload", {}).has("rng_seed"):') != -1)
 
 	print("\n-- B: canonical state hash --")
+	# compute_state_hash now hashes the CANONICAL gameplay subset
+	# (units/players/factions/meta minus volatile keys) — full-state hashing
+	# could never match between a host (raw state) and a client (snapshot-
+	# enriched state). Exercise order-insensitivity and content-sensitivity
+	# within that subset, and confirm non-canonical keys are ignored.
 	var gs = root.get_node_or_null("GameState")
 	var prev = gs.state.duplicate(true)
-	gs.state = {"b": 2, "a": 1, "nested": {"y": [1, 2], "x": "v"}}
+	gs.state = {"units": {"b": {"hp": 2}, "a": {"hp": 1}}, "meta": {"y": [1, 2], "x": "v"}}
 	var h1 = nm.compute_state_hash()
-	gs.state = {"a": 1, "nested": {"x": "v", "y": [1, 2]}, "b": 2}
+	gs.state = {"meta": {"x": "v", "y": [1, 2]}, "units": {"a": {"hp": 1}, "b": {"hp": 2}}}
 	var h2 = nm.compute_state_hash()
 	_check("insertion order does not change the hash", h1 == h2, "%d vs %d" % [h1, h2])
-	gs.state = {"a": 1, "nested": {"x": "v", "y": [1, 2]}, "b": 3}
+	gs.state = {"units": {"a": {"hp": 1}, "b": {"hp": 3}}, "meta": {"x": "v", "y": [1, 2]}}
 	_check("content change changes the hash", nm.compute_state_hash() != h1)
+	gs.state = {"units": {"b": {"hp": 2}, "a": {"hp": 1}}, "meta": {"y": [1, 2], "x": "v"}, "phase_log": ["local-only noise"]}
+	_check("non-canonical keys (snapshot enrichment / local logs) do not change the hash",
+		nm.compute_state_hash() == h1)
 	gs.state = prev
 
 	print("\n-- C: desync detector wiring --")

--- a/40k/tests/test_mp_relay_json_roundtrip.gd
+++ b/40k/tests/test_mp_relay_json_roundtrip.gd
@@ -1,0 +1,99 @@
+extends SceneTree
+
+# Web-relay (online / game-code) JSON round-trip — regression net.
+#
+# The WebSocket relay is JSON, so NetworkManager._sanitize_for_json converts
+# every Vector2 in an outgoing action to an {x, y} dict. The host receiving a
+# relayed action fed that dict straight into phase handlers that take typed
+# Vector2 parameters (e.g. DeploymentPhase._validate_model_position), which
+# hard-crashed mid-validation — no rejection was ever sent, so the guest kept
+# its optimistic apply forever (permanent online desync on the FIRST deploy).
+# _desanitize_from_json is the inverse, applied to every relayed action before
+# the phase sees it. This pins the round-trip contract. (ENet never hits this;
+# Godot RPCs serialize Variants natively.)
+#
+# Usage: godot --headless --path . -s tests/test_mp_relay_json_roundtrip.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_mp_relay_json_roundtrip ===\n")
+	var nm = root.get_node_or_null("NetworkManager")
+	if nm == null:
+		_check("NetworkManager autoload reachable", false)
+		print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+		quit(1)
+		return
+
+	# A representative DEPLOY_UNIT action carrying a Vector2 (as the UI builds it).
+	var action := {
+		"type": "DEPLOY_UNIT",
+		"unit_id": "U_TEST",
+		"player": 2,
+		"payload": {
+			"model_id": "m1",
+			"position": Vector2(520, 450),
+			"rotation": 0.0,
+			"nested": {"dest": Vector2(1, 2)},
+			"list_of_points": [Vector2(3, 4), Vector2(5, 6)],
+		}
+	}
+
+	# Simulate the wire: sanitize (what send_game_data does), JSON-encode/decode
+	# (what the relay actually does to the bytes), then desanitize (the fix).
+	var sanitized = nm._sanitize_for_json(action)
+	_check("sanitize turns Vector2 into {x,y} dict",
+		sanitized.payload.position is Dictionary and sanitized.payload.position.has("x"))
+	var wire = JSON.stringify(sanitized)
+	var decoded = JSON.parse_string(wire)
+	_check("survives JSON encode/decode", decoded != null)
+
+	var restored = nm._desanitize_from_json(decoded)
+	_check("top-level position restored to Vector2",
+		restored.payload.position is Vector2,
+		str(typeof(restored.payload.position)))
+	_check("position value preserved",
+		restored.payload.position == Vector2(520, 450),
+		str(restored.payload.position))
+	_check("nested dict Vector2 restored",
+		restored.payload.nested.dest is Vector2 and restored.payload.nested.dest == Vector2(1, 2))
+	_check("array-of-Vector2 restored",
+		restored.payload.list_of_points.size() == 2 \
+			and restored.payload.list_of_points[0] is Vector2 \
+			and restored.payload.list_of_points[0] == Vector2(3, 4))
+	_check("non-position scalars untouched",
+		restored.unit_id == "U_TEST" and int(restored.player) == 2 \
+			and restored.payload.model_id == "m1")
+
+	# A plain {x, y} that is NOT a serialized Vector2 context still round-trips as
+	# a Vector2 by shape — that's acceptable (handlers reading .x/.y work either
+	# way) but confirm a 3-key dict is left as a dict (not mis-coerced).
+	var three = nm._desanitize_from_json({"x": 1, "y": 2, "z": 3})
+	_check("dict with extra keys is NOT coerced to Vector2", three is Dictionary)
+
+	# The handler guard: _handle_relayed_action desanitizes before validate.
+	var src = FileAccess.get_file_as_string("res://autoloads/NetworkManager.gd")
+	_check("_handle_relayed_action desanitizes before validation",
+		src.find("action = _desanitize_from_json(action)") != -1)
+	_check("relay validation uses defensive .get(\"valid\")",
+		src.find("if not validation.valid:") == -1)
+	_check("WebLobby reloads terrain on host start",
+		FileAccess.get_file_as_string("res://scripts/WebLobby.gd").find("Reloaded terrain layout") != -1)
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_mp_v1_launch_fixes.gd
+++ b/40k/tests/test_mp_v1_launch_fixes.gd
@@ -1,0 +1,133 @@
+extends SceneTree
+
+# Multiplayer v1.0 launch-readiness fixes — regression net.
+#
+# Pins the contracts introduced by the 2026-07 multiplayer hardening pass.
+# Each of these guarded a LIVE, reproduced failure in a two-instance ENet
+# game (see version_history entry for the play-facing summary):
+#
+#   A) Roll-off phases expose roll_off_result and validate the choose action
+#      (MP-1: every LAN game soft-locked at the deployment roll-off).
+#   B) GameManager delegates unknown action types to the current phase
+#      (MP-8: END_SCOUT_PHASE, DECLINE_COMMAND_REROLL, END_PILE_IN,
+#      USE_COUNTER_OFFENSIVE, ... all hard-failed in multiplayer only).
+#   C) NetworkManager exempts reactive/cross-turn actions from turn
+#      validation (roll-off completions + reactive stratagem windows).
+#   D) PhaseManager: clients never self-advance phases; outgoing phase
+#      instances are disconnected before queue_free (MP-5: stale deferred
+#      phase_completed skipped FIRST_TURN_ROLLOFF and cascaded clients
+#      through COMMAND→CHARGE alone).
+#   E) compute_state_hash hashes the canonical gameplay subset (MP-2: the
+#      full-state hash could never match after a snapshot sync, so the
+#      desync detector cried wolf on every check).
+#   F) Multiplayer lobby reloads the terrain layout on the host (MP-3: host
+#      adjudicated terrain rules against an empty board.terrain).
+#
+# Usage: godot --headless --path . -s tests/test_mp_v1_launch_fixes.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_mp_v1_launch_fixes ===\n")
+
+	print("-- A: roll-off result signal + winner-gated choice --")
+	var roll_off_script = load("res://phases/RollOffPhase.gd")
+	var ftro_script = load("res://phases/FirstTurnRollOffPhase.gd")
+	var ro = roll_off_script.new()
+	_check("RollOffPhase declares roll_off_result", ro.has_signal("roll_off_result"))
+	var ftro = ftro_script.new()
+	_check("FirstTurnRollOffPhase declares roll_off_result", ftro.has_signal("roll_off_result"))
+
+	# Behavioral: CHOOSE_DEPLOYMENT winner enforcement.
+	ro._roll_complete = true
+	ro._roll_off_winner = 1
+	var v_wrong = ro.validate_action({"type": "CHOOSE_DEPLOYMENT", "choice": "first", "player": 2})
+	_check("CHOOSE_DEPLOYMENT by non-winner rejected", not v_wrong.get("valid", true))
+	var v_right = ro.validate_action({"type": "CHOOSE_DEPLOYMENT", "choice": "first", "player": 1})
+	_check("CHOOSE_DEPLOYMENT by winner accepted", v_right.get("valid", false),
+		str(v_right.get("errors", [])))
+	var v_unstamped = ro.validate_action({"type": "CHOOSE_DEPLOYMENT", "choice": "second"})
+	_check("CHOOSE_DEPLOYMENT without player accepted (SP/test dispatch)",
+		v_unstamped.get("valid", false), str(v_unstamped.get("errors", [])))
+	ro.free()
+	ftro.free()
+
+	print("\n-- B: GameManager delegates unknown actions to the phase --")
+	var gm_src = FileAccess.get_file_as_string("res://autoloads/GameManager.gd")
+	_check("default arm delegates instead of hard-failing",
+		gm_src.find("not handled directly — delegating to current phase") != -1)
+	_check("old unconditional unknown-action failure removed",
+		gm_src.find('return {"success": false, "error": "Unknown action type: " + str(action.get("type", "UNKNOWN"))}') == -1)
+
+	print("\n-- C: reactive/cross-turn actions exempt from turn validation --")
+	var nm_src = FileAccess.get_file_as_string("res://autoloads/NetworkManager.gd")
+	for a in ["CHOOSE_DEPLOYMENT", "CONFIRM_FIRST_TURN", "USE_EPIC_CHALLENGE",
+			"DECLINE_EPIC_CHALLENGE", "USE_COUNTER_OFFENSIVE", "DECLINE_COUNTER_OFFENSIVE",
+			"USE_FIRE_OVERWATCH", "DECLINE_FIRE_OVERWATCH", "USE_COMMAND_REROLL",
+			"DECLINE_COMMAND_REROLL"]:
+		_check("exempt list contains %s" % a, nm_src.find('"%s"' % a) != -1)
+	_check("roll_off_result re-emitted for clients",
+		nm_src.find('phase.emit_signal("roll_off_result"') != -1)
+	_check("epic_challenge_opportunity re-emitted for clients",
+		nm_src.find('phase.emit_signal("epic_challenge_opportunity"') != -1)
+	_check("client-action broadcasts carry state hash",
+		nm_src.find("result[\"_state_hash\"] = compute_state_hash()\n\t\t_broadcast_result.rpc(result)") != -1)
+
+	print("\n-- D: phase-advance hardening --")
+	var pm_src = FileAccess.get_file_as_string("res://autoloads/PhaseManager.gd")
+	_check("client phase_completed suppression present",
+		pm_src.find("phase_completed on CLIENT — waiting for host to advance") != -1)
+	_check("outgoing phase signals disconnected before queue_free",
+		pm_src.find("current_phase_instance.phase_completed.disconnect(_on_phase_completed)") != -1)
+	var main_src = FileAccess.get_file_as_string("res://scripts/Main.gd")
+	_check("Main skips duplicate phase transition",
+		main_src.find("skipping duplicate transition") != -1)
+	_check("Main gates phase action button on local turn",
+		main_src.find("Phase action button blocked — not local player's turn") != -1)
+
+	print("\n-- E: canonical state hash --")
+	var nm = root.get_node_or_null("NetworkManager")
+	var gs = root.get_node_or_null("GameState")
+	if nm and gs:
+		# Enrichment keys that only exist on snapshot-loaded peers must not
+		# affect the hash — that asymmetry meant host/client hashes never matched.
+		var h1 = nm.compute_state_hash()
+		gs.state["mission_manager"] = {"only": "on snapshot-loaded peers"}
+		gs.state["phase_log"] = ["local", "noise"]
+		var h2 = nm.compute_state_hash()
+		gs.state.erase("mission_manager")
+		gs.state.erase("phase_log")
+		_check("hash ignores snapshot-enrichment/local-noise keys", h1 == h2,
+			"h1=%d h2=%d" % [h1, h2])
+		# ...while genuinely divergent unit state must change it.
+		var had_units = gs.state.has("units")
+		if had_units:
+			gs.state.units["__mp_test_unit"] = {"owner": 1}
+			var h3 = nm.compute_state_hash()
+			gs.state.units.erase("__mp_test_unit")
+			_check("hash reacts to unit divergence", h1 != h3)
+	else:
+		_check("NetworkManager+GameState autoloads reachable", false)
+
+	print("\n-- F: lobby reloads terrain on host --")
+	var lobby_src = FileAccess.get_file_as_string("res://scripts/MultiplayerLobby.gd")
+	_check("host terrain reload present in _do_start_game",
+		lobby_src.find("Reloaded terrain layout") != -1)
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)


### PR DESCRIPTION
## Summary

A thorough multiplayer validation pass for the 1.0 release, driven by playing full two-instance games (not just headless tests). Both multiplayer modes had launch-blocking bugs; all are fixed and re-validated live end-to-end.

**LAN (ENet)** was unplayable past the pre-deployment roll-off, and even past that, phases desynced. **Online (game-code / WebSocket relay)** — the itch.io flow where one player shares a code and the other joins — permanently desynced on the joining player's first deployment.

## LAN / core multiplayer fixes (v0.7.0)

- **Roll-off soft-lock (P0):** every LAN game stalled at "Who Deploys First?". The dialog read roll results from a return value that in multiplayer contains no dice data, so neither peer's dialog updated and the winner's deploy-order choice was rejected as "not your turn". Roll-offs are now signal-driven on both peers and the winner makes the choice.
- **Phase-advance cascade (P0):** one "End Deployment" created duplicate phase instances via three overlapping sync paths; stale signals from half-destroyed phases skipped the first-turn roll-off on the host while the client free-ran through Command→Charge alone. Instances are now disconnected on exit, duplicate transitions deduped, and clients never self-advance.
- **"Unknown action type" only in multiplayer (P0):** GameManager hard-failed any action it didn't enumerate — which single-player never routes through it. Ending Scout, Command Re-rolls, Counter-Offensive, Fire Overwatch, Epic Challenge, End Pile In/Consolidation, warlord designation, Beacon and more were dead online. It now delegates to the phase.
- **Reactive prompts on the wrong screen (P1):** Epic Challenge appeared on the host regardless of whose decision it was; the deciding player's peer now gets the prompt, and reactive stratagems (Epic Challenge, Counter-Offensive, Fire Overwatch, Command Re-roll) are turn-exempt with authority still enforced.
- **Host terrain blind spot (P1):** the authoritative host adjudicated movement/wall rules against `board.terrain = []` while clients had the real layout. Host re-mirrors the layout on start.
- **Desync detector false positives (P1):** the state hash compared incompatible host/client views, so it fired after nearly every action; it now hashes the canonical gameplay subset and also covers client-submitted actions.
- **Turn-gating (P1):** the phase button and roll-off dice were clickable by the non-active player; both are now gated with a toast, and fight-selection buttons disable for the non-selecting player.
- Charge-phase client sync, a dropped `charge_targets_available` signal, and "Unknown Phase" game-log entries also fixed.

## Online / web-relay fixes (v0.7.1)

- **JSON Vector2 round-trip (P0):** relay actions are JSON, so positions are serialized to `{x, y}` dicts. The host fed those straight into phase handlers with typed `Vector2` params, which crashed mid-validation — no rejection was sent, so the guest's optimistic first deploy was never confirmed or rolled back (permanent desync). Added the recursive inverse conversion before validation and hardened the bare `validation.valid` accesses so a handler error surfaces as a rejection instead of a second crash. ENet is unaffected (native Variant RPC serialization).
- **Online host terrain:** same empty-`board.terrain` bug as LAN, fixed in `WebLobby._start_game`.

## Validation

Every bug was reproduced live before fixing and re-driven live after, using two windowed instances driven through the in-game MCP bridge (real button clicks, board clicks, screenshots, both peers' logs).

- **LAN:** full game — lobby host/join, formations, deployment roll-off (both branches), full alternating deployment, first-turn roll-off, scout/command/movement, a complete shooting sequence with defender save allocation on the remote peer, fight phase via mid-game save resume (pile-in alternation, fight selection, Epic Challenge on the correct peer, Counter-Offensive with CP sync), abrupt-disconnect grace dialog, and continue-as-single-player. Zero desyncs, `verify_delivery` PASS on both peers.
- **Online (relay):** validated against a local instance of the production `relay-server.js` — matchmaking by code, initial-state sync, formations, deployment roll-off, full deployment (guest optimistic execution now confirmed by host), first-turn roll-off, command/movement, and a shooting sequence with the defender's save dialog rendering on the guest and damage syncing back. Zero desyncs.
- **Headless:** 6/6 single-player roll-off scenarios, roll-off dialog/pipeline suites green, and new pin tests (`test_mp_v1_launch_fixes.gd` 27 checks, `test_mp_relay_json_roundtrip.gd` 11 checks) wired into the suite runner. Also fixed the scenario runner so fixture-based tests run on fresh checkouts.

## Known caveat

Online play was validated against a **local** copy of the relay server (the production `fly.dev` host is unreachable from the CI environment). The code path is identical; a final smoke test on the deployed server from two networks is worth doing before release.

## Note on scope

Alongside the 3 multiplayer commits, this branch also carries 4 pre-existing UI fixes committed before the multiplayer work (dialog-height overflow fixes and the infantry-through-ruins terrain fix, issues #517–#521) that were not yet on `main`; they're included here since they were already on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E9dzYTH7SGh3HLQHdGewUR

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9dzYTH7SGh3HLQHdGewUR)_