### PR TITLE
Fix Waaagh! advance-and-charge: allow charging after Advancing

### DIFF
--- a/40k/autoloads/FactionAbilityManager.gd
+++ b/40k/autoloads/FactionAbilityManager.gd
@@ -443,6 +443,34 @@ func deactivate_waaagh(player: int) -> void:
 		_clear_waaagh_effects(player)
 		print("FactionAbilityManager: Waaagh! deactivated for player %d" % player)
 
+# The persistent effect_* flags a Waaagh! (army Waaagh!, Da Boss Is Watchin',
+# Plant the Waaagh! Banner, Grab and Bash — all set waaagh_active) grants to a
+# unit. Per the core rules these last "until the start of your next Command
+# phase", so a per-phase blanket effect-flag clear (e.g. ShootingPhase's
+# end-of-phase stratagem cleanup) must NOT strip them.
+const WAAAGH_PERSISTENT_EFFECT_FLAGS := [
+	"effect_advance_and_charge",
+	"effect_invuln", "effect_invuln_source",
+	"effect_fnp", "effect_fnp_source",
+	"effect_crit_hit_on", "effect_crit_hit_on_source",
+	"effect_oc_override", "effect_oc_source",
+]
+
+func snapshot_persistent_ability_flags(flags: Dictionary) -> Dictionary:
+	"""Return a copy of the Waaagh!-granted effect_* flags on a unit so a
+	phase-end blanket effect-flag clear can restore them afterwards. Returns an
+	empty dict when the unit has no active Waaagh! (waaagh_active is set by every
+	Waaagh! variant, so it is the single gate). Bug (2026-07): units that
+	Advanced during an active Waaagh! lost effect_advance_and_charge at the end
+	of the Shooting phase and so could not charge; the 5+ invuln vanished too."""
+	if not flags.get("waaagh_active", false):
+		return {}
+	var preserved := {}
+	for flag_name in WAAAGH_PERSISTENT_EFFECT_FLAGS:
+		if flags.has(flag_name):
+			preserved[flag_name] = flags[flag_name]
+	return preserved
+
 # ---- DA BOSS IS WATCHIN' (Bully Boyz detachment rule) ----
 # At the start of your Command phase, in a turn in which you have not called
 # a Waaagh!, if you have one or more WARBOSS models on the battlefield (or

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.17.5",
+			"date": "2026-07-10",
+			"summary": "Fixed a Waaagh! bug: Ork units that Advanced during an active Waaagh! (or that have Full Throttle, like Stormboyz) can now declare charges in the Charge phase. The Waaagh!'s advance-and-charge and 5+ invulnerable save now correctly last until the start of your next Command phase instead of being wiped at the end of the Shooting phase.",
+			"changes": [
+				"Units eligible to charge after Advancing (Waaagh!, Full Throttle, Kult of Speed's Adrenaline Junkies) are no longer refused a charge with 'advanced or fell back this turn' — the 11th-edition charge check now honours those abilities, matching the Charge-phase eligibility list.",
+				"Waaagh! effects (advance-and-charge, 5+ invulnerable save, and its other buffs) are no longer stripped at the end of the Shooting phase — they now persist until the start of your next Command phase as the rules intend, so an Ork unit that Advanced can still charge and keeps its invuln through the enemy's turn."
+			]
+		},
+		{
 			"version": "0.17.4",
 			"date": "2026-07-10",
 			"summary": "Disembark fixes: disembarked units no longer vanish from the board (previously they were left as invisible 'still embarked' ghosts marked Cannot Disembark), and the Combat Disembark option only appears when enemies are actually close enough to block a normal 3\" set-up.",

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -4376,13 +4376,24 @@ func _clear_phase_flags() -> void:
 			unit.flags.erase("performed_action")
 
 func _clear_stratagem_phase_flags() -> void:
-	"""Clear effect-granted flags from all units at end of shooting phase."""
+	"""Clear effect-granted flags from all units at end of shooting phase.
+
+	The blanket clear expires phase-scoped stratagem effects (Go to Ground,
+	Smokescreen). It must NOT strip Waaagh!-granted effects, which last until
+	the owner's next Command phase (bug 2026-07: a unit that Advanced under an
+	active Waaagh! lost effect_advance_and_charge here and so was refused a
+	charge, and the Waaagh! 5+ invuln vanished after one shooting phase). Snap
+	those flags before the wipe and restore them after."""
+	var fam = get_node_or_null("/root/FactionAbilityManager")
 	var units = game_state_snapshot.get("units", {})
 	for unit_id in units:
 		var unit = units[unit_id]
 		if unit.has("flags"):
 			var flags = unit.flags
+			var preserved = fam.snapshot_persistent_ability_flags(flags) if fam else {}
 			EffectPrimitivesData.clear_all_effect_flags(flags)
+			for flag_name in preserved:
+				flags[flag_name] = preserved[flag_name]
 	# Also tell StratagemManager to clear its phase-scoped effects
 	StratagemManager.on_phase_end(GameStateData.Phase.SHOOTING)
 

--- a/40k/scripts/rules/movetypes/ChargeMove11e.gd
+++ b/40k/scripts/rules/movetypes/ChargeMove11e.gd
@@ -10,7 +10,12 @@ extends MoveType
 ##     end of the turn (24.13) — not a turn-order flag.
 ##
 ## ELIGIBLE IF (11.02): on the battlefield, within 12" of one or more
-## enemy units, unengaged, and did not advance or fall back this turn.
+## enemy units, unengaged, and did not advance or fall back this turn —
+## unless an ability makes the unit eligible anyway (Waaagh! / Full
+## Throttle set effect_advance_and_charge / effect_fall_back_and_charge;
+## Kult of Speed's Adrenaline Junkies is detachment-wide). Mirrors the
+## overrides in ChargePhase._can_unit_charge so the UI list and the
+## DECLARE_CHARGE validator agree.
 
 func _init():
 	id = "charge"
@@ -18,6 +23,10 @@ func _init():
 
 static func _measurement() -> Node:
 	return Engine.get_main_loop().root.get_node("/root/Measurement")
+
+static func _has_adrenaline_junkies(unit: Dictionary) -> bool:
+	var fam = Engine.get_main_loop().root.get_node_or_null("/root/FactionAbilityManager")
+	return fam != null and fam.unit_has_adrenaline_junkies(unit)
 
 func eligible(unit_id: String, board: Dictionary) -> Dictionary:
 	if GameConstants.edition < 11:
@@ -28,10 +37,27 @@ func eligible(unit_id: String, board: Dictionary) -> Dictionary:
 	if _rules().is_unit_engaged(unit_id, board):
 		return {"eligible": false, "reasons": ["engaged units cannot declare a charge"]}
 	var flags = unit.get("flags", {})
-	if flags.get("advanced", false) or flags.get("fell_back", false):
+	# Turbo Boostas (Speedwaaagh!): a hard charge lock no advance-and-charge
+	# effect can override.
+	if flags.get("turbo_boosted", false):
+		return {"eligible": false, "reasons": ["turbo boost locks charging this turn"]}
+	# Adrenaline Junkies does NOT override other charge locks (e.g.
+	# Wazblasta's post-shooting move).
+	var adrenaline = _has_adrenaline_junkies(unit) and not flags.get("wazblasta_no_charge", false)
+	var charge_after_advance = EffectPrimitivesData.has_effect_advance_and_charge(unit) or adrenaline
+	var charge_after_fall_back = EffectPrimitivesData.has_effect_fall_back_and_charge(unit) or adrenaline
+	if flags.get("advanced", false) and not charge_after_advance:
+		return {"eligible": false, "reasons": ["advanced or fell back this turn"]}
+	if flags.get("fell_back", false) and not charge_after_fall_back:
 		return {"eligible": false, "reasons": ["advanced or fell back this turn"]}
 	if flags.get("cannot_charge", false):
-		return {"eligible": false, "reasons": ["unit cannot charge (action/disembark lock, 16.01/18.04)"]}
+		# Advance/Fall Back moves set cannot_charge too — the overrides above
+		# clear that source. Standalone locks (actions 16.01, disembark
+		# 18.04) have no advanced/fell_back flag and stay locked.
+		var overridden = (flags.get("advanced", false) and charge_after_advance) \
+			or (flags.get("fell_back", false) and charge_after_fall_back)
+		if not overridden:
+			return {"eligible": false, "reasons": ["unit cannot charge (action/disembark lock, 16.01/18.04)"]}
 	if _closest_enemy_inches(unit_id, board) > 12.0:
 		return {"eligible": false, "reasons": ["no enemy unit within 12\""]}
 	return {"eligible": true, "reasons": []}

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1190,6 +1190,24 @@
       "status": "covered"
     },
     {
+      "id": "scripts.rules.movetypes.ChargeMove11e.ability_overrides",
+      "description": "ChargeMove11e.eligible honours advance-and-charge / fall-back-and-charge ability overrides (Waaagh!, Full Throttle, Adrenaline Junkies) and the turbo_boosted hard lock, matching ChargePhase._can_unit_charge so an advanced Waaagh! unit is offered a charge.",
+      "scenarios": [
+        "waaagh_advance_then_charge"
+      ],
+      "fidelity": "RULES",
+      "status": "covered"
+    },
+    {
+      "id": "charge.eligibility.waaagh_advance_and_charge",
+      "description": "A unit that Advanced during an active Waaagh! can declare a charge: the Waaagh!'s effect_advance_and_charge (and 5+ invuln) survive the Shooting phase's end-of-phase effect-flag clear and last until the owner's next Command phase.",
+      "scenarios": [
+        "waaagh_advance_then_charge"
+      ],
+      "fidelity": "RULES",
+      "status": "covered"
+    },
+    {
       "id": "movetypes.DisembarkMove",
       "description": "DisembarkMove template enforces tactical/combat set-up distances.",
       "scenarios": [

--- a/40k/tests/saves/waaagh_advance_charge.meta
+++ b/40k/tests/saves/waaagh_advance_charge.meta
@@ -1,0 +1,89 @@
+{
+	"created_at": 1777894597.844,
+	"description": "Waaagh! advance-and-charge fixture: audit_baseline_postdeploy_p2first with Warboss B moved to (400,890) \u2014 16\" from the Contemptor dread \u2014 and P1 CP zeroed to suppress Fire Overwatch pauses. Orks (P2) active in the Command phase.",
+	"game_state": {
+		"active_player": 2,
+		"game_id": "c02b1ee3-2b22-48a0-b65b-3033f9c810e94c65",
+		"is_multiplayer": false,
+		"phase": 6,
+		"player1_difficulty": -1,
+		"player1_type": "HUMAN",
+		"player2_difficulty": -1,
+		"player2_type": "HUMAN",
+		"turn": 1
+	},
+	"preview": {
+		"battle_round": 1,
+		"players": {
+			"1": {
+				"alive_models": 18,
+				"alive_units": 9,
+				"cp": 0,
+				"detachment": "Shield Host",
+				"faction": "Adeptus Custodes",
+				"points": 1000.0,
+				"primary_vp": 0,
+				"secondary_vp": 0,
+				"total_models": 18,
+				"total_units": 9,
+				"unit_names": [
+					"Shield-Captain",
+					"Blade Champion",
+					"Custodian Guard",
+					"Witchseekers",
+					"Witchseekers",
+					"Caladius Grav-tank",
+					"Contemptor-Achillus Dreadnought",
+					"Telemon Heavy Dreadnought",
+					"Shield-captain On Dawneagle Jetbike"
+				],
+				"vp": 0
+			},
+			"2": {
+				"alive_models": 88,
+				"alive_units": 17,
+				"cp": 4,
+				"detachment": "War Horde",
+				"faction": "Orks",
+				"points": 2000.0,
+				"primary_vp": 0,
+				"secondary_vp": 0,
+				"total_models": 88,
+				"total_units": 17,
+				"unit_names": [
+					"Strike Force",
+					"Warboss",
+					"Warboss",
+					"Warboss in Mega Armour",
+					"Boyz",
+					"Boyz",
+					"Battlewagon",
+					"Kommandos",
+					"Painboss",
+					"Weirdboy",
+					"Boyz",
+					"Lootas",
+					"Meganobz",
+					"Wazbom Blastajet",
+					"Kaptin Badrukk",
+					"Ghazghkull Thraka",
+					"Nob with Waaagh! Banner"
+				],
+				"vp": 0
+			}
+		}
+	},
+	"save_info": {
+		"description": "Audit baseline: Round 1 COMMAND phase, P1 active, 16 deployed + 10 in reserves (HACK: undeployed forced to IN_RESERVES via direct status set due to terrain/zone constraints)",
+		"save_type": "manual",
+		"tags": [
+			"audit_2026_05",
+			"postdeploy"
+		]
+	},
+	"tags": [
+		"audit_2026_05",
+		"postdeploy"
+	],
+	"version": "1.1.0"
+}

--- a/40k/tests/saves/waaagh_advance_charge.w40ksave
+++ b/40k/tests/saves/waaagh_advance_charge.w40ksave
@@ -1,0 +1,6188 @@
+{
+	"_serialization": {
+		"game_version": "1.1.0",
+		"serializer": "StateSerializer",
+		"timestamp": 1777894597.85005,
+		"version": "1.1.0"
+	},
+	"board": {
+		"deployment_zones": [
+			{
+				"player": 1.0,
+				"poly": [
+					{
+						"x": 0.0,
+						"y": 0.0
+					},
+					{
+						"x": 44.0,
+						"y": 0.0
+					},
+					{
+						"x": 44.0,
+						"y": 8.0
+					},
+					{
+						"x": 34.0,
+						"y": 8.0
+					},
+					{
+						"x": 34.0,
+						"y": 14.0
+					},
+					{
+						"x": 10.0,
+						"y": 14.0
+					},
+					{
+						"x": 10.0,
+						"y": 8.0
+					},
+					{
+						"x": 0.0,
+						"y": 8.0
+					}
+				]
+			},
+			{
+				"player": 2.0,
+				"poly": [
+					{
+						"x": 0.0,
+						"y": 52.0
+					},
+					{
+						"x": 10.0,
+						"y": 52.0
+					},
+					{
+						"x": 10.0,
+						"y": 46.0
+					},
+					{
+						"x": 34.0,
+						"y": 46.0
+					},
+					{
+						"x": 34.0,
+						"y": 52.0
+					},
+					{
+						"x": 44.0,
+						"y": 52.0
+					},
+					{
+						"x": 44.0,
+						"y": 60.0
+					},
+					{
+						"x": 0.0,
+						"y": 60.0
+					}
+				]
+			}
+		],
+		"objectives": [
+			{
+				"id": "obj_center",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 1200.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_nml_1",
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 880.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_nml_2",
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 1520.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_home_1",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 160.0
+				},
+				"radius_mm": 40.0,
+				"zone": "player1"
+			},
+			{
+				"id": "obj_home_2",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 2240.0
+				},
+				"radius_mm": 40.0,
+				"zone": "player2"
+			}
+		],
+		"size": {
+			"height": 60,
+			"width": 44
+		},
+		"terrain": [],
+		"terrain_features": [
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_1",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 80.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 720.0,
+					"y": 200.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 320.0
+						},
+						"id": "ruins_1_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 680.0,
+							"y": 80.0
+						},
+						"id": "ruins_1_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_2",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2080.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2080.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1040.0,
+					"y": 2200.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						"id": "ruins_2_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2080.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						"id": "ruins_2_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 1080.0,
+							"y": 2320.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_3",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 960.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 440.0,
+					"y": 1080.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						"id": "ruins_3_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 1200.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_4",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1320.0,
+					"y": 1320.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1200.0
+						},
+						"id": "ruins_4_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_5",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 260.0,
+					"y": 1400.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 200.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1600.0
+						},
+						"id": "ruins_5_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1600.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_6",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 800.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 800.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1500.0,
+					"y": 1000.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 200.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 800.0
+						},
+						"id": "ruins_6_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 800.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_7",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 440.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 320.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 200.0
+						},
+						"id": "ruins_7_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 200.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 440.0
+						},
+						"id": "ruins_7_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 440.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 360.0
+						},
+						"id": "ruins_7_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 280.0
+						},
+						"type": "door"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 390.0
+						},
+						"id": "ruins_7_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 250.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "medium",
+				"id": "ruins_8",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 560.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 560.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 440.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 560.0
+						},
+						"id": "ruins_8_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 440.0
+						},
+						"id": "ruins_8_wall_center",
+						"start": {
+							"_type": "Vector2",
+							"x": 280.0,
+							"y": 440.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "ruins_9",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 1840.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 1840.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 2080.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2080.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 1960.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins"
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_10",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 1960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 2200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 2200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 2080.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 1960.0
+						},
+						"id": "ruins_10_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 2200.0
+						},
+						"id": "ruins_10_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "medium",
+				"id": "ruins_11",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 844.852783203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 505.441558837891
+						},
+						{
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 675.147216796875
+						},
+						{
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1014.55847167969
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 760.0
+				},
+				"rotation": -45.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 505.441558837891
+						},
+						"id": "ruins_11_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 844.852783203125
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_12",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 1724.85278320312
+						},
+						{
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 1385.44152832031
+						},
+						{
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 1555.14721679688
+						},
+						{
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1894.55847167969
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 1640.0
+				},
+				"rotation": -45.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 1555.14721679688
+						},
+						"id": "ruins_12_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1894.55847167969
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "woods_1",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 80.0,
+							"y": 640.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 240.0,
+							"y": 640.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 240.0,
+							"y": 800.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 80.0,
+							"y": 800.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 720.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 160.0
+				},
+				"traits": [
+					"difficult_ground"
+				],
+				"type": "woods"
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "woods_2",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1520.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1680.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1680.0,
+							"y": 1760.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1520.0,
+							"y": 1760.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1600.0,
+					"y": 1680.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 160.0
+				},
+				"traits": [
+					"difficult_ground"
+				],
+				"type": "woods"
+			}
+		],
+		"terrain_layout": "layout_2"
+	},
+	"factions": {
+		"1": {
+			"created_date": "2025-03-01",
+			"detachment": "Shield Host",
+			"name": "Adeptus Custodes",
+			"player_name": "",
+			"points": 1000.0,
+			"team_name": ""
+		},
+		"2": {
+			"created_date": "2025-02-20",
+			"detachment": "War Horde",
+			"name": "Orks",
+			"player_name": "",
+			"points": 2000.0,
+			"team_name": ""
+		}
+	},
+	"history": [
+		{
+			"actions": [
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.formations_p1_confirmed",
+							"value": true
+						},
+						{
+							"op": "set",
+							"path": "meta.active_player",
+							"value": 2
+						}
+					],
+					"player": 1.0,
+					"type": "CONFIRM_FORMATIONS"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.formations_p2_confirmed",
+							"value": true
+						}
+					],
+					"player": 2.0,
+					"type": "CONFIRM_FORMATIONS"
+				}
+			],
+			"phase": 0,
+			"turn": 1
+		},
+		{
+			"actions": [
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_A.models.0.position",
+							"value": {
+								"x": 50.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 50.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_SHIELD_CAPTAIN_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_C.models.0.position",
+							"value": {
+								"x": 120.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_C.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 120.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_C"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_BLADE_CHAMPION_A.models.0.position",
+							"value": {
+								"x": 120.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_BLADE_CHAMPION_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 120.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BLADE_CHAMPION_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_B.models.0.position",
+							"value": {
+								"x": 50.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_B.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 50.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_B"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.0.position",
+							"value": {
+								"x": 200.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.1.position",
+							"value": {
+								"x": 280.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.2.position",
+							"value": {
+								"x": 360.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.3.position",
+							"value": {
+								"x": 440.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 200.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 280.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 440.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CUSTODIAN_GUARD_B"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_IN_MEGA_ARMOUR_D.models.0.position",
+							"value": {
+								"x": 200.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_IN_MEGA_ARMOUR_D.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 200.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_IN_MEGA_ARMOUR_D"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.0.position",
+							"value": {
+								"x": 850.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.1.position",
+							"value": {
+								"x": 910.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.2.position",
+							"value": {
+								"x": 970.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.3.position",
+							"value": {
+								"x": 1030.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 850.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 910.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 970.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1030.0,
+							"y": 50.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_C"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WEIRDBOY_J.models.0.position",
+							"value": {
+								"x": 400.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WEIRDBOY_J.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 400.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WEIRDBOY_J"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.0.position",
+							"value": {
+								"x": 1100.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.1.position",
+							"value": {
+								"x": 1160.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.2.position",
+							"value": {
+								"x": 1220.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.3.position",
+							"value": {
+								"x": 1280.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1100.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1160.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1220.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1280.0,
+							"y": 50.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_D"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_PAINBOSS_I.models.0.position",
+							"value": {
+								"x": 300.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_PAINBOSS_I.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 300.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_PAINBOSS_I"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H.models.0.position",
+							"value": {
+								"x": 400.0,
+								"y": 250.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 400.0,
+							"y": 250.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_KAPTIN_BADRUKK_A.models.0.position",
+							"value": {
+								"x": 500.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_KAPTIN_BADRUKK_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 500.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_KAPTIN_BADRUKK_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_TELEMON_HEAVY_DREADNOUGHT_I.models.0.position",
+							"value": {
+								"x": 600.0,
+								"y": 250.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_TELEMON_HEAVY_DREADNOUGHT_I.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 600.0,
+							"y": 250.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_TELEMON_HEAVY_DREADNOUGHT_I"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_NOB_WAAAGH_BANNER_A.models.0.position",
+							"value": {
+								"x": 720.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_NOB_WAAAGH_BANNER_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 720.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_NOB_WAAAGH_BANNER_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_JETBIKE_A.models.0.position",
+							"value": {
+								"x": 1600.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_JETBIKE_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_SHIELD_CAPTAIN_JETBIKE_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_STRIKE_FORCE_A.models.0.position",
+							"value": {
+								"x": 1200.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_STRIKE_FORCE_A.status",
+							"value": 2
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1200.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_STRIKE_FORCE_A"
+				}
+			],
+			"phase": 1,
+			"turn": 1
+		},
+		{
+			"actions": [
+				{
+					"_replay_diffs": [],
+					"type": "END_DEPLOYMENT"
+				}
+			],
+			"phase": 2,
+			"turn": 1
+		},
+		{
+			"actions": [
+				{
+					"_log_text": "Roll-off: Player 1 = 3, Player 2 = 6 \u2014 Player 2 wins!",
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.roll_off_player1_roll",
+							"value": 3
+						},
+						{
+							"op": "set",
+							"path": "meta.roll_off_player2_roll",
+							"value": 6
+						},
+						{
+							"op": "set",
+							"path": "meta.roll_off_winner",
+							"value": 2
+						}
+					],
+					"player": 1.0,
+					"type": "ROLL_FOR_FIRST_TURN"
+				},
+				{
+					"_log_text": "Player 2 chose second \u2014 Player 1 takes the first turn",
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.roll_off_choice",
+							"value": "second"
+						},
+						{
+							"op": "set",
+							"path": "meta.first_turn_player",
+							"value": 1
+						},
+						{
+							"op": "set",
+							"path": "meta.active_player",
+							"value": 1
+						}
+					],
+					"choice": "second",
+					"player": 2.0,
+					"type": "CHOOSE_TURN_ORDER"
+				}
+			],
+			"phase": 3,
+			"turn": 1
+		}
+	],
+	"meta": {
+		"active_player": 2,
+		"battle_round": 1,
+		"created_at": 1777894246.48332,
+		"deployment_type": "crucible_of_battle",
+		"first_turn_player": 2,
+		"formations_p1_confirmed": true,
+		"formations_p2_confirmed": true,
+		"game_id": "c02b1ee3-2b22-48a0-b65b-3033f9c810e94c65",
+		"phase": 6,
+		"roll_off_choice": "first",
+		"roll_off_player1_roll": 3,
+		"roll_off_player2_roll": 6,
+		"roll_off_winner": 2,
+		"turn_number": 1,
+		"version": "1.1.0"
+	},
+	"phase_log": [],
+	"players": {
+		"1": {
+			"bonus_cp_gained_this_round": 0,
+			"cp": 0,
+			"primary_vp": 0,
+			"secondary_vp": 0,
+			"vp": 0
+		},
+		"2": {
+			"bonus_cp_gained_this_round": 0,
+			"cp": 4,
+			"primary_vp": 0,
+			"secondary_vp": 0,
+			"vp": 0
+		}
+	},
+	"secondary_missions": {
+		"active_actions": {
+			"1": [],
+			"2": []
+		},
+		"objective_control_at_turn_start": {
+			"obj_center": 0,
+			"obj_home_1": 0,
+			"obj_home_2": 0,
+			"obj_nml_1": 0,
+			"obj_nml_2": 0
+		},
+		"player_state": {
+			"1": {
+				"active": [
+					{
+						"achieved": false,
+						"action": {},
+						"category": "Purge the Enemy",
+						"id": "no_prisoners",
+						"interaction_details": {},
+						"interaction_type": "",
+						"mission_data": {},
+						"name": "No Prisoners",
+						"number": 14,
+						"pending_interaction": false,
+						"requires_action": false,
+						"scoring": {
+							"conditions": [
+								{
+									"check": "enemy_unit_destroyed",
+									"params": {},
+									"vp": 2
+								}
+							],
+							"max_vp_per_score": 5,
+							"when": "while_active"
+						},
+						"vp_scored": 0
+					},
+					{
+						"achieved": false,
+						"action": {},
+						"category": "Battlefield Supremacy",
+						"id": "display_of_might",
+						"interaction_details": {},
+						"interaction_type": "",
+						"mission_data": {},
+						"name": "Display of Might",
+						"number": 4,
+						"pending_interaction": false,
+						"requires_action": false,
+						"scoring": {
+							"conditions": [
+								{
+									"check": "more_units_wholly_in_no_mans_land_than_opponent",
+									"params": {},
+									"vp": 5
+								}
+							],
+							"when": "end_of_your_turn"
+						},
+						"vp_scored": 0
+					}
+				],
+				"deck": [
+					"secure_no_mans_land",
+					"extend_battle_lines",
+					"a_tempting_target",
+					"bring_it_down",
+					"behind_enemy_lines",
+					"overwhelming_force",
+					"area_denial",
+					"assassination",
+					"deploy_teleport_homer",
+					"defend_stronghold",
+					"storm_hostile_objective",
+					"establish_locus",
+					"marked_for_death",
+					"cull_the_horde",
+					"cleanse",
+					"engage_on_all_fronts"
+				],
+				"discard": [],
+				"initialized": true,
+				"mode": "tactical",
+				"secondary_vp": 0
+			},
+			"2": {
+				"active": [],
+				"deck": [
+					"display_of_might",
+					"bring_it_down",
+					"assassination",
+					"cleanse",
+					"deploy_teleport_homer",
+					"extend_battle_lines",
+					"engage_on_all_fronts",
+					"behind_enemy_lines",
+					"overwhelming_force",
+					"defend_stronghold",
+					"a_tempting_target",
+					"marked_for_death",
+					"secure_no_mans_land",
+					"storm_hostile_objective",
+					"no_prisoners",
+					"area_denial",
+					"cull_the_horde",
+					"establish_locus"
+				],
+				"discard": [],
+				"initialized": true,
+				"mode": "tactical",
+				"secondary_vp": 0
+			}
+		},
+		"units_destroyed_this_turn": []
+	},
+	"unit_visuals": {},
+	"units": {
+		"U_BATTLEWAGON_G": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BATTLEWAGON_G",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D6 mortal wounds.",
+						"name": "Deadly Demise D6",
+						"type": "Core"
+					},
+					{
+						"description": "Firing Deck 11. Each time this transport shoots, up to 11 models embarked within it can be selected to shoot as well. Each time such a model makes a ranged attack, it is treated as if it were not embarked, except that it cannot use any abilities that require it to be on the battlefield.",
+						"name": "FIRING DECK",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model loses one or more wounds, roll one D6: on a 6, this model does not lose a wound.",
+						"name": "Ramshackle",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-5 Wounds Remaining",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Add 2 to this model's Toughness characteristic. If this model is equipped with this wargear, it loses the Firing Deck ability.",
+						"name": "'Ard Case",
+						"type": "Wargear"
+					},
+					{
+						"description": "This model has a transport capacity of 22 ORKS INFANTRY models. Each MEGA ARMOUR model takes up the space of 2 models. This model cannot transport models that are JUMP PACK models.",
+						"name": "TRANSPORT",
+						"type": "Special"
+					}
+				],
+				"display_name": "Battlewagon",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLEWAGON",
+					"ORKS",
+					"TRANSPORT",
+					"VEHICLE"
+				],
+				"name": "Battlewagon",
+				"points": 160.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 10.0,
+					"objective_control": 5.0,
+					"save": 3.0,
+					"toughness": 12.0,
+					"wounds": 16.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Battlewagon",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Deff rolla",
+					"1x Grabbin' klaw",
+					"1x Kannon",
+					"1x Lobba",
+					"1x Wreckin' ball",
+					"1x 'Ard Case"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "D6+3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kannon \u2013 frag",
+						"range": "36",
+						"special_rules": "blast",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "D6",
+						"name": "Kannon \u2013 shell",
+						"range": "36",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D6+1",
+						"ballistic_skill": "5",
+						"damage": "2",
+						"name": "Killkannon",
+						"range": "24",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Lobba",
+						"range": "48",
+						"special_rules": "blast, indirect fire",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "5",
+						"name": "Zzap gun",
+						"range": "36",
+						"special_rules": "anti-vehicle 4+",
+						"strength": "D6+6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Deff rolla",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "2",
+						"damage": "2",
+						"name": "Grabbin' klaw",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "6",
+						"damage": "1",
+						"name": "Tracks and wheels",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"damage": "D6",
+						"name": "Wreckin' ball",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 180.0,
+						"width": 110.0
+					},
+					"base_mm": 180.0,
+					"base_type": "rectangular",
+					"current_wounds": 16.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 16.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_BATTLEWAGON_G",
+			"status": 7,
+			"transport_data": {
+				"capacity": 22,
+				"capacity_keywords": [
+					"ORKS",
+					"INFANTRY"
+				],
+				"capacity_multipliers": {
+					"MEGA ARMOUR": 2
+				},
+				"embarked_units": [],
+				"excluded_keywords": [
+					"JUMP PACK"
+				],
+				"firing_deck": 0
+			}
+		},
+		"U_BLADE_CHAMPION_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BLADE_CHAMPION_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, you can re-roll Charge rolls made for that unit",
+						"name": "Swift Onslaught",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Charge phase, this model's unit is eligible to declare a charge in a turn which it Advanced.",
+						"name": "Martial Inspiration",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Blade Champion",
+				"enhancements": [
+					"Adamantine Talisman (+25 pts)"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BLADE CHAMPION",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"leader_data": {
+					"can_lead": [
+						"CUSTODIAN GUARD"
+					]
+				},
+				"name": "Blade Champion",
+				"points": 145.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Blade Champion",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Vaultswords \u2013 Behemor",
+						"range": "Melee",
+						"special_rules": "precision",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "9",
+						"damage": "1",
+						"name": "Vaultswords \u2013 Hurricanus",
+						"range": "Melee",
+						"special_rules": "sustained hits 1",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-3",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Vaultswords \u2013 Victus",
+						"range": "Melee",
+						"special_rules": "devastating wounds",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 120.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_BLADE_CHAMPION_A",
+			"status": 2
+		},
+		"U_BOYZ_E": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_E",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "If this unit has a Starting Strength of 20, you can attach up to two Leader units to it instead of one (but only if one of those is a WARBOSS model). If you do, and this unit is destroyed, the Leader units attached to it become separate units with their original Starting Strengths.",
+						"name": "BODYGUARD",
+						"type": "Special (\u043f\u0440\u0430\u0432\u0430\u044f \u043a\u043e\u043b\u043e\u043d\u043a\u0430)"
+					}
+				],
+				"display_name": "Boyz Alpha",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9-19 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m12",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m13",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m14",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m15",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m16",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m17",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m18",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m19",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m20",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_BOYZ_E",
+			"status": 7
+		},
+		"U_BOYZ_F": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_F",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "If this unit has a Starting Strength of 20, you can attach up to two Leader units to it instead of one (but only if one of those is a WARBOSS model). If you do, and this unit is destroyed, the Leader units attached to it become separate units with their original Starting Strengths.",
+						"name": "BODYGUARD",
+						"type": "Special (\u043f\u0440\u0430\u0432\u0430\u044f \u043a\u043e\u043b\u043e\u043d\u043a\u0430)"
+					}
+				],
+				"display_name": "Boyz Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"model_profiles": {
+					"boss_nob": {
+						"label": "Boss Nob",
+						"stats_override": {
+							"save": 4.0,
+							"weapon_skill": 3.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Big choppa",
+							"Choppa",
+							"Power klaw",
+							"Slugga",
+							"Kombi-weapon"
+						]
+					},
+					"boy": {
+						"label": "Boy",
+						"stats_override": {
+							"weapon_skill": 4.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Choppa",
+							"Close combat weapon",
+							"Shoota",
+							"Slugga",
+							"Big shoota",
+							"Rokkit launcha"
+						]
+					}
+				},
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9-19 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"model_type": "boss_nob",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m12",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m13",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m14",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m15",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m16",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m17",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m18",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m19",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m20",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_BOYZ_F",
+			"status": 7
+		},
+		"U_BOYZ_K": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_K",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Boyz Gamma",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_BOYZ_K",
+			"status": 7
+		},
+		"U_CALADIUS_GRAV-TANK_E": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_CALADIUS_GRAV-TANK_E",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model makes an attack with its twin iliastus accelerator cannon that targets an enemy unit (excluding MONSTERS and VEHICLES), that attack has the [LETHAL HITS] ability. Each time this model makes an attack with its twin arachnus heavy blaze cannon that targets an enemy MONSTER or VEHICLE unit, that attack has the [LETHAL HITS] ability.",
+						"name": "Advanced Firepower",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-5 Wounds Remaining",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Caladius Grav-tank",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CALADIUS GRAV-TANK",
+					"FLY",
+					"IMPERIUM",
+					"VEHICLE"
+				],
+				"name": "Caladius Grav-tank",
+				"points": 215.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 10.0,
+					"objective_control": 4.0,
+					"save": 2.0,
+					"toughness": 11.0,
+					"wounds": 14.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Caladius Grav-tank",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "4",
+						"ballistic_skill": "2",
+						"damage": "D6+2",
+						"name": "Twin arachnus heavy blaze cannon",
+						"range": "48",
+						"special_rules": "twin-linked",
+						"strength": "12",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "4",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Twin iliastus accelerator cannon",
+						"range": "48",
+						"special_rules": "rapid fire 4, twin-linked",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Twin lastrum bolt cannon",
+						"range": "36",
+						"special_rules": "sustained hits 1",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "4",
+						"damage": "1",
+						"name": "Armoured hull",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 170.0,
+						"width": 105.0
+					},
+					"base_mm": 170.0,
+					"base_type": "oval",
+					"current_wounds": 14.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 14.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_CALADIUS_GRAV-TANK_E",
+			"status": 7
+		},
+		"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers 1 mortal wound.",
+						"name": "Deadly Demise 1",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model is selected to fight, you can select one enemy unit within Engagement Range of it and roll one D6, adding 2 to the result if this model made a Charge move this turn: on a 4-5, that enemy unit suffers D3 mortal wounds; on a 6+, that enemy unit suffers 3 mortal wounds.",
+						"name": "Dread Foe",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Contemptor-Achillus Dreadnought",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CONTEMPTOR-ACHILLUS DREADNOUGHT",
+					"IMPERIUM",
+					"VEHICLE",
+					"WALKER"
+				],
+				"name": "Contemptor-Achillus Dreadnought",
+				"points": 155.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 3.0,
+					"save": 2.0,
+					"toughness": 9.0,
+					"wounds": 10.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Contemptor-Achillus Dreadnought",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Achillus dreadspear",
+						"range": "12",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Infernus incinerator",
+						"range": "12",
+						"special_rules": "torrent, ignores cover",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Twin adrathic destructor",
+						"range": "18",
+						"special_rules": "twin-linked",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "D6+1",
+						"name": "Achillus dreadspear",
+						"range": "Melee",
+						"special_rules": "lance",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 60.0,
+					"current_wounds": 10.0,
+					"id": "m1",
+					"position": {
+						"x": 400.0,
+						"y": 250.0
+					},
+					"status_effects": [],
+					"wounds": 10.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H",
+			"status": 2
+		},
+		"U_CUSTODIAN_GUARD_B": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_CUSTODIAN_GUARD_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					},
+					{
+						"description": "Add 1 to the Objective Control characteristic of models in the bearer's unit.",
+						"name": "Vexilla",
+						"type": "Wargear"
+					},
+					{
+						"description": "Each time a model in this unit makes an attack, re-roll a Wound roll of 1. While this unit is within range of an objective marker you control, you can re-roll the Wound roll instead.",
+						"name": "Stand Vigil",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Shooting phase, after this unit has shot, it can shoot again.",
+						"name": "Sentinel Storm",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Custodian Guard",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BATTLELINE",
+					"CUSTODIAN GUARD",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Custodian Guard",
+				"points": 170.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 3.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "4-5 Custodian Guard",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Custodian Guard",
+					"Custodian Guard (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "24",
+						"special_rules": "assault",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Misericordia",
+						"range": "Melee",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": {
+						"x": 200.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m2",
+					"position": {
+						"x": 280.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m3",
+					"position": {
+						"x": 360.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m4",
+					"position": {
+						"x": 440.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_CUSTODIAN_GUARD_B",
+			"status": 2
+		},
+		"U_GHAZGHKULL_THRAKA_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_GHAZGHKULL_THRAKA_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While a Waaagh! is active for Ghazghkull's army, each time a model in this unit makes a melee attack, add 1 to the Hit roll and the Wound roll. In addition, each time a model in this unit makes a melee attack, a Critical Hit is scored on a 5+ rather than a 6.",
+						"name": "Prophet of Da Great Waaagh!",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While a Waaagh! is active for Ghazghkull's army, friendly ORKS units within 12\" of this unit have the Lethal Hits ability on their melee weapons.",
+						"name": "Ghazghkull's Waaagh! Banner (Aura)",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Ghazghkull Thraka",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"MONSTER",
+					"CHARACTER",
+					"EPIC HERO",
+					"WARBOSS",
+					"GHAZGHKULL THRAKA"
+				],
+				"name": "Ghazghkull Thraka",
+				"points": 300.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 9.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Ghazghkull Thraka",
+						"line": 1.0
+					},
+					{
+						"description": "1 Makari",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"1x Gork's Klaw",
+					"1x Mork's Roar",
+					"1x Makari's Stabba"
+				],
+				"weapons": [
+					{
+						"ap": "-4",
+						"attacks": "5",
+						"damage": "D3+3",
+						"name": "Gork's Klaw",
+						"range": "Melee",
+						"strength": "14",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "D6",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Mork's Roar",
+						"range": "24",
+						"special_rules": "rapid fire 2",
+						"strength": "7",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "4",
+						"damage": "1",
+						"name": "Makari's Stabba",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 100.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 12.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_GHAZGHKULL_THRAKA_A",
+			"status": 7
+		},
+		"U_KAPTIN_BADRUKK_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_KAPTIN_BADRUKK_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a ranged attack, re-roll a Hit roll of 1.",
+						"name": "Flashiest Gitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is on the battlefield, subtract 1 from the Toughness characteristic of enemy INFANTRY units that are within 6\" of this model.",
+						"name": "Ded Glowy Ammo (Aura)",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Kaptin Badrukk can be attached to a Flash Gitz unit.",
+						"name": "Leader",
+						"type": "Core"
+					}
+				],
+				"display_name": "Kaptin Badrukk",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"INFANTRY",
+					"CHARACTER",
+					"FREEBOOTER",
+					"KAPTIN BADRUKK"
+				],
+				"name": "Kaptin Badrukk",
+				"points": 100.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Kaptin Badrukk",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Da Rippa",
+					"1x Kustom mega-blasta",
+					"1x Power klaw"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Da Rippa",
+						"range": "Melee",
+						"special_rules": "lethal hits",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "2",
+						"damage": "D6",
+						"name": "Kustom mega-blasta",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "8",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 500.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_KAPTIN_BADRUKK_A",
+			"status": 2
+		},
+		"U_KOMMANDOS_H": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_KOMMANDOS_H",
+			"meta": {
+				"abilities": [
+					{
+						"description": "During deployment, this unit can be set up anywhere on the battlefield that is more than 9\" horizontally away from the enemy deployment zone and more than 9\" away from all enemy models.",
+						"name": "Infiltrators",
+						"type": "Core"
+					},
+					{
+						"description": "If every model in a unit has this ability, then each time a ranged attack is made against this unit, subtract 1 from the Hit roll.",
+						"name": "Stealth",
+						"type": "Core"
+					},
+					{
+						"description": "After deployment, this unit can make a Normal Move of up to 6\", but must end that move more than 9\" horizontally away from all enemy models.",
+						"name": "Scout 6\"",
+						"range": 6.0,
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the start of your Shooting phase, if this unit is within 9\" of one or more enemy units, it can use this ability. If it does, until the end of the phase, this unit is not eligible to shoot, but you roll one D6 for each model in this unit that is within 9\" of an enemy unit: for each 5+, that enemy unit suffers 1 mortal wound.",
+						"name": "Throat Slittas",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Enemy units cannot use the Fire Overwatch Stratagem to shoot at this unit.",
+						"name": "Sneaky Surprise",
+						"type": "Datasheet"
+					},
+					{
+						"description": "At the start of the Declare Battle Formations step, this unit can be split into two units, each containing five models.",
+						"name": "Patrol Squad",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your opponent's Shooting phase, when this unit is selected as the target of a ranged attack, until the end of the phase, models in this unit have a 5+ invulnerable save.",
+						"name": "Distraction Grot",
+						"type": "Wargear"
+					},
+					{
+						"description": "Once per battle, after this unit ends a Normal move, you can select one enemy unit within 12\" of and visible to this unit and roll one D6: on a 3+, that enemy unit suffers D3 mortal wounds.",
+						"name": "Bomb Squigs",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Kommandos",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"GRENADES",
+					"INFANTRY",
+					"KOMMANDOS",
+					"ORKS"
+				],
+				"name": "Kommandos",
+				"points": 135.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9 Kommandos",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"10x Choppa",
+					"10x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_KOMMANDOS_H",
+			"status": 7
+		},
+		"U_LOOTAS_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_LOOTAS_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "If your Army Faction is ORKS, once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase, the Waaagh! is active for your army and:\n- Units from your army with this ability are eligible to declare a charge in a turn in which they Advanced.\n- Add 1 to the Strength and Attacks characteristics of melee weapons equipped by models from your army with this ability.\n- Models from your army with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time a model in this unit makes a ranged attack, re-roll a Hit roll of 1. If that attack targets a unit that is within range of an objective marker, you can re-roll the Hit roll instead.",
+						"name": "Dat's Our Loot!",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Lootas",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"LOOTAS",
+					"INFANTRY"
+				],
+				"model_profiles": {
+					"loota_deffgun": {
+						"label": "Loota (Deffgun)",
+						"stats_override": {},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Deffgun",
+							"Close combat weapon"
+						]
+					},
+					"loota_kmb": {
+						"label": "Loota (Kustom Mega-blasta)",
+						"stats_override": {},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Kustom mega-blasta",
+							"Close combat weapon"
+						]
+					},
+					"spanner": {
+						"label": "Spanner",
+						"stats_override": {
+							"ballistic_skill": 4.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Kustom mega-blasta",
+							"Close combat weapon"
+						]
+					}
+				},
+				"name": "Lootas",
+				"points": 100.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Spanner",
+						"line": 1.0
+					},
+					{
+						"description": "8 Lootas",
+						"line": 2.0
+					},
+					{
+						"description": "2 Lootas (KMB)",
+						"line": 3.0
+					}
+				],
+				"wargear": [
+					"1x Spanner",
+					"1x Close combat weapon",
+					"1x Kustom mega-blasta",
+					"2x Loota (KMB)",
+					"2x Close combat weapon",
+					"2x Kustom mega-blasta",
+					"8x Loota",
+					"8x Close combat weapon",
+					"8x Deffgun"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "6",
+						"damage": "2",
+						"name": "Deffgun",
+						"range": "48",
+						"special_rules": "heavy, rapid fire 1",
+						"strength": "8",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "D6",
+						"name": "Kustom mega-blasta",
+						"range": "24",
+						"special_rules": "hazardous",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"model_type": "loota_kmb",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"model_type": "loota_kmb",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"model_type": "spanner",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_LOOTAS_A",
+			"status": 7
+		},
+		"U_MEGANOBZ_L": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_MEGANOBZ_L",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time a model in this unit makes a melee attack, if this unit made a Charge move this turn, add 1 to the Wound roll.",
+						"name": "Krumpin' Time",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Meganobz",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"INFANTRY",
+					"MEGA ARMOUR",
+					"ORKS",
+					"MEGANOBZ",
+					"GRENADES"
+				],
+				"model_profiles": {
+					"meganob_klaw": {
+						"label": "Meganob (Power Klaw)",
+						"stats_override": {},
+						"transport_slots": 2.0,
+						"weapons": [
+							"Kustom shoota",
+							"Power klaw"
+						]
+					},
+					"meganob_saws": {
+						"label": "Meganob (Killsaws)",
+						"stats_override": {},
+						"transport_slots": 2.0,
+						"weapons": [
+							"Kustom shoota",
+							"Killsaws"
+						]
+					}
+				},
+				"name": "Meganobz",
+				"points": 160.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 5.0,
+					"objective_control": 1.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "2-6 Meganobz",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "4",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kustom shoota",
+						"range": "18",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-3",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Killsaws",
+						"range": "Melee",
+						"special_rules": "twin-linked",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m2",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m3",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m4",
+					"model_type": "meganob_saws",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m5",
+					"model_type": "meganob_saws",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_MEGANOBZ_L",
+			"status": 7
+		},
+		"U_NOB_WAAAGH_BANNER_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_NOB_WAAAGH_BANNER_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, at the start of the battle round, this model can use this ability. If it does, until the start of the next battle round, this model's unit gains the benefits of the Waaagh! ability as if you had called a Waaagh! this battle round.",
+						"name": "Plant the Waaagh! Banner",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is gaining the benefits of the Waaagh! ability, it has a 4+ invulnerable save and an Objective Control characteristic of 5.",
+						"name": "Da Boss Iz Watchin'",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Nob with Waaagh! Banner can be attached to a Boyz, Breaka Boyz, or Nobz unit.",
+						"name": "Leader",
+						"type": "Core"
+					}
+				],
+				"display_name": "Nob with Waaagh! Banner",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"NOB WITH WAAAGH! BANNER",
+					"INFANTRY",
+					"CHARACTER"
+				],
+				"name": "Nob with Waaagh! Banner",
+				"points": 70.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Nob with Waaagh! Banner",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kustom shoota",
+					"1x Waaagh! banner"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "4",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kustom shoota",
+						"range": "18",
+						"special_rules": "rapid fire 2",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Waaagh! banner",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"position": {
+						"x": 720.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_NOB_WAAAGH_BANNER_A",
+			"status": 2
+		},
+		"U_PAINBOSS_I": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_PAINBOSS_I",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Each time this model would lose a wound, roll one D6: on a 5+, that wound is not lost.",
+						"name": "Feel No Pain 5+",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, models in that unit have the Feel No Pain 5+ ability.",
+						"name": "Dok's Toolz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "At the end of your Movement phase, you can select one friendly BEAST SNAGGA CHARACTER model within 3\" of this model. That model regains up to 3 lost wounds.",
+						"name": "Sawbonez",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is leading a unit, that unit is eligible to declare a charge in a turn in which it Fell Back.",
+						"name": "One Scalpel Short of a Medpack",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, if the bearer's unit is below its Starting Strength, you can return up to D3 destroyed Bodyguard models to that unit.",
+						"name": "Grot Orderly",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Painboss",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"BEAST SNAGGA",
+					"ORKS",
+					"PAINBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BEAST SNAGGA BOYZ",
+						"BOYZ"
+					]
+				},
+				"name": "Painboss",
+				"points": 70.0,
+				"stats": {
+					"fnp": 5.0,
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Painboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Beast Snagga klaw",
+					"1x Grot Orderly"
+				],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Beast Snagga klaw",
+						"range": "Melee",
+						"special_rules": "anti-monster 4+, anti-vehicle 4+",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": {
+						"x": 300.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_PAINBOSS_I",
+			"status": 2
+		},
+		"U_SHIELD_CAPTAIN_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_SHIELD_CAPTAIN_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, when this model's unit is selected to fight, it can use this ability. If it does, until that fight is resolved, both Ka'tah Stances are active for that unit instead of only one.",
+						"name": "Master of the Stances",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle round, you can select one model from your army with this ability and target that model's unit with a Stratagem. If you do, reduce the CP cost of that use of that Stratagem by 1CP.",
+						"name": "Strategic Mastery",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Shield-Captain",
+				"enhancements": [],
+				"is_warlord": true,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY",
+					"SHIELD-CAPTAIN"
+				],
+				"leader_data": {
+					"can_lead": [
+						"CUSTODIAN GUARD"
+					]
+				},
+				"name": "Shield-Captain",
+				"points": 120.0,
+				"stats": {
+					"invuln": 4.0,
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 7.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Shield-Captain",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Shield-Captain (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "7",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 7.0,
+					"id": "m1",
+					"position": {
+						"x": 50.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 7.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_SHIELD_CAPTAIN_A",
+			"status": 2
+		},
+		"U_SHIELD_CAPTAIN_JETBIKE_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_SHIELD_CAPTAIN_JETBIKE_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "This model can be attached to a unit of Vertus Praetors.",
+						"name": "Leader",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, at the end of the Fight phase, if this model's unit has fought this phase, if it is within Engagement Range of one or more enemy units, it can make a Fall Back move or, if it is not within Engagement Range of one or more enemy units, it can make a Normal move",
+						"name": "Sweeping Advance",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle round, you can select one model from your army with this ability and target that model's unit with a Stratagem. If you do, reduce the CP cost of that use of that Stratagem by 1CP.",
+						"name": "Strategic Mastery",
+						"type": "Datasheet"
+					}
+				],
+				"base_dimensions": {
+					"length": 75.0,
+					"width": 42.0
+				},
+				"base_type": "oval",
+				"display_name": "Shield-captain On Dawneagle Jetbike",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"MOUNTED",
+					"CHARACTER",
+					"FLY",
+					"SHIELD-CAPTAIN",
+					"DAWNEAGLE JETBIKE",
+					"IMPERIUM"
+				],
+				"leader_data": {
+					"can_lead": [
+						"VERTUS PRAETORS"
+					]
+				},
+				"name": "Shield-captain On Dawneagle Jetbike",
+				"points": 150.0,
+				"stats": {
+					"invuln": 4.0,
+					"leadership": 6.0,
+					"move": 12.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 7.0,
+					"wounds": 8.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Shield-Captain on Dawneagle Jetbike",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "D6+1",
+						"name": "Salvo launcher",
+						"range": "24",
+						"special_rules": "twin-linked",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Interceptor lance",
+						"range": "Melee",
+						"special_rules": "lance",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 75.0,
+						"width": 42.0
+					},
+					"base_mm": 75.0,
+					"base_type": "oval",
+					"current_wounds": 8.0,
+					"id": "m1",
+					"position": {
+						"x": 1600.0,
+						"y": 100.0
+					},
+					"status_effects": [],
+					"wounds": 8.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_SHIELD_CAPTAIN_JETBIKE_A",
+			"status": 2
+		},
+		"U_STRIKE_FORCE_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_STRIKE_FORCE_A",
+			"meta": {
+				"display_name": "Strike Force",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"UNKNOWN"
+				],
+				"name": "Strike Force",
+				"points": 2000.0,
+				"stats": {
+					"move": 6.0,
+					"save": 3.0,
+					"toughness": 4.0
+				},
+				"wargear": []
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": {
+						"x": 1200.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_STRIKE_FORCE_A",
+			"status": 2
+		},
+		"U_TELEMON_HEAVY_DREADNOUGHT_I": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_TELEMON_HEAVY_DREADNOUGHT_I",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time an attack is allocated to this model, subtract 1 from the Damage characteristic of that attack.",
+						"name": "Guardian Eternal",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-4 Wounds Remaining",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Telemon Heavy Dreadnought",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"IMPERIUM",
+					"TELEMON HEAVY DREADNOUGHT",
+					"VEHICLE",
+					"WALKER"
+				],
+				"name": "Telemon Heavy Dreadnought",
+				"points": 265.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 8.0,
+					"objective_control": 5.0,
+					"save": 2.0,
+					"toughness": 12.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Telemon Heavy Dreadnought",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Telemon Caestus",
+						"range": "12",
+						"special_rules": "twin-linked",
+						"strength": "7",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "6",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Spiculus bolt launcher",
+						"range": "36",
+						"special_rules": "",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "8",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Iliastus accelerator culverin",
+						"range": "48",
+						"special_rules": "",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Telemon Caestus",
+						"range": "Melee",
+						"special_rules": "",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "16",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Telemon Storm Cannon",
+						"range": "72",
+						"special_rules": "",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-4",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "D6+1",
+						"name": "Twin arachnus las-blaze",
+						"range": "48",
+						"special_rules": "twin-linked",
+						"strength": "14",
+						"type": "Ranged"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 100.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": {
+						"x": 600.0,
+						"y": 250.0
+					},
+					"status_effects": [],
+					"wounds": 12.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_TELEMON_HEAVY_DREADNOUGHT_I",
+			"status": 2
+		},
+		"U_WARBOSS_B": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WARBOSS_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, add 4 to the Attacks characteristic of this model's melee weapons.",
+						"name": "Da Biggest and da Best",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss Alpha",
+				"enhancements": [],
+				"is_warlord": true,
+				"keywords": [
+					"CHARACTER",
+					"GRENADES",
+					"INFANTRY",
+					"ORKS",
+					"WARBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss",
+				"points": 75.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kombi-weapon",
+					"1x Power klaw",
+					"1x Twin sluggas"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Twin slugga",
+						"range": "12",
+						"special_rules": "pistol, twin-linked",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Attack squig",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 400.0,
+						"y": 890.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_WARBOSS_B",
+			"status": 2
+		},
+		"U_WARBOSS_C": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WARBOSS_C",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, add 4 to the Attacks characteristic of this model's melee weapons.",
+						"name": "Da Biggest and da Best",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"GRENADES",
+					"INFANTRY",
+					"ORKS",
+					"WARBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss",
+				"points": 75.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kombi-weapon",
+					"1x Power klaw",
+					"1x Twin sluggas"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Twin slugga",
+						"range": "12",
+						"special_rules": "pistol, twin-linked",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Attack squig",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 120.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_WARBOSS_C",
+			"status": 2
+		},
+		"U_WARBOSS_IN_MEGA_ARMOUR_D": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WARBOSS_IN_MEGA_ARMOUR_D",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, this model's 'uge choppa has a Damage characteristic of 3.",
+						"name": "Dead Brutal",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss in Mega Armour",
+				"enhancements": [
+					"Tellyporta"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"MEGA ARMOUR",
+					"ORKS",
+					"WARBOSS",
+					"WARBOSS IN MEGA ARMOUR"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss in Mega Armour",
+				"points": 115.0,
+				"stats": {
+					"fnp": 5.0,
+					"leadership": 6.0,
+					"move": 5.0,
+					"objective_control": 1.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 7.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss in Mega Armour",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x 'Uge choppa"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "4",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "'Uge choppa",
+						"range": "Melee",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 50.0,
+					"current_wounds": 7.0,
+					"id": "m1",
+					"position": {
+						"x": 200.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 7.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_WARBOSS_IN_MEGA_ARMOUR_D",
+			"status": 2
+		},
+		"U_WAZBOM_BLASTAJET": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WAZBOM_BLASTAJET",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Deadly Demise D3",
+						"name": "Deadly Demise",
+						"parameter": "D3",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model makes a ranged attack that targets a unit that cannot FLY, re-roll a Hit roll of 1.",
+						"name": "Blastajet Attack Run",
+						"type": "Datasheet"
+					}
+				],
+				"damaged_profile": {
+					"description": "While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+					"wounds_remaining": "1-4"
+				},
+				"display_name": "Wazbom Blastajet",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"WAZBOM BLASTAJET",
+					"ORKS",
+					"GRENADES",
+					"AIRCRAFT",
+					"VEHICLE",
+					"SPEED FREEKS",
+					"FLY"
+				],
+				"name": "Wazbom Blastajet",
+				"points": 175.0,
+				"stats": {
+					"invulnerable_save": 6.0,
+					"leadership": 7.0,
+					"move": 20.0,
+					"objective_control": 0.0,
+					"save": 3.0,
+					"toughness": 9.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Wazbom Blastajet",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "D3",
+						"ballistic_skill": "4",
+						"damage": "4",
+						"name": "Smasha gun",
+						"range": "48",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "4",
+						"damage": "D6",
+						"name": "Twin wazbom mega-kannon",
+						"range": "36",
+						"special_rules": "blast, hazardous, twin-linked",
+						"strength": "12",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Armoured hull",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 120.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 12.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_WAZBOM_BLASTAJET",
+			"status": 7
+		},
+		"U_WEIRDBOY_J": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WEIRDBOY_J",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, add 1 to the Strength and Damage characteristics of this model's 'Eadbanger weapon for every 5 models in that unit (rounding down), but while that unit contains 10 or more models, that weapon has the [HAZARDOUS] ability.",
+						"name": "Waaagh! Energy",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per turn, at the end of your Movement phase, one WEIRDBOY from your army can use this ability. If it does, roll one D6: on a 1, that WEIRDBOY's unit suffers D6 mortal wounds; on a 2+, remove this WEIRDBOY's unit from the battlefield and set it up again anywhere on the battlefield that is more than 9\" horizontally away from all enemy models.",
+						"name": "Da Jump",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Weirdboy",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"PSYKER",
+					"ORKS",
+					"WEIRDBOY"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Weirdboy",
+				"points": 65.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Weirdboy",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x 'Eadbanger",
+					"1x Weirdboy staff"
+				],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "4",
+						"damage": "1",
+						"name": "'Eadbanger",
+						"range": "24",
+						"special_rules": "precision, psychic",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "D3",
+						"name": "Weirdboy staff",
+						"range": "Melee",
+						"special_rules": "psychic",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": {
+						"x": 400.0,
+						"y": 2330.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 2,
+			"squad_id": "U_WEIRDBOY_J",
+			"status": 2
+		},
+		"U_WITCHSEEKERS_C": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WITCHSEEKERS_C",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"parameter": "6\"",
+						"type": "Core"
+					},
+					{
+						"description": "Models in this unit have the Feel No Pain 3+ ability against Psychic Attacks and mortal wounds.",
+						"name": "Daughters of the Abyss",
+						"type": "Datasheet"
+					},
+					{
+						"description": "In your Shooting phase, after this unit has shot, select one enemy unit hit by one or more of those attacks. That enemy unit must take a Battle-shock test.",
+						"name": "Sanctified Flames",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Witchseekers Alpha",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"ANATHEMA PSYKANA",
+					"IMPERIUM",
+					"INFANTRY",
+					"WITCHSEEKERS"
+				],
+				"name": "Witchseekers",
+				"points": 50.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 3.0,
+					"toughness": 3.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Witchseeker Sister Superior",
+						"line": 1.0
+					},
+					{
+						"description": "3-9 Witchseekers",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"Witchseeker Sister Superior",
+					"Witchseeker"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Witchseeker flamer",
+						"range": "12",
+						"special_rules": "ignores cover, torrent",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": {
+						"x": 850.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": {
+						"x": 910.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": {
+						"x": 970.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": {
+						"x": 1030.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_WITCHSEEKERS_C",
+			"status": 2
+		},
+		"U_WITCHSEEKERS_D": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WITCHSEEKERS_D",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"parameter": "6\"",
+						"type": "Core"
+					},
+					{
+						"description": "Models in this unit have the Feel No Pain 3+ ability against Psychic Attacks and mortal wounds.",
+						"name": "Daughters of the Abyss",
+						"type": "Datasheet"
+					},
+					{
+						"description": "In your Shooting phase, after this unit has shot, select one enemy unit hit by one or more of those attacks. That enemy unit must take a Battle-shock test.",
+						"name": "Sanctified Flames",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Witchseekers Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"ANATHEMA PSYKANA",
+					"IMPERIUM",
+					"INFANTRY",
+					"WITCHSEEKERS"
+				],
+				"name": "Witchseekers",
+				"points": 65.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 3.0,
+					"toughness": 3.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Witchseeker Sister Superior",
+						"line": 1.0
+					},
+					{
+						"description": "3-9 Witchseekers",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"Witchseeker Sister Superior",
+					"Witchseeker"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Witchseeker flamer",
+						"range": "12",
+						"special_rules": "ignores cover, torrent",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": {
+						"x": 1100.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": {
+						"x": 1160.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": {
+						"x": 1220.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": {
+						"x": 1280.0,
+						"y": 50.0
+					},
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_WITCHSEEKERS_D",
+			"status": 2
+		}
+	}
+}

