### PR TITLE
Remove redundant OK button from fight-phase dialogs

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.16.2",
+			"date": "2026-07-10",
+			"summary": "Fight phase dialogs now have a single, clear confirm button: the redundant 'OK' button that duplicated 'Fight!' in the attack-assignment dialog (and did nothing useful in the unit picker) is gone.",
+			"changes": [
+				"Assign Attacks dialog: removed the built-in 'OK' button that sat next to 'Fight!' and did the same thing — 'Fight!' is now the one button that confirms your weapon/target assignments and rolls the attacks.",
+				"Fight unit picker: removed its 'OK' button too — you pick a unit by clicking it, and 'OK' could only close the picker without selecting anything, stalling the fight sequence."
+			]
+		},
+		{
 			"version": "0.16.1",
 			"date": "2026-07-10",
 			"summary": "Fixed the board mouseover tooltip: it now works on every model anywhere on the board (not just a lucky few), and shows the unit's real name and stats instead of 'Unknown' with question marks.",

--- a/40k/dialogs/AttackAssignmentDialog.gd
+++ b/40k/dialogs/AttackAssignmentDialog.gd
@@ -198,6 +198,11 @@ func _build_ui() -> void:
 	confirm_attacks_button.pressed.connect(_on_confirmed)
 	button_container.add_child(confirm_attacks_button)
 
+	# Hide the built-in OK button: it duplicated "Fight!" (both fired
+	# _on_confirmed) and, unlike "Fight!", auto-hid the dialog even when the
+	# confirm was rejected for having no assignments.
+	get_ok_button().visible = false
+
 	container.add_child(button_container)
 
 	# Current assignments display
@@ -420,12 +425,18 @@ func _on_confirmed() -> void:
 
 	if assignments.is_empty() and extra_attacks_weapons.is_empty():
 		push_warning("No attacks assigned")
+		if not visible:
+			# A `confirmed`-signal accept auto-hides the dialog before this
+			# validation runs — re-show so the fight flow can't strand.
+			show()
 		return
 
 	# T3-3: Extra Attacks weapons cannot be used alone — need at least one regular weapon assignment
 	if assignments.is_empty() and not extra_attacks_weapons.is_empty():
 		push_warning("Extra Attacks weapons must be used IN ADDITION to another weapon — assign a regular weapon first")
 		print("[AttackAssignmentDialog] Blocked: Extra Attacks weapons cannot be the only weapon choice")
+		if not visible:
+			show()
 		return
 
 	# T3-3: Auto-include Extra Attacks weapons in assignments

--- a/40k/dialogs/FightSelectionDialog.gd
+++ b/40k/dialogs/FightSelectionDialog.gd
@@ -92,7 +92,10 @@ func _build_ui() -> void:
 
 	add_child(main_container)
 
-	# Connect OK button
+	# Hide the built-in OK button: picking a unit is a single click on its
+	# button, so OK had nothing to confirm — clicking it just dismissed the
+	# picker with no unit selected and stalled the fight sequence.
+	get_ok_button().visible = false
 	confirmed.connect(_on_confirmed)
 
 func _add_subphase_units(container: VBoxContainer, subphase_name: String, units_by_player: Dictionary) -> void:
@@ -177,10 +180,14 @@ func _on_unit_selected(unit_id: String) -> void:
 	queue_free()
 
 func _on_confirmed() -> void:
-	# This is only called if user clicks OK button explicitly
+	# Only reachable via a programmatic `confirmed` emission now that the
+	# built-in OK button is hidden (unit buttons select-and-close directly)
 	if selected_unit_id.is_empty():
-		# Show error
 		push_warning("No unit selected - please click on a unit")
+		if not visible:
+			# `confirmed` auto-hides the dialog before this validation runs —
+			# re-show so the selecting player isn't left without a picker.
+			show()
 		return
 
 	# Close dialog first to avoid exclusive child window error

--- a/40k/tests/scenarios/sp/fight_dialogs_single_confirm_11e.json
+++ b/40k/tests/scenarios/sp/fight_dialogs_single_confirm_11e.json
@@ -1,0 +1,52 @@
+{
+  "id": "fight_dialogs_single_confirm_11e",
+  "covers": [
+    "dialogs.AttackAssignmentDialog.ok_button_hidden",
+    "dialogs.FightSelectionDialog.ok_button_hidden",
+    "phases.FightPhase.attack_assignment",
+    "ui.fight.single_confirm_affordance"
+  ],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "UX guard: the fight-flow dialogs must expose exactly ONE confirm affordance. Previously the AttackAssignmentDialog showed both its own 'Fight!' button and the AcceptDialog built-in 'OK' button, wired to the same handler — confusing, and the OK path auto-hid the dialog even when the confirm was rejected (no assignments). Same for FightSelectionDialog, where unit choice is a single click and OK could only dismiss the picker without selecting. This scenario drives the real player path: pass both Pile In halves, assert the FightSelectionDialog has NO visible built-in OK button, pick the Warboss, assert the AttackAssignmentDialog has NO visible built-in OK button while its 'Fight!' ConfirmButton IS visible, then assign all weapons and resolve the fight through that single button, proving the picker re-pops for the next activation. Setup-only privileges: CP zeroed to suppress stratagem prompts not under test; model wounds inflated so no unit dies mid-scenario.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[1].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[2].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[3].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_TELEMON_HEAVY_DREADNOUGHT_I\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSelectionDialog\").get_ok_button().visible", "equals": false },
+    { "act": "screenshot", "label": "01_fight_selection_no_ok_button" },
+    { "act": "click_node", "node": "/root/FightSelectionDialog/Content/UnitScroll/UnitList/Fight_U_WARBOSS_B", "emit_pressed": true },
+
+    { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"AttackAssignmentDialog\").get_ok_button().visible", "equals": false },
+    { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "timeout_s": 3.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton\").text", "equals": "Fight!" },
+    { "act": "screenshot", "label": "02_attack_assignment_single_fight_button" },
+    { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
+    { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSelectionDialog\").get_ok_button().visible", "equals": false },
+    { "act": "screenshot", "label": "03_fight_resolved_next_selection_repops" }
+  ]
+}


