### PR TITLE
Fix missing Speedwaaagh! detachment enhancements in the Army Builder

### DIFF
--- a/40k/data/40kdc/detachments.json
+++ b/40k/data/40kdc/detachments.json
@@ -8819,7 +8819,12 @@
   "name": "Speedwaaagh!",
   "faction_id": "orks",
   "detachment_rule_id": "turbo-boostas",
-  "enhancement_ids": [],
+  "enhancement_ids": [
+   "kustom-shokk-box-speedwaaagh",
+   "dakkamek-speedwaaagh",
+   "supa-burny-fuel-speedwaaagh",
+   "master-meknologist-speedwaaagh"
+  ],
   "stratagem_ids": [],
   "game_version": {
    "edition": "11th",

--- a/40k/data/40kdc/enhancements.json
+++ b/40k/data/40kdc/enhancements.json
@@ -28304,5 +28304,77 @@
   "points_provisional": false,
   "upgrade_tag": true,
   "max_targets": 1
+ },
+ {
+  "id": "kustom-shokk-box-speedwaaagh",
+  "name": "Kustom Shokk Box",
+  "detachment_id": "speedwaaagh",
+  "cost": 10,
+  "keyword_restrictions": [
+   "Orks"
+  ],
+  "ability_id": null,
+  "is_unique": true,
+  "game_version": {
+   "edition": "11th",
+   "dataslate": "launch"
+  },
+  "points_provisional": false,
+  "upgrade_tag": false,
+  "max_targets": 1
+ },
+ {
+  "id": "dakkamek-speedwaaagh",
+  "name": "Dakkamek",
+  "detachment_id": "speedwaaagh",
+  "cost": 25,
+  "keyword_restrictions": [
+   "Orks"
+  ],
+  "ability_id": null,
+  "is_unique": true,
+  "game_version": {
+   "edition": "11th",
+   "dataslate": "launch"
+  },
+  "points_provisional": false,
+  "upgrade_tag": false,
+  "max_targets": 1
+ },
+ {
+  "id": "supa-burny-fuel-speedwaaagh",
+  "name": "Supa-burny Fuel",
+  "detachment_id": "speedwaaagh",
+  "cost": 15,
+  "keyword_restrictions": [
+   "Orks"
+  ],
+  "ability_id": null,
+  "is_unique": true,
+  "game_version": {
+   "edition": "11th",
+   "dataslate": "launch"
+  },
+  "points_provisional": false,
+  "upgrade_tag": false,
+  "max_targets": 1
+ },
+ {
+  "id": "master-meknologist-speedwaaagh",
+  "name": "Master Meknologist",
+  "detachment_id": "speedwaaagh",
+  "cost": 20,
+  "keyword_restrictions": [
+   "Orks"
+  ],
+  "ability_id": null,
+  "is_unique": true,
+  "game_version": {
+   "edition": "11th",
+   "dataslate": "launch"
+  },
+  "points_provisional": false,
+  "upgrade_tag": false,
+  "max_targets": 1
  }
 ]

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.2",
+			"date": "2026-07-09",
+			"summary": "Army Builder: the Orks 'Speedwaaagh!' detachment now offers its four Enhancements. They were missing from the dataset, so the builder showed no Enhancement option and imported lists silently dropped enhancements like Kustom Shokk Box.",
+			"changes": [
+				"You can now add the Speedwaaagh! detachment's Enhancements in the browser Army Builder: Kustom Shokk Box (10 pts), Dakkamek (25 pts), Supa-burny Fuel (15 pts) and Master Meknologist (20 pts). Previously a Speedwaaagh! Character showed no 'Enhancement' dropdown at all.",
+				"Uploading/pasting a Speedwaaagh! list that includes one of these Enhancements now resolves it and keeps it (with its points) instead of dropping it as unresolved on import.",
+				"Added browser tests (unit + real-page end-to-end) that fail if these Enhancements ever go missing from the builder again."
+			]
+		},
+		{
 			"version": "0.8.1",
 			"date": "2026-07-09",
 			"summary": "Fix: the 'AI Suggestion' button now actually appears when you start a game against the AI (it was being created hidden and never shown).",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "relay-server.js",
   "scripts": {
     "start": "node relay-server.js",
-    "test": "node --test tests/gameformat.test.mjs && node public/js/parser.test.js",
+    "test": "node --test tests/gameformat.test.mjs tests/speedwaaagh-enhancements.test.mjs && node public/js/parser.test.js",
     "test:e2e": "node tests/e2e-builder.mjs"
   },
   "dependencies": {

--- a/server/public/js/builder/store.js
+++ b/server/public/js/builder/store.js
@@ -10,6 +10,13 @@
 import * as DC from '../vendor/40kdc-data.mjs';
 import { GAME_NAME_CANON_ENTRIES } from '../lib/canon.mjs';
 import { createConverter, ALLIED_FACTIONS, FACTION_DISPLAY_OVERRIDES } from '../lib/gameformat.mjs';
+import { applyDataPatches } from '../lib/data-patches.mjs';
+
+// Inject local dataset corrections (e.g. the Speedwaaagh! detachment's missing
+// enhancements) into RAW_DATA before anything reads it. createConverter below
+// and the package importer both hold these arrays by reference, so the in-place
+// patch reaches every consumer.
+applyDataPatches(DC.RAW_DATA);
 
 export const dc = DC; // the full engine, re-exported for views/dialogs
 export const ds = DC.dataset;

--- a/server/public/js/lib/data-patches.mjs
+++ b/server/public/js/lib/data-patches.mjs
@@ -1,0 +1,73 @@
+// Local corrections applied on top of the vendored @alpaca-software/40kdc-data
+// dataset (server/public/js/vendor/40kdc-data.mjs).
+//
+// Why this exists: upstream ships the Orks "Speedwaaagh!" detachment flagged
+// `dataslate: "pre-launch-provisional"` with an EMPTY enhancement_ids list and
+// no enhancement records at all. As a result the army builder showed no
+// "Enhancement" dropdown for a Speedwaaagh! roster (enhancementChoices() → [])
+// and silently dropped any imported enhancement (e.g. "Kustom Shokk Box") as
+// unresolved on export. See the four official Speedwaaagh! enhancements below
+// (Orks codex / Wahapedia).
+//
+// We inject the data at load time rather than editing the minified vendor
+// bundle so the fix survives a re-bundle (scripts/40kdc/bundle-browser.mjs
+// re-pulls the still-incomplete upstream package).
+//
+// Environment-free (no fs / DOM). applyDataPatches() mutates the RAW_DATA
+// arrays in place and is idempotent — the converter (createConverter) and the
+// package importer (tryImportRoster) both read these arrays/objects by
+// reference, so an in-place patch reaches every consumer.
+
+// Enhancement records use the same shape the dataset emits (see any
+// *-war-horde entry in the bundle): id, name, detachment_id, cost,
+// keyword_restrictions, ability_id, is_unique, game_version, points_provisional,
+// upgrade_tag, max_targets.
+function orkEnhancement(id, name, cost) {
+  return {
+    id,
+    name,
+    detachment_id: 'speedwaaagh',
+    cost,
+    keyword_restrictions: ['Orks'],
+    ability_id: null,
+    is_unique: true,
+    game_version: { edition: '11th', dataslate: 'launch' },
+    points_provisional: false,
+    upgrade_tag: false,
+    max_targets: 1,
+  };
+}
+
+// The official Orks "Speedwaaagh!" detachment enhancements.
+export const SPEEDWAAAGH_ENHANCEMENTS = [
+  orkEnhancement('kustom-shokk-box-speedwaaagh', 'Kustom Shokk Box', 10),
+  orkEnhancement('dakkamek-speedwaaagh', 'Dakkamek', 25),
+  orkEnhancement('supa-burny-fuel-speedwaaagh', 'Supa-burny Fuel', 15),
+  orkEnhancement('master-meknologist-speedwaaagh', 'Master Meknologist', 20),
+];
+
+// detachment id -> enhancement records that upstream is missing.
+const ENHANCEMENT_PATCHES = [
+  { detachmentId: 'speedwaaagh', enhancements: SPEEDWAAAGH_ENHANCEMENTS },
+];
+
+/**
+ * Idempotently add the missing enhancement records to rawData.enhancements and
+ * wire their ids into the owning detachment's enhancement_ids. Returns rawData.
+ */
+export function applyDataPatches(rawData) {
+  if (!rawData) return rawData;
+  const enhancements = rawData.enhancements ?? (rawData.enhancements = []);
+  const detachments = rawData.detachments ?? [];
+
+  for (const { detachmentId, enhancements: adds } of ENHANCEMENT_PATCHES) {
+    const det = detachments.find(d => d.id === detachmentId);
+    if (!det) continue; // detachment no longer in the dataset — nothing to attach to
+    if (!Array.isArray(det.enhancement_ids)) det.enhancement_ids = [];
+    for (const e of adds) {
+      if (!enhancements.some(x => x.id === e.id)) enhancements.push({ ...e });
+      if (!det.enhancement_ids.includes(e.id)) det.enhancement_ids.push(e.id);
+    }
+  }
+  return rawData;
+}

--- a/server/tests/e2e-builder.mjs
+++ b/server/tests/e2e-builder.mjs
@@ -145,6 +145,25 @@ Boyz (150 Points)
   check('imported detachment selected',
     (await page.locator('.topbar-config select').nth(1).inputValue()) === 'war-horde');
 
+  // --- Speedwaaagh! enhancement dropdown (regression: upstream ships it empty) --
+  await page.locator('button', { hasText: 'New' }).click();
+  page.once('dialog', d => d.accept());
+  await page.locator('.topbar-config select').first().selectOption('orks');
+  await page.locator('.topbar-config select').nth(1).selectOption('speedwaaagh');
+  await page.locator('.search').fill('Deffkilla');
+  await page.locator('.browser-unit', { hasText: 'Deffkilla Wartrike' }).first().click();
+  await page.locator('.roster-unit', { hasText: 'Deffkilla Wartrike' }).first().click();
+  const enhRow = page.locator('.field-row', { hasText: 'Enhancement' });
+  check('Speedwaaagh! Deffkilla shows an Enhancement row', await enhRow.count() === 1);
+  const enhOptions = await enhRow.locator('select option').allTextContents();
+  check('Kustom Shokk Box is offered', enhOptions.some(o => /Kustom Shokk Box/.test(o)),
+    enhOptions.join(' | '));
+  await enhRow.locator('select').selectOption({ label: enhOptions.find(o => /Kustom Shokk Box/.test(o)) });
+  // Deffkilla Wartrike is 70 base; Kustom Shokk Box adds +10 -> 80.
+  check('selecting the enhancement adds its +10 pts',
+    /80 \/ 2000 pts/.test(await page.locator('.points-badge').textContent()),
+    await page.locator('.points-badge').textContent());
+
   check('no uncaught page errors', pageErrors.length === 0, pageErrors.join(' | '));
 
   await browser.close();

--- a/server/tests/speedwaaagh-enhancements.test.mjs
+++ b/server/tests/speedwaaagh-enhancements.test.mjs
@@ -1,0 +1,108 @@
+// Regression test for the missing Orks "Speedwaaagh!" detachment enhancements.
+//
+// Upstream 40kdc ships Speedwaaagh! with an empty enhancement list, so the army
+// builder offered no "Enhancement" dropdown for that detachment and dropped any
+// imported enhancement (e.g. "Kustom Shokk Box") as unresolved. data-patches.mjs
+// injects the four official enhancements; this test drives the real builder
+// store + importer to prove they now surface, resolve on import, and export.
+//
+// Run: node --test server/tests/speedwaaagh-enhancements.test.mjs
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const S = await import(new URL('../public/js/builder/store.js', import.meta.url).href);
+const { importText } = await import(new URL('../public/js/builder/importers.js', import.meta.url).href);
+const { applyDataPatches, SPEEDWAAAGH_ENHANCEMENTS } =
+  await import(new URL('../public/js/lib/data-patches.mjs', import.meta.url).href);
+
+const EXPECTED = new Map([
+  ['Kustom Shokk Box', 10],
+  ['Dakkamek', 25],
+  ['Supa-burny Fuel', 15],
+  ['Master Meknologist', 20],
+]);
+
+test('data patch registers the four Speedwaaagh! enhancements in RAW_DATA', () => {
+  const enh = S.dc.RAW_DATA.enhancements;
+  for (const [name, cost] of EXPECTED) {
+    const e = enh.find(x => x.name === name && x.detachment_id === 'speedwaaagh');
+    assert.ok(e, `missing enhancement record: ${name}`);
+    assert.equal(e.cost, cost, `${name}: cost`);
+  }
+  const det = S.dc.RAW_DATA.detachments.find(d => d.id === 'speedwaaagh');
+  for (const e of SPEEDWAAAGH_ENHANCEMENTS) {
+    assert.ok(det.enhancement_ids.includes(e.id), `detachment not wired to ${e.id}`);
+  }
+});
+
+test('enhancementChoices() exposes them to the builder dropdown', () => {
+  S.setFaction('orks');
+  S.setDetachment('speedwaaagh');
+  S.addUnit('deffkilla-wartrike');
+  const choices = S.enhancementChoices();
+  assert.equal(choices.length, EXPECTED.size, 'choice count');
+  for (const [name, cost] of EXPECTED) {
+    const c = choices.find(x => x.name === name);
+    assert.ok(c, `dropdown missing ${name}`);
+    assert.equal(c.cost, cost, `${name}: cost in dropdown`);
+  }
+});
+
+test('importing a Speedwaaagh! list resolves "Kustom Shokk Box" and exports it', () => {
+  const pasted = [
+    'Speed Freeks (80 Points)',
+    '',
+    'Orks',
+    'Speedwaaagh!',
+    'Strike Force (2000 Points)',
+    '',
+    'CHARACTERS',
+    '',
+    'Deffkilla Wartrike (80 Points)',
+    '  • 1x Boomstikks',
+    '  • 1x Killa jet',
+    '  • 1x Snagga klaw',
+    '  • Enhancement: Kustom Shokk Box',
+    '',
+  ].join('\n');
+
+  const { roster, report } = importText(pasted);
+  const u = roster.units[0];
+  assert.equal(roster.detachments[0].ref.id, 'speedwaaagh', 'detachment resolved');
+  assert.equal(u.enhancement?.resolved, true, 'enhancement resolved');
+  assert.equal(u.enhancement?.id, 'kustom-shokk-box-speedwaaagh', 'enhancement id');
+  assert.ok(
+    !report.warnings.some(w => /enhancement-unresolved|not found|unresolved/i.test(w)),
+    `no unresolved-enhancement warning, got: ${JSON.stringify(report.warnings)}`,
+  );
+
+  // The enhancement survives export into the game army JSON, with its points.
+  const { army } = S.conv.rosterToGame(roster, { createdDate: '2026-01-01' });
+  const unit = Object.values(army.units)[0];
+  assert.ok(
+    (unit.meta.enhancements ?? []).some(n => /kustom shokk box/i.test(n)),
+    `exported unit missing enhancement: ${JSON.stringify(unit.meta.enhancements)}`,
+  );
+
+  // Its +10 cost is added on top of the datasheet base (Deffkilla Wartrike is
+  // 70 base, so 80 here). Assert the delta vs. the same unit without the
+  // enhancement rather than a hard-coded total, so a base-points change can't
+  // silently mask a dropped enhancement cost.
+  const bare = structuredClone(roster);
+  bare.units[0].enhancement = null;
+  bare.units[0].enhancement_points = null;
+  const { army: bareArmy } = S.conv.rosterToGame(bare, { createdDate: '2026-01-01' });
+  const bareUnit = Object.values(bareArmy.units)[0];
+  assert.equal(unit.meta.points - bareUnit.meta.points, 10, 'enhancement adds its +10 cost');
+});
+
+test('applyDataPatches is idempotent', () => {
+  const before = S.dc.RAW_DATA.enhancements.length;
+  const detBefore = S.dc.RAW_DATA.detachments.find(d => d.id === 'speedwaaagh').enhancement_ids.length;
+  applyDataPatches(S.dc.RAW_DATA);
+  applyDataPatches(S.dc.RAW_DATA);
+  assert.equal(S.dc.RAW_DATA.enhancements.length, before, 'no duplicate enhancement records');
+  assert.equal(
+    S.dc.RAW_DATA.detachments.find(d => d.id === 'speedwaaagh').enhancement_ids.length,
+    detBefore, 'no duplicate ids on the detachment');
+});


### PR DESCRIPTION
## Problem

When importing an Orks **Speedwaaagh!** list into the browser Army Builder, the list parsed correctly but its Enhancement (e.g. `Kustom Shokk Box`) was silently dropped, and there was **no Enhancement dropdown** to add one manually.

Root cause: the Speedwaaagh! detachment shipped from upstream `@alpaca-software/40kdc-data` flagged `pre-launch-provisional` with an **empty enhancement list** and no enhancement records — one of only 3 detachments in the whole dataset missing its enhancements. So:

- `enhancementChoices()` returned `[]` → the builder's `renderEnhancementRow` returned `null` → no dropdown rendered for any Speedwaaagh! Character.
- On import, the parsed enhancement name matched nothing → marked unresolved → dropped on export.

The builder's enhancement UI was working correctly; it simply had no data to show (a control detachment like War Horde returned 4 enhancements and rendered fine).

## Fix

Add the four official Speedwaaagh! enhancements as a local dataset correction:

- **`server/public/js/lib/data-patches.mjs`** (new) — an idempotent, environment-free patch that injects the enhancement records into `RAW_DATA.enhancements` and wires their ids onto the `speedwaaagh` detachment. Applied once at builder load in `store.js`. It lives in a patch module rather than editing the minified vendor bundle so it **survives a re-bundle** (re-running `bundle-browser.mjs` would otherwise re-pull the still-incomplete upstream data). Both the converter and the package importer read these arrays by reference, so the in-place patch reaches every consumer.
- **`40k/data/40kdc/enhancements.json` + `detachments.json`** — same records added to the checked-in dataset mirror for consistency (nothing loads these at runtime, so no regression risk).

Enhancements added: Kustom Shokk Box (10), Dakkamek (25), Supa-burny Fuel (15), Master Meknologist (20).

After the fix, the builder renders the Enhancement dropdown for a Speedwaaagh! Character, importing a Speedwaaagh! list keeps the enhancement with its points, and export carries it into the game army JSON.

## Validation

- **Node integration test** (`server/tests/speedwaaagh-enhancements.test.mjs`) drives the real store + importer: dropdown lists all 4, import resolves `Kustom Shokk Box` with zero warnings, +10 pts survives export.
- **Playwright e2e** (`server/tests/e2e-builder.mjs`) drives the real page in headless Chromium: Enhancement row renders, `Kustom Shokk Box` is offered and selectable, points update.
- Full suite green: 9/9 node tests, 99/99 parser tests, all e2e checks pass.

## Scope note

This makes the enhancements selectable, importable, and exportable. It does **not** implement the in-game rule *effect* of each enhancement (a separate rules-engine change). The Speedwaaagh! detachment is also still missing its **stratagems** (same upstream gap), left out of this change as it was scoped to enhancements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ovdzctQKhD4H5ZunyYx3h

---
_Generated by [Claude Code](https://claude.ai/code/session_018ovdzctQKhD4H5ZunyYx3h)_