### PR TITLE
Fix disembarked units vanishing + spurious Combat Disembark prompt

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.17.4",
+			"date": "2026-07-10",
+			"summary": "Disembark fixes: disembarked units no longer vanish from the board (previously they were left as invisible 'still embarked' ghosts marked Cannot Disembark), and the Combat Disembark option only appears when enemies are actually close enough to block a normal 3\" set-up.",
+			"changes": [
+				"Fixed: after placing all models of a disembarking unit, the models disappeared (leaving only blue coherency rings) and the unit was listed as 'Embarked in Transport — Cannot Disembark' even though the game log said it disembarked. The unit's embark state was being reset with the wrong empty value after the disembark completed.",
+				"The Combat Disembark (18.04) toggle in the disembark dialog now only appears when an enemy unit is near enough to the transport that setting up within 3\" outside Engagement Range could actually be impossible — with no enemies nearby it no longer suggests the disembark will be a Combat Disembark.",
+				"Reworded the Combat Disembark toggle to make clear it is an opt-in mode ('Use Combat Disembark…'), and the disembark dialog no longer shows raw [color=…] markup in its text."
+			]
+		},
+		{
 			"version": "0.17.3",
 			"date": "2026-07-10",
 			"summary": "Fixed the charge-phase 'Snap to Contact' button doing nothing when clicked — it now moves every remaining charging model into base-to-base contact with the nearest charge target, sliding models around the target's base when a squadmate blocks the straight line.",

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -41,6 +41,10 @@ const OVERLAP_TOLERANCE_PX: float = 0.5
 
 # Movement state tracking
 var active_moves: Dictionary = {}
+# 11e 18.04: unit_id -> bool, set when the DisembarkDialog's Combat Disembark
+# toggle was checked (phase-owned dialog path); consumed when the resulting
+# CONFIRM_DISEMBARK payload is built. Mirrors MovementController.
+var _pending_combat_disembark: Dictionary = {}
 # ISS-061: take-to-the-skies declarations awaiting the advance roll.
 var _pending_take_to_skies: Dictionary = {}  # unit_id -> move_data
 # ISS-073 (24.35): Super-Heavy Walker MOBILE-grant declarations awaiting the advance roll.
@@ -8075,9 +8079,16 @@ func _show_disembark_dialog(unit_id: String) -> void:
 	get_tree().root.add_child(dialog)
 	dialog.popup_centered()
 
-func _on_disembark_confirmed(unit_id: String) -> void:
-	"""Handle disembark confirmation - start placement"""
+func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
+	"""Handle disembark confirmation - start placement.
+	Signature note: disembark_confirmed emits (combat_mode) and unit_id is
+	bound at connect time — a 1-arg handler here fails the signal call."""
 	var controller = preload("res://scripts/DisembarkController.gd").new()
+	# 11e 18.04: the dialog's Combat Disembark toggle switches the placement
+	# rules (6" set-up, engaged-with-transport's-foes allowed) and is echoed
+	# to CONFIRM_DISEMBARK via payload.can_setup_tactical=false.
+	controller.combat_requested = combat_mode
+	_pending_combat_disembark[unit_id] = combat_mode
 	controller.disembark_completed.connect(_on_disembark_placement_completed)
 	controller.disembark_canceled.connect(_on_disembark_placement_canceled)
 	get_tree().root.add_child(controller)
@@ -8092,9 +8103,16 @@ func _on_disembark_placement_completed(unit_id: String, positions: Array) -> voi
 	var action = {
 		"type": "CONFIRM_DISEMBARK",
 		"actor_unit_id": unit_id,
-		"payload": {"positions": positions}
+		"payload": {
+			"positions": positions,
+			"can_setup_tactical": not _pending_combat_disembark.get(unit_id, false)
+		}
 	}
-	var result = process_action(action)
+	_pending_combat_disembark.erase(unit_id)
+	# execute_action (not process_action): the returned changes — the 11e
+	# after-move flags (disembarked_this_turn, cannot_charge, battle_shocked)
+	# — are only applied by execute_action, matching the controller path.
+	var result = execute_action(action)
 
 	if not result.get("success", false):
 		log_phase_message("Disembark failed: %s" % result.get("error", "Unknown error"))

--- a/40k/scripts/DisembarkDialog.gd
+++ b/40k/scripts/DisembarkDialog.gd
@@ -73,8 +73,9 @@ func _build_dialog_text() -> void:
 	var text = "Do you want to disembark %s from %s?" % [unit_name, transport_name]
 
 	# Add warnings based on transport status
+	# (Plain text only — AcceptDialog's label does not render BBCode.)
 	if transport_advanced:
-		text += "\n\n[color=red]WARNING: Cannot disembark![/color]"
+		text += "\n\nWARNING: Cannot disembark!"
 		text += "\nThe transport has Advanced this turn."
 		text += "\nUnits cannot disembark from a transport that Advanced."
 
@@ -82,7 +83,7 @@ func _build_dialog_text() -> void:
 		get_ok_button().disabled = true
 
 	elif transport_fell_back:
-		text += "\n\n[color=red]WARNING: Cannot disembark![/color]"
+		text += "\n\nWARNING: Cannot disembark!"
 		text += "\nThe transport has Fallen Back this turn."
 		text += "\nUnits cannot disembark from a transport that Fell Back."
 
@@ -90,7 +91,7 @@ func _build_dialog_text() -> void:
 		get_ok_button().disabled = true
 
 	elif transport_moved:
-		text += "\n\n[color=yellow]WARNING: Movement Restrictions[/color]"
+		text += "\n\nWARNING: Movement Restrictions"
 		text += "\nThe transport has already moved this turn."
 		text += "\n• The disembarked unit cannot move further"
 		text += "\n• The disembarked unit cannot charge"
@@ -101,26 +102,74 @@ func _build_dialog_text() -> void:
 		text += "\nThe disembarked unit will be able to move normally."
 
 	# Add disembark rules
-	text += "\n\n[color=cyan]Disembark Rules:[/color]"
+	text += "\n\nDisembark Rules:"
 	text += "\n• Models must be placed wholly within 3\" of the transport"
 	text += "\n• Models cannot be placed within Engagement Range of enemies"
 	text += "\n• All models must be placed or the unit cannot disembark"
 
 	dialog_text = text
 
-	# 11e 18.04: offer Combat Disembark when tactical set-up may be
-	# impossible — transport stationary (rapid is forced after a normal/
-	# ingress move, and an advanced/fallen-back transport blocks
-	# disembarking entirely).
-	if GameConstants.edition >= 11 and not transport_advanced and not transport_fell_back and not transport_moved:
+	# 11e 18.04: Combat Disembark is mandatory-if-applicable, and it applies
+	# only when the unit CANNOT be set up per Tactical Disembark (within 3",
+	# outside Engagement Range). Only offer the toggle when enemies are close
+	# enough to the transport that a tactical set-up could actually be blocked
+	# — with no foes near the 3" ring it always read as "this will be a combat
+	# disembark" while being rules-impossible.
+	if GameConstants.edition >= 11 and not transport_advanced and not transport_fell_back and not transport_moved \
+			and _combat_disembark_could_apply():
 		combat_checkbox = CheckBox.new()
-		combat_checkbox.text = "Combat Disembark (18.04): 6\" set-up, may be set up engaged with\nthe transport's foes — hazard roll per model, battle-shocked, no charge"
-		combat_checkbox.tooltip_text = "Select when you cannot (or choose not to) set up outside Engagement Range within 3\". The unit is set up within 6\" instead and may be placed engaged with enemy units the transport is engaged with."
+		combat_checkbox.text = "Use Combat Disembark (18.04) — only if the unit cannot be set up\nwithin 3\" outside Engagement Range: 6\" set-up, may be placed engaged\nwith the transport's foes; hazard roll per model, battle-shocked, no charge"
+		combat_checkbox.tooltip_text = "Tick only when you cannot set up the whole unit outside Engagement Range within 3\". The unit is set up within 6\" instead and may be placed engaged with enemy units the transport is engaged with."
 		var label = get_label()
 		if label != null and label.get_parent() != null:
 			label.get_parent().add_child(combat_checkbox)
 		else:
 			add_child(combat_checkbox)
+
+## True when an enemy model is close enough to the transport that the 3"
+## tactical set-up ring could be inside Engagement Range — i.e. Combat
+## Disembark (18.04) could actually be the mandatory mode. A placed model's
+## near edge sits within 3" of the hull, so an ER clash needs an enemy edge
+## within 3" + ER + the model's own base size of the hull (edge-to-edge).
+## Beyond that, a tactical set-up can never be blocked by ER and the combat
+## mode is not applicable. (Overlap/terrain crowding can still be dodged by
+## cancelling placement and staying embarked.)
+func _combat_disembark_could_apply() -> bool:
+	var unit = GameState.get_unit(unit_id)
+	var transport = GameState.get_unit(transport_id)
+	if not unit or not transport:
+		return false
+
+	# Largest base dimension among the disembarking unit's alive models.
+	var max_base_inches := 0.0
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var base_mm = float(model.get("base_mm", 32))
+		var dims = model.get("base_dimensions", {})
+		if dims is Dictionary and not dims.is_empty():
+			base_mm = max(base_mm, float(dims.get("length", base_mm)), float(dims.get("width", base_mm)))
+		max_base_inches = max(max_base_inches, base_mm / Measurement.MM_PER_INCH)
+
+	var threshold_inches := 3.0 + GameConstants.engagement_range_inches() + max_base_inches
+
+	var enemy_owner = 3 - int(unit.get("owner", 1))
+	for enemy_id in GameState.state.units:
+		var enemy = GameState.state.units[enemy_id]
+		if int(enemy.get("owner", 0)) != enemy_owner:
+			continue
+		if enemy.get("embarked_in", null) != null:
+			continue
+		for enemy_model in enemy.get("models", []):
+			if not enemy_model.get("alive", true) or enemy_model.get("position") == null:
+				continue
+			for transport_model in transport.get("models", []):
+				if not transport_model.get("alive", true) or transport_model.get("position") == null:
+					continue
+				if Measurement.model_to_model_distance_inches(transport_model, enemy_model) <= threshold_inches:
+					print("DisembarkDialog: Combat Disembark offered — enemy %s within %.1f\" of transport" % [enemy_id, threshold_inches])
+					return true
+	return false
 
 func _on_ok_pressed() -> void:
 	var combat_mode: bool = combat_checkbox != null and combat_checkbox.button_pressed

--- a/40k/scripts/rules/movetypes/DisembarkMove.gd
+++ b/40k/scripts/rules/movetypes/DisembarkMove.gd
@@ -26,7 +26,10 @@ func eligible(unit_id: String, board: Dictionary) -> Dictionary:
 	var unit = _unit(board, unit_id)
 	if unit.is_empty():
 		return {"eligible": false, "reasons": ["unknown unit"]}
-	var transport_id = str(unit.get("embarked_in", ""))
+	# null is the codebase-wide "not embarked" sentinel; str(null) would give
+	# "<null>", so guard before stringifying.
+	var embarked_raw = unit.get("embarked_in", null)
+	var transport_id = str(embarked_raw) if embarked_raw != null else ""
 	if transport_id == "":
 		return {"eligible": false, "reasons": ["unit is not embarked"]}
 	var transport = _unit(board, transport_id)
@@ -48,7 +51,8 @@ func mode_ids() -> Array:
 ## driven by the transport's move history this phase.
 func select_mode(unit_id: String, board: Dictionary, context: Dictionary = {}) -> Dictionary:
 	var unit = _unit(board, unit_id)
-	var transport = _unit(board, str(unit.get("embarked_in", "")))
+	var embarked_raw = unit.get("embarked_in", null)
+	var transport = _unit(board, str(embarked_raw) if embarked_raw != null else "")
 	var tf = transport.get("flags", {})
 	if tf.get("moved_this_phase", false):
 		# normal or ingress move this phase (advance/fall-back are barred
@@ -82,7 +86,12 @@ func before_moving(unit_id: String, board: Dictionary, rng, context: Dictionary)
 func after_moving_effects(unit_id: String, context: Dictionary) -> Array:
 	var fx = [
 		{"op": "set", "path": StateSchema.path_unit_flag(unit_id, "disembarked_this_turn"), "value": true},
-		{"op": "set", "path": StateSchema.path_unit_field(unit_id, "embarked_in"), "value": ""},
+		# null, not "": the codebase-wide "not embarked" check is
+		# `embarked_in != null` (token rendering, unit lists, can_disembark).
+		# This diff is applied AFTER TransportManager.disembark_unit() already
+		# set null — writing "" here turned the unit into an invisible
+		# "still embarked" ghost (models hidden, listed as Cannot Disembark).
+		{"op": "set", "path": StateSchema.path_unit_field(unit_id, "embarked_in"), "value": null},
 	]
 	match str(context.get("mode", "")):
 		"rapid":

--- a/40k/scripts/rules/movetypes/EmergencyDisembarkMove.gd
+++ b/40k/scripts/rules/movetypes/EmergencyDisembarkMove.gd
@@ -14,7 +14,8 @@ func eligible(unit_id: String, board: Dictionary) -> Dictionary:
 	if GameConstants.edition < 11:
 		return {"eligible": false, "reasons": ["11e move type"]}
 	var unit = _unit(board, unit_id)
-	if str(unit.get("embarked_in", "")) == "":
+	var embarked_raw = unit.get("embarked_in", null)
+	if embarked_raw == null or str(embarked_raw) == "":
 		return {"eligible": false, "reasons": ["unit is not embarked"]}
 	# Caller asserts the transport was just destroyed (the destruction
 	# handler drives this move; there is no standing board state for it).
@@ -36,7 +37,9 @@ func before_moving(unit_id: String, board: Dictionary, rng, _context: Dictionary
 func after_moving_effects(unit_id: String, _context: Dictionary) -> Array:
 	return [
 		{"op": "set", "path": StateSchema.path_unit_flag(unit_id, "disembarked_this_turn"), "value": true},
-		{"op": "set", "path": StateSchema.path_unit_field(unit_id, "embarked_in"), "value": ""},
+		# null, not "": `embarked_in != null` is the codebase-wide embark check
+		# (see DisembarkMove.after_moving_effects for the failure mode).
+		{"op": "set", "path": StateSchema.path_unit_field(unit_id, "embarked_in"), "value": null},
 		{"op": "set", "path": StateSchema.path_unit_flag(unit_id, "battle_shocked"), "value": true},
 		{"op": "set", "path": StateSchema.path_unit_flag(unit_id, "cannot_charge"), "value": true},
 	]

--- a/40k/tests/scenarios/sp/iss058_disembark_11e.json
+++ b/40k/tests/scenarios/sp/iss058_disembark_11e.json
@@ -158,6 +158,26 @@
       "equals": true
     },
     {
+      "act": "expect_state",
+      "path": "units.U_KOMMANDOS_H.embarked_in",
+      "equals": null,
+      "comment": "Regression net: after_moving_effects used to overwrite null with \"\" AFTER TransportManager.disembark_unit, turning the unit into an invisible still-embarked ghost (tokens skipped, listed as Cannot Disembark)."
+    },
+    {
+      "act": "expect_state",
+      "path": "units.U_KOMMANDOS_H.disembarked_this_phase",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main._recreate_unit_visuals()",
+      "comment": "Mirror the visual refresh Main performs after routing CONFIRM_DISEMBARK (Main.gd CONFIRM_DISEMBARK branch); _recreate_unit_visuals skips any unit whose embarked_in is non-null."
+    },
+    {
+      "act": "expect_token_visible",
+      "unit_id": "U_KOMMANDOS_H"
+    },
+    {
       "act": "screenshot",
       "label": "03_combat_disembark_6in_shocked"
     }


### PR DESCRIPTION
## Summary

Fixes two player-facing disembark bugs in the 11e movement phase (plus one latent bug on a secondary code path).

### 1. Disembarked models disappeared, unit shown as "Cannot Disembark"
When a unit finished disembarking, `DisembarkMove` / `EmergencyDisembarkMove.after_moving_effects()` reset `embarked_in` to `""` via a state diff applied **after** `TransportManager.disembark_unit()` had already correctly set it to `null`. The codebase-wide "not embarked" check is `embarked_in != null`, and `"" != null` is **true**, so the unit read as still embarked:
- `_recreate_unit_visuals()` skips embarked units → the placed models vanished
- `can_disembark()` treats `""` as falsy → returns "not embarked" → the unit list shows "Cannot Disembark"
- Leftover coherency / engagement-range rings are the "blue circles" the player saw

The game log still said "disembarked" because it fires before the bad diff lands. **Fix:** both move-type templates now write `null`, and their `eligible()` / `select_mode()` reads are made null-safe so `str(null)` is never used as a transport id.

### 2. Combat Disembark toggle offered with no enemies nearby
The dialog always added the Combat Disembark (18.04) toggle whenever the transport was stationary, reading as "this **will** be a combat disembark" even with no enemies in range. Per 18.04, combat mode only applies when a tactical set-up (within 3", outside Engagement Range) is impossible. **Fix:** the toggle now appears only when an enemy model is within `3" + Engagement Range + the unit's base size` of the transport hull (shape-aware, edge-to-edge). Reworded to "Use Combat Disembark…" and dropped the `[color=…]` BBCode that rendered literally in the plain label.

### 3. Latent: phase-owned dialog handler had the wrong signal signature
`MovementPhase._on_disembark_confirmed` took 1 arg and dropped the `disembark_confirmed(combat_mode)` signal. It now takes `(combat_mode, unit_id)`, sets `controller.combat_requested`, threads `can_setup_tactical` into the `CONFIRM_DISEMBARK` payload, and routes via `execute_action` so the after-move flags are applied — matching the `MovementController` path.

## Testing

**Live windowed game** (original fixture, Kommandos in a Battlewagon):
- Enemy 15.8" away → Combat Disembark checkbox **hidden**, dialog text clean (no BBCode)
- Enemy teleported to 2.5" → checkbox **reappears** with reworded text (proves it isn't over-hidden)
- Disembarked the unit → models **render on the board**, `embarked_in` is `null`, log reads "Kommandos disembarked"
- Debug log: **0 errors, 0 warnings** on the feature path

**Windowed scenario** `iss058_disembark_11e` — extended to assert `embarked_in == null` and `expect_token_visible` after disembark. Verified it genuinely fails on the pre-fix code (2 failures) and passes after.

**Headless suites green:** iss058 (28), t029a (9), iss060 (13), iss040 (18), t080 (4), plus the iss058b combat-disembark-engaged scenario.

Changelog bumped to **0.16.1** (player-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KeEywf4w6r6qK2aK4ck1gV

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeEywf4w6r6qK2aK4ck1gV)_