### PR TITLE
Fix engagement-range circles to match the enforced 2" rule (11e)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.17.1",
+			"date": "2026-07-10",
+			"summary": "Engagement-range circles now match the rule. The red rings shown while moving were drawn at the old 1\" range while the game (11th edition) enforces 2\", so moves were refused when a model still looked clear of the circle — the rings, the fight-phase reach circles and the amber engaged rings are now all drawn at base edge + 2\".",
+			"changes": [
+				"Movement: the red no-go rings around enemy models are now drawn at the 11th-edition 2\" engagement range instead of a hardcoded 1\" — if your base stays off the red circle, the move is legal.",
+				"Fight phase: each fighter's orange engagement-reach circle now includes the model's own base radius, matching the base-edge-to-base-edge measurement the rules use.",
+				"The always-on amber 'engaged' rings now detect engagement base-edge to base-edge (like the rules engine) instead of centre-to-centre, size themselves to the anchor model's base, and ignore dead models."
+			]
+		},
+		{
 			"version": "0.17.0",
 			"date": "2026-07-10",
 			"summary": "You can now change the AI speed mid-game from the top menu: a new 'AI Speed' dropdown sits next to the AI Suggestion button with the same Fast / Normal / Slow / Step-by-step presets as the setup screen.",

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -645,11 +645,14 @@ func _show_engagement_indicators() -> void:
 		if model_pos == Vector2.ZERO:
 			continue
 		
-		# T5-V9: Create pulsing engagement range circle (1 inch)
+		# T5-V9: Create pulsing engagement range circle (edition-aware ER).
+		# ER is measured base-edge to base-edge, so include the model's own
+		# base radius — a bare ER-radius circle under-draws the true reach.
 		var circle = Node2D.new()
 		circle.set_script(EngagementRangeVisualScript)
 		circle.position = model_pos
-		circle.setup_engagement_range(Measurement.inches_to_px(GameConstants.engagement_range_inches()), Color.ORANGE)
+		var er_base_radius_px = Measurement.base_radius_px(model.get("base_mm", 32))
+		circle.setup_engagement_range(er_base_radius_px + Measurement.inches_to_px(GameConstants.engagement_range_inches()), Color.ORANGE)
 
 		range_visual.add_child(circle)
 	

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -326,7 +326,7 @@ func _create_path_visuals() -> void:
 	move_range_visual.name = "MoveRangeVisual"
 	board_root.add_child(move_range_visual)
 
-	# T-094: ER overlay container (1" rings around enemy models during movement)
+	# T-094: ER overlay container (engagement-range rings around enemy models during movement)
 	er_overlay_visual = Node2D.new()
 	er_overlay_visual.name = "MovementERVisual"
 	board_root.add_child(er_overlay_visual)
@@ -1618,7 +1618,7 @@ func _on_unit_move_begun(unit_id: String, mode: String) -> void:
 	# T-094 (revised): the movement-reach circle is now drawn per-model when a
 	# model is picked up (see _start_model_drag / _start_group_movement), not as a
 	# unit-wide bubble centred on the unit's centre of mass.
-	# T-094: Show 1" engagement-range rings around enemy units
+	# T-094: Show engagement-range rings around enemy units (edition-aware ER)
 	_show_er_overlay(unit_id)
 	# T-094: Show 2" coherency rings around friendly models in this unit
 	_show_coherency_dots(unit_id)
@@ -5145,10 +5145,13 @@ func _clear_move_range_overlay() -> void:
 		child.queue_free()
 
 
-# T-094: 1" engagement-range rings around enemy units during movement
+# T-094: engagement-range rings around enemy units during movement.
+# ISS-002: the ring radius MUST use the edition-aware
+# GameConstants.engagement_range_inches() (2" at 11e, 1" at 10e). A hardcoded
+# 1" here previously under-drew the no-go zone at 11e, so moves were refused
+# while the model still looked clear of the red circles.
 const MOVE_ER_OVERLAY_COLOR: Color = Color(1.0, 0.3, 0.3, 0.45)
 const MOVE_ER_OVERLAY_WIDTH: float = 6.0
-const MOVE_ER_OVERLAY_INCHES: float = 1.0
 
 func _show_er_overlay(unit_id: String) -> void:
 	if not is_instance_valid(er_overlay_visual):
@@ -5175,7 +5178,9 @@ func _show_er_overlay(unit_id: String) -> void:
 			else:
 				pos = pos_data
 			var base_radius = Measurement.base_radius_px(em.get("base_mm", 32))
-			var ring_radius = base_radius + Measurement.inches_to_px(MOVE_ER_OVERLAY_INCHES)
+			# Engagement range is measured base-edge to base-edge, so the ring
+			# marks the line the moving model's BASE may not touch.
+			var ring_radius = base_radius + Measurement.inches_to_px(GameConstants.engagement_range_inches())
 			var ring = Line2D.new()
 			ring.width = MOVE_ER_OVERLAY_WIDTH
 			ring.default_color = MOVE_ER_OVERLAY_COLOR

--- a/40k/scripts/PersistentEngagementOverlay.gd
+++ b/40k/scripts/PersistentEngagementOverlay.gd
@@ -3,9 +3,11 @@ class_name PersistentEngagementOverlay
 
 # PersistentEngagementOverlay — always-on engagement rings (T29, doc §5).
 #
-# For every unit currently engaged with an enemy (any model within 1 inch
-# of any enemy model), spawn a persistent EngagementRangeVisual at one of
-# its models' position. Refreshes whenever GameState changes, on a debounce.
+# For every unit currently engaged with an enemy (any model within the
+# edition-aware engagement range of any enemy model, measured base-edge to
+# base-edge like the phases do), spawn a persistent EngagementRangeVisual at
+# one of its models' position. Refreshes whenever GameState changes, on a
+# debounce.
 #
 # Child nodes are named `EngagementRing_<unit_id>` so scenarios can address
 # them via NodePath.
@@ -47,6 +49,11 @@ func _do_deferred_refresh() -> void:
 func refresh() -> void:
 	# Tear down + rebuild. Cheap because engagement count is small.
 	for c in get_children():
+		# Detach before queue_free: a queued-free child keeps its name until
+		# end of frame, so re-adding a ring with the same name in the same
+		# frame would get auto-renamed (@Node2D@...) and scenarios could no
+		# longer address it as EngagementRing_<unit_id>.
+		remove_child(c)
 		c.queue_free()
 	var engaged_ids := _compute_engaged_unit_ids()
 	var gs = get_node_or_null("/root/GameState")
@@ -56,15 +63,19 @@ func refresh() -> void:
 		var unit = gs.get_unit(uid)
 		if typeof(unit) != TYPE_DICTIONARY or not unit.has("models"):
 			continue
-		var anchor := _first_model_position(unit)
-		if anchor == Vector2.INF:
+		var anchor_model := _first_anchor_model(unit)
+		if anchor_model.is_empty():
 			continue
+		var anchor := _model_position(anchor_model)
 		var ring = preload("res://scripts/EngagementRangeVisual.gd").new()
 		ring.name = "EngagementRing_%s" % uid
 		ring.is_persistent = true
 		ring.position = anchor
+		# ER is measured base-edge to base-edge, so the drawn ring spans the
+		# anchor model's base plus the edition-aware engagement range.
 		ring.setup_engagement_range(
-			Measurement.inches_to_px(GameConstants.engagement_range_inches()),
+			Measurement.base_radius_px(int(anchor_model.get("base_mm", 32)))
+				+ Measurement.inches_to_px(GameConstants.engagement_range_inches()),
 			Color(0.85, 0.6, 0.2, 1.0)  # subdued amber so it's not loud
 		)
 		ring.pulse_enabled = false  # ambient ring; pulsing reserved for active selection
@@ -89,39 +100,57 @@ func _compute_engaged_unit_ids() -> Array:
 	var owners: Array = by_owner.keys()
 	if owners.size() < 2:
 		return []
-	var threshold_px := float(Measurement.inches_to_px(GameConstants.engagement_range_inches()))
-	var threshold_sq := threshold_px * threshold_px
 	var engaged: Dictionary = {}
 	for i in range(owners.size()):
 		for j in range(i + 1, owners.size()):
 			for uid_a in by_owner[owners[i]]:
 				for uid_b in by_owner[owners[j]]:
-					if _units_within(units[uid_a], units[uid_b], threshold_sq):
+					if _units_within(units[uid_a], units[uid_b]):
 						engaged[uid_a] = true
 						engaged[uid_b] = true
 	return engaged.keys()
 
 
-func _units_within(unit_a: Dictionary, unit_b: Dictionary, threshold_sq: float) -> bool:
+## True if any alive model of unit_a is within engagement range of any alive
+## model of unit_b, using the same shape-aware base-edge-to-base-edge
+## measurement as the phases. (This previously compared centre-to-centre
+## distance against the ER, which under-detected engagement by both models'
+## base radii and disagreed with the rules checks.)
+func _units_within(unit_a: Dictionary, unit_b: Dictionary) -> bool:
+	var er_px := float(Measurement.inches_to_px(GameConstants.engagement_range_inches()))
 	for ma in unit_a.get("models", []):
 		var pa := _model_position(ma)
-		if pa == Vector2.INF:
+		if pa == Vector2.INF or not ma.get("alive", true):
 			continue
 		for mb in unit_b.get("models", []):
 			var pb := _model_position(mb)
-			if pb == Vector2.INF:
+			if pb == Vector2.INF or not mb.get("alive", true):
 				continue
-			if pa.distance_squared_to(pb) <= threshold_sq:
+			# Cheap centre-distance prefilter before the iterative shape solve.
+			if pa.distance_to(pb) > er_px + _bound_radius_px(ma) + _bound_radius_px(mb):
+				continue
+			if Measurement.is_in_engagement_range_shape_aware(ma, mb):
 				return true
 	return false
 
 
-func _first_model_position(unit: Dictionary) -> Vector2:
+## Upper bound of a model base's reach from its centre, in px (covers
+## circular, rectangular and oval bases).
+func _bound_radius_px(m: Dictionary) -> float:
+	var base_mm := float(m.get("base_mm", 32))
+	var dims: Dictionary = m.get("base_dimensions", {})
+	var max_mm: float = max(base_mm, max(float(dims.get("length", 0.0)), float(dims.get("width", 0.0))))
+	return Measurement.mm_to_px(max_mm) / 2.0
+
+
+## First alive model with a valid position — the ring anchor.
+func _first_anchor_model(unit: Dictionary) -> Dictionary:
 	for m in unit.get("models", []):
-		var p := _model_position(m)
-		if p != Vector2.INF:
-			return p
-	return Vector2.INF
+		if _model_position(m) == Vector2.INF:
+			continue
+		if m.get("alive", true):
+			return m
+	return {}
 
 
 func _model_position(m) -> Vector2:

--- a/40k/tests/scenarios/sp/movement_er_ring_matches_check_11e.json
+++ b/40k/tests/scenarios/sp/movement_er_ring_matches_check_11e.json
@@ -1,0 +1,71 @@
+{
+  "id": "movement_er_ring_matches_check_11e",
+  "covers": [
+    "movementcontroller.t094_er_overlay_edition_aware",
+    "movement.engagement_range.ring_matches_rule_11e"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "edition": 11,
+  "description": "The red engagement-range rings drawn during movement must match the rule the engine enforces. Player report: Normal Move drops were refused for being 'within engagement range' while the model looked comfortably clear of the red circles — the T-094 overlay hardcoded 1\" while 11e ER is 2\". Setup teleports the enemy Warboss (40mm) to open ground at (300,1000) with the Shield-Captain (40mm, M6) at (300,800). Asserts: (a) after a real token click begins a Normal Move, the ring around the Warboss has radius base_radius+2\" (~111.5px), not the old base_radius+1\" (~71.5px); (b) a real drag-drop ending with a 1.43\" base gap — which looked legal under the old ring — is refused and the model stays put; (c) a drag-drop ending with a 2.17\" gap, just outside the corrected ring, stages and confirms.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_SHIELD_CAPTAIN_A\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 800.0}}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_WARBOSS_B\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 1000.0}}, true)" },
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().game_state_snapshot[\"units\"][\"U_SHIELD_CAPTAIN_A\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 800.0}}, true)" },
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().game_state_snapshot[\"units\"][\"U_WARBOSS_B\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 1000.0}}, true)" },
+    { "act": "execute_script", "script": "main._recreate_unit_visuals()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_setup_captain_above_warboss" },
+
+    { "act": "click_unit", "unit_id": "U_SHIELD_CAPTAIN_A" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script",
+      "script": "main.movement_controller.active_unit_id",
+      "equals": "U_SHIELD_CAPTAIN_A" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/MovementERVisual\").get_child_count()",
+      "expect_min": 8 },
+
+    { "act": "execute_script",
+      "script": "((main.get_node(\"BoardRoot/MovementERVisual\").get_child(4).points[0] + main.get_node(\"BoardRoot/MovementERVisual\").get_child(4).points[16]) / 2.0).distance_to(Vector2(300.0, 1000.0)) < 1.0",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "abs((main.get_node(\"BoardRoot/MovementERVisual\").get_child(4).points[0] - main.get_node(\"BoardRoot/MovementERVisual\").get_child(4).points[16]).length() / 2.0 - (Measurement.base_radius_px(40) + Measurement.inches_to_px(2.0))) < 0.5",
+      "equals": true },
+    { "act": "screenshot", "label": "02_er_ring_base_plus_2in" },
+
+    { "act": "drag_board", "from_x": 300, "from_y": 800, "to_x": 300, "to_y": 880 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script",
+      "script": "main.movement_controller._has_pending_unconfirmed_move(\"U_SHIELD_CAPTAIN_A\")",
+      "equals": false },
+    { "act": "execute_script",
+      "script": "abs(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\") - 800.0) < 0.5",
+      "equals": true },
+    { "act": "screenshot", "label": "03_drop_at_1p43in_gap_refused" },
+
+    { "act": "drag_board", "from_x": 300, "from_y": 800, "to_x": 300, "to_y": 850 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script",
+      "script": "main.movement_controller._has_pending_unconfirmed_move(\"U_SHIELD_CAPTAIN_A\")",
+      "equals": true },
+    { "act": "screenshot", "label": "04_drop_at_2p17in_gap_staged" },
+
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_UNIT_MOVE", "actor_unit_id": "U_SHIELD_CAPTAIN_A" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.U_SHIELD_CAPTAIN_A.flags.moved", "equals": true },
+    { "act": "execute_script",
+      "script": "abs(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\") - 850.0) < 1.0",
+      "equals": true },
+    { "act": "screenshot", "label": "05_move_confirmed_outside_er" }
+  ]
+}


