### PR TITLE
Add on-demand AI suggestion feature for human players

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -96,6 +96,7 @@ signal spectator_phase_summary(player: int, phase: int, summary: Dictionary)
 # T7-56: Turn history signal — emitted when a turn's actions are stored
 signal turn_history_updated()
 signal ai_alpha_targets_selected(drawing_player: int, alpha_targets: Array, eligible_units: Array)  # AI opponent selected alphas; human card holder needs to pick gamma
+signal ai_suggestion_ready(player: int, decision: Dictionary, description: String)  # On-demand hint computed (preview only — not executed)
 
 func _ready() -> void:
 	# ISS-032: AI cache policy is reset-by-design across save/load — the
@@ -475,6 +476,77 @@ func get_action_log() -> Array:
 
 func clear_action_log() -> void:
 	_action_log.clear()
+
+# =============================================================================
+# ON-DEMAND AI SUGGESTION — human-facing hint / AI-reasoning inspector
+# =============================================================================
+
+func request_suggestion() -> Dictionary:
+	"""Compute what the AI would do for the CURRENT active player and surface its
+	reasoning in the game log — WITHOUT executing anything. Built for a human
+	playing against the AI who wants a hint, or for debugging the AI's reasoning
+	on any board position. Pure preview: dispatches no action, advances no phase,
+	appends nothing to the AI action log, and (via AIDecisionMaker.suggest_action)
+	does not disturb the opponent AI's planning caches. Returns the decision dict
+	(with _ai_* reasoning fields), or an empty dict if no suggestion is available."""
+	# Don't interleave with the AI actively taking its own turn — that path owns
+	# the decision caches while it runs.
+	if _processing_turn:
+		_log_ai_thinking(GameState.get_active_player(), "Suggestion unavailable — the AI is currently taking its turn.")
+		return {}
+
+	if not _phase_manager_ref:
+		_phase_manager_ref = get_node_or_null("/root/PhaseManager")
+	var phase_manager = _phase_manager_ref
+	if not phase_manager or not phase_manager.current_phase_instance:
+		push_warning("AIPlayer.request_suggestion: no active phase to reason about")
+		return {}
+
+	# Whose decision is it? Normally the active player; in the fight phase the
+	# alternating-activation selecting player may differ from the active player.
+	var player = GameState.get_active_player()
+	var phase = GameState.get_current_phase()
+	if phase == GameStateData.Phase.FIGHT:
+		var sel = _get_fight_phase_selecting_player()
+		if sel > 0:
+			player = sel
+
+	var snapshot = GameState.create_snapshot()
+	var available = phase_manager.get_available_actions()
+	if available.is_empty():
+		_log_ai_thinking(player, "No actions available to suggest right now.")
+		emit_signal("ai_suggestion_ready", player, {}, "No actions available")
+		return {}
+
+	# Preview at the difficulty of the AI the player is actually facing, so the
+	# hint reflects that specific opponent. If the active player is themselves an
+	# AI, use their own difficulty. Never preview at Easy (random picks, no scored
+	# rationale) — bump to Normal so there is an actual reasoning trace to show.
+	var difficulty = get_difficulty(player)
+	if not is_ai_player(player):
+		var opponent = 2 if player == 1 else 1
+		difficulty = get_difficulty(opponent) if is_ai_player(opponent) else AIDifficultyConfigData.Difficulty.NORMAL
+	if AIDifficultyConfigData.use_random_actions(difficulty):
+		difficulty = AIDifficultyConfigData.Difficulty.NORMAL
+
+	var decision = AIDecisionMaker.suggest_action(phase, snapshot, available, player, difficulty)
+	if decision.is_empty():
+		_log_ai_thinking(player, "The AI could not find a recommended action here.")
+		emit_signal("ai_suggestion_ready", player, {}, "No recommendation")
+		return {}
+
+	# Surface the reasoning in the game log using the same collapsible thinking-card
+	# path the live AI uses, so the player sees the chosen action, the rejected
+	# alternatives, and (when available) the considered options highlighted on the board.
+	var description = decision.get("_ai_description", str(decision.get("type", "unknown")))
+	var steps = decision.get("_ai_thinking_steps", [])
+	var context = decision.get("_ai_thinking_context", {})
+	var phase_name = PHASE_DISPLAY_NAMES.get(phase, "Unknown")
+	_log_ai_thinking_block(player, "Suggestion (%s): %s" % [phase_name, description], steps, context)
+	emit_signal("ai_suggestion_ready", player, decision, description)
+	print("AIPlayer: Suggestion for P%d in %s phase -> %s" % [player, phase_name, description])
+	DebugLogger.info("AIPlayer suggestion", {"player": player, "phase": phase_name, "type": decision.get("type", ""), "description": description})
+	return decision
 
 # T7-56: Per-turn action history for AI turn replay panel
 

