### PR TITLE
Fix AI suggestion / lone log entry overlapping the game log

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.8.6",
+			"date": "2026-07-09",
+			"summary": "Fixed the AI 'AI Suggestion' hint (and any log entry added on its own) drawing on top of the existing game log instead of slotting in at the bottom.",
+			"changes": [
+				"Asking the AI for a suggestion no longer covers earlier game-log entries: the new card is now appended at the bottom of the log where it belongs. Previously the card's slide-in animation left it stuck at the top overlapping older entries until the next thing was logged, which then bumped it into place.",
+				"This also fixes the same glitch for any single game-log entry added in isolation (not just AI suggestions)."
+			]
+		},
+		{
 			"version": "0.8.5",
 			"date": "2026-07-09",
 			"summary": "Speedwaaagh! (Orks) is now fully implemented: all four of its Enhancements and all six of its Stratagems work in-game.",

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -293,6 +293,28 @@ func get_ai_card_count() -> int:
 			n += 1
 	return n
 
+func newest_card_is_below_earlier_cards() -> bool:
+	"""True when the most-recently-added card sits BELOW every earlier visible card
+	— i.e. it was appended at the bottom of the log rather than left overlapping the
+	top. Guards the AI-advice overlap regression: a card whose slide-in animation
+	captured its target position before the VBoxContainer laid it out would stick at
+	y=0 and cover existing entries. Returns true when there are fewer than two
+	visible cards (nothing to overlap)."""
+	if _card_container == null:
+		return false
+	var visible_cards: Array = []
+	for c in _card_container.get_children():
+		if is_instance_valid(c) and c.visible:
+			visible_cards.append(c)
+	if visible_cards.size() < 2:
+		return true
+	var last: Control = visible_cards[visible_cards.size() - 1]
+	var last_y: float = last.position.y
+	for i in range(visible_cards.size() - 1):
+		if visible_cards[i].position.y >= last_y:
+			return false
+	return true
+
 # ==========================================================================
 # Board-linked thinking — hover/click a card to see the options on the board
 # ==========================================================================
@@ -1186,14 +1208,26 @@ func _create_icon(category: int) -> PanelContainer:
 # ==========================================================================
 
 func _animate_card_in(card: Control) -> void:
+	# The card lives in a VBoxContainer, which positions its children on a
+	# DEFERRED sort (queue_sort), NOT synchronously on add_child. If we captured
+	# card.position.y right now it would still be the pre-sort default (0), so the
+	# tween would animate the card toward y=0 and LEAVE it there — overlapping the
+	# top of the log — because the container never re-asserts the layout until the
+	# next entry triggers another sort. (This is exactly why an on-demand AI
+	# suggestion card, added in isolation with nothing after it, was drawn on top
+	# of existing entries until something else was logged.) Wait one frame for the
+	# container to lay the card out at its real position, then slide into THAT.
 	card.modulate.a = 0.0
-	var original_pos = card.position.y
-	card.position.y += 15.0
+	await get_tree().process_frame
+	if not is_instance_valid(card):
+		return
+	var target_y := card.position.y
+	card.position.y = target_y + 15.0
 
 	var tween = card.create_tween()
 	tween.set_parallel(true)
 	tween.tween_property(card, "modulate:a", 1.0, 0.25).set_ease(Tween.EASE_OUT)
-	tween.tween_property(card, "position:y", original_pos, 0.25).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC)
+	tween.tween_property(card, "position:y", target_y, 0.25).set_ease(Tween.EASE_OUT).set_trans(Tween.TRANS_CUBIC)
 
 # ==========================================================================
 # Text formatting

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2499,6 +2499,15 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "ui.gamelog.newest_card_no_overlap",
+      "description": "A newly logged game-log card (e.g. an on-demand AI suggestion added in isolation) is appended at the BOTTOM of the log, not drawn on top of existing entries. Regression guard for GameLogPanel._animate_card_in capturing its slide target before the VBoxContainer laid the card out, which left the card stuck at y=0 overlapping the top until the next entry forced a re-sort.",
+      "scenarios": [
+        "ai_suggestion_no_log_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/ai_suggestion_no_log_overlap.json
+++ b/40k/tests/scenarios/sp/ai_suggestion_no_log_overlap.json
@@ -1,0 +1,49 @@
+{
+  "id": "ai_suggestion_no_log_overlap",
+  "covers": [
+    "ui.gamelog.newest_card_no_overlap"
+  ],
+  "fixture": "audit_382_cp_grant",
+  "edition": 11,
+  "rng_seed": 7,
+  "description": "Regression guard for the AI-advice game-log overlap. With a populated game log, asking the AI for an on-demand suggestion (the K-hotkey / 'AI Suggestion' button) must APPEND its reasoning card at the BOTTOM of the log, not draw it on top of existing entries. The bug: GameLogPanel._animate_card_in captured the card's slide target position before the VBoxContainer had laid it out, so a card added in isolation (nothing logged after it) stuck at y=0 and covered the top of the log until the next entry forced a re-sort. This scenario populates the log with real entries, triggers the suggestion WITHOUT clearing the log, and asserts newest_card_is_below_earlier_cards() — i.e. the suggestion card is positioned below every earlier visible card.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
+    { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(1)" },
+    { "act": "execute_script", "script": "AIPlayer.clear_action_log()" },
+    { "act": "execute_script", "script": "GameState.set_active_player(1)" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(7)" },
+    { "act": "execute_script", "script": "main.refresh_ai_suggestion_button()" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Bottom/HBoxContainer/AISuggestionButton", "timeout_s": 2.0 },
+
+    { "act": "execute_script", "script": "GameEventLog.clear()" },
+    { "act": "execute_script", "script": "GameEventLog.add_entry(\"--- Movement Phase, Battle Round 2, Player 1 turn ---\", \"phase_header\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Warboss moved 6 inches\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Gretchin advanced\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Deffkoptas moved 12 inches\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_info_entry(\"P1 gained 1 CP\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Boyz remained stationary\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Meganobz moved 5 inches\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Trukk moved 12 inches\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_info_entry(\"Objective 3 contested\")" },
+    { "act": "execute_script", "script": "GameEventLog.add_player_entry(1, \"Stormboyz advanced 4 inches\")" },
+    { "act": "wait_frames", "frames": 40 },
+
+    { "act": "screenshot", "label": "01_before_suggestion", "region": [0, 105, 400, 720] },
+    { "act": "execute_script", "script": "main.game_log_panel.newest_card_is_below_earlier_cards()", "equals": true },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Bottom/HBoxContainer/AISuggestionButton" },
+    { "act": "wait_frames", "frames": 45 },
+
+    { "act": "execute_script", "script": "GameEventLog.count_ai_thinking_entries()", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.game_log_panel.get_ai_card_count()", "expect_min": 1 },
+
+    { "act": "screenshot", "label": "02_after_suggestion", "region": [0, 105, 400, 720] },
+
+    { "act": "execute_script", "script": "main.game_log_panel.newest_card_is_below_earlier_cards()", "equals": true }
+  ]
+}


### PR DESCRIPTION
## Summary

An on-demand AI suggestion (the "AI Suggestion" hint / K hotkey) — or any single game-log entry added in isolation — was drawn **on top of** the existing game log instead of being appended at the bottom. It only snapped into its correct place once something else was logged.

## Root cause

`GameLogPanel._animate_card_in` captured the card's slide target (`card.position.y`) **synchronously right after `add_child`** — before the `VBoxContainer` had run its *deferred* sort (`queue_sort`). At that point `position.y` is still the pre-sort default `0`, so the tween animated the card toward `y=0` and left it there, overlapping the top of the log. The container never re-asserts the layout until the next entry triggers another sort, which is why logging anything afterward "fixed" it. During the AI's own turn many entries stream in and each re-sort heals the previous card, so the glitch was only visible for a card added on its own — exactly the on-demand suggestion case.

## Fix

Wait one frame for the container to lay the card out at its real position, then capture that as the slide target and animate into it — so the end state matches the container's layout even with no follow-up sort.

## Validation (windowed, per project gate)

- **New regression scenario** `ai_suggestion_no_log_overlap`: populates the log with real entries, asks the AI for a suggestion *without* clearing the log, and asserts the newest card sits below every earlier card via the new `GameLogPanel.newest_card_is_below_earlier_cards()` helper. Passes **29/0** with the fix; fails **2 assertions without it** (guard proven real).
- `ai_suggestion_on_demand` + 9 other game-log scenarios (dice render, filters, verbose thinking, thought links) all still pass — no regression. Debug log shows **0 script errors** while exercising the path.

## Files changed

- `40k/scripts/GameLogPanel.gd` — the animation fix + `newest_card_is_below_earlier_cards()` introspection helper.
- `40k/tests/scenarios/sp/ai_suggestion_no_log_overlap.json` — new regression scenario.
- `40k/tests/coverage.json` — new coverage tile for `ui.gamelog.newest_card_no_overlap`.
- `40k/data/version_history.json` — 0.8.6 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQVxk4kij1nMByP183a8m6

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQVxk4kij1nMByP183a8m6)_