### PR DESCRIPTION
## Problem

When selecting targets to fight and allocating attacks per weapon, the Assign Attacks dialog showed **two buttons that did the same thing**: its own **"Fight!"** button and the `AcceptDialog` built-in **"OK"** button — both wired to the same confirm handler. This was confusing.

Worse, the OK path auto-hid the dialog even when the confirm was *rejected* (e.g. no weapons assigned yet), which could strand the fight flow. The fight unit picker (`FightSelectionDialog`) had the same duplicate OK button, where unit choice is a single click on a unit's button — so OK could only ever dismiss the picker with nothing selected and stall the fight sequence.

## Changes

- **Assign Attacks dialog** (`AttackAssignmentDialog.gd`): hide the built-in OK button so **"Fight!" is the single confirm affordance**, matching the convention every other dialog in the codebase already follows. Defensively re-show the dialog if a programmatic `confirmed` accept slips past the "no assignments" validation.
- **Fight unit picker** (`FightSelectionDialog.gd`): hide the built-in OK button too; add the same defensive re-show guard.
- Version bumped to **0.16.1** in `version_history.json` with a player-facing changelog entry.

## Validation

Per the project's windowed-scenario gate, added `tests/scenarios/sp/fight_dialogs_single_confirm_11e.json` which drives the real player path — pile-in passes, unit pick, weapon assignment, and fight resolution through the single "Fight!" button — asserting live in-game that `get_ok_button().visible == false` on both dialogs (31/31 steps pass), with screenshots confirming the button row is now just "Add Assignment | All to Target | Fight!". The existing full fight-phase scenario `global_consolidation_step_11e` (87 steps) still passes, and no script errors fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Nt3m9b3KMGWcbFNKqqG75

---
_Generated by [Claude Code](https://claude.ai/code/session_012Nt3m9b3KMGWcbFNKqqG75)_