--- a/40k/autoloads/KeybindingManager.gd
+++ b/40k/autoloads/KeybindingManager.gd
@@ -60,6 +60,7 @@ func _register_defaults() -> void:
 	_register("toggle_unit_labels", "Toggle Unit Labels", CATEGORY_GAMEPLAY, KEY_N)
 	_register("shortcut_overlay", "Shortcut Overlay", CATEGORY_GAMEPLAY, KEY_SLASH, {"shift": true})
 	_register("toggle_mathhammer", "Toggle Mathhammer", CATEGORY_GAMEPLAY, KEY_H)
+	_register("ai_suggestion", "AI Suggestion (hint)", CATEGORY_GAMEPLAY, KEY_K)
 
 	# Shooting phase (T5-UX12 → KeybindingManager registration 2026-05-05)
 	# These were previously hardcoded keycode matches in ShootingController; promoting

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.0",
+			"date": "2026-07-08",
+			"summary": "When playing against the AI you can now ask it for a suggestion on your own turn — a new 'AI Suggestion' button (hotkey K) shows what the AI would do and why, without taking the action for you.",
+			"changes": [
+				"New 'AI Suggestion' button in the bottom HUD (and hotkey K) for games against the AI. Press it on your turn and the AI reasons about your current position — the phase you're in, your units, the enemy, the objectives — and posts its recommended action to the game log, e.g. 'Suggestion (Movement): Witchseekers advances aggressively toward Kommandos (28.0\" away)'.",
+				"The suggestion is a full reasoning card: it shows the chosen action plus the alternatives it considered and rejected, each with a score, and (where it applies) highlights the options it weighed on the board. Great for learning the game, or for understanding and debugging how the AI thinks.",
+				"It only suggests — it never acts for you. Asking for a hint takes no game action, doesn't end your turn or phase, and has no effect on the AI opponent. The advice reflects the difficulty of the AI you're actually facing.",
+				"The button appears only in games with an AI opponent; the K hotkey is rebindable and listed in the shortcut overlay (press ? )."
+			]
+		},
+		{
 			"version": "0.7.8",
 			"date": "2026-07-08",
 			"summary": "Charges that declare more targets than the roll can reach are now clearly reported instead of showing a misleading 'SUCCESS', and the charge panel now tells you the roll needed to reach every target you've picked.",

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -1051,6 +1051,91 @@ static func decide(phase: int, snapshot: Dictionary, available_actions: Array, p
 	return result
 
 # =============================================================================
+# ON-DEMAND SUGGESTION — human-facing "what would you do?" preview
+# =============================================================================
+
+# Preview the decision the AI would make for `player` in the current situation
+# WITHOUT mutating the persistent planning caches the live AI opponent relies on.
+# decide() writes several static caches (multi-phase plan, focus-fire plan,
+# charge/fight coordination, secondary/primary awareness, bodyguard pairing,
+# current player & difficulty). Those are round-keyed, so a human asking for a
+# hint on their own turn — the same battle round as the AI's upcoming turn —
+# could otherwise leave a stale plan behind that the AI then reuses. We snapshot
+# the caches, run the decision, and restore them, so a suggestion is truly
+# side-effect-free. Returns the same dict decide() returns, including the
+# _ai_thinking_steps / _ai_decision_records / _ai_thinking_context reasoning.
+static func suggest_action(phase: int, snapshot: Dictionary, available_actions: Array, player: int, difficulty: int = AIDifficultyConfigData.Difficulty.NORMAL) -> Dictionary:
+	var saved := _snapshot_planning_state()
+	var decision := decide(phase, snapshot, available_actions, player, difficulty)
+	_restore_planning_state(saved)
+	return decision
+
+static func _snapshot_planning_state() -> Dictionary:
+	# Deep-copy every static cache decide() may write that outlives a single call
+	# and is consulted on later turns. Config/profile state (_config_overrides,
+	# _player_profiles) is intentionally left out — decide() never mutates it.
+	return {
+		"focus_fire_plan": _focus_fire_plan.duplicate(true),
+		"focus_fire_plan_built": _focus_fire_plan_built,
+		"focus_fire_plan_logged": _focus_fire_plan_logged,
+		"grenade_evaluated": _grenade_evaluated,
+		"phase_plan": _phase_plan.duplicate(true),
+		"phase_plan_built": _phase_plan_built,
+		"phase_plan_round": _phase_plan_round,
+		"fight_order_plan": _fight_order_plan.duplicate(true),
+		"fight_order_plan_built": _fight_order_plan_built,
+		"fight_order_logged": _fight_order_logged,
+		"fight_attack_retry_count": _fight_attack_retry_count.duplicate(true),
+		"charge_coordination": _charge_coordination.duplicate(true),
+		"charge_coordination_round": _charge_coordination_round,
+		"fight_coordination": _fight_coordination.duplicate(true),
+		"fight_coordination_round": _fight_coordination_round,
+		"bodyguards_with_leaders": _bodyguards_with_leaders.duplicate(true),
+		"movement_plan_logged": _movement_plan_logged,
+		"secondary_awareness_p1": _secondary_awareness_p1.duplicate(true),
+		"secondary_awareness_p2": _secondary_awareness_p2.duplicate(true),
+		"secondary_awareness_round_p1": _secondary_awareness_round_p1,
+		"secondary_awareness_round_p2": _secondary_awareness_round_p2,
+		"primary_awareness_p1": _primary_awareness_p1.duplicate(true),
+		"primary_awareness_p2": _primary_awareness_p2.duplicate(true),
+		"primary_awareness_round_p1": _primary_awareness_round_p1,
+		"primary_awareness_round_p2": _primary_awareness_round_p2,
+		"active_rule_overrides": _active_rule_overrides.duplicate(true),
+		"current_player": _current_player,
+		"current_difficulty": _current_difficulty,
+	}
+
+static func _restore_planning_state(s: Dictionary) -> void:
+	_focus_fire_plan = s["focus_fire_plan"]
+	_focus_fire_plan_built = s["focus_fire_plan_built"]
+	_focus_fire_plan_logged = s["focus_fire_plan_logged"]
+	_grenade_evaluated = s["grenade_evaluated"]
+	_phase_plan = s["phase_plan"]
+	_phase_plan_built = s["phase_plan_built"]
+	_phase_plan_round = s["phase_plan_round"]
+	_fight_order_plan = s["fight_order_plan"]
+	_fight_order_plan_built = s["fight_order_plan_built"]
+	_fight_order_logged = s["fight_order_logged"]
+	_fight_attack_retry_count = s["fight_attack_retry_count"]
+	_charge_coordination = s["charge_coordination"]
+	_charge_coordination_round = s["charge_coordination_round"]
+	_fight_coordination = s["fight_coordination"]
+	_fight_coordination_round = s["fight_coordination_round"]
+	_bodyguards_with_leaders = s["bodyguards_with_leaders"]
+	_movement_plan_logged = s["movement_plan_logged"]
+	_secondary_awareness_p1 = s["secondary_awareness_p1"]
+	_secondary_awareness_p2 = s["secondary_awareness_p2"]
+	_secondary_awareness_round_p1 = s["secondary_awareness_round_p1"]
+	_secondary_awareness_round_p2 = s["secondary_awareness_round_p2"]
+	_primary_awareness_p1 = s["primary_awareness_p1"]
+	_primary_awareness_p2 = s["primary_awareness_p2"]
+	_primary_awareness_round_p1 = s["primary_awareness_round_p1"]
+	_primary_awareness_round_p2 = s["primary_awareness_round_p2"]
+	_active_rule_overrides = s["active_rule_overrides"]
+	_current_player = s["current_player"]
+	_current_difficulty = s["current_difficulty"]
+
+# =============================================================================
 # T7-40: EASY DIFFICULTY — RANDOM VALID ACTIONS
 # =============================================================================
 

--- a/40k/scripts/KeyboardShortcutOverlay.gd
+++ b/40k/scripts/KeyboardShortcutOverlay.gd
@@ -99,6 +99,7 @@ func _build_ui() -> void:
 	var _rb = KeybindingManager.get_key_display_name("rotate_board") if KeybindingManager else "V"
 	var _mh = KeybindingManager.get_key_display_name("toggle_mathhammer") if KeybindingManager else "H"
 	var _ul = KeybindingManager.get_key_display_name("toggle_unit_labels") if KeybindingManager else "N"
+	var _as = KeybindingManager.get_key_display_name("ai_suggestion") if KeybindingManager else "K"
 	_add_shortcut(_dz, "Toggle deployment zones")
 	_add_shortcut(_tt, "Toggle terrain")
 	_add_shortcut(_ul, "Toggle unit labels")
@@ -108,6 +109,7 @@ func _build_ui() -> void:
 	_add_shortcut("%s  /  %s" % [_zu, _zd], "Zoom in/out")
 	_add_shortcut(_rb, "Rotate board view")
 	_add_shortcut(_mh, "Toggle Mathhammer")
+	_add_shortcut(_as, "AI suggestion (vs AI — shows its reasoning)")
 
 	# Separator before shooting section (2026-05-05 — task: register shooting shortcuts)
 	var sep_shoot = HSeparator.new()

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -156,6 +156,10 @@ var _ai_speed_panel: PanelContainer = null
 var _ai_speed_label: Label = null
 var _ai_step_continue_button: Button = null
 
+# On-demand "AI Suggestion" button (human-vs-AI mode) — asks the AI what it would
+# do and shows its reasoning without taking the action. Hidden until an AI game.
+var _ai_suggestion_button: Button = null
+
 # P2-44: Player turn screen-edge color indicator
 var _player_turn_border: PlayerTurnBorder = null
 var _last_active_player: int = -1  # Track player changes for flash animation
@@ -510,6 +514,9 @@ func _ready() -> void:
 	# T7-36: Setup AI speed controls HUD
 	_setup_ai_speed_hud()
 
+	# On-demand AI suggestion button (revealed later for human-vs-AI games)
+	_setup_ai_suggestion_button()
+
 	# Apply White Dwarf gothic UI theme
 	_apply_white_dwarf_theme()
 
@@ -611,6 +618,9 @@ func _initialize_ai_player() -> void:
 		_update_ai_speed_label(ai_player.get_ai_speed_name())
 		if _ai_speed_panel:
 			_ai_speed_panel.visible = true
+
+	# Reveal the on-demand AI suggestion button for human-vs-AI games
+	refresh_ai_suggestion_button()
 
 	# T7-55: Setup spectator mode if both players are AI
 	if _is_spectator_mode:
@@ -2007,6 +2017,52 @@ func _setup_reserves_button() -> void:
 	hud_right.move_child(reserves_button, unit_list_idx + 1)
 
 	print("Main: Reserves button created and added to HUD_Right")
+
+func _setup_ai_suggestion_button() -> void:
+	"""Create the on-demand 'AI Suggestion' button in the bottom HUD. Hidden until
+	an AI game is confirmed (revealed by refresh_ai_suggestion_button). Lets a human
+	ask the AI what it would do on the current turn — surfacing its reasoning in the
+	game log for hints and for debugging the AI — without taking the action."""
+	var hud_container = get_node_or_null("HUD_Bottom/HBoxContainer")
+	if not hud_container:
+		print("Main: HUD_Bottom/HBoxContainer not found for AI suggestion button")
+		return
+
+	_ai_suggestion_button = Button.new()
+	_ai_suggestion_button.name = "AISuggestionButton"
+	var _hint_key = KeybindingManager.get_key_display_name("ai_suggestion") if KeybindingManager else "K"
+	_ai_suggestion_button.text = "AI Suggestion (%s)" % _hint_key
+	_ai_suggestion_button.tooltip_text = "Ask the AI what it would do on this turn. Shows its reasoning in the log — it does NOT take the action. Hotkey: %s" % _hint_key
+	_ai_suggestion_button.visible = false
+	_ai_suggestion_button.size_flags_horizontal = Control.SIZE_SHRINK_END
+	_WhiteDwarfTheme.apply_to_button(_ai_suggestion_button)
+	# Cyan-tinted font to distinguish the advisory action from phase controls.
+	_ai_suggestion_button.add_theme_color_override("font_color", Color(0.6, 0.9, 1.0))
+	_ai_suggestion_button.add_theme_color_override("font_hover_color", Color(0.8, 0.97, 1.0))
+	_ai_suggestion_button.pressed.connect(_on_ai_suggestion_pressed)
+	hud_container.add_child(_ai_suggestion_button)
+	print("Main: AI suggestion button created")
+
+func refresh_ai_suggestion_button() -> void:
+	"""Show the AI-suggestion button only for single-viewer AI games (an AI player
+	present, not AI-vs-AI spectator). Safe to call repeatedly; also invoked by
+	windowed test scenarios after configuring the AI."""
+	if not _ai_suggestion_button:
+		return
+	var ai_player = get_node_or_null("/root/AIPlayer")
+	var should_show := false
+	if ai_player and ai_player.enabled and not ai_player.is_spectator_mode():
+		if ai_player.is_ai_player(1) or ai_player.is_ai_player(2):
+			should_show = true
+	_ai_suggestion_button.visible = should_show
+
+func _on_ai_suggestion_pressed() -> void:
+	"""Ask the AI for a suggestion on the current turn and show its reasoning in the
+	game log. Pure preview — nothing is dispatched."""
+	var ai_player = get_node_or_null("/root/AIPlayer")
+	if not ai_player:
+		return
+	ai_player.request_suggestion()
 
 func _on_reserves_button_pressed() -> void:
 	if _selected_unit_for_reserves == "":
@@ -4951,6 +5007,15 @@ func _input(event: InputEvent) -> void:
 		_toggle_army_panel()
 		get_viewport().set_input_as_handled()
 		return
+
+	# AI suggestion hint (default KEY_K, rebindable) — only when the button is
+	# available, i.e. a human-vs-AI game. Registered in KeybindingManager so it
+	# never collides with H (Toggle Mathhammer) and shows in the shortcut overlay.
+	if event is InputEventKey and event.pressed and not event.echo and KeybindingManager.matches_action(event, "ai_suggestion"):
+		if _ai_suggestion_button and _ai_suggestion_button.visible:
+			_on_ai_suggestion_pressed()
+			get_viewport().set_input_as_handled()
+			return
 
 	# T-095/T-110: Hotkey help overlay - KEY_QUESTION (?) or KEY_SLASH with shift
 	if event is InputEventKey and event.pressed and not event.echo and (event.keycode == KEY_QUESTION or (event.keycode == KEY_SLASH and event.shift_pressed)):

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2463,6 +2463,42 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "ai.suggestion.on_demand_hint",
+      "description": "On-demand AI suggestion: the human player can ask the AI what it would do on the current turn (AI Suggestion HUD button + rebindable K hotkey) and get a recommended action without executing it.",
+      "scenarios": [
+        "ai_suggestion_on_demand"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ai.suggestion.reasoning_in_log",
+      "description": "The AI suggestion posts its full reasoning to the game log as a thinking card (chosen action plus scored, rejected alternatives), reusing the same AI-thinking display path.",
+      "scenarios": [
+        "ai_suggestion_on_demand"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ai.suggestion.pure_preview",
+      "description": "Requesting an AI suggestion is side-effect-free: it dispatches no action, does not advance the phase or active player, leaves the AI action log empty, and (via AIDecisionMaker.suggest_action) does not disturb the opponent AI's planning caches.",
+      "scenarios": [
+        "ai_suggestion_on_demand"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "ui.HUD.ai_suggestion_button",
+      "description": "The 'AI Suggestion' button appears in the bottom HUD only for human-vs-AI games and triggers a suggestion for the active player when clicked.",
+      "scenarios": [
+        "ai_suggestion_on_demand"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/ai_suggestion_on_demand.json
+++ b/40k/tests/scenarios/sp/ai_suggestion_on_demand.json
@@ -1,0 +1,58 @@
+{
+  "id": "ai_suggestion_on_demand",
+  "covers": [
+    "ai.suggestion.on_demand_hint",
+    "ai.suggestion.reasoning_in_log",
+    "ai.suggestion.pure_preview",
+    "ui.HUD.ai_suggestion_button"
+  ],
+  "fixture": "audit_382_cp_grant",
+  "edition": 11,
+  "rng_seed": 7,
+  "description": "On-demand AI suggestion for the human player. P1 (human) vs P2 (AI). During P1's Movement phase, revealing and clicking the 'AI Suggestion' HUD button (a) logs the AI's reasoning as a thinking card in the left game log, and (b) executes NOTHING — the AI action log stays empty and the phase/active-player do not advance. Proves the feature is a pure, side-effect-free preview driven from the real UI button (plus KEY_H hotkey path).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
+    { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(1)" },
+    { "act": "execute_script", "script": "AIPlayer.clear_action_log()" },
+    { "act": "execute_script", "script": "GameState.set_active_player(1)" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(7)" },
+    { "act": "execute_script", "script": "main.refresh_ai_suggestion_button()" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Bottom/HBoxContainer/AISuggestionButton", "timeout_s": 2.0 },
+    { "act": "expect_node_property", "node": "/root/Main/HUD_Bottom/HBoxContainer/AISuggestionButton", "property": "disabled", "equals": false },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "AIPlayer.get_action_log().size()", "equals": 0 },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Bottom/HBoxContainer/AISuggestionButton" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "screenshot", "label": "01_suggestion_in_left_log", "region": [0, 105, 400, 720] },
+
+    { "act": "execute_script", "script": "GameEventLog.count_ai_thinking_entries()", "expect_min": 1 },
+    { "act": "execute_script", "script": "GameEventLog.has_ai_entry_containing_any([\"Suggestion\"])", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.get_ai_card_count()", "expect_min": 1 },
+
+    { "act": "execute_script", "script": "AIPlayer.get_action_log().size()", "equals": 0 },
+    { "act": "execute_script", "script": "GameState.get_active_player()", "equals": 1 },
+    { "act": "expect_phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "AIPlayer.request_suggestion().size()", "expect_min": 1 },
+    { "act": "execute_script", "script": "AIPlayer.request_suggestion().get(\"type\", \"\")" },
+    { "act": "execute_script", "script": "AIPlayer.get_action_log().size()", "equals": 0 },
+    { "act": "execute_script", "script": "GameState.get_active_player()", "equals": 1 },
+    { "act": "expect_phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "simulate_key", "keycode": "K" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "GameEventLog.count_ai_thinking_entries()", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.get_ai_card_count()", "expect_min": 1 },
+    { "act": "execute_script", "script": "AIPlayer.get_action_log().size()", "equals": 0 },
+    { "act": "screenshot", "label": "03_hotkey_suggestion", "region": [0, 105, 400, 720] },
+
+    { "act": "screenshot", "label": "02_full_screen" }
+  ]
+}

--- a/40k/tests/test_charge_multitarget_reachability.gd.uid
+++ b/40k/tests/test_charge_multitarget_reachability.gd.uid
@@ -1,0 +1,1 @@
+uid://bpojr3at5wyly

--- a/40k/tests/test_mp_relay_json_roundtrip.gd.uid
+++ b/40k/tests/test_mp_relay_json_roundtrip.gd.uid
@@ -1,0 +1,1 @@
+uid://b60mqqjbn3ldg

--- a/40k/tests/test_mp_v1_launch_fixes.gd.uid
+++ b/40k/tests/test_mp_v1_launch_fixes.gd.uid
@@ -1,0 +1,1 @@
+uid://df6hjkidqci4a


### PR DESCRIPTION
## Summary

Adds an on-demand AI suggestion feature allowing human players to request the AI's decision and reasoning while playing against the AI. This aids debugging by exposing AI decision logic without affecting game state.

## Changes

### Core Implementation
- **AIDecisionMaker.gd**: Added `suggest_action()` static method that wraps the decision engine with snapshot/restore pattern, enabling side-effect-free previewing of AI decisions without mutating internal caches
- **AIPlayer.gd**: Added `request_suggestion()` method that:
  - Guards against running during active turns
  - Respects opponent AI difficulty (bumps Easy→Normal for meaningful reasoning)
  - Calls AIDecisionMaker with cache snapshot
  - Logs reasoning via existing AI thinking display system

### User Interface
- **Main.gd**: Added AI suggestion button to bottom HUD (cyan color, tooltip enabled) with visibility logic (human-vs-AI, non-spectator games only)
- **KeybindingManager.gd**: Registered `ai_suggestion` action (default: K) as a rebindable hotkey
- **KeyboardShortcutOverlay.gd**: Added suggestion shortcut to the ? overlay help panel

### Metadata
- **version_history.json**: Bumped version to 0.8.0 with player-facing summary and feature bullets
- **coverage.json**: Registered 4 coverage tiles for CI validation (button, reasoning display, pure preview guarantee, visibility logic)

### Testing
- **tests/scenarios/sp/ai_suggestion_on_demand.json**: New windowed scenario (34/0 PASS)
  - Validates button visibility and click interaction
  - Verifies reasoning card appears in game log
  - Confirms side-effect-free guarantee (action log, phase, active player unchanged)
  - Tests hotkey K path

### Hygiene
- Fixed untracked .uid files for three test scripts committed in earlier work

## Validation

✅ Windowed scenario: 34/0 PASS  
✅ Feature gate requirements met (button click drives real suggestion, reasoning displays in log)  
✅ Pure-preview verified (no state mutation during suggestion)  
✅ Existing AI reasoning scenarios confirmed green (18/0 each)  
✅ Hotkey rebindable via KeybindingManager integration

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5jH9poGBy5wwXpJFrjsDd)_