### PR TITLE
Fix AI Overwatch popup covering reserve-deployment Undo/controls

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.18.3",
+			"date": "2026-07-11",
+			"summary": "Fixed the AI 'Fire Overwatch' popup covering your control buttons: when the AI reacts during your turn (e.g. firing Overwatch while you arrive a unit from Reserves), the AI Actions log now floats to the left of the right-hand panel instead of sitting on top of your Undo / Reset / Confirm buttons — so you can always undo or confirm a deployment.",
+			"changes": [
+				"The AI Actions log (shown when the AI acts, including reactive Overwatch during your own turn) no longer overlaps the right-hand control panel. It now sits just left of that panel, over the board, so it never hides the reserve-deployment Undo / Reset Unit / Confirm Move buttons.",
+				"The overlay is also fully click-through now (a stray click on it always passes to the controls behind), so it can never intercept a button press even where it appears."
+			]
+		},
+		{
 			"version": "0.18.2",
 			"date": "2026-07-11",
 			"summary": "Fixed the Fight-phase pile-in 'ghost': moving a model during pile-in/consolidate no longer leaves a duplicate of it behind at its starting spot.",

--- a/40k/scripts/AIActionLogOverlay.gd
+++ b/40k/scripts/AIActionLogOverlay.gd
@@ -10,8 +10,9 @@ const WhiteDwarfThemeData = preload("res://scripts/WhiteDwarfTheme.gd")
 # Layout constants
 const OVERLAY_WIDTH: float = 320.0
 const OVERLAY_MAX_HEIGHT: float = 200.0
-const OVERLAY_MARGIN_RIGHT: float = 10.0
+const OVERLAY_MARGIN_RIGHT: float = 10.0  # Gap between the overlay and the right-hand control panel
 const OVERLAY_MARGIN_BOTTOM: float = 310.0  # Above the bottom stats panel
+const DEFAULT_RIGHT_HUD_WIDTH: float = 400.0  # Fallback panel width if HUD_Right can't be located
 const FONT_SIZE: int = 11
 const HEADER_FONT_SIZE: int = 12
 const MAX_VISIBLE_ENTRIES: int = 30  # Max entries before trimming old ones
@@ -55,13 +56,24 @@ func _ready() -> void:
 func _build_ui() -> void:
 	name = "AIActionLogOverlay"
 
-	# Anchor to bottom-right corner
+	# Anchor to the bottom-right corner.
 	anchor_left = 1.0
 	anchor_right = 1.0
 	anchor_top = 1.0
 	anchor_bottom = 1.0
-	offset_left = -(OVERLAY_WIDTH + OVERLAY_MARGIN_RIGHT)
-	offset_right = -OVERLAY_MARGIN_RIGHT
+
+	# The right-hand HUD panel (HUD_Right) hosts the player's active-control
+	# buttons — reserve-deployment Undo/Reset, movement Confirm/Reset, the model
+	# type picker, etc. Historically this overlay was anchored flush to the
+	# screen's right edge, which parked it directly on top of those buttons. When
+	# a reactive AI action fires during the human's turn (e.g. Fire Overwatch
+	# while the player is arriving a unit from reserves) the log popped up over
+	# the Undo button, and the player could not dismiss the log or undo the drop.
+	# Shift the overlay left of the control panel so it floats over the board and
+	# never obscures the interactive controls.
+	var right_panel_width := _get_right_hud_width()
+	offset_right = -(right_panel_width + OVERLAY_MARGIN_RIGHT)
+	offset_left = offset_right - OVERLAY_WIDTH
 	offset_top = -(OVERLAY_MAX_HEIGHT + OVERLAY_MARGIN_BOTTOM)
 	offset_bottom = -OVERLAY_MARGIN_BOTTOM
 
@@ -97,6 +109,9 @@ func _build_ui() -> void:
 	_gsep1.custom_minimum_size = Vector2(0, 2)
 	_gsep1.color = Color(WhiteDwarfThemeData.WH_GOLD.r, WhiteDwarfThemeData.WH_GOLD.g, WhiteDwarfThemeData.WH_GOLD.b, 0.4)
 	_gsep1.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	# ColorRect defaults to MOUSE_FILTER_STOP; keep the whole overlay click-through
+	# so it can never intercept a click meant for the controls behind it.
+	_gsep1.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	vbox.add_child(_gsep1)
 
 	# Scroll container for log entries
@@ -105,6 +120,15 @@ func _build_ui() -> void:
 	_scroll_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	_scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	_scroll_container.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	# The ScrollContainer's auto-generated scrollbars default to MOUSE_FILTER_STOP,
+	# so once the log overflows they would swallow clicks in a thin strip. Make
+	# them ignore the mouse too so the overlay is fully click-through.
+	var _vbar := _scroll_container.get_v_scroll_bar()
+	if _vbar:
+		_vbar.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var _hbar := _scroll_container.get_h_scroll_bar()
+	if _hbar:
+		_hbar.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	vbox.add_child(_scroll_container)
 
 	# RichTextLabel for color-coded BBCode entries
@@ -297,6 +321,23 @@ func clear_log() -> void:
 	_entry_count = 0
 
 # ── Private Helpers ───────────────────────────────────────────────────────
+
+func _get_right_hud_width() -> float:
+	"""Width of the right-hand control panel (HUD_Right), so the overlay can be
+	positioned to its left and never cover the player's active controls.
+
+	The overlay is added as a direct child of Main, alongside HUD_Right, so we
+	look it up as a sibling. HUD_Right is right-anchored with a negative left
+	offset; the magnitude of that offset is its width. Falls back to a sane
+	default when the panel can't be located (e.g. a non-Main scene)."""
+	var parent := get_parent()
+	if parent:
+		var hud_right := parent.get_node_or_null("HUD_Right")
+		if hud_right and hud_right is Control:
+			var w: float = absf((hud_right as Control).offset_left)
+			if w > 0.0:
+				return w
+	return DEFAULT_RIGHT_HUD_WIDTH
 
 func _auto_scroll() -> void:
 	"""Scroll to the bottom of the log after the current frame processes layout."""

--- a/40k/tests/scenarios/sp/ai_overlay_clears_control_panel.json
+++ b/40k/tests/scenarios/sp/ai_overlay_clears_control_panel.json
@@ -1,0 +1,19 @@
+{
+  "id": "ai_overlay_clears_control_panel",
+  "covers": ["scripts.AIActionLogOverlay._build_ui", "scripts.AIActionLogOverlay._get_right_hud_width", "ui.ai_action_overlay.no_control_panel_overlap"],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "description": "Regression for the reserves-deploy Undo being blocked: when the AI fires reactive Overwatch during the human's Movement phase (e.g. while arriving a unit from reserves) the AI Action log overlay pops up. It must float to the LEFT of the right-hand control panel (HUD_Right) and never overlap it, so the player's Undo / Reset / Confirm buttons stay visible and clickable. Before the fix the overlay was anchored flush to the screen's right edge and sat directly on top of those controls.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right" },
+    { "act": "execute_script", "script": "main.get_node(\"AIActionLogOverlay\").add_thinking_entry(2, \"Fire Overwatch window (enemy moved)\")" },
+    { "act": "execute_script", "script": "main.get_node(\"AIActionLogOverlay\").add_action_entry(2, {}, \"AI fires overwatch with Allarus Custodians at Deffkoptas (4.6 expected hits)\")" },
+    { "act": "expect_node_visible", "node": "/root/Main/AIActionLogOverlay" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_overlay_left_of_controls" },
+    { "act": "execute_script", "script": "main.get_node(\"AIActionLogOverlay\").get_global_rect().intersects(main.get_node(\"HUD_Right\").get_global_rect())", "equals": false },
+    { "act": "execute_script", "script": "main.get_node(\"AIActionLogOverlay\").get_global_rect().end.x <= main.get_node(\"HUD_Right\").get_global_rect().position.x", "equals": true },
+    { "act": "expect_node_property", "node": "/root/Main/AIActionLogOverlay", "property": "mouse_filter", "equals": 2 }
+  ]
+}


