### PR TITLE
Dock Fight-phase Pile In / Consolidate windows to bottom of screen

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.7.2",
+			"date": "2026-07-08",
+			"summary": "The Fight phase 'Pile In' and 'Consolidate' windows now dock to the bottom of the screen instead of sitting in the middle of the battlefield, and match the rest of the game's menus.",
+			"changes": [
+				"When you pile in or consolidate, the pop-up used to open centered right over the board — covering the very models you were trying to drag. It now docks to the bottom-centre of the screen with the battlefield fully visible above it, so you can see and drag your models while the controls stay out of the way.",
+				"Restyled both windows to match the rest of the menus: a gold heading, a gold divider between sections, and a red 'Confirm Move' button like 'Start Game'. The legend at the bottom (green arrow / red arrow / dashed line / green dots / red X) was almost unreadable dark-grey text and is now a legible muted tone.",
+				"Removed the redundant extra 'OK' button — the window's own 'Confirm Move', 'Skip / Confirm (No Models Move)' and 'Reset Positions' buttons are the controls (pressing Enter still confirms)."
+			]
+		},
+		{
 			"version": "0.7.1",
 			"date": "2026-07-07",
 			"summary": "Fixed the Game Log drawing on top of the Save & Load menu — the menu now always sits above the log and other side panels while it's open.",

--- a/40k/dialogs/ConsolidateDialog.gd
+++ b/40k/dialogs/ConsolidateDialog.gd
@@ -4,6 +4,11 @@ class_name ConsolidateDialog
 signal consolidate_confirmed(movements: Dictionary)
 signal consolidate_skipped()
 
+# Shared muted tones so the neutral status line and the legend read the same
+# way the other White Dwarf menus do (readable, but subordinate to the gold).
+const _NEUTRAL_STATUS := Color(0.7, 0.7, 0.8)
+const _LEGEND_COLOR := Color(0.7, 0.7, 0.8)
+
 var unit_id: String = ""
 var max_distance: float = 3.0
 var phase_reference = null
@@ -30,32 +35,41 @@ func setup(fighter_id: String, max_dist: float, phase, controller = null) -> voi
 func _build_ui() -> void:
 	var container = VBoxContainer.new()
 	container.name = "Content"
-	container.add_theme_constant_override("separation", 10)
+	container.add_theme_constant_override("separation", 8)
 
+	# Heading — gold, to match the gold section headers used across the menus.
 	var instruction = Label.new()
+	instruction.name = "Instruction"
 	# Determine consolidate mode
 	var mode_text = _get_consolidate_mode_text()
 	instruction.text = mode_text
 	instruction.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	instruction.add_theme_font_size_override("font_size", 15)
+	instruction.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
 	container.add_child(instruction)
 
 	# Status label to show validation feedback
 	status_label = Label.new()
-	status_label.text = "Ready - Click and drag models to move them"
+	status_label.name = "Status"
+	status_label.text = "Ready — click and drag models to move them"
 	status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	status_label.add_theme_font_size_override("font_size", 12)
-	status_label.add_theme_color_override("font_color", Color.GRAY)
+	status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
 	container.add_child(status_label)
 
-	# Button container
+	WhiteDwarfTheme.add_gold_separator(container)
+
+	# Button container — centered, evenly spaced action row like the other menus.
 	var button_container = HBoxContainer.new()
 	button_container.name = "Buttons"
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
 	button_container.add_theme_constant_override("separation", 10)
 
 	# Reset button
 	reset_button = Button.new()
 	reset_button.name = "ResetButton"
 	reset_button.text = "Reset Positions"
+	reset_button.custom_minimum_size = Vector2(0, 36)
 	reset_button.pressed.connect(_on_reset_pressed)
 	button_container.add_child(reset_button)
 
@@ -65,29 +79,42 @@ func _build_ui() -> void:
 	var no_move_button = Button.new()
 	no_move_button.name = "SkipButton"
 	no_move_button.text = "Confirm (No Models Move)"
+	no_move_button.custom_minimum_size = Vector2(0, 36)
 	no_move_button.pressed.connect(_on_skip_pressed)
 	button_container.add_child(no_move_button)
 
 	# Explicit confirm button with a stable path (the built-in AcceptDialog
-	# OK button lives under auto-named internal containers)
+	# OK button lives under auto-named internal containers). Styled as the
+	# primary (red) action so it reads as the main affordance like Start Game.
 	var confirm_button = Button.new()
 	confirm_button.name = "ConfirmButton"
 	confirm_button.text = "Confirm Move"
+	confirm_button.custom_minimum_size = Vector2(0, 36)
 	confirm_button.pressed.connect(_on_confirmed)
 	button_container.add_child(confirm_button)
+	WhiteDwarfTheme.apply_primary_button(confirm_button)
 
 	container.add_child(button_container)
 
-	# Info label
+	WhiteDwarfTheme.add_gold_separator(container)
+
+	# Legend — muted but readable. (Was Color.DARK_GRAY, near-invisible on the
+	# dark parchment-on-black dialog background.)
 	var info = Label.new()
+	info.name = "Legend"
 	info.text = "• Green arrow = valid (closer to enemy, within 3\")\n• Red arrow = invalid (too far or wrong direction)\n• Dashed line = movement path with distance\n• Green dots = unit coherency maintained"
 	info.add_theme_font_size_override("font_size", 11)
-	info.add_theme_color_override("font_color", Color.DARK_GRAY)
+	info.add_theme_color_override("font_color", _LEGEND_COLOR)
 	container.add_child(info)
 
 	add_child(container)
 
 	confirmed.connect(_on_confirmed)
+
+	# Redundant with the explicit "Confirm Move" button and out of keeping with
+	# the menu-style action row — hide the built-in AcceptDialog OK button.
+	# (Enter still confirms via the `confirmed` signal above.)
+	get_ok_button().visible = false
 
 	# Set minimum size for dialog
 	min_size = DialogConstants.SMALL
@@ -108,7 +135,7 @@ func _update_status() -> void:
 
 	if model_movements.is_empty():
 		status_label.text = "No models moved yet"
-		status_label.add_theme_color_override("font_color", Color.GRAY)
+		status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
 		return
 
 	# Validate movements

--- a/40k/dialogs/PileInDialog.gd
+++ b/40k/dialogs/PileInDialog.gd
@@ -4,6 +4,11 @@ class_name PileInDialog
 signal pile_in_confirmed(movements: Dictionary)
 signal pile_in_skipped()
 
+# Shared muted tones so the neutral status line and the legend read the same
+# way the other White Dwarf menus do (readable, but subordinate to the gold).
+const _NEUTRAL_STATUS := Color(0.7, 0.7, 0.8)
+const _LEGEND_COLOR := Color(0.7, 0.7, 0.8)
+
 var unit_id: String = ""
 var max_distance: float = 3.0
 var phase_reference = null
@@ -30,30 +35,39 @@ func setup(fighter_id: String, max_dist: float, phase, controller = null) -> voi
 func _build_ui() -> void:
 	var container = VBoxContainer.new()
 	container.name = "Content"
-	container.add_theme_constant_override("separation", 10)
+	container.add_theme_constant_override("separation", 8)
 
+	# Heading — gold, to match the gold section headers used across the menus.
 	var instruction = Label.new()
-	instruction.text = "Drag models on the battlefield to pile in\nUp to %.1f\" toward closest enemy" % max_distance
+	instruction.name = "Instruction"
+	instruction.text = "Drag models on the battlefield to pile in\nUp to %.1f\" toward the closest enemy" % max_distance
 	instruction.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	instruction.add_theme_font_size_override("font_size", 15)
+	instruction.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
 	container.add_child(instruction)
 
 	# Status label to show validation feedback
 	status_label = Label.new()
-	status_label.text = "Ready - Click and drag models to move them"
+	status_label.name = "Status"
+	status_label.text = "Ready — click and drag models to move them"
 	status_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	status_label.add_theme_font_size_override("font_size", 12)
-	status_label.add_theme_color_override("font_color", Color.GRAY)
+	status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
 	container.add_child(status_label)
 
-	# Button container
+	WhiteDwarfTheme.add_gold_separator(container)
+
+	# Button container — centered, evenly spaced action row like the other menus.
 	var button_container = HBoxContainer.new()
 	button_container.name = "Buttons"
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
 	button_container.add_theme_constant_override("separation", 10)
 
 	# Reset button
 	reset_button = Button.new()
 	reset_button.name = "ResetButton"
 	reset_button.text = "Reset Positions"
+	reset_button.custom_minimum_size = Vector2(0, 36)
 	reset_button.pressed.connect(_on_reset_pressed)
 	button_container.add_child(reset_button)
 
@@ -61,29 +75,42 @@ func _build_ui() -> void:
 	var skip_button = Button.new()
 	skip_button.name = "SkipButton"
 	skip_button.text = "Skip (No Movement)"
+	skip_button.custom_minimum_size = Vector2(0, 36)
 	skip_button.pressed.connect(_on_skip_pressed)
 	button_container.add_child(skip_button)
 
 	# Explicit confirm button with a stable path (the built-in AcceptDialog
-	# OK button lives under auto-named internal containers)
+	# OK button lives under auto-named internal containers). Styled as the
+	# primary (red) action so it reads as the main affordance like Start Game.
 	var confirm_button = Button.new()
 	confirm_button.name = "ConfirmButton"
 	confirm_button.text = "Confirm Move"
+	confirm_button.custom_minimum_size = Vector2(0, 36)
 	confirm_button.pressed.connect(_on_confirmed)
 	button_container.add_child(confirm_button)
+	WhiteDwarfTheme.apply_primary_button(confirm_button)
 
 	container.add_child(button_container)
 
-	# Info label
+	WhiteDwarfTheme.add_gold_separator(container)
+
+	# Legend — muted but readable. (Was Color.DARK_GRAY, near-invisible on the
+	# dark parchment-on-black dialog background.)
 	var info = Label.new()
+	info.name = "Legend"
 	info.text = "• Green arrow = valid (closer to enemy, within 3\")\n• Red arrow = invalid (too far or wrong direction)\n• Dashed line = movement path with distance\n• Green dots = unit coherency maintained\n• Red X (B2B) = model in base contact, cannot move"
 	info.add_theme_font_size_override("font_size", 11)
-	info.add_theme_color_override("font_color", Color.DARK_GRAY)
+	info.add_theme_color_override("font_color", _LEGEND_COLOR)
 	container.add_child(info)
 
 	add_child(container)
 
 	confirmed.connect(_on_confirmed)
+
+	# Redundant with the explicit "Confirm Move" button and out of keeping with
+	# the menu-style action row — hide the built-in AcceptDialog OK button.
+	# (Enter still confirms via the `confirmed` signal above.)
+	get_ok_button().visible = false
 
 	# Set minimum size for dialog
 	min_size = DialogConstants.SMALL
@@ -104,7 +131,7 @@ func _update_status() -> void:
 
 	if model_movements.is_empty():
 		status_label.text = "No models moved yet"
-		status_label.add_theme_color_override("font_color", Color.GRAY)
+		status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
 		return
 
 	# Validate movements

--- a/40k/scripts/DialogUtils.gd
+++ b/40k/scripts/DialogUtils.gd
@@ -61,6 +61,58 @@ static func _refit_to_viewport(dialog: Window) -> void:
 	dialog.popup_centered(Vector2i(w, h))
 
 
+## Show `dialog` anchored to the BOTTOM-CENTER of the screen instead of the
+## middle. Used by the interactive drag-to-move Fight steps (Pile In /
+## Consolidate): their modal must stay OUT of the way of the battlefield the
+## player is dragging models across, so it hugs the bottom edge like a docked
+## control bar rather than sitting on top of the action.
+##
+## Clamped to the viewport, then re-anchored one frame later (once the content
+## has settled its real height) so the window keeps hugging the bottom no matter
+## how its content measures. `margin_bottom` is the gap left below the window.
+static func popup_at_bottom(dialog: Window, base_size: Vector2 = DialogConstants.SMALL, margin_bottom: int = 24) -> void:
+	if dialog == null:
+		return
+	if not dialog.is_inside_tree():
+		# Can't resolve the screen size before the dialog is in the tree; fall
+		# back to a plain popup rather than doing nothing.
+		dialog.popup(Rect2i(Vector2i.ZERO, Vector2i(int(base_size.x), int(base_size.y))))
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var max_w: int = int(vp_size.x * 0.95)
+	var max_h: int = int(vp_size.y * 0.9)
+	# Hard ceiling so the window can never exceed the viewport.
+	dialog.max_size = Vector2i(max_w, max_h)
+	var w: int = min(int(base_size.x), max_w)
+	var h: int = min(int(base_size.y), max_h)
+	dialog.popup(Rect2i(_bottom_position(vp_size, w, h, margin_bottom), Vector2i(w, h)))
+	# Re-anchor once the content has been laid out to its real height.
+	var t := dialog.get_tree()
+	if t != null:
+		t.process_frame.connect(DialogUtils._reanchor_bottom.bind(dialog, margin_bottom), CONNECT_ONE_SHOT)
+
+
+static func _reanchor_bottom(dialog: Window, margin_bottom: int) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var max_w: int = int(vp_size.x * 0.95)
+	var max_h: int = int(vp_size.y * 0.9)
+	# Snap to the real content size, clamp to the viewport, then re-pin to the
+	# bottom edge so it never spills off-screen and never drifts to the middle.
+	dialog.reset_size()
+	var w: int = min(int(dialog.size.x), max_w)
+	var h: int = min(int(dialog.size.y), max_h)
+	dialog.size = Vector2i(w, h)
+	dialog.position = _bottom_position(vp_size, w, h, margin_bottom)
+
+
+static func _bottom_position(vp_size: Vector2, w: int, h: int, margin_bottom: int) -> Vector2i:
+	var x: int = int((vp_size.x - w) / 2.0)
+	var y: int = int(vp_size.y - h - margin_bottom)
+	return Vector2i(max(x, 0), max(y, 0))
+
+
 ## The size of the screen/root viewport the `dialog` popup is embedded in.
 ## NOTE: a Window is itself a Viewport, so `dialog.get_viewport()` returns the
 ## dialog, not the screen — use the SceneTree root viewport instead.

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -1791,7 +1791,9 @@ func _on_pile_in_required(unit_id: String, max_distance: float) -> void:
 	dialog.pile_in_skipped.connect(_on_pile_in_skipped.bind(unit_id))
 	dialog.tree_exiting.connect(_on_pile_in_dialog_closed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Dock to the bottom of the screen so it doesn't cover the battlefield the
+	# player is dragging models across.
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.SMALL)
 
 	# Enable pile-in mode
 	_enable_pile_in_mode(unit_id, dialog)
@@ -1938,7 +1940,9 @@ func _on_consolidate_required(unit_id: String, max_distance: float) -> void:
 	dialog.consolidate_skipped.connect(_on_consolidate_skipped.bind(unit_id))
 	dialog.tree_exiting.connect(_on_consolidate_dialog_closed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	# Dock to the bottom of the screen so it doesn't cover the battlefield the
+	# player is dragging models across (same treatment as the Pile In dialog).
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.SMALL)
 
 	# Enable consolidate mode (uses same system as pile-in)
 	_enable_consolidate_mode(unit_id, dialog)

--- a/40k/tests/scenarios/sp/global_consolidation_step_11e.json
+++ b/40k/tests/scenarios/sp/global_consolidation_step_11e.json
@@ -9,6 +9,11 @@
     "movetypes.ConsolidationMove",
     "dialogs.PileInStepDialog",
     "dialogs.ConsolidationStepDialog",
+    "dialogs.PileInDialog",
+    "dialogs.ConsolidateDialog",
+    "ui.layout.PileInDialog_bottom_dock",
+    "ui.layout.ConsolidateDialog_bottom_dock",
+    "scripts.DialogUtils.popup_at_bottom",
     "scenario_runner.drag_board"
   ],
   "fixture": "co_pretrigger",
