### PR TITLE
Add 'Abilities' game-log filter for repeating passive-ability lines

### DIFF
--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -404,6 +404,15 @@ func add_player_entry(player: int, text: String) -> void:
 	var entry_type = "p1_action" if player == 1 else "p2_action"
 	_add_entry(prefix + text, entry_type)
 
+func add_ability_entry(player: int, text: String) -> void:
+	"""Log a passive / always-on ability activation (e.g. 'Stand Vigil active').
+	These re-fire at the start of every phase for every unit that has the ability,
+	so they are tagged with the dedicated 'ability' type. GameLogPanel groups them
+	under the 'Abilities' filter, which is hidden by default to keep the log from
+	being flooded with the same passive-ability lines every turn."""
+	var prefix = "P%d: " % player
+	_add_entry(prefix + text, "ability")
+
 func add_entry(text: String, entry_type: String) -> void:
 	"""Add an entry with an explicit entry type."""
 	_add_entry(text, entry_type)

--- a/40k/autoloads/UnitAbilityManager.gd
+++ b/40k/autoloads/UnitAbilityManager.gd
@@ -1879,7 +1879,7 @@ func _apply_leader_abilities(bodyguard_unit_id: String, bodyguard_unit: Dictiona
 				if game_event_log:
 					var owner = int(bodyguard_unit.get("owner", 0))
 					var desc = effect_def.get("description", ability_name)
-					game_event_log.add_player_entry(owner,
+					game_event_log.add_ability_entry(owner,
 						"%s ability '%s' active on %s (%s)" % [char_name, ability_name, bg_name, desc])
 
 func _apply_unit_abilities(unit_id: String, unit: Dictionary, phase: int) -> void:
@@ -1971,7 +1971,7 @@ func _apply_unit_abilities(unit_id: String, unit: Dictionary, phase: int) -> voi
 			if game_event_log:
 				var owner = int(unit.get("owner", 0))
 				var desc = effect_def.get("description", ability_name)
-				game_event_log.add_player_entry(owner,
+				game_event_log.add_ability_entry(owner,
 					"%s ability '%s' active (%s)" % [unit_name, ability_name, desc])
 
 # ============================================================================
@@ -2315,7 +2315,7 @@ func _apply_aura_to_unit(target_unit_id: String, target_unit: Dictionary,
 	if game_event_log:
 		var owner = int(target_unit.get("owner", 0))
 		var desc = effect_def.get("description", ability_name)
-		game_event_log.add_player_entry(owner,
+		game_event_log.add_ability_entry(owner,
 			"Aura '%s' from %s active on %s (%s)" % [ability_name, source_name, target_name, desc])
 
 func _closest_model_distance(unit_a: Dictionary, unit_b: Dictionary) -> float:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.3",
+			"date": "2026-07-09",
+			"summary": "New 'Abilities' filter in the game log groups the repeating passive-ability lines (e.g. 'Stand Vigil active', 'Guardian Eternal active') and hides them by default, so the log stays focused on what actually happened.",
+			"changes": [
+				"Passive, always-on ability activations are re-checked at the start of every phase, so lines like \"Custodian Guard ability 'Stand Vigil' active\", \"Telemon Heavy Dreadnought ability 'Guardian Eternal' active\" and aura effects were repeated in the game log every turn. They are now all tagged as 'Abilities' — no matter which phase they fire in — instead of being scattered across the Move / Charge / Info buckets by chance wording in their description.",
+				"Added an 'Abilities' filter chip (teal 'A' badge) to the game-log filter bar. It is OFF by default, so these repetitive passive-ability lines no longer clutter the log. Open Filters and toggle 'Abilities' on any time you want to see exactly which passive abilities are active.",
+				"Only the repeating passive/aura activations moved under this filter — one-off actions you take (Waaagh!, Oath of Moment, stratagems, mission actions) stay in their normal categories."
+			]
+		},
+		{
 			"version": "0.8.2",
 			"date": "2026-07-09",
 			"summary": "Army Builder: the Orks 'Speedwaaagh!' detachment now offers its four Enhancements. They were missing from the dataset, so the builder showed no Enhancement option and imported lists silently dropped enhancements like Kustom Shokk Box.",

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -26,6 +26,7 @@ enum EntryCategory {
 	INFO,
 	SCORING,
 	COMBAT,
+	ABILITY,
 }
 
 # --- Color Palette ---
@@ -44,6 +45,7 @@ const BORDER_COLORS = {
 	EntryCategory.INFO: Color(0.6, 0.6, 0.6),              # Gray
 	EntryCategory.SCORING: Color(0.3, 0.8, 0.4),           # Green
 	EntryCategory.COMBAT: Color(0.91, 0.77, 0.47),         # Gold (combat header)
+	EntryCategory.ABILITY: Color(0.36, 0.75, 0.72),        # Teal (passive abilities)
 }
 
 # Icon characters for each category
@@ -58,6 +60,7 @@ const ICON_CHARS = {
 	EntryCategory.INFO: "i",
 	EntryCategory.SCORING: "VP",
 	EntryCategory.COMBAT: "X",
+	EntryCategory.ABILITY: "A",
 }
 
 # --- Filters ---
@@ -73,7 +76,14 @@ const FILTER_ORDER = [
 	EntryCategory.OVERWATCH,
 	EntryCategory.SCORING,
 	EntryCategory.INFO,
+	EntryCategory.ABILITY,
 	EntryCategory.AI_THINKING,
+]
+# Categories hidden by default (off until the player turns them on). Passive
+# always-on ability activations re-fire every phase for every unit that has one,
+# so they flood the log with repeated lines — hide them unless explicitly wanted.
+const DEFAULT_HIDDEN_CATEGORIES = [
+	EntryCategory.ABILITY,
 ]
 # Short chip labels (the icon badge already carries the letter).
 const FILTER_LABELS = {
@@ -85,6 +95,7 @@ const FILTER_LABELS = {
 	EntryCategory.OVERWATCH: "Overwatch",
 	EntryCategory.SCORING: "VP",
 	EntryCategory.INFO: "Info",
+	EntryCategory.ABILITY: "Abilities",
 	EntryCategory.AI_THINKING: "AI",
 }
 # Stable string keys for tests / external callers to name a category.
@@ -97,6 +108,7 @@ const FILTER_KEYS = {
 	EntryCategory.OVERWATCH: "overwatch",
 	EntryCategory.SCORING: "vp",
 	EntryCategory.INFO: "info",
+	EntryCategory.ABILITY: "ability",
 	EntryCategory.AI_THINKING: "ai",
 }
 
@@ -141,9 +153,12 @@ func _ready() -> void:
 	_dice_regex.compile("\\[([0-9, ]+)\\]")
 	_threshold_regex = RegEx.new()
 	_threshold_regex.compile("(?:needed |Save |Pain |vs )(\\d+)\\+")
-	# Every filterable category starts visible.
+	# Every filterable category starts visible, except those in the default-hidden
+	# list (passive ability activations) which are off until the player opts in.
 	for cat in FILTER_ORDER:
 		_category_visible[cat] = true
+	for cat in DEFAULT_HIDDEN_CATEGORIES:
+		_category_visible[cat] = false
 
 func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 105.0, offset_bottom: float = 0.0) -> void:
 	name = "GameLogPanel"
@@ -1198,6 +1213,8 @@ func _entry_text_color(entry_type: String) -> String:
 			return "#8899AA"
 		"overwatch":
 			return "#FF6600"
+		"ability":
+			return "#6FC7C0"
 		_:
 			return "#B0B8C0"
 
@@ -1213,6 +1230,8 @@ func _format_entry_text(text: String, entry_type: String) -> String:
 			return "[i][color=#8899AA]%s[/color][/i]" % text
 		"overwatch":
 			return "[b][color=#FF6600]%s[/color][/b]" % text
+		"ability":
+			return "[i][color=#6FC7C0]%s[/color][/i]" % text
 		"combat_result":
 			if "destroyed" in text and "No models" not in text:
 				return "[b][color=#FF6B6B]%s[/color][/b]" % text
@@ -1255,6 +1274,8 @@ func _categorize_entry_type(entry_type: String) -> int:
 			return EntryCategory.AI_THINKING
 		"overwatch":
 			return EntryCategory.OVERWATCH
+		"ability":
+			return EntryCategory.ABILITY
 		"combat_header", "combat_detail", "combat_result":
 			return EntryCategory.COMBAT
 		"info":

--- a/40k/tests/scenarios/sp/game_log_ability_filter.json
+++ b/40k/tests/scenarios/sp/game_log_ability_filter.json
@@ -1,0 +1,47 @@
+{
+  "id": "game_log_ability_filter",
+  "covers": [
+    "ui.GameLogPanel.ability_filter",
+    "log.ability.tagging",
+    "log.ability.hidden_by_default",
+    "log.ability.real_manager_path"
+  ],
+  "fixture": "audit_367_warlord",
+  "transition_to_phase": 0,
+  "description": "Passive always-on ability activations (e.g. 'Stand Vigil active', 'Guardian Eternal active') repeat at the start of every phase for every unit that has one, flooding the game log. This scenario proves the new 'Abilities' filter. Part A drives the real logging API (GameEventLog.add_ability_entry, the exact call UnitAbilityManager now makes): the entry is tagged type 'ability', lands in the ABILITY category, and is HIDDEN by default while an ordinary shooting entry stays visible. It then opens the filter bar with a real click, confirms the 'Abilities' chip exists, clicks it, and the ability card appears. Part B drives the REAL UnitAbilityManager.on_phase_start(SHOOTING) path against a Custodes/Ork fixture and asserts the always-on abilities it re-applies are logged with type 'ability' (not p1_action/charge/info), so they filter as a group regardless of phase.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "main.game_log_panel.is_category_visible('ability')", "equals": false },
+
+    { "act": "execute_script", "script": "GameEventLog.add_ability_entry(1, \"Custodian Guard ability 'Stand Vigil' active (Re-roll Wound rolls of 1)\")" },
+    { "act": "execute_script", "script": "str(GameEventLog.entries.back().get('type',''))", "equals": "ability" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, 'Custodian Guard shot at Ork Boyz')" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+
+    { "act": "execute_script", "script": "main.game_log_panel.count_cards_in_category('ability')", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('ability')", "equals": 0 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('shoot')", "expect_min": 1 },
+    { "act": "screenshot", "label": "01_ability_hidden_by_default", "region": [0, 100, 360, 760] },
+
+    { "act": "click_node", "node": "/root/Main/GameLogPanel/VBox/HeaderRow/FilterToggle", "emit_pressed": true },
+    { "act": "expect_node_visible", "node": "/root/Main/GameLogPanel/VBox/FilterBar", "timeout_s": 2.0 },
+    { "act": "expect_node_visible", "node": "/root/Main/GameLogPanel/VBox/FilterBar/Chip_ability", "timeout_s": 2.0 },
+    { "act": "screenshot", "label": "02_filter_bar_shows_abilities_chip", "region": [0, 100, 360, 760] },
+
+    { "act": "click_node", "node": "/root/Main/GameLogPanel/VBox/FilterBar/Chip_ability", "emit_pressed": true },
+    { "act": "execute_script", "script": "main.game_log_panel.is_category_visible('ability')", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('ability')", "expect_min": 1 },
+    { "act": "screenshot", "label": "03_ability_shown_after_toggle", "region": [0, 100, 360, 760] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.set_category_filter('ability', false)" },
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "UnitAbilityManager.on_phase_start(8)" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "GameEventLog.count_entries_of_type('ability')", "expect_min": 1 },
+    { "act": "execute_script", "script": "GameEventLog.count_entries_of_type('p1_action')", "equals": 0 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_visible_cards_in_category('ability')", "equals": 0 },
+    { "act": "screenshot", "label": "04_real_manager_ability_entries_hidden", "region": [0, 100, 360, 760] }
+  ]
+}


### PR DESCRIPTION
## Summary

Passive, always-on ability activations are re-checked at the start of **every phase** (`UnitAbilityManager._apply_all_ability_effects`), so lines like *"Custodian Guard ability 'Stand Vigil' active"*, *"Telemon Heavy Dreadnought ability 'Guardian Eternal' active"*, and aura effects were re-logged every turn. Because they went through `add_player_entry`, they were also scattered across the **Move / Charge / Info** filter buckets by chance wording in their descriptions (e.g. *Full Throttle* contains "charge", *Stand Vigil* contains "ability").

This groups every such passive/aura activation under one new **Abilities** filter that is hidden by default, no matter which phase it fires in.

## Changes

- **`GameEventLog.gd`** — new `add_ability_entry(player, text)`, tagging these lines with a dedicated `"ability"` entry type.
- **`UnitAbilityManager.gd`** — route the three passive/aura activation log sites (own-unit ability, leader-granted ability, aura) through it. One-off *actions* you take (Waaagh!, Oath of Moment, stratagems, Big Booms roll) keep their existing categories.
- **`GameLogPanel.gd`** — add `EntryCategory.ABILITY` (teal **A** badge), an **"Abilities"** filter chip, and a `DEFAULT_HIDDEN_CATEGORIES` list so the category is **off by default**. `"ability"` entries route straight to the category regardless of phase/description wording.
- **`version_history.json`** — new 0.8.2 entry (player-facing change).

## Validation

Added windowed scenario `tests/scenarios/sp/game_log_ability_filter.json` — **27/27 steps pass, 0 errors**:

- An ability line is tagged `"ability"` and **hidden by default** while an ordinary shooting entry stays visible.
- A real click on the **Filters** button then the **Abilities** chip reveals the ability card (teal **A** badge, teal styling).
- **Part B** drives the real `UnitAbilityManager.on_phase_start(SHOOTING)` path against the Custodes/Ork fixture and asserts it produces ≥1 `ability`-typed entry and **0** `p1_action` entries — proving abilities are no longer miscategorized — all hidden by default.

Existing `game_log_clarity_filters` scenario re-run clean (57/57) — no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfW9CvgvYF6fSrHM1dwfHA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfW9CvgvYF6fSrHM1dwfHA)_