### PR DESCRIPTION
## Problem

When the AI fires reactive Overwatch during the human's Movement phase (e.g. while arriving a unit from Reserves), the **AI Actions log overlay** popped up flush against the screen's right edge — directly on top of the right-hand control panel (`HUD_Right`). This covered the reserve-deployment **Undo / Reset Unit / Confirm Move** buttons, so the player could not undo a partial deployment.

Measured live: the overlay occupied `x[1590–1910]`, entirely inside the panel's `x[1520–1920]`. It was nominally click-through (`MOUSE_FILTER_IGNORE`), but its `ColorRect` separator and scrollbar defaulted to `STOP`, and either way it visually hid the buttons.

## Fix (`40k/scripts/AIActionLogOverlay.gd`)

- **Repositioned the overlay to the left of the control panel** — it now reads `HUD_Right`'s width and anchors its right edge just left of the panel, so it floats over the board and never obscures the interactive controls. After the fix: overlay at `x[1190–1510]`, a 10px gap to the panel, zero overlap.
- **Hardened it to be fully click-through** — the separator `ColorRect` and the `ScrollContainer`'s scrollbars defaulted to `MOUSE_FILTER_STOP` and could otherwise swallow a click meant for the controls behind them; all are now `IGNORE`.

## Validation

- Drove the running game live: before the fix the overlay overlapped `HUD_Right`; after the fix there's a 10px gap and no intersection. A Movement-phase screenshot with the Overwatch popup reproduced shows Undo Model / Reset Unit / Confirm Move fully visible and clickable.
- Added windowed regression scenario `40k/tests/scenarios/sp/ai_overlay_clears_control_panel.json` (Movement phase): reproduces the Overwatch popup and asserts the overlay does not intersect `HUD_Right`, its right edge sits left of the panel, and it stays click-through. **Passes 10/10** with no script errors.
- Bumped `40k/data/version_history.json` → `0.18.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M3c9aCng6g3q7TZKmBuhzM

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3c9aCng6g3q7TZKmBuhzM)_