@@ -16,7 +21,7 @@
   "rng_seed": 42,
   "transition_to_phase": 10,
   "disable_ai": true,
-  "description": "The FULL 11e fight-phase structure (12.02-12.08), played end-to-end as a human. The phase OPENS with the global Pile In step: the active player (P2) passes with End Pile In, then P1 picks the Custodian Guard and DRAGS a model with real mouse-motion events, confirms, and ends their half with the Telemon unmoved. The Fight step then runs three activations through the real dialogs (Warboss P2, Custodian Guard and Telemon P1 — all engaged from the start, so NO per-activation pile-in dialog appears). End Fight Phase enters the global Consolidate step: P2 passes (optional per unit), P1 consolidates the Telemon by drag, ends their half with the Custodians unmoved, and the phase completes. Setup-only privileges: CP zeroed to suppress stratagem prompts not under test; model wounds inflated so no unit dies (deterministic aliveness for the drag targets). Every in-game decision is a real click or drag.",
+  "description": "The FULL 11e fight-phase structure (12.02-12.08), played end-to-end as a human. The phase OPENS with the global Pile In step: the active player (P2) passes with End Pile In, then P1 picks the Custodian Guard and DRAGS a model with real mouse-motion events, confirms, and ends their half with the Telemon unmoved. The Fight step then runs three activations through the real dialogs (Warboss P2, Custodian Guard and Telemon P1 — all engaged from the start, so NO per-activation pile-in dialog appears). End Fight Phase enters the global Consolidate step: P2 passes (optional per unit), P1 consolidates the Telemon by drag, ends their half with the Custodians unmoved, and the phase completes. Setup-only privileges: CP zeroed to suppress stratagem prompts not under test; model wounds inflated so no unit dies (deterministic aliveness for the drag targets). Every in-game decision is a real click or drag. Also guards the interactive-move dialog placement: when the live PileInDialog / ConsolidateDialog open, they must be docked near the BOTTOM of the screen (position.y in the lower half) and fully on-screen, so they no longer sit centered on top of the battlefield the player is dragging models across.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.8 },
     { "act": "expect_state", "path": "meta.phase", "equals": 10 },
