### PR TITLE
Fix reserves/Deep Strike offered on turn one when Player 2 goes first

### DIFF
--- a/40k/autoloads/GameManager.gd
+++ b/40k/autoloads/GameManager.gd
@@ -801,8 +801,10 @@ func process_end_scoring(action: Dictionary) -> Dictionary:
 		"value": next_player
 	})
 
-	# If Player 2 just finished their turn, advance battle round
-	if current_player == 2:
+	# If the round's SECOND player just finished their turn, advance battle
+	# round (the first-turn roll-off may have given Player 2 the first turn,
+	# in which case Player 1 closes each round — see GameState.is_last_turn_of_round).
+	if GameState.is_last_turn_of_round(current_player):
 		var new_battle_round = GameState.get_battle_round() + 1
 		print("GameManager: Completing battle round, advancing to battle round %d" % new_battle_round)
 

--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -1069,6 +1069,22 @@ func advance_battle_round() -> void:
 	state["meta"]["battle_round"] = get_battle_round() + 1
 	print("GameState: Advanced to battle round ", get_battle_round())
 
+func get_first_turn_player() -> int:
+	# Which player takes the FIRST turn of each battle round. Set by the
+	# first-turn roll-off (meta.first_turn_player); saves/flows that never ran
+	# it fall back to Player 1 (the historical assumption).
+	var ftp = int(state["meta"].get("first_turn_player", 0))
+	return ftp if (ftp == 1 or ftp == 2) else 1
+
+func is_last_turn_of_round(player: int) -> bool:
+	# True when the given player takes the SECOND (final) turn of each battle
+	# round — the battle round ends when their turn ends. Callers must NOT
+	# assume Player 2 always goes second: when the first-turn roll-off gives
+	# Player 2 the first turn, the round ends after Player 1's turn. Advancing
+	# after P2 unconditionally ended Round 1 after a single player turn,
+	# which unlocked reserves/deep strike arrivals on P1's first turn.
+	return player != get_first_turn_player()
+
 func is_game_complete() -> bool:
 	if state.get("meta", {}).get("game_ended", false):
 		return true

--- a/40k/autoloads/MissionManager.gd
+++ b/40k/autoloads/MissionManager.gd
@@ -892,8 +892,10 @@ func _process_supply_drop_removal(battle_round: int, active_player: int) -> void
 	"""Remove NML objectives at the start of round 4 for Supply Drop."""
 	var removal_rules = current_mission.get("removal_rules", {})
 
-	# Only process removal once, when the first player scores in round 4
-	if battle_round == 4 and not supply_drop_resolved_round_4 and active_player == 1:
+	# Only process removal once, when the round's first-turn player scores in
+	# round 4 (the start of round 4). NOT hardcoded to Player 1 — when the
+	# roll-off gives Player 2 the first turn, round 4 begins on P2's turn.
+	if battle_round == 4 and not supply_drop_resolved_round_4 and active_player == GameState.get_first_turn_player():
 		var remove_count = removal_rules.get("round_4_remove_count", 1)
 		var nml_objectives = _get_nml_objective_ids()
 
