### PR TITLE
Fix iss15_heroic_intervention_decline_11e scenario: give the fixture an HI-eligible unit

### DIFF
--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -1598,6 +1598,14 @@ func _process_end_charge(action: Dictionary) -> Dictionary:
 					result["heroic_intervention_eligible_units"] = hi_eligible
 					result["heroic_intervention_charging_unit_id"] = ""
 					return result
+				else:
+					log_phase_message("[11e 15.11] HI window skipped: Player %d has no eligible units (no unit with an actionable LEAP/FRAY target)" % defending_player)
+			elif not hi_check.available:
+				log_phase_message("[11e 15.11] HI window skipped: %s" % hi_check.reason)
+			else:
+				log_phase_message("[11e 15.11] HI window skipped: StratagemManager has no get_heroic_intervention_eligible_units_11e")
+		else:
+			log_phase_message("[11e 15.11] HI window skipped: no StratagemManager autoload")
 
 	log_phase_message("Ending Charge Phase")
 	emit_signal("phase_completed")

--- a/40k/tests/scenarios/sp/iss15_heroic_intervention_decline_11e.json
+++ b/40k/tests/scenarios/sp/iss15_heroic_intervention_decline_11e.json
@@ -8,11 +8,15 @@
   "edition": 11,
   "transition_to_phase": 9,
   "disable_ai": true,
-  "description": "15.11 HEROIC INTERVENTION decline path: the active player (P1) ends the Charge phase via the real button, the defender's dialog opens (end-of-phase window, no charging unit named), and the defender clicks Decline. The phase must then complete to Fight with no CP spent and no counter-charge. Guards the _should_complete_phase fix: END_CHARGE must not silently complete past the open HI window, and the decline must complete the phase it deferred.",
+  "description": "15.11 HEROIC INTERVENTION decline path: the active player (P1) ends the Charge phase via the real button, the defender's dialog opens (end-of-phase window, no charging unit named), and the defender clicks Decline. The phase must then complete to Fight with no CP spent and no counter-charge. Guards the _should_complete_phase fix: END_CHARGE must not silently complete past the open HI window, and the decline must complete the phase it deferred. Setup places the Warboss 2.5\" edge-to-edge from the Shield-Captain (same as the fray scenario) because since the #499 eligibility tightening the window only opens if some unit has an actionable HI mode — with the fixture's stock positions no unit qualifies and the phase (correctly) ends without the dialog.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 9 },
     { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_WARBOSS_C\")[\"models\"][0].merge({\"position\": {\"x\": 933.24, \"y\": 1343.63}}, true)" },
+    { "act": "execute_script", "script": "main._sync_all_token_positions()" },
+    { "act": "wait_seconds", "seconds": 1.0 },
 
     { "act": "click_node", "node": "/root/Main/PhaseActionButton", "emit_pressed": true },
     { "act": "expect_node_visible", "node": "/root/HeroicInterventionDialog", "timeout_s": 3.0 },


### PR DESCRIPTION
## Summary

The windowed scenario `iss15_heroic_intervention_decline_11e` has been failing since PR #499 tightened the 11e Heroic Intervention eligibility rules: a unit is only offered the end-of-Charge-phase HI window if it has an actionable target for LEAP TO DEFEND (charged enemy within 12") or INTO THE FRAY (any enemy within 6"). With the `audit_370_bgnt_shoot` fixture's stock positions, **zero defender units qualify**, so the game (correctly) skips the window and completes the phase — and the scenario failed waiting for the dialog. Its sibling `iss15_heroic_intervention_fray_11e` was repaired with a setup step back then; the decline scenario never got the same repair.

## Changes

- **`40k/tests/scenarios/sp/iss15_heroic_intervention_decline_11e.json`** — mirror the fray scenario's setup: teleport `U_WARBOSS_C` to 2.5" edge-to-edge from the Shield-Captain (outside the 2" engagement range so it stays offerable, inside 6" so INTO THE FRAY has a target) before clicking End Phase. The scenario `description` now records why the teleport is needed.
- **`40k/phases/ChargePhase.gd`** — the three formerly-silent HI-window skip branches in `_process_end_charge()` (stratagem unavailable / no eligible units / no StratagemManager) now each log a `[11e 15.11] HI window skipped: ...` message, so the next regression diagnoses itself from the debug log instead of requiring a live probe.

No engine behavior change: when the window opens, the code path is identical; the new lines only add logging on the skip paths. Test + logging only, so no `version_history.json` entry.

## Verification (windowed, real UI)

- `iss15_heroic_intervention_decline_11e`: **15/15 PASS** — dialog opens with phase held at Charge, Decline click completes the phase to Fight with P2 CP unchanged (screenshots captured).
- `iss15_heroic_intervention_fray_11e`: **27/27 PASS** — no regression from the shared-code change.
- New logging exercised for real via a throwaway probe scenario reproducing the pre-fix setup: phase completes and the debug log shows `[11e 15.11] HI window skipped: Player 2 has no eligible units (no unit with an actionable LEAP/FRAY target)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xW2wyCdnmx368FKkW8Cz8

---
_Generated by [Claude Code](https://claude.ai/code/session_013xW2wyCdnmx368FKkW8Cz8)_