@@ -42,6 +47,8 @@
     { "act": "click_node", "node": "/root/PileInStepDialog/Content/UnitScroll/UnitList/PileIn_U_CUSTODIAN_GUARD_B", "emit_pressed": true },
 
     { "act": "expect_node_visible", "node": "/root/PileInDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"PileInDialog\").position.y", "expect_min": 500 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"PileInDialog\").position.y + main.get_tree().root.get_node(\"PileInDialog\").size.y <= main.get_viewport().get_visible_rect().size.y", "equals": true },
     { "act": "drag_board", "from_x": 200, "from_y": 100, "to_x": 255, "to_y": 170 },
     { "act": "screenshot", "label": "03_pile_in_model_dragged" },
     { "act": "click_node", "node": "/root/PileInDialog/Content/Buttons/ConfirmButton", "emit_pressed": true },
@@ -102,6 +109,8 @@
     { "act": "click_node", "node": "/root/ConsolidationStepDialog/Content/UnitScroll/UnitList/Consolidate_U_TELEMON_HEAVY_DREADNOUGHT_I", "emit_pressed": true },
 
     { "act": "expect_node_visible", "node": "/root/ConsolidateDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"ConsolidateDialog\").position.y", "expect_min": 500 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"ConsolidateDialog\").position.y + main.get_tree().root.get_node(\"ConsolidateDialog\").size.y <= main.get_viewport().get_visible_rect().size.y", "equals": true },
     { "act": "drag_board", "from_x": 600, "from_y": 250, "to_x": 573, "to_y": 208 },
     { "act": "screenshot", "label": "07_consolidate_model_dragged" },
     { "act": "click_node", "node": "/root/ConsolidateDialog/Content/Buttons/ConfirmButton", "emit_pressed": true },

