### PR TITLE
Game-log step replay: click a log entry to revert the board to that step

### DIFF
--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -354,8 +354,18 @@ func _model_suffix(unit_id: String) -> String:
 	var label = "model" if n == 1 else "models"
 	return " (%d %s)" % [n, label]
 
+func _current_history_marker() -> int:
+	"""Recording index that represents the board state as of this log line, used
+	by the in-game history browser (click a log entry → see the board then).
+	ReplayManager records an action's event just before GameEventLog logs it (it
+	is an earlier autoload), so for player/AI action entries this resolves to that
+	action's own resulting state. -1 when recording is unavailable/empty."""
+	if ReplayManager and ReplayManager.has_method("get_history_marker"):
+		return ReplayManager.get_history_marker()
+	return -1
+
 func _add_entry(text: String, entry_type: String) -> void:
-	entries.append({"text": text, "type": entry_type})
+	entries.append({"text": text, "type": entry_type, "history_index": _current_history_marker()})
 	print("[GameEventLog] %s" % text)
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, entry_type)
@@ -382,10 +392,18 @@ func add_ai_thinking_block(player: int, header: String, lines: Array, context: D
 	var text = "P%d AI: %s" % [player, header]
 	for line in lines:
 		text += "\n" + str(line)
-	entries.append({"text": text, "type": "ai_thinking_block", "context": context})
+	entries.append({"text": text, "type": "ai_thinking_block", "context": context, "history_index": _current_history_marker()})
 	print("[GameEventLog] %s" % text)
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, "ai_thinking_block")
+
+func get_last_entry_history_index() -> int:
+	"""History-browser marker of the most recent entry (-1 if none). GameLogPanel
+	reads this synchronously from its entry_added handler to make the new card
+	clickable for board reconstruction."""
+	if entries.is_empty():
+		return -1
+	return int(entries[entries.size() - 1].get("history_index", -1))
 
 func get_last_entry_context() -> Dictionary:
 	"""Board-link context of the most recent entry (empty if none). GameLogPanel

--- a/40k/autoloads/ReplayManager.gd
+++ b/40k/autoloads/ReplayManager.gd
@@ -37,6 +37,11 @@ enum Mode { IDLE, RECORDING, PLAYBACK }
 
 var is_recording: bool = false
 var auto_record_ai: bool = true  # Auto-record AI vs AI games
+# When true, incremental/final recordings are also written to disk as replay
+# files. AI-vs-AI games set this (so they appear in the menu's replay browser);
+# human games record purely in memory to power the in-game "view a past step"
+# feature without spamming disk with replay files every turn.
+var persist_to_disk: bool = false
 var _recording_initial_state: Dictionary = {}
 var _recording_events: Array = []
 var _recording_snapshots: Array = []  # Array of {event_index, state}
@@ -132,7 +137,7 @@ func _connect_recording_signals() -> void:
 # Recording - Start/Stop
 # ============================================================================
 
-func start_recording() -> void:
+func start_recording(persist_flag: bool = false) -> void:
 	if is_recording:
 		print("ReplayManager: Already recording")
 		return
@@ -141,6 +146,7 @@ func start_recording() -> void:
 		print("ReplayManager: Cannot record during playback")
 		return
 
+	persist_to_disk = persist_flag
 	is_recording = true
 	current_mode = Mode.RECORDING
 	_recording_events.clear()
@@ -196,8 +202,11 @@ func stop_recording() -> void:
 	_recording_meta["final_round"] = GameState.get_battle_round()
 	_recording_meta["status"] = "complete"
 
-	# Save to file (reuses stable path so final save overwrites incremental)
-	var file_path = _save_replay_to_file()
+	# Save to file only for persisted recordings (AI-vs-AI). Human games keep the
+	# recording in memory for the in-game history browser but write no replay file.
+	var file_path = ""
+	if persist_to_disk:
+		file_path = _save_replay_to_file()
 
 	current_mode = Mode.IDLE
 	print("ReplayManager: Recording stopped (%d events, %d snapshots)" % [
@@ -355,6 +364,10 @@ func save_replay_incremental() -> void:
 	"""Save the current recording to disk without stopping. Used for per-turn saves
 	so that incomplete games still have replay data available."""
 	if not is_recording:
+		return
+
+	# Human games record in memory only (no per-turn replay files on disk).
+	if not persist_to_disk:
 		return
 
 	# Update metadata with current state (but keep status as in_progress)
@@ -907,6 +920,86 @@ func get_recorded_event_descriptions_for_round(battle_round: int) -> Array:
 			"phase": event.get("phase", -1),
 		})
 	return descriptions
+
+# ============================================================================
+# In-Game History Browser (log step replay)
+# ============================================================================
+#
+# These power the "click a game-log entry to see the board as it was at that
+# step" feature. They read the LIVE recording arrays (_recording_events /
+# _recording_snapshots) — which are populated for every game, not just AI vs AI —
+# and reconstruct a historical GameState WITHOUT mutating the live state.
+
+func get_history_marker() -> int:
+	"""Index of the most recently recorded event ('the board as it is right now').
+	GameEventLog stamps each log entry with this value at the moment it is added,
+	so clicking that entry later can reconstruct the matching board state.
+	Returns -1 when nothing has been recorded yet."""
+	return _recording_event_index - 1
+
+func has_history() -> bool:
+	"""True when there is at least one recorded snapshot to reconstruct from."""
+	return not _recording_snapshots.is_empty()
+
+func get_recorded_event(index: int) -> Dictionary:
+	"""Return the recorded event at a live-recording index (empty if out of range)."""
+	if index >= 0 and index < _recording_events.size():
+		return _recording_events[index]
+	return {}
+
+func _find_recording_snapshot_index_at_or_before(target_index: int) -> int:
+	"""Index into _recording_snapshots of the newest snapshot whose event_index is
+	<= target_index. Snapshot 0 is always the initial state (event_index -1)."""
+	var best := 0
+	for i in range(_recording_snapshots.size()):
+		var snap_event_idx = _recording_snapshots[i].get("event_index", -1)
+		if snap_event_idx <= target_index:
+			best = i
+		else:
+			break
+	return best
+
+func build_recorded_state_at(target_index: int) -> Dictionary:
+	"""Reconstruct and RETURN the full GameState dictionary as it was at the given
+	recorded-event index. Pure with respect to the live game: GameState.state is
+	left exactly as it was found. Returns {} if there is no recording to rebuild
+	from.
+
+	Reconstruction mirrors the live application path: start from the nearest
+	phase-transition snapshot at/before the target, then re-apply each recorded
+	event's diffs through GameState.apply_state_changes (which faithfully handles
+	set/add/remove — the same code that applied them live). The caller MUST have
+	GameState.state pointing at a state it is happy to see restored on return
+	(normally the real live state)."""
+	if _recording_snapshots.is_empty():
+		return {}
+
+	# Clamp the target into the valid recorded range.
+	var last_event := _recording_events.size() - 1
+	if target_index > last_event:
+		target_index = last_event
+
+	var snap_idx := _find_recording_snapshot_index_at_or_before(target_index)
+	var snapshot: Dictionary = _recording_snapshots[snap_idx]
+	var snapshot_event_idx: int = snapshot.get("event_index", -1)
+
+	# Fresh deep copy so we never alias the stored snapshot.
+	var base: Dictionary = GameState._deep_copy_dict(snapshot.get("state", {}))
+
+	# Temporarily point GameState at our scratch copy so we can reuse the exact
+	# live diff-application code, then restore the caller's state. The live state
+	# object itself is never mutated — only `base` is.
+	var preserved = GameState.state
+	GameState.state = base
+	for i in range(snapshot_event_idx + 1, target_index + 1):
+		if i < 0 or i >= _recording_events.size():
+			continue
+		var diffs = _recording_events[i].get("diffs", [])
+		if diffs is Array and not diffs.is_empty():
+			GameState.apply_state_changes(diffs)
+	var reconstructed = GameState.state
+	GameState.state = preserved
+	return reconstructed
 
 # ============================================================================
 # Timer Callback

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,19 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+
+			"version": "0.18.0",
+			"date": "2026-07-11",
+			"summary": "Game-log step replay: click any entry in the game log to see the board exactly as it was at that moment. It's a read-only look back — the live game is never changed — with a banner and an Exit button (or Esc) to return.",
+			"changes": [
+				"Click a line in the Game Log to revert the board tokens to how they looked at that step (deployments, moves, casualties, etc.).",
+				"The step you're viewing is highlighted in the log; a banner across the top names the step and the board is dimmed to show it's read-only.",
+				"Click another log line to jump to that step, or press the 'Return to Live Game' button (or Esc) to go back to playing — your live game is untouched.",
+				"Every game now records its steps in memory to power this (previously only AI-vs-AI games were recorded); the AI vs AI replay browser is unchanged.",
+				"History view is disabled in multiplayer games."
+			]
+		},
+		{
 			"version": "0.17.7",
 			"date": "2026-07-10",
 			"summary": "Fixed a Shooting phase soft-lock: after a unit threw a GRENADE, the shooting UI could get stuck — clicks did nothing, or 'Rolling dice…' showed with no result. Rejected shooting actions are now explained instead of failing silently.",

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -1,6 +1,12 @@
 extends PanelContainer
 class_name GameLogPanel
 
+## Emitted when the player clicks a log card to view the board as it was at that
+## step. `history_index` is the ReplayManager recording marker stamped on the
+## entry; `description` is a short label for the history banner. Main handles the
+## actual board reconstruction / read-only history view.
+signal history_step_requested(history_index: int, description: String)
+
 const DiceRowVisualScript := preload("res://scripts/DiceRowVisual.gd")
 
 ## GameLogPanel — Self-contained card-based game event log UI.
@@ -134,6 +140,14 @@ var _pinned_link_card: PanelContainer = null
 var _thought_link_visual: Node2D = null
 var _card_count: int = 0
 var _is_visible: bool = true
+
+# --- History browser (click a card to revert the board to that step) ---
+# Set immediately before each card is built so _register_card can stamp the card
+# with the recording marker (and plain text) of the entry it represents.
+var _pending_history_index: int = -1
+var _pending_history_text: String = ""
+# The card currently selected in the history browser (highlighted); null = live.
+var _active_history_card: Control = null
 var _current_combat_card: PanelContainer = null
 var _current_combat_details_text: String = ""
 var _current_combat_details_container: VBoxContainer = null
@@ -272,7 +286,11 @@ func setup(parent: Node, hud_bottom: HBoxContainer = null, offset_top: float = 1
 		print("GameLogPanel: Connected to GameEventLog.entry_added")
 		# Populate existing entries (no animation for backfill)
 		for entry in game_event_log.get_all_entries():
+			_pending_history_index = int(entry.get("history_index", -1))
+			_pending_history_text = str(entry.get("text", ""))
 			_create_card(entry.text, entry.type, false)
+		_pending_history_index = -1
+		_pending_history_text = ""
 
 	# Connect to DiceHistoryPanel for real-time dice display
 	var dice_history = Engine.get_main_loop().root.get_node_or_null("DiceHistoryPanel") if Engine.get_main_loop() else null
@@ -378,7 +396,14 @@ func get_linked_ai_card_count() -> int:
 # ==========================================================================
 
 func _on_entry_added(text: String, entry_type: String) -> void:
+	# Stamp the incoming card with the recording marker of this entry so it can be
+	# clicked later to reconstruct the board state at this step.
+	var gel = Engine.get_main_loop().root.get_node_or_null("GameEventLog") if Engine.get_main_loop() else null
+	_pending_history_index = gel.get_last_entry_history_index() if (gel and gel.has_method("get_last_entry_history_index")) else -1
+	_pending_history_text = text
 	_create_card(text, entry_type, true)
+	_pending_history_index = -1
+	_pending_history_text = ""
 	# Auto-scroll to bottom
 	if _scroll:
 		await get_tree().process_frame
@@ -1569,6 +1594,100 @@ func _register_card(card: Control, category: int) -> void:
 		return
 	card.set_meta("log_category", category)
 	card.visible = _category_visible.get(category, true)
+	# Make the card clickable to revert the board to this step (history browser).
+	_make_card_clickable(card, _pending_history_index)
+
+# ==========================================================================
+# History browser — click a card to see the board as it was at that step
+# ==========================================================================
+
+func _make_card_clickable(card: Control, history_index: int) -> void:
+	"""Wire a log card so clicking it asks Main to show the board at `history_index`.
+	Skipped for entries with no recording marker and for board-linked AI cards
+	(which already use their click to pin option arrows on the board)."""
+	if card == null or history_index < 0:
+		return
+	if card.has_meta("ai_link_context"):
+		return
+	card.set_meta("history_index", history_index)
+	card.set_meta("history_desc", _pending_history_text)
+	# Let clicks reach the card everywhere except on real Buttons (detail toggles).
+	_set_descendant_mouse_ignore(card)
+	card.mouse_filter = Control.MOUSE_FILTER_STOP
+	card.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	if card.tooltip_text == "":
+		card.tooltip_text = "Click to view the board as it was at this step"
+	var desc := _card_history_description(card)
+	card.gui_input.connect(func(event):
+		if event is InputEventMouseButton and event.pressed and event.button_index == MOUSE_BUTTON_LEFT:
+			_set_active_history_card(card)
+			emit_signal("history_step_requested", history_index, desc))
+
+func _set_descendant_mouse_ignore(node: Node) -> void:
+	"""Set every descendant Control that is NOT a Button to MOUSE_FILTER_IGNORE so
+	pointer events fall through to the card. Buttons keep their own input (so the
+	'Show details' / 'considerations' toggles still work)."""
+	for child in node.get_children():
+		if child is Control and not (child is Button):
+			child.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		_set_descendant_mouse_ignore(child)
+
+func _card_history_description(card: Control) -> String:
+	"""Short label for a card, for the history banner. Uses the plain entry text
+	stashed on the card (the first line, since combat cards etc. can be multi-line)."""
+	var t := str(card.get_meta("history_desc", "")).strip_edges()
+	var nl := t.find("\n")
+	if nl >= 0:
+		t = t.substr(0, nl).strip_edges()
+	if t.length() > 70:
+		t = t.substr(0, 67).strip_edges() + "…"
+	return t
+
+func _set_active_history_card(card: Control) -> void:
+	"""Highlight the card currently being viewed in the history browser."""
+	if _active_history_card != null and is_instance_valid(_active_history_card):
+		_active_history_card.self_modulate = Color(1, 1, 1, 1)
+	_active_history_card = card
+	if card != null and is_instance_valid(card):
+		# Warm gold tint on the card's own panel (self_modulate does not dim children).
+		card.self_modulate = Color(1.5, 1.35, 0.7, 1)
+
+func clear_active_history() -> void:
+	"""Called by Main when leaving history view — drop the selection highlight."""
+	if _active_history_card != null and is_instance_valid(_active_history_card):
+		_active_history_card.self_modulate = Color(1, 1, 1, 1)
+	_active_history_card = null
+
+func has_active_history() -> bool:
+	return _active_history_card != null and is_instance_valid(_active_history_card)
+
+func count_history_cards() -> int:
+	"""Number of log cards that are clickable for history reconstruction."""
+	var n := 0
+	if _card_container == null:
+		return 0
+	for card in _card_container.get_children():
+		if is_instance_valid(card) and card.has_meta("history_index"):
+			n += 1
+	return n
+
+func debug_click_history_card_matching(substring: String) -> bool:
+	"""Test hook (windowed scenarios): drive the exact same code path as a real
+	left-click on the first clickable log card whose text contains `substring`.
+	Returns false if no matching clickable card exists."""
+	if _card_container == null:
+		return false
+	for card in _card_container.get_children():
+		if not is_instance_valid(card):
+			continue
+		if not card.has_meta("history_index"):
+			continue
+		var txt := str(card.get_meta("history_desc", ""))
+		if substring in txt:
+			_set_active_history_card(card)
+			emit_signal("history_step_requested", int(card.get_meta("history_index")), _card_history_description(card))
+			return true
+	return false
 
 func _on_ai_filter_pressed() -> void:
 	# The header 'AI' shortcut drives the same state as the AI chip.

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -241,6 +241,13 @@ var game_log_panel = null  # GameLogPanel instance
 var game_log_toggle_button: Button
 var _current_combat_card = null  # GameLogEntry - Tracks active combat card for grouping
 
+# --- History browser (click a game-log entry to revert the board to that step) ---
+var _history_view_active: bool = false
+var _history_live_state: Dictionary = {}      # the real, live GameState.state (held safe)
+var _history_overlay: Control = null          # blocks input on the board while viewing
+var _history_banner_label: RichTextLabel = null
+var _history_saved_ai_enabled: bool = false   # AI enabled flag to restore on exit
+
 # P3-117: Dice Roll History panel UI elements
 var _dice_history_panel: PanelContainer = null
 var _dice_history_label: RichTextLabel = null
@@ -5016,6 +5023,11 @@ func _input(event: InputEvent) -> void:
 	# Use direct keycode check for reliability (is_action_pressed can miss with physical_keycode-only mappings)
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_ESCAPE:
 		print("Main: Escape key pressed")
+		# History browser: ESC returns to the live game before anything else.
+		if _history_view_active:
+			_exit_history_view()
+			get_viewport().set_input_as_handled()
+			return
 		# T7-56: Close replay panel on ESC if open
 		if _ai_turn_replay_panel and _ai_turn_replay_panel.visible:
 			_ai_turn_replay_panel.hide_panel()
@@ -5039,6 +5051,14 @@ func _input(event: InputEvent) -> void:
 		# Open settings menu
 		_open_settings_menu()
 		get_viewport().set_input_as_handled()
+		return
+
+	# History browser: while viewing a past step, none of Main's own game-input
+	# handlers (board clicks, hotkeys, right-click menu) should run. We deliberately
+	# do NOT mark the event handled, so GUI input still flows to the game-log panel
+	# (to pick another step) and the overlay's Exit button. Camera pan/zoom lives in
+	# _process and keeps working so the player can look around the historical board.
+	if _history_view_active:
 		return
 
 	# MA-41: Skip all non-Escape keyboard input when a text input field has focus
@@ -8627,6 +8647,16 @@ func _refresh_after_load() -> void:
 	# P2-12: Dismiss the fade overlay now that everything is restored
 	_dismiss_game_loaded_overlay()
 
+	# History browser: the pre-load recording describes a different game, so reset
+	# it and start fresh from the loaded state (which becomes the new step 0).
+	if ReplayManager and ReplayManager.has_method("cleanup"):
+		var nm = get_node_or_null("/root/NetworkManager")
+		var is_client: bool = nm != null and nm.is_networked() and not nm.is_host()
+		ReplayManager.cleanup()
+		if not is_client:
+			ReplayManager.start_recording(ReplayManager.should_auto_record())
+			print("Main: Replay recording restarted after load")
+
 	print("Main: _refresh_after_load() complete — all state fully restored")
 
 func update_deployment_zone_visibility() -> void:
@@ -10347,6 +10377,9 @@ func _setup_game_log_panel() -> void:
 	var hud_bottom = get_node_or_null("HUD_Bottom/HBoxContainer")
 	game_log_panel.setup(self, hud_bottom, 105.0, 0.0)
 	game_log_toggle_button = game_log_panel.get_toggle_button()
+	# History browser: clicking a log card reverts the board to that step.
+	if game_log_panel.has_signal("history_step_requested"):
+		game_log_panel.history_step_requested.connect(_on_history_step_requested)
 	print("Main: Game Event Log panel created (card-based)")
 
 func _prune_old_log_entries() -> void:
@@ -10509,21 +10542,272 @@ func _on_dice_history_clear_pressed() -> void:
 		_dice_history_label.clear()
 
 # ============================================================================
+# History Browser — click a game-log entry to revert the board to that step
+# ============================================================================
+#
+# This is a READ-ONLY view of a past board state, not a rewind: the live game is
+# untouched. We hold the real GameState.state safe, swap in a reconstructed
+# historical copy (built by ReplayManager from recorded diffs/snapshots), refresh
+# the board tokens, and block all game input behind an overlay until the player
+# returns to the live game (Exit button or ESC).
+
+func _on_history_step_requested(history_index: int, description: String) -> void:
+	# Not available while loading a replay file (that has its own controls) or as
+	# a networked client (local state swaps would fight the network sync).
+	if is_replay_mode:
+		return
+	var nm = get_node_or_null("/root/NetworkManager")
+	if nm and nm.is_networked():
+		if ToastManager:
+			ToastManager.show_toast("History view isn't available in multiplayer", Color(1, 0.7, 0.3))
+		return
+	if not ReplayManager or not ReplayManager.has_method("build_recorded_state_at"):
+		return
+	if not ReplayManager.has_history():
+		if ToastManager:
+			ToastManager.show_toast("Nothing recorded yet for this game", Color(1, 0.7, 0.3))
+		return
+	_show_history_state(history_index, description)
+
+func _show_history_state(history_index: int, description: String) -> void:
+	# On first entry, stash the real live state so we can restore it verbatim.
+	if not _history_view_active:
+		_history_live_state = GameState.state
+		_enter_history_view_mode()
+
+	# Reconstruct the historical state WITHOUT touching the live state, then make
+	# it the state the board renders from. (build_recorded_state_at preserves
+	# whatever GameState.state currently is, so passing through repeated clicks is
+	# safe — the live state stays held in _history_live_state.)
+	# Ensure reconstruction bases its save/restore on the real live state.
+	GameState.state = _history_live_state
+	var historical: Dictionary = ReplayManager.build_recorded_state_at(history_index)
+	if historical.is_empty():
+		# Could not rebuild — bail out of history view cleanly.
+		_exit_history_view()
+		return
+	GameState.state = historical
+	_history_refresh_visuals()
+	_update_history_banner(description)
+
+func _enter_history_view_mode() -> void:
+	_history_view_active = true
+	print("Main: Entering history view")
+	DebugLogger.info("Main: Entering history view", {})
+
+	# Pause the AI so it can't act on the historical state.
+	var ai_player = get_node_or_null("/root/AIPlayer")
+	if ai_player:
+		_history_saved_ai_enabled = ai_player.enabled
+		ai_player.enabled = false
+
+	# Pause autosave so we never persist a historical snapshot as the live game.
+	if SaveLoadManager and SaveLoadManager.has_method("disable_autosave"):
+		SaveLoadManager.disable_autosave()
+
+	# Silence the phase controllers. The full-screen overlay blocks _gui_input /
+	# _unhandled_input, but a few controllers (Shooting/Fight/Charge) read board
+	# clicks in _input(), which fires BEFORE the overlay can consume the event —
+	# so a stray click could otherwise dispatch an action onto the historical
+	# state. Disabling their input processing closes that gap.
+	_set_controllers_input_enabled(false)
+
+	_build_history_overlay()
+
+func _set_controllers_input_enabled(enabled: bool) -> void:
+	"""Enable/disable input processing on every phase controller — used to make the
+	board fully inert while the player browses a past step."""
+	for c in [deployment_controller, command_controller, movement_controller,
+			shooting_controller, charge_controller, fight_controller, scoring_controller]:
+		if c != null and is_instance_valid(c):
+			c.set_process_input(enabled)
+			c.set_process_unhandled_input(enabled)
+
+func _build_history_overlay() -> void:
+	if _history_overlay and is_instance_valid(_history_overlay):
+		_history_overlay.visible = true
+		return
+
+	# Full-screen input blocker. Sits above the board/HUD but BELOW the game log
+	# panel (whose z is raised) so the player can keep clicking other log entries.
+	var overlay := Control.new()
+	overlay.name = "HistoryViewOverlay"
+	overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	overlay.mouse_filter = Control.MOUSE_FILTER_STOP
+	overlay.z_index = UI_PANEL_Z + 50
+	add_child(overlay)
+	_history_overlay = overlay
+
+	# Keep the game-log panel clickable on top of the overlay.
+	if game_log_panel and is_instance_valid(game_log_panel):
+		game_log_panel.z_index = UI_PANEL_Z + 100
+
+	# A subtle dim so it's obvious the board isn't live.
+	var tint := ColorRect.new()
+	tint.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
+	tint.color = Color(0.05, 0.06, 0.10, 0.28)
+	tint.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	overlay.add_child(tint)
+
+	# Banner across the top.
+	var banner := PanelContainer.new()
+	banner.name = "HistoryBanner"
+	banner.anchor_left = 0.0
+	banner.anchor_right = 1.0
+	banner.anchor_top = 0.0
+	banner.anchor_bottom = 0.0
+	banner.offset_left = 348.0   # clear the game-log panel on the left
+	banner.offset_right = -12.0
+	banner.offset_top = 12.0
+	banner.offset_bottom = 60.0
+	banner.mouse_filter = Control.MOUSE_FILTER_STOP
+	var banner_style := StyleBoxFlat.new()
+	banner_style.bg_color = Color(0.12, 0.10, 0.06, 0.96)
+	banner_style.border_color = Color(0.833, 0.588, 0.376)
+	banner_style.set_border_width_all(2)
+	banner_style.set_corner_radius_all(6)
+	banner_style.content_margin_left = 12
+	banner_style.content_margin_right = 12
+	banner_style.content_margin_top = 6
+	banner_style.content_margin_bottom = 6
+	banner.add_theme_stylebox_override("panel", banner_style)
+	overlay.add_child(banner)
+
+	var hbox := HBoxContainer.new()
+	hbox.add_theme_constant_override("separation", 12)
+	banner.add_child(hbox)
+
+	_history_banner_label = RichTextLabel.new()
+	_history_banner_label.bbcode_enabled = true
+	_history_banner_label.fit_content = true
+	_history_banner_label.scroll_active = false
+	_history_banner_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_history_banner_label.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	_history_banner_label.add_theme_font_size_override("normal_font_size", 14)
+	_history_banner_label.add_theme_font_size_override("bold_font_size", 15)
+	hbox.add_child(_history_banner_label)
+
+	var exit_btn := Button.new()
+	exit_btn.name = "HistoryExitButton"
+	exit_btn.text = "Return to Live Game  (Esc)"
+	exit_btn.size_flags_vertical = Control.SIZE_SHRINK_CENTER
+	exit_btn.pressed.connect(_exit_history_view)
+	hbox.add_child(exit_btn)
+
+func _update_history_banner(description: String) -> void:
+	if _history_banner_label == null or not is_instance_valid(_history_banner_label):
+		return
+	var desc := description.strip_edges()
+	_history_banner_label.clear()
+	if desc == "":
+		_history_banner_label.append_text("[b][color=#E8C477]🕑 Viewing a past step[/color][/b]  [color=#B0B8C0]— the board below is read-only.[/color]")
+	else:
+		_history_banner_label.append_text("[b][color=#E8C477]🕑 Viewing:[/color][/b] [color=#DCE3EC]%s[/color]  [color=#8892A0]— read-only[/color]" % desc)
+
+func _history_refresh_visuals() -> void:
+	"""Rebuild the board tokens from the (historical) GameState.state. Deliberately
+	minimal: it recreates unit tokens and updates score/round labels only. It does
+	NOT rebuild phase controllers or run any phase logic — this is a passive view."""
+	# Clear existing tokens
+	for child in token_layer.get_children():
+		child.queue_free()
+	await get_tree().process_frame
+	if not _history_view_active:
+		return  # exited while we were awaiting
+
+	var units = GameState.state.get("units", {})
+	for unit_id in units:
+		var unit = units[unit_id]
+		if unit.get("embarked_in", null) != null:
+			continue
+		var status = unit.get("status", 0)
+		if status >= GameStateData.UnitStatus.DEPLOYED and status != GameStateData.UnitStatus.IN_RESERVES:
+			var models = unit.get("models", [])
+			for i in range(models.size()):
+				var model = models[i]
+				var pos = model.get("position")
+				if pos != null and model.get("alive", true):
+					var token = _create_token_visual(unit_id, model)
+					if token:
+						token_layer.add_child(token)
+						var final_pos: Vector2
+						if pos is Dictionary:
+							final_pos = Vector2(pos.x, pos.y)
+						else:
+							final_pos = pos
+						token.position = final_pos
+
+	# Refresh score / CP / round read-outs so the HUD matches the historical state.
+	if has_method("_update_score_display"):
+		_update_score_display()
+	if has_method("_update_round_indicator"):
+		_update_round_indicator()
+	if active_player_badge:
+		active_player_badge.text = "P%d" % GameState.get_active_player()
+
+func _exit_history_view() -> void:
+	if not _history_view_active:
+		return
+	print("Main: Exiting history view — restoring live game")
+	DebugLogger.info("Main: Exiting history view", {})
+
+	# Restore the live state reference (never mutated while viewing history).
+	if not _history_live_state.is_empty():
+		GameState.state = _history_live_state
+	_history_live_state = {}
+	_history_view_active = false
+
+	# Drop the log selection highlight.
+	if game_log_panel and is_instance_valid(game_log_panel) and game_log_panel.has_method("clear_active_history"):
+		game_log_panel.clear_active_history()
+
+	# Remove the overlay and restore the log panel's normal z.
+	if _history_overlay and is_instance_valid(_history_overlay):
+		_history_overlay.queue_free()
+	_history_overlay = null
+	_history_banner_label = null
+	if game_log_panel and is_instance_valid(game_log_panel):
+		game_log_panel.z_index = UI_PANEL_Z
+
+	# Rebuild the live board and re-run normal UI refresh.
+	_recreate_unit_visuals()
+	refresh_unit_list()
+	update_ui()
+
+	# Resume AI + autosave + controller input.
+	var ai_player = get_node_or_null("/root/AIPlayer")
+	if ai_player:
+		ai_player.enabled = _history_saved_ai_enabled
+	if SaveLoadManager and SaveLoadManager.has_method("enable_autosave"):
+		SaveLoadManager.enable_autosave()
+	_set_controllers_input_enabled(true)
+
+func is_history_view_active() -> bool:
+	return _history_view_active
+
+# ============================================================================
 # Replay Mode
 # ============================================================================
 
 func _start_replay_recording_if_needed() -> void:
-	"""Start replay recording for AI vs AI games automatically."""
+	"""Start replay recording. Every game records in memory so the player can click
+	a game-log entry to see the board as it was at that step. AI-vs-AI games also
+	persist the recording to disk (so they show up in the menu's replay browser)."""
 	if not ReplayManager:
 		return
 
-	if ReplayManager.should_auto_record():
-		print("Main: Auto-starting replay recording (AI vs AI game)")
-		# Small delay to ensure all initialization is complete
-		await get_tree().create_timer(0.2).timeout
-		ReplayManager.start_recording()
-	else:
-		print("Main: Replay recording not auto-started (not AI vs AI)")
+	# A multiplayer CLIENT must not record — the host is the source of truth and
+	# already records. Recording locally would fight the network state sync.
+	var nm = get_node_or_null("/root/NetworkManager")
+	if nm and nm.is_networked() and not nm.is_host():
+		print("Main: Replay recording skipped (multiplayer client)")
+		return
+
+	# Small delay to ensure all initialization is complete
+	await get_tree().create_timer(0.2).timeout
+	var persist := ReplayManager.should_auto_record()  # AI vs AI → also write files
+	ReplayManager.start_recording(persist)
+	print("Main: Replay recording started (persist_to_disk=%s)" % persist)
 
 func _initialize_replay_mode() -> void:
 	"""Initialize the Main scene in replay mode - streamlined, no game logic."""

--- a/40k/tests/scenarios/sp/game_log_step_replay.json
+++ b/40k/tests/scenarios/sp/game_log_step_replay.json
@@ -1,0 +1,74 @@
+{
+  "id": "game_log_step_replay",
+  "covers": [
+    "ui.GameLogPanel.history_step_click",
+    "ui.Main.history_view",
+    "replay.ReplayManager.build_recorded_state_at",
+    "replay.ReplayManager.record_all_games",
+    "log.GameEventLog.history_index"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Game-log step replay. Starts a fresh in-memory recording, then makes two REAL confirmed moves (Blade Champion via unit-switch auto-confirm, then Shield Captain via end-phase auto-confirm) so ReplayManager captures both and GameEventLog stamps each log card with its recording marker. Clicking the 'Blade Champion moved' log card (same code path as a real click) enters read-only history view: GameState is swapped to the reconstructed state at that step, where the Blade Champion has moved (y=320) but the Shield Captain is still at its ORIGINAL position (y=100, its later move not applied). Asserts the input-blocking overlay is up and the card is highlighted, screenshots the reverted board + banner, then exits history and asserts the LIVE state is restored verbatim (Shield Captain back at y=280).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "ReplayManager.cleanup()" },
+    { "act": "execute_script", "script": "ReplayManager.start_recording(false)" },
+    { "act": "execute_script", "script": "ReplayManager.is_recording", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "not_equals": 280 },
+
+    { "act": "execute_script", "script": "main.movement_controller._select_unit_in_list_by_id(\"U_BLADE_CHAMPION_A\")", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_BLADE_CHAMPION_A",
+      "payload": { "model_id": "m1", "dest": [120, 320], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script", "script": "main.movement_controller._select_unit_in_list_by_id(\"U_SHIELD_CAPTAIN_A\")", "equals": true },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"flags\", {}).get(\"moved\", false)", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_SHIELD_CAPTAIN_A",
+      "payload": { "model_id": "m1", "dest": [50, 280], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script", "script": "main.phase_action_button.emit_signal(\"pressed\")" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"flags\", {}).get(\"moved\", false)", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 280 },
+    { "act": "screenshot", "label": "01_live_both_units_moved" },
+
+    { "act": "execute_script", "script": "ReplayManager.get_history_marker()", "expect_min": 1 },
+    { "act": "execute_script", "script": "ReplayManager.has_history()", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.count_history_cards()", "expect_min": 2 },
+
+    { "act": "execute_script", "script": "main.game_log_panel.debug_click_history_card_matching(\"Blade Champion\")", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script", "script": "main.is_history_view_active()", "equals": true },
+    { "act": "execute_script", "script": "main._history_overlay != null", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.has_active_history()", "equals": true },
+    { "act": "execute_script", "script": "main.shooting_controller.is_processing_input()", "equals": false },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 100 },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "screenshot", "label": "02_history_view_shield_captain_reverted" },
+
+    { "act": "execute_script", "script": "main._exit_history_view()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "main.is_history_view_active()", "equals": false },
+    { "act": "execute_script", "script": "main._history_overlay == null", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.has_active_history()", "equals": false },
+    { "act": "execute_script", "script": "main.shooting_controller.is_processing_input()", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 280 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "screenshot", "label": "03_returned_to_live_game" }
+  ]
+}


### PR DESCRIPTION
## Summary

Players can now click any entry in the in-game Game Log to see the board exactly as it was at that moment (deployments, moves, casualties, etc.). It is a **read-only** look back — the live game is never modified — surfaced with a banner + "Return to Live Game" button (or Esc). Clicking another entry jumps to that step; the selected entry is highlighted.

This is the "just so users can see what happened" feature — not a rewind for alternate play.

## How it works

Reuses `ReplayManager`'s existing recording machinery (per-action diffs + phase snapshots) rather than building a parallel system:

- **`ReplayManager`** — now records *every* game in memory (previously only AI-vs-AI), gating disk-persistence to AI-vs-AI so human games stay file-free. New `build_recorded_state_at()` reconstructs a historical `GameState` from the nearest snapshot + recorded diffs **without mutating the live state**; `get_history_marker()` / `has_history()` let the log stamp and query steps.
- **`GameEventLog`** — stamps each entry with the recording marker at emit time (recording runs just before the log line, so action entries resolve to their own resulting board state).
- **`GameLogPanel`** — every card is clickable and emits `history_step_requested` with the entry's marker + description; the active step is highlighted. Board-linked AI cards keep their pin-on-click behaviour.
- **`Main`** — on click, holds the live `GameState.state` safe, swaps in the reconstructed copy, refreshes the board tokens, and blocks interaction behind a full-screen overlay + banner. AI, autosave, and the Shooting/Fight/Charge controllers' `_input()` (which fire before the overlay can consume events) are paused; Esc / Exit restores the live state verbatim. Disabled in multiplayer and during replay-file mode.

## Validation

Windowed scenario `tests/scenarios/sp/game_log_step_replay.json` (**41/41 passing**) drives the real player path: two real confirmed moves are recorded, clicking the first move's log card reconstructs the board with that unit moved and the *other* reverted to its original position (proving genuine reversion), the input-blocking overlay + controller-gating are asserted, and exiting restores the live board. No script errors fired; three existing log/AI scenarios still pass (no regressions).

## Notes / scope

- The bottom phase strip and right-hand panel still reflect the *live* phase while viewing a past step (the board tokens are what revert). It's clearly read-only via the banner + dimming; left focused for this change and easy to extend if the whole HUD should follow the historical state.
- A review catch: the overlay blocks GUI/`_unhandled_input`, but Shooting/Fight/Charge controllers read board clicks in `_input()` (fires before the overlay) — that gap is closed by disabling those controllers' input while viewing history, asserted by the scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3Pu2s6iTpXjoMYyeMMfHY

---
_Generated by [Claude Code](https://claude.ai/code/session_01P3Pu2s6iTpXjoMYyeMMfHY)_