@@ -2274,9 +2276,11 @@ func _evaluate_primary_rule_11e(player: int, rule: Dictionary, battle_round: int
 			return _kills_this_turn_11e(player) * int(rule.get("vp_per", 0))
 		"killed_more_than_opponent_last_turn":
 			var my_kills = _kills_this_turn_11e(player)
-			# Opponent's most recent turn: same round if they already went this
-			# round (player 2 scoring), otherwise the previous round.
-			var opp_round = battle_round if player == 2 else battle_round - 1
+			# Opponent's most recent turn: same round if the opponent already
+			# went this round (i.e. `player` takes the round's SECOND/last turn),
+			# otherwise the previous round. NOT hardcoded to P2-second — when the
+			# roll-off gives P2 the first turn, P1 takes the round's last turn.
+			var opp_round = battle_round if GameState.is_last_turn_of_round(player) else battle_round - 1
 			var opp_kills = int(kills_per_round.get(str(opp_round), {}).get(str(opponent), 0))
 			return rule.get("vp", 0) if my_kills > opp_kills else 0
 		"quarters":

--- a/40k/autoloads/SaveLoadManager.gd
+++ b/40k/autoloads/SaveLoadManager.gd
@@ -149,13 +149,16 @@ func _on_phase_completed_autosave(completed_phase: int) -> void:
 	if not autosave_on_round_end:
 		return
 
-	# Auto-save at round end: when SCORING phase completes and it's the end of a battle round
-	# The round advances when Player 2's scoring completes (active_player switches to 1)
+	# Auto-save at round end: when SCORING phase completes and it's the end of a battle round.
+	# The round ends when the round's SECOND player finishes scoring and control
+	# wraps back to the first-turn player. NOT hardcoded to Player 1 — when the
+	# roll-off gives Player 2 the first turn, the round ends after P1's turn and
+	# active_player switches back to 2.
 	if completed_phase == GameStateData.Phase.SCORING:
 		var current_player = GameState.get_active_player()
-		# After scoring completes, ScoringPhase already switched active_player
-		# If active_player is now 1, Player 2 just finished → round ended
-		if current_player == 1:
+		# After scoring completes, ScoringPhase already switched active_player.
+		# If active_player is now the first-turn player, the round just ended.
+		if current_player == GameState.get_first_turn_player():
 			var battle_round = GameState.get_battle_round()
 			# battle_round was already incremented by ScoringPhase._handle_end_turn()
 			var completed_round = battle_round - 1

--- a/40k/autoloads/TurnManager.gd
+++ b/40k/autoloads/TurnManager.gd
@@ -59,8 +59,11 @@ func _on_phase_completed(completed_phase: GameStateData.Phase) -> void:
 			var current_battle_round = GameState.get_battle_round()
 			var current_player = GameState.get_active_player()
 
-			# If we're at player 1 after scoring, battle round was advanced
-			if current_player == 1:
+			# If the active player after scoring is the round's first-turn player,
+			# a battle round just ended (control wrapped back to the first player).
+			# NOT hardcoded to Player 1 — when P2 takes the first turn the round
+			# ends after P1's turn and control returns to P2.
+			if current_player == GameState.get_first_turn_player():
 				print("TurnManager: Battle round advanced to ", current_battle_round)
 				emit_signal("battle_round_advanced", current_battle_round)
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,7 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
-
+			"version": "0.18.1",
+			"date": "2026-07-11",
+			"summary": "Fixed first-turn handling when Player 2 wins the roll-off to go first: the battle round no longer advances after a single player's turn. Previously that made Player 1's very first turn count as Battle Round 2, so the movement phase wrongly let units arrive from Reserves / Deep Strike on turn one (the AI would 'suggest' bringing reserves in immediately).",
+			"changes": [
+				"Reserves and Deep Strike units can no longer arrive on the first turn of the game when Player 2 takes the first turn — reinforcements are correctly gated to Battle Round 2 onward for both players.",
+				"The battle round now advances after the round's SECOND player finishes their turn (Player 1 when Player 2 went first), instead of always after Player 2 — so the game lasts the correct number of turns and ends on the right turn.",
+				"Start-of-round effects (per-round Command Point cap, kill counters, battle-round stratagem timing, Supply Drop objective removal, round-end autosave) now trigger on the correct turn when Player 2 goes first.",
+				"AI reserve/Deep Strike placement now reads the real battle round, fixing round-gated placement decisions."
+			]
+		},
+		{
 			"version": "0.18.0",
 			"date": "2026-07-11",
 			"summary": "Game-log step replay: click any entry in the game log to see the board exactly as it was at that moment. It's a read-only look back — the live game is never changed — with a banner and an Exit button (or Esc) to return.",

--- a/40k/phases/CommandPhase.gd
+++ b/40k/phases/CommandPhase.gd
@@ -54,8 +54,12 @@ func _on_phase_enter() -> void:
 		if u.get("flags", {}).get(EffectPrimitivesData.FLAG_PSYCHIC_VEIL, false):
 			GameState.apply_state_changes([{"op": "remove", "path": "units.%s.flags.%s" % [uid, EffectPrimitivesData.FLAG_PSYCHIC_VEIL]}])
 
-	# Step 0a: Reset per-round tracking at start of each battle round (Player 1's turn)
-	if current_player == 1:
+	# Step 0a: Reset per-round tracking at the START of each battle round — the
+	# first-turn player's Command phase. NOT hardcoded to Player 1: when the
+	# first-turn roll-off gives Player 2 the first turn, the round begins on P2's
+	# turn, so the per-round resets (round kills, bonus-CP cap, battle-round
+	# stratagem expiry) must fire then, not on P1's (second) turn.
+	if current_player == GameState.get_first_turn_player():
 		if MissionManager:
 			MissionManager.reset_round_kills()
 		# Reset bonus CP tracking — per core rules FAQ, each player can only gain 1 bonus CP per battle round

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -368,8 +368,11 @@ func _initialize_movement() -> void:
 			can_move = true
 			break
 
-	# Also check for reserve units that can be deployed (Turn 2+)
-	if not can_move and game_state_snapshot.get("battle_round", 1) >= 2:
+	# Also check for reserve units that can be deployed (Turn 2+).
+	# battle_round lives under meta in snapshots — the old top-level read
+	# always returned 1, so an all-in-reserves army had its movement phase
+	# auto-completed even in rounds where reinforcements could arrive.
+	if not can_move and GameState.get_battle_round() >= 2:
 		var reserves = GameState.get_reserves_for_player(current_player)
 		if reserves.size() > 0:
 			can_move = true

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -108,13 +108,13 @@ func _on_phase_enter() -> void:
 	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
 	if secondary_mgr and secondary_mgr.is_initialized(current_player):
 		# Score end-of-your-turn missions for active player.
-		# 11e: on the game's FINAL turn (P2, last battle round) cards that say
-		# "at the end of your opponent's turn or the end of the fifth battle
-		# round, whichever comes first" (Beacon, Burden of Trust, Defend
-		# Stronghold) also score for the active player — they get no further
-		# opponent-turn end.
+		# 11e: on the game's FINAL turn (the round's last player, last battle
+		# round) cards that say "at the end of your opponent's turn or the end
+		# of the fifth battle round, whichever comes first" (Beacon, Burden of
+		# Trust, Defend Stronghold) also score for the active player — they get
+		# no further opponent-turn end.
 		var is_final_turn: bool = GameConstants.edition >= 11 \
-			and current_player == 2 \
+			and GameState.is_last_turn_of_round(current_player) \
 			and GameState.get_battle_round() >= GameState.MAX_BATTLE_ROUNDS
 		_secondary_results = secondary_mgr.score_secondary_missions_for_player(current_player, is_final_turn)
 		if _secondary_results.size() > 0:
@@ -453,10 +453,12 @@ func _handle_end_turn() -> Dictionary:
 		var battle_round = GameState.get_battle_round()
 		MissionManager.record_vp_snapshot(battle_round)
 
-	# Detect end-of-game: P2 finishing the final battle round (10e: 5 rounds).
+	# Detect end-of-game: the round's LAST player finishing the final battle
+	# round (10e: 5 rounds). With P1 first that is P2's turn; when the roll-off
+	# gave P2 the first turn it is P1's.
 	# Set meta.game_ended/winner in state so saves, replays, MCP queries, and
 	# PhaseManager._handle_game_end() (via is_game_complete()) all observe it.
-	if current_player == 2 and GameState.get_battle_round() >= GameState.MAX_BATTLE_ROUNDS:
+	if GameState.is_last_turn_of_round(current_player) and GameState.get_battle_round() >= GameState.MAX_BATTLE_ROUNDS:
 		return _handle_game_end_turn()
 
 	# Reset unit flags for the player whose turn is starting
@@ -469,8 +471,12 @@ func _handle_end_turn() -> Dictionary:
 		"value": next_player
 	})
 
