### PR TITLE
Fix pile-in "ghost token": moving a model no longer leaves a copy behind

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -932,6 +932,31 @@ func _do_expect_baseline_unchanged(_step: Dictionary) -> Dictionary:
 # HELPERS
 # ============================================================================
 
+# Test invariant for the pile-in "ghost token" regression: the highest number of
+# TokenLayer tokens that share the same (unit_id, model_id). 1 == healthy (every
+# model has exactly one token); 2+ == duplicate/overlapping tokens, which an
+# interactive pile-in/consolidate drag then splits into a moved token and a
+# stranded "ghost" at the original spot. Duplicates arose when the async
+# Main._recreate_unit_visuals() ran twice in one frame; a scenario asserts this
+# stays 1 even after firing concurrent recreates. Size-independent, so it is
+# robust to fixture changes. Callable from `execute_script` steps as a bare
+# `max_tokens_per_model()` (the runner is the Expression base instance).
+func max_tokens_per_model() -> int:
+	var scene := get_tree().current_scene
+	if scene == null:
+		return -1
+	var tl := scene.get_node_or_null("BoardRoot/TokenLayer")
+	if tl == null:
+		return -1
+	var counts := {}
+	var mx := 0
+	for c in tl.get_children():
+		if c.has_meta("unit_id") and c.has_meta("model_id"):
+			var k := "%s/%s" % [str(c.get_meta("unit_id")), str(c.get_meta("model_id"))]
+			counts[k] = int(counts.get(k, 0)) + 1
+			mx = max(mx, int(counts[k]))
+	return mx
+
 func _send_click(screen_pos: Vector2) -> void:
 	# Warp the live cursor to the target BEFORE injecting the event. GUI Controls
 	# route by event position, but board/world handlers (e.g. DeploymentController

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.18.2",
+			"date": "2026-07-11",
+			"summary": "Fixed the Fight-phase pile-in 'ghost': moving a model during pile-in/consolidate no longer leaves a duplicate of it behind at its starting spot.",
+			"changes": [
+				"Fight phase pile-in/consolidate: dragging a model no longer strands a copy of it at its original position. Previously a model could appear twice — once where it moved to and once where it started — so it looked like two overlapping models.",
+				"Under the hood: rapid board refreshes could rebuild the whole token set twice in the same frame, leaving an invisible duplicate token on every model; an interactive drag then moved only one of the pair and revealed the other as a 'ghost'. The refresh now ignores overlapping re-runs so each model keeps exactly one token."
+			]
+		},
+		{
 			"version": "0.18.1",
 			"date": "2026-07-11",
 			"summary": "Fixed first-turn handling when Player 2 wins the roll-off to go first: the battle round no longer advances after a single player's turn. Previously that made Player 1's very first turn count as Battle Round 2, so the movement phase wrongly let units arrive from Reserves / Deep Strike on turn one (the AI would 'suggest' bringing reserves in immediately).",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7922,15 +7922,33 @@ func _sync_board_state_with_game_state() -> void:
 	# readers. Kept as a no-op so the two load-path call sites stay stable.
 	pass
 
+# Re-entrancy guard for _recreate_unit_visuals(). See the function below.
+var _recreate_unit_visuals_running: bool = false
+
 func _recreate_unit_visuals() -> void:
+	# Guard against overlapping runs. This is an async coroutine: queue_free is
+	# deferred, so we await a frame before recreating. Two calls landing in the
+	# same frame — common when a fight/charge action refresh (update_after_*_action)
+	# and a phase-change / sync refresh fire together — would EACH rebuild the
+	# full token set, leaving two overlapping tokens per model. That duplicate is
+	# invisible at rest, but an interactive pile-in / consolidate drag then moves
+	# only the first matching token and strands its twin at the original spot as a
+	# "ghost" (the reported bug). Dropping the re-entrant call is safe: this run's
+	# recreate loop reads GameState fresh AFTER the await, so it already reflects
+	# whatever state change triggered the dropped call.
+	if _recreate_unit_visuals_running:
+		print("Main: _recreate_unit_visuals() already running — skipping re-entrant call to avoid duplicate tokens")
+		return
+	_recreate_unit_visuals_running = true
+
 	# Clear existing tokens
 	print("Clearing existing token visuals...")
 	for child in token_layer.get_children():
 		child.queue_free()
-	
+
 	# Wait a frame for queue_free to process
 	await get_tree().process_frame
-	
+
 	# Recreate tokens for deployed units
 	var units = GameState.state.get("units", {})
 	var tokens_created = 0
@@ -7980,6 +7998,8 @@ func _recreate_unit_visuals() -> void:
 					print("        Skipped model (no position or dead)")
 	
 	print("Recreated ", tokens_created, " unit tokens")
+
+	_recreate_unit_visuals_running = false
 
 func _create_token_visual(unit_id: String, model: Dictionary) -> Node2D:
 	# Use the existing TokenVisual class

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2664,6 +2664,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "main.recreate_unit_visuals_reentrancy",
+      "description": "Windowed regression: Main._recreate_unit_visuals() guards against overlapping async runs, so two refreshes landing in one frame no longer rebuild the token set twice and leave duplicate/overlapping model tokens (the pile-in 'ghost'). Verified by pile_in_no_ghost_token.",
+      "scenarios": [
+        "pile_in_no_ghost_token"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "fight.pile_in.ghost_token_fix",
+      "description": "Windowed regression: moving a model during Fight-phase pile-in/consolidate no longer leaves a duplicate of it at its original position. Verified by pile_in_no_ghost_token.",
+      "scenarios": [
+        "pile_in_no_ghost_token"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/pile_in_no_ghost_token.json
+++ b/40k/tests/scenarios/sp/pile_in_no_ghost_token.json
@@ -1,0 +1,28 @@
+{
+  "id": "pile_in_no_ghost_token",
+  "covers": [
+    "phases.FightPhase.pile_in_11e",
+    "main.recreate_unit_visuals_reentrancy",
+    "fight.pile_in.ghost_token_fix"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Regression for the pile-in 'ghost token' bug: after moving a model during pile-in, a duplicate of it stayed at the original spot, so it looked like two overlapping models. Root cause was Main._recreate_unit_visuals() — an async coroutine (deferred queue_free + await frame) that many refresh paths call. Two calls landing in the same frame (e.g. a fight-action refresh plus a phase/sync refresh) each rebuilt the FULL token set, leaving two overlapping tokens per model; the pile-in drag then moved only the first match and stranded its twin. Main now guards the function against re-entrant runs. This scenario fires two concurrent recreates in a single frame (the exact race) and asserts every model still has exactly one token (max_tokens_per_model == 1); before the fix it would be 2.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "execute_script", "script": "max_tokens_per_model()", "equals": 1 },
+    { "act": "screenshot", "label": "01_fight_phase_one_token_per_model" },
+
+    { "act": "execute_script", "script": "[main._recreate_unit_visuals(), main._recreate_unit_visuals()]" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script", "script": "max_tokens_per_model()", "equals": 1 },
+    { "act": "execute_script", "script": "main.get_node(\"BoardRoot/TokenLayer\").get_child_count()", "expect_min": 40 },
+    { "act": "screenshot", "label": "02_no_duplicate_tokens_after_concurrent_recreate" }
+  ]
+}


### PR DESCRIPTION
## Problem

In the Fight phase pile-in/consolidate move, dragging a model left a duplicate of it stranded at its **original** position — so it looked like two overlapping copies of the same model.

[reported bug: two overlapping Stormboyz after a pile-in move]

## Root cause

`Main._recreate_unit_visuals()` (rebuilds all model tokens from game state) is an **async coroutine** — it defers `queue_free()` and `await`s a frame before recreating tokens. Many refresh paths call it (`update_after_fight_action()`, `update_after_charge_action()`, phase transitions, …). When **two calls land in the same frame**, each rebuilds the *full* token set, leaving **two overlapping tokens per model**. The duplicate is invisible while stationary, but the pile-in drag (`_start_model_drag_pile_in`) grabs only the *first* matching token and moves it, stranding its twin at the origin as the "ghost."

The codebase already acknowledged this race defensively — see `Main._on_model_drop_committed`: *"duplicates from concurrent `_recreate_unit_visuals` calls."* This PR fixes the source instead of working around it.

## Fix

A one-flag re-entrancy guard on `_recreate_unit_visuals()`, the same pattern `_replay_refresh_visuals()` already uses. Overlapping calls are dropped, which is safe: the in-flight run reads game state *after* its await, so it already reflects whatever change triggered the dropped call.

## Validation

- **Reproduced live** via the in-game MCP bridge: two concurrent recreates → 132 tokens (2/model); the pile-in drag left one token at the new spot **and a ghost at the original**. After the fix: 66 tokens (1/model), drag leaves **no ghost**. `verify_delivery` → PASS, zero ERROR lines.
- New **windowed regression scenario** `tests/scenarios/sp/pile_in_no_ghost_token.json` fires the exact race and asserts `max_tokens_per_model()` stays `1`. It **passes with the fix and fails (got 2) with the guard disabled** — proving the test catches the regression.
- Existing fight / movement / charge scenarios still pass — no regressions.

## Changes

- `40k/scripts/Main.gd` — re-entrancy guard on `_recreate_unit_visuals()` (the fix)
- `40k/autoloads/ScenarioRunner.gd` — `max_tokens_per_model()` test helper
- `40k/tests/scenarios/sp/pile_in_no_ghost_token.json` — regression scenario
- `40k/data/version_history.json` — new `0.16.1` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017pZX4vYZ3u25Gh2WtE8Yb9

---
_Generated by [Claude Code](https://claude.ai/code/session_017pZX4vYZ3u25Gh2WtE8Yb9)_