--- a/40k/tests/test_shooting_sequential_pause.gd.uid
+++ b/40k/tests/test_shooting_sequential_pause.gd.uid
@@ -1,0 +1,1 @@
+uid://e6ekg3a50yi6

--- a/40k/tests/test_staged_shooting_reroll.gd.uid
+++ b/40k/tests/test_staged_shooting_reroll.gd.uid
@@ -1,0 +1,1 @@
+uid://c7end40awgrbw


### PR DESCRIPTION
## Problem

The interactive **Pile In** and **Consolidate** dialogs opened *centered* (`popup_centered()`), sitting directly on top of the battlefield — covering the very models the player needs to see and drag. They also didn't match the rest of the game's White Dwarf menu chrome (the legend text was near-invisible dark-grey, and a redundant built-in OK button doubled up with the explicit action row).

## Changes

- **Dock to the bottom of the screen.** New reusable `DialogUtils.popup_at_bottom()` anchors a `Window` to the bottom-centre of the viewport, clamped on-screen and re-anchored one frame later once content settles its real height. `FightController` now uses it for both drag dialogs instead of `popup_centered()`. Live position moved from centre `(735, 400)` → bottom `(735, 776)`, leaving the board visible above.
- **Restyle to match the menus.** `PileInDialog` / `ConsolidateDialog` now use the shared language: gold heading, gold section separators, a red primary **Confirm Move** button (like "Start Game"), and a legible muted legend (was `Color.DARK_GRAY`, near-invisible on the dark background). The redundant built-in OK button is hidden — the explicit Confirm/Skip/Reset row is the control, and Enter still confirms.
- **Node paths preserved.** `Content/Buttons/ConfirmButton`, `SkipButton`, `ResetButton` are unchanged so existing windowed scenarios keep working.
- **Version bump** to `0.7.2` in `version_history.json` (player-facing change).
- **Housekeeping:** committed two missing Godot `.uid` companions for already-tracked test scripts (regenerated on import; the repo tracks `.uid` files).

## Validation (ran the real game, not just headless)

- Live end-to-end scenario `global_consolidation_step_11e` → **87/87 passed, 0 failed** — drives both dialogs through the real `FightController` path, clicks their `ConfirmButton`s, and now asserts each opens in the lower half of the screen and fully on-screen.
- Adjacent step-picker scenario `fight_step_dialogs_height` → **22/22** (no regression).
- In-game screenshots confirm both dialogs render docked at the bottom with the battlefield visible above them; `read_debug_log` shows **0 ERROR lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRu3Un4p1DhRH4XXTPKWAo

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRu3Un4p1DhRH4XXTPKWAo)_