### PR DESCRIPTION
## Summary

The red engagement-range rings shown while moving were drawn at a hardcoded **1″** while the game runs 11th edition, where engagement range is **2″**. So Normal/Advance move drops were refused for being "within engagement range" while the model still looked comfortably clear of the red circle. This was a **display bug, not a measurement bug** — the engine's `Measurement.is_in_engagement_range_shape_aware()` check was correct all along; three separate ER *visuals* were drawing the wrong zone.

The gap looked even larger than 1″ because ER is measured **base-edge to base-edge**, so the true forbidden zone for a model's centre is `enemy base radius + 2″ + own base radius` — nearly double the radius of the (already-too-small) ring being drawn.

## Changes

- **`MovementController._show_er_overlay`** — replace the hardcoded `MOVE_ER_OVERLAY_INCHES = 1.0` with `GameConstants.engagement_range_inches()`, so the red rings match the edition-aware ER the phase actually enforces (2″ at 11e, 1″ at 10e). This is the direct cause of the reported bug; the charge-phase overlay already did this correctly.
- **`FightController._show_engagement_indicators`** — add the model's own base radius to its orange reach circle. ER is measured base-edge to base-edge, so a bare ER-radius circle under-drew the reach.
- **`PersistentEngagementOverlay`** — detect engagement base-edge to base-edge via `Measurement.is_in_engagement_range_shape_aware` (was centre-to-centre, under-detecting by both models' base radii and disagreeing with the rules engine), size the amber "engaged" ring to the anchor model's base + ER, ignore dead models, and detach children before `queue_free` so a same-frame refresh keeps the `EngagementRing_<unit_id>` node names.

## Validation

New windowed scenario **`movement_er_ring_matches_check_11e`** (31 assertions, passing) drives the real player path against the running UI:

1. After a real **token click** begins a Normal Move, the enemy ring radius is `base + 2″` (~111.5px), not the old `base + 1″` (~71.5px).
2. A real **drag-drop** ending with a 1.43″ base gap — which looked legal under the old ring — is refused and the model stays put.
3. A drag-drop ending with a 2.17″ gap, just outside the corrected ring, stages and confirms.

Regression scenarios still pass: `T29_persistent_engagement`, `iss050_fight_11e`, `click_select_unit_movement`, `51_confirm_movement_mode`, and the full `--changed-only` batch (15 scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7iBkCH5K4oEeLHymMRpxG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7iBkCH5K4oEeLHymMRpxG)_