-	# If Player 2 just finished their turn, advance battle round
-	if current_player == 2:
+	# If the round's SECOND player just finished their turn, advance battle
+	# round. NOT hardcoded to Player 2: the first-turn roll-off can give
+	# Player 2 the first turn, in which case Player 1 closes each round.
+	# (Hardcoding P2 ended Round 1 after one player turn whenever P2 went
+	# first, letting reserves/deep strike arrive on P1's FIRST turn.)
+	if GameState.is_last_turn_of_round(current_player):
 		var current_battle_round = GameState.get_battle_round()
 		# ISS-038: End of Battle Round step (07.03).
 		PhaseManager.emit_signal("battle_round_ending", current_battle_round)

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -4476,7 +4476,7 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 		# Key insight: Orks should NOT abandon objectives to chase distant enemies
 		var hold_faction_aggression = _get_faction_aggression(snapshot, player)
 		var hold_is_melee = _is_melee_seeker(unit)
-		var hold_battle_round = snapshot.get("battle_round", 1)
+		var hold_battle_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 		if assignment_action == "hold":
 			# Check if there's a nearby enemy worth charging
 			var skip_hold_for_melee = false
@@ -4545,7 +4545,7 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 		var faction_aggression = _get_faction_aggression(snapshot, player)
 		var is_aggressive_faction = faction_aggression >= 1.5
 		var should_seek_enemies = _is_melee_seeker(unit)