--- a/40k/tests/scenarios/sp/waaagh_advance_then_charge.json
+++ b/40k/tests/scenarios/sp/waaagh_advance_then_charge.json
@@ -1,0 +1,74 @@
+{
+  "id": "waaagh_advance_then_charge",
+  "covers": [
+    "charge.eligibility.waaagh_advance_and_charge",
+    "scripts.rules.movetypes.ChargeMove11e.ability_overrides"
+  ],
+  "fixture": "waaagh_advance_charge",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "description": "Waaagh! advance-and-charge (bug report 2026-07-10): an Ork unit that Advanced while the Waaagh! is active must be allowed to DECLARE_CHARGE. Full player path: P2 (Orks) calls the Waaagh! in the Command phase, Advances Warboss B from 16\" toward the Contemptor-Achillus Dreadnought (declining the Command Re-roll offer), ends within 12\", then in the Charge phase the unit is listed as charge-eligible and DECLARE_CHARGE succeeds. Before the ChargeMove11e fix the declaration failed with 'advanced or fell back this turn' even though the Waaagh! grants effect_advance_and_charge. Fixture note (documented setup privilege): P1 CP is zeroed so Fire Overwatch offers never pause the single-thread flow.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 6 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "execute_script", "script": "FactionAbilityManager.is_waaagh_available(2)", "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "CALL_WAAAGH" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.waaagh_active", "equals": true },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.effect_advance_and_charge", "equals": true },
+    { "act": "screenshot", "label": "01_waaagh_called" },
+
+    { "act": "dispatch_action", "action": { "type": "END_COMMAND" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 7 },
+
+    { "act": "dispatch_action", "action": { "type": "BEGIN_ADVANCE", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_COMMAND_REROLL", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "SET_MODEL_DEST",
+      "actor_unit_id": "U_WARBOSS_B",
+      "payload": { "model_id": "m1", "dest": [400, 620] }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_UNIT_MOVE", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.advanced", "equals": true },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.cannot_charge", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "02_warboss_advanced_toward_dread" },
+
+    { "act": "dispatch_action", "action": { "type": "END_MOVEMENT" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 8 },
+    { "act": "dispatch_action", "action": { "type": "END_SHOOTING" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 9 },
+
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.effect_advance_and_charge", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().get_eligible_charge_units().has(\"U_WARBOSS_B\")", "equals": true },
+    { "act": "screenshot", "label": "03_charge_phase_warboss_eligible" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DECLARE_CHARGE",
+      "actor_unit_id": "U_WARBOSS_B",
+      "payload": { "target_unit_ids": ["U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H"] }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "CHARGE_ROLL", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_COMMAND_REROLL", "actor_unit_id": "U_WARBOSS_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "04_charge_declared_and_rolled" }
+  ]
+}

--- a/40k/tests/test_waaagh_advance_charge.gd
+++ b/40k/tests/test_waaagh_advance_charge.gd
@@ -1,0 +1,176 @@
+extends SceneTree
+
+# Waaagh! advance-and-charge (bug report 2026-07-10): Ork units that Advanced
+# while the Waaagh! is active must be able to declare a charge, but the 11e
+# charge template (ChargeMove11e.eligible) rejected every unit with the
+# advanced/fell_back/cannot_charge flags without checking the ability
+# overrides (effect_advance_and_charge / effect_fall_back_and_charge from
+# Waaagh! or Full Throttle, Adrenaline Junkies detachment rule) that the
+# legacy path (ChargePhase._can_unit_charge) honours. The UI listed the unit
+# as eligible, then DECLARE_CHARGE failed with "advanced or fell back this
+# turn".
+#
+# Usage: godot --headless --path . -s tests/test_waaagh_advance_charge.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _board() -> Dictionary:
+	return {"units": {
+		"U_BOYZ": {"id": "U_BOYZ", "owner": 1, "flags": {},
+			"meta": {"name": "Boyz", "keywords": ["INFANTRY", "ORKS"], "stats": {}},
+			"models": [{"id": "m0", "alive": true, "base_mm": 32, "base_type": "circular",
+				"position": {"x": 500, "y": 500}}]},
+		"U_FOE": {"id": "U_FOE", "owner": 2, "flags": {},
+			"meta": {"name": "Foe", "keywords": ["INFANTRY"], "stats": {}},
+			"models": [{"id": "e0", "alive": true, "base_mm": 32, "base_type": "circular",
+				"position": {"x": 700, "y": 500}}]},
+	}, "meta": {}}
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_waaagh_advance_charge ===\n")
+	GameConstants.edition = 11
+	var chg: MoveType = MoveTypes.get_type("charge")
+
+	print("-- 11e template: advance/fall-back overrides --")
+	var b = _board()
+	_check("baseline: unit with no flags is eligible", chg.eligible("U_BOYZ", b).eligible,
+		str(chg.eligible("U_BOYZ", b)))
+
+	# Advance with no ability: blocked (11.02).
+	b = _board()
+	b.units["U_BOYZ"].flags["advanced"] = true
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	var el = chg.eligible("U_BOYZ", b)
+	_check("advanced without ability cannot charge", not el.eligible, str(el))
+
+	# Advance while Waaagh!/Full Throttle grants advance-and-charge: eligible.
+	# The Advance move sets BOTH advanced and cannot_charge — both must be
+	# overridden by the effect flag.
+	b = _board()
+	b.units["U_BOYZ"].flags["advanced"] = true
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	b.units["U_BOYZ"].flags["effect_advance_and_charge"] = true
+	el = chg.eligible("U_BOYZ", b)
+	_check("advanced WITH advance_and_charge effect (Waaagh!) is eligible", el.eligible, str(el))
+
+	# Fall back with fall_back_and_charge (Full Throttle): eligible.
+	b = _board()
+	b.units["U_BOYZ"].flags["fell_back"] = true
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	b.units["U_BOYZ"].flags["effect_fall_back_and_charge"] = true
+	el = chg.eligible("U_BOYZ", b)
+	_check("fell back WITH fall_back_and_charge effect is eligible", el.eligible, str(el))
+
+	# The advance effect does NOT excuse a fall back (and vice versa).
+	b = _board()
+	b.units["U_BOYZ"].flags["fell_back"] = true
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	b.units["U_BOYZ"].flags["effect_advance_and_charge"] = true
+	el = chg.eligible("U_BOYZ", b)
+	_check("advance effect does not override a fall back", not el.eligible, str(el))
+
+	# Turbo Boostas: hard lock that no advance-and-charge effect overrides.
+	b = _board()
+	b.units["U_BOYZ"].flags["advanced"] = true
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	b.units["U_BOYZ"].flags["effect_advance_and_charge"] = true
+	b.units["U_BOYZ"].flags["turbo_boosted"] = true
+	el = chg.eligible("U_BOYZ", b)
+	_check("turbo_boosted is a hard lock (effect cannot override)", not el.eligible, str(el))
+
+	# A standalone cannot_charge lock (action 16.01 / disembark 18.04 — no
+	# advanced/fell_back flag) is NOT overridable by the effect.
+	b = _board()
+	b.units["U_BOYZ"].flags["cannot_charge"] = true
+	b.units["U_BOYZ"].flags["effect_advance_and_charge"] = true
+	el = chg.eligible("U_BOYZ", b)
+	_check("standalone cannot_charge lock (action/disembark) stays locked", not el.eligible, str(el))
+
+	print("\n-- real Waaagh! activation path (FactionAbilityManager) --")
+	var fam = root.get_node_or_null("FactionAbilityManager")
+	var gs = root.get_node_or_null("GameState")
+	_check("FactionAbilityManager + GameState autoloads present", fam != null and gs != null)
+	if fam != null and gs != null:
+		gs.state.units["U_WAAAGH_TEST"] = {"id": "U_WAAAGH_TEST", "owner": 2, "flags": {},
+			"meta": {"name": "Test Boyz", "keywords": ["INFANTRY", "ORKS"],
+				"abilities": [{"name": "Waaagh!", "type": "Faction"}], "stats": {}},
+			"models": [{"id": "m0", "alive": true, "base_mm": 32, "base_type": "circular",
+				"position": {"x": 500, "y": 500}}]}
+		gs.state.units["U_WAAAGH_FOE"] = {"id": "U_WAAAGH_FOE", "owner": 1, "flags": {},
+			"meta": {"name": "Test Foe", "keywords": ["INFANTRY"], "stats": {}},
+			"models": [{"id": "e0", "alive": true, "base_mm": 32, "base_type": "circular",
+				"position": {"x": 700, "y": 500}}]}
+		fam.detect_faction_abilities(2)
+		_check("player 2 detected as having Waaagh!", fam.player_has_ability(2, "Waaagh!"))
+		var act = fam.activate_waaagh(2)
+		_check("activate_waaagh succeeds", act.get("success", false), str(act))
+		var test_unit = gs.state.units["U_WAAAGH_TEST"]
+		_check("Waaagh! sets effect_advance_and_charge on the unit",
+			test_unit.flags.get("effect_advance_and_charge", false), str(test_unit.flags))
+		# Simulate the Advance move's flags, then ask the 11e template.
+		test_unit.flags["advanced"] = true
+		test_unit.flags["cannot_charge"] = true
+		el = chg.eligible("U_WAAAGH_TEST", gs.state)
+		_check("advanced unit is charge-eligible while Waaagh! is active", el.eligible, str(el))
+		# Waaagh! over: the unit goes back to being blocked after advancing.
+		fam.deactivate_waaagh(2)
+		el = chg.eligible("U_WAAAGH_TEST", gs.state)
+		_check("after Waaagh! ends, advanced unit is blocked again", not el.eligible, str(el))
+		gs.state.units.erase("U_WAAAGH_TEST")
+		gs.state.units.erase("U_WAAAGH_FOE")
+
+	print("\n-- Shooting-phase blanket clear preserves Waaagh! effects --")
+	# Bug 2026-07: ShootingPhase._clear_stratagem_phase_flags blanket-erased
+	# every effect_* flag at end of phase, stripping the Waaagh!'s
+	# effect_advance_and_charge + effect_invuln (which last until the owner's
+	# next Command phase) — so a unit that Advanced under a Waaagh! could not
+	# charge, and its 5+ invuln vanished. Reproduce the snapshot→wipe→restore.
+	if fam != null:
+		# A Waaagh! unit that ALSO has a genuine phase-scoped stratagem effect
+		# (effect_cover from Go to Ground): Waaagh! flags survive, cover clears.
+		var waaagh_flags = {
+			"waaagh_active": true,
+			"effect_advance_and_charge": true,
+			"effect_invuln": 5,
+			"effect_invuln_source": "Waaagh!",
+			"effect_cover": true,
+		}
+		var preserved = fam.snapshot_persistent_ability_flags(waaagh_flags)
+		EffectPrimitivesData.clear_all_effect_flags(waaagh_flags)
+		for k in preserved:
+			waaagh_flags[k] = preserved[k]
+		_check("Waaagh! effect_advance_and_charge survives the blanket clear",
+			waaagh_flags.get("effect_advance_and_charge", false), str(waaagh_flags))
+		_check("Waaagh! effect_invuln survives the blanket clear",
+			int(waaagh_flags.get("effect_invuln", 0)) == 5, str(waaagh_flags))
+		_check("phase-scoped effect_cover is still cleared for the Waaagh! unit",
+			not waaagh_flags.has("effect_cover"), str(waaagh_flags))
+
+		# A unit WITHOUT an active Waaagh! keeps the old behaviour: everything
+		# effect_* is wiped (no preservation).
+		var plain_flags = {"effect_advance_and_charge": true, "effect_cover": true}
+		var plain_preserved = fam.snapshot_persistent_ability_flags(plain_flags)
+		EffectPrimitivesData.clear_all_effect_flags(plain_flags)
+		for k in plain_preserved:
+			plain_flags[k] = plain_preserved[k]
+		_check("non-Waaagh unit's effect flags are fully cleared",
+			not plain_flags.has("effect_advance_and_charge") and not plain_flags.has("effect_cover"),
+			str(plain_flags))
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_waaagh_advance_charge.gd.uid
+++ b/40k/tests/test_waaagh_advance_charge.gd.uid
@@ -1,0 +1,1 @@
+uid://d26lvxck4eblb


### PR DESCRIPTION
## Summary

Orks that Advanced during an active Waaagh! (or that have **Full Throttle**, e.g. Stormboyz) were refused a charge in the Charge phase with _"units that have advanced or fallen back are not able to charge"_. This was two independent bugs — both root-caused by driving the running game and probing live state, not by inspection alone.

### Bug 1 — the 11e charge check ignored the ability
`ChargeMove11e.eligible` (the 11th-edition charge-eligibility template) rejected any unit flagged `advanced` / `fell_back` / `cannot_charge` **without** checking the advance-and-charge / fall-back-and-charge overrides (`effect_advance_and_charge` / `effect_fall_back_and_charge` from Waaagh! and Full Throttle, plus Kult of Speed's **Adrenaline Junkies**), unlike the legacy `ChargePhase._can_unit_charge` path. The Charge-phase UI listed the unit as eligible, then `DECLARE_CHARGE` failed. The template now mirrors the legacy overrides and adds the `turbo_boosted` hard lock.

### Bug 2 — Waaagh! effects were wiped at end of Shooting phase
`ShootingPhase._clear_stratagem_phase_flags` blanket-erased **every** `effect_*` flag on **every** unit at end of phase (to expire Go to Ground / Smokescreen). That also stripped the Waaagh!'s `effect_advance_and_charge` **and** `effect_invuln` — flags that per the rules last until the owner's next Command phase. So even a Waaagh!-only unit that Advanced lost its charge eligibility (and its 5+ invuln) before the Charge phase. `FactionAbilityManager` now exposes `snapshot_persistent_ability_flags()`, and the shooting-end clear preserves the Waaagh! flags across the wipe while still clearing genuine phase-scoped stratagem effects.

## Changes
- `40k/scripts/rules/movetypes/ChargeMove11e.gd` — honour advance/fall-back charge overrides + Adrenaline Junkies; add `turbo_boosted` hard lock.
- `40k/autoloads/FactionAbilityManager.gd` — add `WAAAGH_PERSISTENT_EFFECT_FLAGS` + `snapshot_persistent_ability_flags()`.
- `40k/phases/ShootingPhase.gd` — preserve Waaagh! effect flags across the end-of-phase blanket clear.
- `40k/data/version_history.json` — new entry `0.16.1`.
- Tests: `40k/tests/test_waaagh_advance_charge.gd` (headless), `40k/tests/scenarios/sp/waaagh_advance_then_charge.json` (+ fixture), coverage tiles.

## Validation
- **Headless (17/17):** `tests/test_waaagh_advance_charge.gd` covers the template overrides and the shooting-end preservation via the real `FactionAbilityManager.activate_waaagh` path.
- **Windowed (44/44):** `tests/scenarios/sp/waaagh_advance_then_charge.json` drives the full player path — `CALL_WAAAGH`, Advance a Warboss 11" toward a Dreadnought, then the Charge phase lists it in "UNITS THAT CAN CHARGE" and `DECLARE_CHARGE` + `CHARGE_ROLL` succeed (screenshots show the eligibility list and "Charge successful!").
- **No regressions:** `test_ork_detachments_sweep` (293), `test_iss049_charge_11e` (12), `test_iss057_actions_11e` (25), `test_iss048_shooting_types_11e` (29), `test_full_throttle_ability` (11), Speedwaaagh suites.

Note: Stormboyz have **Full Throttle** (charge after Advancing every turn, independent of the Waaagh!) — Bug 1 unblocks them. Bug 2 additionally makes the Waaagh! itself correctly grant advance-and-charge (and persist the 5+ invuln) to any Ork unit that Advances while it's active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CFgNM8q9mvpABZgR1vn72L

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFgNM8q9mvpABZgR1vn72L)_