### PR TITLE
Fix: AI Suggestion button never appeared in real games

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.1",
+			"date": "2026-07-09",
+			"summary": "Fix: the 'AI Suggestion' button now actually appears when you start a game against the AI (it was being created hidden and never shown).",
+			"changes": [
+				"The 'AI Suggestion' button (and its K hotkey path) is now visible from the moment a human-vs-AI game starts. Previously the button was built after the code that reveals it had already run, so it stayed hidden for the whole game and the feature could not be used from the UI.",
+				"Added a regression test that starts a human-vs-AI game through the normal flow and fails if the button is not shown, so this cannot silently break again."
+			]
+		},
+		{
 			"version": "0.8.0",
 			"date": "2026-07-08",
 			"summary": "When playing against the AI you can now ask it for a suggestion on your own turn — a new 'AI Suggestion' button (hotkey K) shows what the AI would do and why, without taking the action for you.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2042,6 +2042,10 @@ func _setup_ai_suggestion_button() -> void:
 	_ai_suggestion_button.pressed.connect(_on_ai_suggestion_pressed)
 	hud_container.add_child(_ai_suggestion_button)
 	print("Main: AI suggestion button created")
+	# _ready() calls _initialize_ai_player() (which reveals this button) BEFORE this
+	# setup runs, so that earlier refresh no-ops on the still-null button. Refresh now
+	# that the button exists so it becomes visible immediately for human-vs-AI games.
+	refresh_ai_suggestion_button()
 
 func refresh_ai_suggestion_button() -> void:
 	"""Show the AI-suggestion button only for single-viewer AI games (an AI player

--- a/40k/tests/scenarios/sp/ai_suggestion_on_demand.json
+++ b/40k/tests/scenarios/sp/ai_suggestion_on_demand.json
@@ -9,9 +9,14 @@
   "fixture": "audit_382_cp_grant",
   "edition": 11,
   "rng_seed": 7,
-  "description": "On-demand AI suggestion for the human player. P1 (human) vs P2 (AI). During P1's Movement phase, revealing and clicking the 'AI Suggestion' HUD button (a) logs the AI's reasoning as a thinking card in the left game log, and (b) executes NOTHING — the AI action log stays empty and the phase/active-player do not advance. Proves the feature is a pure, side-effect-free preview driven from the real UI button (plus KEY_H hotkey path).",
+  "description": "On-demand AI suggestion for the human player. P1 (human) vs P2 (AI). The fixture's game_config is already human-vs-AI, so the button must reveal itself through the NATURAL Main._ready() flow (regression guard for the _initialize_ai_player/_setup ordering bug where the button was created after the reveal call and stayed hidden). Then, during P1's Movement phase, clicking the 'AI Suggestion' HUD button (a) logs the AI's reasoning as a thinking card in the left game log, and (b) executes NOTHING — the AI action log stays empty and the phase/active-player do not advance. Proves the feature is a pure, side-effect-free preview driven from the real UI button (plus KEY_K hotkey path).",
   "steps": [
-    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script", "script": "get_node('/root/AIPlayer').is_ai_player(2)", "equals": true },
+    { "act": "execute_script", "script": "get_node('/root/Main')._ai_suggestion_button != null", "equals": true },
+    { "act": "execute_script", "script": "get_node('/root/Main')._ai_suggestion_button.visible", "equals": true },
+
     { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
     { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(1)" },
     { "act": "execute_script", "script": "AIPlayer.clear_action_log()" },


### PR DESCRIPTION
## Summary

Follow-up fix to #530. The "AI Suggestion" button was created but **never became visible** in an actual human-vs-AI game — a player starting a game against the AI saw no button and the K hotkey path was unreachable from the UI.

## Root cause

In `Main._ready()` the ordering was:
1. `_initialize_ai_player()` (line 441) — which calls `refresh_ai_suggestion_button()` to reveal the button
2. `_setup_ai_suggestion_button()` (line 518) — which actually **creates** the button

`refresh_ai_suggestion_button()` early-returns when the button is `null`:

```gdscript
func refresh_ai_suggestion_button() -> void:
	if not _ai_suggestion_button:
		return
```

So the reveal ran against a still-null button (no-op), the button was then created `visible = false`, and refresh was never called again → hidden for the whole game.

## Fix

Call `refresh_ai_suggestion_button()` at the end of `_setup_ai_suggestion_button()`, so the button reveals itself immediately after creation (the AI is already configured by that point in `_ready()`).

## Why the original test missed it

The windowed scenario force-called `main.refresh_ai_suggestion_button()` right before asserting visibility, masking the real-game ordering bug. Strengthened it: the fixture is already human-vs-AI, so the button must be visible via the **natural** `_ready()` flow **before** any manual configure/refresh. 

## Validation

- Reproduced the bug live by driving a real main-menu game start via the MCP bridge: button node existed but `visible = false`.
- Applied the fix, restarted, drove the real start again: `visible = true`, and confirmed the button renders on-screen via screenshot.
- Regression guard proven: the natural-flow assertion **fails without the fix** (`visible: expected true, got false`) and **passes with it**.
- Full scenario green: **37 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G5jH9poGBy5wwXpJFrjsDd

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5jH9poGBy5wwXpJFrjsDd)_