-		var melee_battle_round = snapshot.get("battle_round", 1)
+		var melee_battle_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 
 		# Determine if this unit is needed at its objective (don't abandon objectives)
 		var unit_centroid_for_obj = _get_unit_centroid(unit)
@@ -4741,7 +4741,7 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 			# EXCEPT: melee units with NEARBY enemies (within charge range) should keep moving
 			var obj_hold_is_melee = _is_melee_seeker(unit)
 			var obj_hold_skip = false
-			var obj_hold_round = snapshot.get("battle_round", 1)
+			var obj_hold_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 			if obj_hold_is_melee and not enemies.is_empty():
 				var obj_hold_nearest = _get_nearest_enemy_for_charge(unit, enemies)
 				# Only leave objective for enemies within charge+move range, not the whole board
@@ -5018,7 +5018,10 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 static func _decide_reserves_arrival(snapshot: Dictionary, reinforcement_actions: Array, player: int) -> Dictionary:
 	"""Decide which reserve unit to deploy and where to place it.
 	Called during the movement phase from Round 2+ when PLACE_REINFORCEMENT actions are available."""
-	var battle_round = snapshot.get("battle_round", 1)
+	# battle_round lives under meta in GameState snapshots — the old top-level
+	# read always returned the default 1, so round-gated placement rules (e.g.
+	# "no Strategic Reserves in the enemy DZ on Round 2") were never applied.
+	var battle_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 	var objectives = _get_objectives(snapshot)
 	var enemies = _get_enemy_units(snapshot, player)
 
