### PR TITLE
Give the Stompa a proper 180mm round base

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.4",
+			"date": "2026-07-09",
+			"summary": "The Stompa now fields on a proper 180mm round base. The dataset ships no base for it ('Use model'), so it was falling back to a tiny 32mm base.",
+			"changes": [
+				"Building or importing an army with a Stompa now gives its model a 180mm round base instead of the 32mm default, so it deploys, blocks movement, and fights at the correct footprint.",
+				"Added a curated base-size override in the army-format converter for models the 40kdc dataset leaves as a dimensionless 'draft' base; the Stompa is the first entry. Added a converter test that fails if the Stompa ever regresses to the 32mm fallback."
+			]
+		},
+		{
 			"version": "0.8.3",
 			"date": "2026-07-09",
 			"summary": "New 'Abilities' filter in the game log groups the repeating passive-ability lines (e.g. 'Stand Vigil active', 'Guardian Eternal active') and hides them by default, so the log stays focused on what actually happened.",

--- a/server/public/js/lib/gameformat.mjs
+++ b/server/public/js/lib/gameformat.mjs
@@ -48,6 +48,21 @@ export const UNIT_ALIASES = {
   'adeptus-astartes': {},
 };
 
+// Curated base-size overrides, keyed by dataset unit id.
+//
+// The 40kdc dataset ships some models with a placeholder base — e.g.
+// `{ shape: 'hull' | 'flying-base' | 'unique', draft: true }` with no
+// dimensions, or a null base — because Games Workshop sells no separate base
+// for them ("Use model"). buildModelsArray() would otherwise fall back to a
+// 32mm round for those, which renders far too small. List real footprints
+// here; an entry wins over the dataset's (usually draft) base_size_mm for that
+// unit. Round bases need `{ shape: 'round', diameter }`; ovals use
+// `{ shape: 'oval', length, width }`.
+export const BASE_SIZE_OVERRIDES = {
+  // Stompa: no GW base (uses the model); play it on a 180mm round footprint.
+  'stompa': { shape: 'round', diameter: 180 },
+};
+
 // 10e -> 11e weapon renames (matched via looseName; -> 11e weapon id),
 // applied when the direct name match fails. Each 11e display name is also
 // self-aliased where it differs from the datasheet's weapon_ids (the Telemon's
@@ -369,7 +384,10 @@ export function createConverter({ rawData, describeAbility, canonEntries = [], d
     for (let k = 0; k < compModels.length; k++) {
       const m = compModels[k];
       const p = profileFor(m.name, m.profile_name);
-      const base = m.base_size_mm ?? dcUnit.base_size_mm ?? { shape: 'round', diameter: 32 };
+      // A curated override wins over the dataset's base (often a dimensionless
+      // draft), then the per-composition-model base, then the unit default.
+      const base = BASE_SIZE_OVERRIDES[dcUnit.id]
+        ?? m.base_size_mm ?? dcUnit.base_size_mm ?? { shape: 'round', diameter: 32 };
       for (let n = 0; n < counts[k]; n++) {
         const model = {
           id: `m${mi++}`,

--- a/server/tests/gameformat.test.mjs
+++ b/server/tests/gameformat.test.mjs
@@ -136,6 +136,20 @@ test('fresh Ork roster builds a valid schema-2 army', () => {
   }
 });
 
+test('Stompa resolves to a 180mm round base, not the 32mm draft fallback', () => {
+  // The dataset ships the Stompa with a dimensionless draft base
+  // ({ shape: 'hull', draft: true }); BASE_SIZE_OVERRIDES pins it to 180mm.
+  const stompa = V.RAW_DATA.units.find(u => u.faction_id === 'orks' && u.id === 'stompa');
+  const comp = V.RAW_DATA.unitCompositions.find(c => c.faction_id === 'orks' && c.unit_id === 'stompa');
+  assert.ok(stompa && comp, 'stompa unit + composition present in dataset');
+
+  const models = conv.buildModelsArray(stompa, comp, 1);
+  assert.equal(models.length, 1, 'stompa is a single-model unit');
+  assert.equal(models[0].base_mm, 180, 'stompa base_mm pinned to 180');
+  assert.ok(models[0].base_type === undefined || models[0].base_type === 'circular',
+    'stompa stays a round base (no oval/rectangular base_type)');
+});
+
 test('package legality checker accepts the fresh roster shape', () => {
   const { roster } = conv.gameToRoster(
     JSON.parse(readFileSync(join(ARMIES, 'Orks_2000.json'), 'utf8')), { name: 'orks' });


### PR DESCRIPTION
## Summary

The 40kdc dataset ships the Stompa with a dimensionless **draft** base (`{ shape: "hull", draft: true }`) because Games Workshop sells no separate base for it — the source datasheet lists its base as *"Use model"*. The army-format converter (`buildModelsArray()`) falls back to a **32mm round** for any such placeholder, so a fielded Stompa deployed, blocked movement, and fought at a tiny footprint.

This pins the Stompa to a **180mm round base**.

## Approach

Rather than hand-editing `40k/data/40kdc/units.json` (which is extraction-generated from the `@alpaca-software/40kdc-data` package and explicitly must not be hand-edited — changes are wiped on re-extraction), the fix lives in the shared converter, `server/public/js/lib/gameformat.mjs`:

- Added a curated `BASE_SIZE_OVERRIDES` table (alongside the existing `UNIT_ALIASES` / `WEAPON_ALIASES_SRC` override tables), keyed by dataset unit id and seeded with `stompa → { shape: 'round', diameter: 180 }`.
- `buildModelsArray()` consults it **before** the dataset base, so the override wins over the Stompa's draft placeholder (which sits on both the unit and its composition model).

This is the single chokepoint both the browser Army Builder (`server/public/js/builder/store.js`) and `scripts/40kdc/generate-armies.mjs` route through, so it survives dataset re-extraction and works for both the browser (vendor bundle) and Node (extracted JSON) data sources.

## Testing

- Added a converter test that asserts the Stompa resolves to `base_mm: 180` (round) and fails if it ever regresses to the 32mm fallback.
- Full suite (`node --test server/tests/gameformat.test.mjs`) passes — 6/6, including the existing army round-trip test (no regression).
- Verified through the real converter: `conv.buildModelsArray(stompa, comp, 1)` now emits the exact model dict the game loads, with `base_mm: 180` and no `base_type` (so Godot renders it circular).

## Notes

This is a converter/army-pipeline change — no Godot rendering code was touched (base-size rendering is existing behavior every unit already uses). No bundled army in `40k/armies/` currently contains a Stompa, so the 180mm base takes effect the moment one is built or imported through the Army Builder. Changelog bumped to 0.8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQbtkqGdrFzPWtnayJq1bu

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQbtkqGdrFzPWtnayJq1bu)_