@@ -6718,7 +6721,7 @@ static func _assign_units_to_objectives(
 			var hold_alive = _get_alive_models(hold_unit_data).size()
 			var hold_is_home = eval_for_obj.get("is_home", false)
 			var hold_fag = _get_faction_aggression(snapshot, player)
-			var hold_round = snapshot.get("battle_round", 1)
+			var hold_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 			var hold_unit_kw = hold_unit_data.get("meta", {}).get("keywords", [])
 			var hold_is_rv = not _is_melee_focused_unit(hold_unit_data) and ("VEHICLE" in hold_unit_kw) and _unit_has_ranged_weapons(hold_unit_data)
 			var hold_has_melee_role = _is_melee_focused_unit(hold_unit_data) or (hold_fag >= 1.5 and _unit_has_melee_weapons(hold_unit_data) and not hold_is_rv)
@@ -19051,7 +19054,10 @@ static func evaluate_rapid_ingress(defending_player: int, eligible_units: Array,
 	Returns a dictionary with:
 	- type: USE_RAPID_INGRESS + embedded _placement_action, or DECLINE_RAPID_INGRESS
 	"""
-	var battle_round = snapshot.get("battle_round", 1)
+	# battle_round lives under meta in GameState snapshots — the old top-level
+	# read always returned the default 1, so the "save last CP unless Round 4+"
+	# guard below never triggered (it thought it was always Round 1).
+	var battle_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
 	var player_cp = _get_player_cp_from_snapshot(snapshot, defending_player)
 
 	print("AIDecisionMaker: [RAPID INGRESS] Evaluating for player %d (%d eligible units, %d CP, Round %d)" % [

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -824,6 +824,28 @@ func set_phase(phase) -> void:  # Remove type hint to accept any phase
 		print("MovementController: Clearing phase reference")
 		current_phase = null
 
+# Read-only accessor for tests/scenarios: how many "arrive from reserves"
+# rows the movement unit list is currently offering the player. 0 means no
+# reinforcements are on offer (correct on the first turn / before Round 2).
+# Counts the reserve rows between the "--- REINFORCEMENTS ---" header and the
+# "--- DEPLOYED UNITS ---" separator (the header itself is not counted).
+func get_reinforcement_row_count() -> int:
+	if not unit_list:
+		return 0
+	var count := 0
+	var in_reinforcements := false
+	for i in range(unit_list.get_item_count()):
+		var text := unit_list.get_item_text(i)
+		if text.begins_with("--- REINFORCEMENTS"):
+			in_reinforcements = true
+			continue
+		if text.begins_with("--- DEPLOYED UNITS"):
+			in_reinforcements = false
+			continue
+		if in_reinforcements:
+			count += 1
+	return count
+
 func _refresh_unit_list() -> void:
 	if not unit_list or not current_phase:
 		return

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2637,6 +2637,33 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "phases.ScoringPhase.round_advance_uses_first_turn_player",
+      "description": "Regression guard: the battle round advances after the round's SECOND player ends their turn (GameState.is_last_turn_of_round), not unconditionally after Player 2. When the first-turn roll-off gives Player 2 the first turn, Player 1 closes each round, preventing Player 1's first turn from counting as Battle Round 2. Validated by 'first_turn_p2_no_reserves_turn_one' and headless test_p2_first_turn_round_advance.gd.",
+      "scenarios": [
+        "first_turn_p2_no_reserves_turn_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "movement.reinforcement.gated_to_round_2",
+      "description": "Reinforcements (Strategic Reserves / Deep Strike) are offered in the movement phase only from Battle Round 2 onward, for whichever player takes the first turn. Positive control confirms reserves DO appear in Round 2. Validated by 'first_turn_p2_no_reserves_turn_one'.",
+      "scenarios": [
+        "first_turn_p2_no_reserves_turn_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "movement.reinforcement.none_offered_turn_one",
+      "description": "The movement unit list offers ZERO reinforcement rows on the first turn of the game even when the active player holds units in reserves \u2014 including when Player 2 took the first turn and Player 1 is now taking the game's first turn. Asserted via MovementController.get_reinforcement_row_count(). Validated by 'first_turn_p2_no_reserves_turn_one'.",
+      "scenarios": [
+        "first_turn_p2_no_reserves_turn_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/first_turn_p2_no_reserves_turn_one.json
+++ b/40k/tests/scenarios/sp/first_turn_p2_no_reserves_turn_one.json
@@ -1,0 +1,75 @@
+{
+  "id": "first_turn_p2_no_reserves_turn_one",
+  "covers": [
+    "phases.ScoringPhase.round_advance_uses_first_turn_player",
+    "movement.reinforcement.gated_to_round_2",
+    "movement.reinforcement.none_offered_turn_one"
+  ],
+  "fixture": "audit_baseline_postdeploy_p2first",
+  "edition": 11,
+  "disable_ai": true,
+  "rng_seed": 7,
+  "description": "Regression: when the first-turn roll-off gives Player 2 the FIRST turn (meta.first_turn_player=2), the battle round must NOT advance after P2's turn — it advances only after Player 1 (the round's SECOND player). Previously the round advanced whenever P2 ended a turn (hardcoded current_player==2), so Player 1's FIRST turn ran as Battle Round 2 and the movement phase wrongly offered reserves/Deep Strike arrivals on turn one (the reported 'AI always suggests deep strike even on turn one' symptom). Drive P2's full turn to the turn boundary, assert the round is STILL 1 as control passes to P1, and assert P1's Round-1 movement UI offers ZERO reinforcement rows even though P1 holds a unit in reserves. Positive control: drive P1's turn so the round genuinely advances to 2, then confirm P2's Round-2 movement UI DOES offer its reserve units — proving the gate is real, not vacuous.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 1 },
+    { "act": "expect_state", "path": "meta.first_turn_player", "equals": 2 },
+    { "act": "execute_script", "script": "GameState.get_first_turn_player()", "equals": 2 },
+    { "act": "execute_script", "script": "GameState.is_last_turn_of_round(1)", "equals": true },
+    { "act": "execute_script", "script": "GameState.is_last_turn_of_round(2)", "equals": false },
+    { "act": "execute_script", "script": "GameState.get_reserves_for_player(2).size()", "expect_min": 1 },
+    { "act": "screenshot", "label": "01_p2_first_turn_round1_command" },
+
+    { "act": "dispatch_action", "action": { "type": "END_COMMAND", "player": 2 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_MOVEMENT", "player": 2 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_SHOOTING", "player": 2 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_CHARGE", "player": 2 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_FIGHT", "player": 2 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_TURN", "player": 2 } },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 1 },
+    { "act": "screenshot", "label": "02_after_p2_turn_still_round1" },
+
+    { "act": "dispatch_action", "action": { "type": "END_COMMAND", "player": 1 } },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 1 },
+    { "act": "execute_script", "script": "GameState.get_reserves_for_player(1).size()", "expect_min": 1 },
+    { "act": "execute_script", "script": "main.movement_controller.get_reinforcement_row_count()", "equals": 0 },
+    { "act": "screenshot", "label": "03_p1_first_turn_movement_no_reserves" },
+
+    { "act": "dispatch_action", "action": { "type": "END_MOVEMENT", "player": 1 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_SHOOTING", "player": 1 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_CHARGE", "player": 1 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_FIGHT", "player": 1 } },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "dispatch_action", "action": { "type": "END_TURN", "player": 1 } },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 2 },
+
+    { "act": "dispatch_action", "action": { "type": "END_COMMAND", "player": 2 } },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 2 },
+    { "act": "execute_script", "script": "main.movement_controller.get_reinforcement_row_count()", "expect_min": 1 },
+    { "act": "screenshot", "label": "04_p2_round2_movement_reserves_offered" }
+  ]
+}

--- a/40k/tests/test_p2_first_turn_round_advance.gd
+++ b/40k/tests/test_p2_first_turn_round_advance.gd
@@ -1,0 +1,174 @@
+extends SceneTree
+
+# Battle-round tracking when Player 2 takes the FIRST turn of each round.
+#
+# Bug: ScoringPhase/GameManager advanced meta.battle_round whenever Player 2
+# ended a turn, assuming P1 always went first. When the first-turn roll-off
+# gave P2 the first turn, Round 1 "ended" after a single player turn — so
+# Player 1's FIRST turn of the game ran as Battle Round 2, which (among other
+# things) unlocked PLACE_REINFORCEMENT and made the AI suggest bringing units
+# in from Deep Strike on turn one.
+#
+# Checks:
+#   A) GameState.get_first_turn_player / is_last_turn_of_round helpers,
+#      including the fallback (missing meta key -> Player 1 first).
+#   B) P2-first: P2's END_TURN does NOT advance the round; P1's does.
+#   C) P2-first: MovementPhase offers no PLACE_REINFORCEMENT during P1's
+#      first turn (still Round 1) even with units in reserves, and offers
+#      them once Round 2 genuinely starts.
+#   D) P2-first: at MAX_BATTLE_ROUNDS the game ends after P1's turn (the
+#      round's second player), not after P2's.
+#
+# Usage: godot --headless --path . -s tests/test_p2_first_turn_round_advance.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _end_turn_via_scoring(gs, player: int) -> Dictionary:
+	var phase = load("res://phases/ScoringPhase.gd").new()
+	root.add_child(phase)
+	phase.game_state_snapshot = gs.create_snapshot()
+	var result = phase.execute_action({"type": "END_TURN", "player": player})
+	root.remove_child(phase)
+	phase.free()
+	return result
+
+func _movement_reinforcement_actions(gs) -> Array:
+	var phase = load("res://phases/MovementPhase.gd").new()
+	root.add_child(phase)
+	phase.game_state_snapshot = gs.create_snapshot()
+	var out := []
+	for a in phase.get_available_actions():
+		if a.get("type", "") == "PLACE_REINFORCEMENT":
+			out.append(a)
+	root.remove_child(phase)
+	phase.free()
+	return out
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_p2_first_turn_round_advance ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var prev = gs.state.duplicate(true)
+
+	print("-- A: first-turn helpers --")
+	gs.initialize_default_state()
+	_check("fallback: no meta.first_turn_player -> P1 first", gs.get_first_turn_player() == 1)
+	_check("fallback: P2 closes the round", gs.is_last_turn_of_round(2) and not gs.is_last_turn_of_round(1))
+	gs.state["meta"]["first_turn_player"] = 2
+	_check("roll-off winner P2 -> P2 first", gs.get_first_turn_player() == 2)
+	_check("P2-first: P1 closes the round", gs.is_last_turn_of_round(1) and not gs.is_last_turn_of_round(2))
+
+	print("\n-- B: P2-first round advance --")
+	gs.initialize_default_state()
+	gs.state["meta"]["first_turn_player"] = 2
+	gs.state["meta"]["active_player"] = 2
+	gs.state["meta"]["battle_round"] = 1
+	var r1 = _end_turn_via_scoring(gs, 2)
+	_check("P2 END_TURN succeeded", r1.get("success", false), str(r1))
+	_check("round did NOT advance after P2 (first) turn", gs.get_battle_round() == 1,
+		"round=%d" % gs.get_battle_round())
+	_check("active player switched to 1", gs.get_active_player() == 1)
+	var r2 = _end_turn_via_scoring(gs, 1)
+	_check("P1 END_TURN succeeded", r2.get("success", false), str(r2))
+	_check("round advanced after P1 (second) turn", gs.get_battle_round() == 2,
+		"round=%d" % gs.get_battle_round())
+	_check("active player switched back to 2", gs.get_active_player() == 2)
+
+	print("\n-- C: no reinforcements on P1's first turn (P2-first) --")
+	gs.initialize_default_state()
+	gs.state["meta"]["first_turn_player"] = 2
+	gs.state["meta"]["battle_round"] = 1
+	gs.state["meta"]["active_player"] = 2
+	# Minimal armies: one deployed unit each + one P1 unit in Deep Strike reserves
+	gs.state["units"] = {
+		"U_P1_LINE": {
+			"owner": 1, "status": 2,  # UnitStatus.DEPLOYED
+			"meta": {"name": "P1 Line", "stats": {"move": 6}},
+			"models": [{"id": "m1", "alive": true, "base_mm": 32, "position": {"x": 400, "y": 2200}, "wounds": 1, "current_wounds": 1}],
+			"flags": {}
+		},
+		"U_P1_DEEPSTRIKER": {
+			"owner": 1, "status": 7,  # UnitStatus.IN_RESERVES
+			"reserve_type": "deep_strike",
+			"meta": {"name": "P1 Deep Striker", "stats": {"move": 12},
+				"abilities": [{"name": "Deep Strike"}]},
+			"models": [{"id": "m1", "alive": true, "base_mm": 40, "position": null, "wounds": 2, "current_wounds": 2}],
+			"flags": {}
+		},
+		"U_P2_LINE": {
+			"owner": 2, "status": 2,  # UnitStatus.DEPLOYED
+			"meta": {"name": "P2 Line", "stats": {"move": 6}},
+			"models": [{"id": "m1", "alive": true, "base_mm": 32, "position": {"x": 400, "y": 200}, "wounds": 1, "current_wounds": 1}],
+			"flags": {}
+		},
+	}
+	var end_p2 = _end_turn_via_scoring(gs, 2)
+	_check("P2 (first) END_TURN succeeded", end_p2.get("success", false), str(end_p2))
+	_check("still Round 1 for P1's first turn", gs.get_battle_round() == 1,
+		"round=%d" % gs.get_battle_round())
+	gs.state["meta"]["phase"] = 7  # Phase.MOVEMENT
+	var reinf_r1 = _movement_reinforcement_actions(gs)
+	_check("no PLACE_REINFORCEMENT during P1's first turn", reinf_r1.is_empty(),
+		"got %d reinforcement actions" % reinf_r1.size())
+	# End P1's turn -> Round 2 genuinely starts -> reinforcements unlock for P2's turn,
+	# and P1's next movement phase offers the deep striker.
+	gs.state["meta"]["phase"] = 11  # Phase.SCORING
+	var end_p1 = _end_turn_via_scoring(gs, 1)
+	_check("P1 (second) END_TURN succeeded", end_p1.get("success", false), str(end_p1))
+	_check("Round 2 after both turns", gs.get_battle_round() == 2, "round=%d" % gs.get_battle_round())
+	gs.state["meta"]["phase"] = 7  # Phase.MOVEMENT
+	gs.state["meta"]["active_player"] = 1
+	var reinf_r2 = _movement_reinforcement_actions(gs)
+	_check("PLACE_REINFORCEMENT offered in Round 2", reinf_r2.size() == 1,
+		"got %d reinforcement actions" % reinf_r2.size())
+
+	print("\n-- D: game end on the round's second player at max rounds --")
+	gs.initialize_default_state()
+	gs.state["meta"]["first_turn_player"] = 2
+	gs.state["meta"]["active_player"] = 2
+	gs.state["meta"]["battle_round"] = gs.MAX_BATTLE_ROUNDS
+	var end_p2_final = _end_turn_via_scoring(gs, 2)
+	_check("P2's final-round turn does not end the game", not end_p2_final.get("game_ended", false),
+		str(end_p2_final))
+	_check("game not flagged ended yet", not gs.state["meta"].get("game_ended", false))
+	var end_p1_final = _end_turn_via_scoring(gs, 1)
+	_check("P1's final-round turn ends the game", end_p1_final.get("game_ended", false),
+		str(end_p1_final))
+	_check("meta.game_ended set", gs.state["meta"].get("game_ended", false))
+
+	print("\n-- E: round-boundary helpers agree for the DEFAULT (P1-first) case --")
+	# Regression guard: with no first_turn_player set (legacy games), the fix
+	# must behave EXACTLY like the old hardcoded 'Player 2 closes the round' /
+	# 'Player 1 opens the round' logic. get_first_turn_player() falls back to 1.
+	gs.initialize_default_state()
+	_check("default first-turn player is 1", gs.get_first_turn_player() == 1)
+	_check("default: P1 opens the round (is_last_turn_of_round(1) == false)",
+		gs.is_last_turn_of_round(1) == false)
+	_check("default: P2 closes the round (is_last_turn_of_round(2) == true)",
+		gs.is_last_turn_of_round(2) == true)
+	# Equivalence with the old hardcoded checks these call sites used:
+	#   CommandPhase per-round reset: old `current_player == 1` == new `== get_first_turn_player()`
+	#   TurnManager/SaveLoadManager round-end: same
+	#   ScoringPhase/GameManager round advance: old `current_player == 2` == new `is_last_turn_of_round`
+	_check("default: reset gate matches old 'current_player == 1'",
+		(1 == gs.get_first_turn_player()) == true and (2 == gs.get_first_turn_player()) == false)
+	_check("default: advance gate matches old 'current_player == 2'",
+		gs.is_last_turn_of_round(2) == true and gs.is_last_turn_of_round(1) == false)
+
+	gs.state = prev
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_p2_first_turn_round_advance.gd.uid
+++ b/40k/tests/test_p2_first_turn_round_advance.gd.uid
@@ -1,0 +1,1 @@
+uid://b1td1muu58ro8


### PR DESCRIPTION
## Problem

In the movement phase the AI (and a human) could bring units in from Reserves / Deep Strike on **turn one** — units that should only be able to set up within their own deployment zone that early.

## Root cause

The AI wasn't the problem — the **battle round was wrong**. The game advanced `meta.battle_round` whenever **Player 2** ended a turn (hardcoded `current_player == 2`), assuming Player 1 always takes the first turn. When the first-turn roll-off gives **Player 2 the first turn**, Round 1 "ended" after a single player turn, so **Player 1's very first turn ran as Battle Round 2**. The movement phase gates reinforcements on `battle_round >= 2`, so it offered Reserves/Deep Strike arrivals on turn one, which the AI then suggested.

## The fix

Added `GameState.get_first_turn_player()` and `is_last_turn_of_round(player)`, then replaced the hardcoded `player == 1/2` round-boundary checks:

- **ScoringPhase / GameManager** — battle-round advance, game-end detection, 11e final-turn scoring window
- **CommandPhase** — per-round resets (CP cap, kill counters, battle-round stratagem expiry) fire on the first-turn player's Command phase
- **TurnManager / SaveLoadManager** — round-advance signal and round-end autosave trigger when control wraps back to the first-turn player
- **MissionManager** — Supply Drop round-4 objective removal and the "killed more than opponent last turn" primary rule
- Also fixed **6 snapshot `battle_round` misreads** (AIDecisionMaker + MovementPhase) that read the value at the snapshot top level (always defaulting to `1`) instead of under `meta`

Because `get_first_turn_player()` falls back to Player 1, every one of these call sites is **behaviour-identical for existing Player-1-first games** — only Player-2-first play changes.

## Validation

- **Windowed scenario** `first_turn_p2_no_reserves_turn_one` — **51/51**. Drives P2's full first turn, proves the round stays 1 as control passes to P1, asserts P1's Round-1 movement UI offers **zero** reinforcement rows even though P1 holds a unit in reserves, then advances to Round 2 as a positive control where reserves **do** appear.
- **Headless test** `test_p2_first_turn_round_advance.gd` — **25/25** (round tracking, reinforcement gating, game-end timing, and P1-first equivalence).
- Existing suites still green: turn hooks (7), rapid-ingress (14), roll-off (10), two-rolloffs (20), primary missions 11e (56). Re-validated after rebasing onto latest `main`.
- Added a read-only `MovementController.get_reinforcement_row_count()` accessor for the scenario to assert the on-screen reinforcement rows.

Version bumped to `0.17.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyrhywdV7y4Sz6W8qbaJmJ