### PR TITLE
Fix charge falsely failing when the roll reaches engagement range but not base contact

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.18.4",
+			"date": "2026-07-11",
+			"summary": "Fixed charge rolls being wrongly reported as failed when the roll would actually reach the enemy. A charging model only has to close to within engagement range (2\"), not touch base-to-base — e.g. a 9\" roll against a target 9.6\" away now succeeds (it only needs to travel 7.6\").",
+			"changes": [
+				"Charge rolls that can reach a target's engagement range are no longer marked FAILED. Previously the after-roll target check compared the full base-to-base gap against the raw roll, ignoring the 2\" engagement range — so a 9\" roll against a target 9.6\" away failed even though the model only needed to move 7.6\" to get within 2\".",
+				"The reachable ceiling for selecting charge targets is now 'roll + engagement range' (capped at the 12\" declaration range) instead of just the roll, matching how the charge move itself is measured.",
+				"Genuinely out-of-reach charges still fail correctly (e.g. a 9\" roll cannot reach a target 12\" away, which needs 10\")."
+			]
+		},
+		{
 			"version": "0.18.3",
 			"date": "2026-07-11",
 			"summary": "Fixed the AI 'Fire Overwatch' popup covering your control buttons: when the AI reacts during your turn (e.g. firing Overwatch while you arrive a unit from Reserves), the AI Actions log now floats to the left of the right-hand panel instead of sitting on top of your Undo / Reset / Confirm buttons — so you can always undo or confirm a deployment.",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -608,7 +608,7 @@ func _process_charge_roll(action: Dictionary) -> Dictionary:
 	# raw first 2D6 made re-rolled/bonused charges fail against a stale list.
 	if GameConstants.edition >= 11:
 		var tmpl_11e = MoveTypes.get_type("charge")
-		charge_data["selectable_targets"] = tmpl_11e._targets_within(unit_id, GameState.state, min(12.0, float(total_distance)))
+		charge_data["selectable_targets"] = tmpl_11e._targets_within(unit_id, GameState.state, ChargeMove11e.selectable_distance_ceiling(float(total_distance)))
 
 	var unit_name = get_unit(unit_id).get("meta", {}).get("name", unit_id)
 	var target_ids = charge_data.targets
@@ -743,13 +743,15 @@ func _resolve_charge_roll(unit_id: String) -> Dictionary:
 		]))
 
 	# ISS-049 step 2 (11e 11.02): targets are selected after the roll, from
-	# enemies within 12" AND within the roll. Computed HERE — from the FINAL
-	# total (after re-rolls and +N bonuses) — and the original declaration is
-	# re-filtered against it. Pre-declared targets the roll cannot reach are
-	# dropped; ones a re-roll newly reaches come back.
+	# enemies within 12" AND reachable by the roll. Reachable means the roll can
+	# close the gap to ENGAGEMENT RANGE (not full base contact), so the raw-gap
+	# ceiling is min(12, roll + ER) — see ChargeMove11e.selectable_distance_ceiling.
+	# Computed HERE — from the FINAL total (after re-rolls and +N bonuses) — and
+	# the original declaration is re-filtered against it. Pre-declared targets the
+	# roll cannot reach are dropped; ones a re-roll newly reaches come back.
 	if GameConstants.edition >= 11:
 		var tmpl_11e = MoveTypes.get_type("charge")
-		var selectable: Array = tmpl_11e._targets_within(unit_id, GameState.state, min(12.0, float(total_distance)))
+		var selectable: Array = tmpl_11e._targets_within(unit_id, GameState.state, ChargeMove11e.selectable_distance_ceiling(float(total_distance)))
 		charge_data["selectable_targets"] = selectable
 		var declared: Array = charge_data.get("declared_targets", charge_data.targets)
 		if not declared.is_empty():

--- a/40k/scripts/rules/movetypes/ChargeMove11e.gd
+++ b/40k/scripts/rules/movetypes/ChargeMove11e.gd
@@ -63,15 +63,27 @@ func eligible(unit_id: String, board: Dictionary) -> Dictionary:
 	return {"eligible": true, "reasons": []}
 
 ## BEFORE MOVING (11.02 step 2): the 2D6 charge roll IS the maximum
-## distance; targets are then selected from enemies within 12" AND within
-## that maximum (selectable_targets).
+## distance; targets are then selected from enemies within 12" AND reachable
+## by the roll (selectable_targets — see selectable_distance_ceiling).
 func before_moving(unit_id: String, board: Dictionary, rng, _context: Dictionary) -> Dictionary:
 	var dice = rng.roll_d6(2)
 	var roll: int = dice[0] + dice[1]
 	return {
 		"charge_roll": roll, "dice": [{"context": "charge_roll", "rolls": dice}],
-		"selectable_targets": _targets_within(unit_id, board, min(12.0, float(roll))),
+		"selectable_targets": _targets_within(unit_id, board, selectable_distance_ceiling(float(roll))),
 	}
+
+## Raw base-to-base distance ceiling (inches) for a target to be selectable after
+## a charge roll. A charging model does NOT have to travel the full base-to-base
+## gap — it stops as soon as it reaches ENGAGEMENT RANGE (ER) of the target. So a
+## target is reachable when its raw gap minus ER fits the roll, i.e.
+##   raw_gap - ER <= roll   ⟺   raw_gap <= roll + ER.
+## Combined with the 12" declaration range, the raw-distance ceiling handed to
+## _targets_within is min(12, roll + ER). Using the bare roll here (the old bug)
+## dropped makeable charges — e.g. a 9" roll against a target 9.6" away, which
+## only needs to close 7.6" to reach a 2" ER.
+static func selectable_distance_ceiling(roll: float) -> float:
+	return min(12.0, roll + GameConstants.engagement_range_inches())
 
 func max_distance_inches(_unit: Dictionary, context: Dictionary) -> float:
 	return float(context.get("charge_roll", 0))

--- a/40k/tests/test_charge_roll_reachability_er.gd
+++ b/40k/tests/test_charge_roll_reachability_er.gd
@@ -1,0 +1,153 @@
+extends SceneTree
+
+# Regression suite for the "reachable target dropped by the post-roll selection
+# filter" bug (branch claude/charge-distance-calc-erzq9r).
+#
+# Reported symptom (11e, ER 2"): a Deffkopta rolled 9" to charge a target 9.6"
+# away (edge-to-edge) and the charge was reported FAILED with
+#   "Rolled 9\" but nearest target is 9.6\" away (need to close to within 2\"
+#    engagement range)"
+# even though a charging model only needs to close to ENGAGEMENT RANGE (2"),
+# i.e. travel 9.6 − 2 = 7.6", which a 9" roll easily covers.
+#
+# Root cause: the 11e post-roll target-selection filter (ChargeMove11e
+# ._targets_within, called from ChargePhase._resolve_charge_roll) kept only
+# targets whose RAW base-to-base distance was <= min(12, roll). It forgot that
+# reaching a target means closing to within ER, so the reachable ceiling is
+# min(12, roll + ER). A target at 9.6" (raw) was dropped by a 9" roll, leaving
+# no selectable targets, so the charge was judged an insufficient roll.
+#
+# Usage: godot --headless --path . -s tests/test_charge_roll_reachability_er.gd
+
+var passed := 0
+var failed := 0
+
+const PX_PER_INCH := 40.0  # project scale (Measurement.inches_to_px)
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s %s" % [label, ("(" + detail + ")") if detail != "" else ""])
+
+func _init():
+	create_timer(0.2).timeout.connect(_run_tests)
+
+func _make_unit(id: String, owner: int, keywords: Array, positions: Array, base_mm: int = 32) -> Dictionary:
+	var models = []
+	for i in range(positions.size()):
+		var pos = positions[i]
+		models.append({
+			"id": "m%d" % (i + 1),
+			"alive": true,
+			"current_wounds": 4,
+			"wounds": 4,
+			"base_mm": base_mm,
+			"base_type": "circular",
+			"position": ({"x": pos.x, "y": pos.y} if pos != null else null),
+		})
+	return {
+		"id": id, "squad_id": id, "owner": owner,
+		"status": GameStateData.UnitStatus.DEPLOYED,
+		"flags": {},
+		"meta": {"name": id, "keywords": keywords, "stats": {"move": 6, "toughness": 4, "save": 4, "wounds": 4}},
+		"models": models,
+		"embarked_in": null,
+	}
+
+func _setup_state(units: Dictionary, active_player: int = 2) -> void:
+	var gs = root.get_node("GameState")
+	gs.state = {
+		"meta": {"phase": GameStateData.Phase.CHARGE, "active_player": active_player, "battle_round": 1, "turn_number": 1, "game_id": "test"},
+		"units": units,
+		"players": {"1": {"cp": 0, "vp": 0}, "2": {"cp": 0, "vp": 0}},
+		"board": {"terrain": []},
+		"phase_log": [],
+	}
+
+func _new_phase() -> Node:
+	var phase = load("res://phases/ChargePhase.gd").new()
+	root.add_child(phase)
+	phase._on_phase_enter()
+	return phase
+
+func _tm() -> Node:
+	return root.get_node("TerrainManager")
+
+# Charger at origin; single enemy target whose edge-to-edge gap ≈ `edge_in`.
+# 32mm circular bases → radius 0.63" each, so center gap = edge_in + 1.26".
+func _two_unit_state(edge_in: float) -> Dictionary:
+	var origin := Vector2(700.0, 2150.0)
+	var center_gap_px := (edge_in + 1.26) * PX_PER_INCH
+	var charger = _make_unit("U_CHG", 2, ["INFANTRY", "FLY"], [origin])
+	var target = _make_unit("U_TGT", 1, ["INFANTRY"], [origin + Vector2(center_gap_px, 0.0)])
+	return {"U_CHG": charger, "U_TGT": target}
+
+func _measured_edge(state: Dictionary) -> float:
+	var m = root.get_node("Measurement")
+	return m.model_to_model_distance_inches(state["U_CHG"].models[0], state["U_TGT"].models[0])
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_charge_roll_reachability_er ===")
+	var prev_edition = GameConstants.edition
+
+	_test_9_roll_reaches_9_6_target()
+	_test_target_just_out_of_reach_still_fails()
+
+	GameConstants.edition = prev_edition
+	print("\n=== %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)
+
+# The reported case: roll 9, target 9.6" away, ER 2" → reachable (needs 7.6").
+func _test_9_roll_reaches_9_6_target() -> void:
+	print("\n-- 11e: roll 9\" reaches a target 9.6\" away (ER 2\") --")
+	GameConstants.edition = 11  # ER = 2"
+	var state := _two_unit_state(9.6)
+	_setup_state(state)
+	_tm().terrain_features.clear()
+	var edge := _measured_edge(state)
+	_check("target edge distance ≈ 9.6\"", edge > 9.4 and edge < 9.8, "edge=%.2f" % edge)
+
+	var phase = _new_phase()
+	phase.pending_charges["U_CHG"] = {
+		"targets": ["U_TGT"],
+		"declared_targets": ["U_TGT"],
+		"distance": 9,
+		"dice_rolls": [4, 5],
+	}
+	var result = phase._resolve_charge_roll("U_CHG")
+
+	_check("charge SUCCEEDS (roll 9 vs 9.6\" − 2\" ER = 7.6\" needed)",
+		result.get("charge_failed", true) == false,
+		"charge_failed=%s" % str(result.get("charge_failed", "missing")))
+	_check("no insufficient-roll failure recorded",
+		phase.failed_charge_attempts.size() == 0,
+		"count=%d" % phase.failed_charge_attempts.size())
+	_check("target retained (not dropped by the selection filter)",
+		phase.pending_charges.get("U_CHG", {}).get("targets", []) == ["U_TGT"],
+		str(phase.pending_charges.get("U_CHG", {}).get("targets", [])))
+	phase.queue_free()
+
+# A genuinely-unreachable target (edge 12", roll 9, ER 2" → needs 10") still fails.
+func _test_target_just_out_of_reach_still_fails() -> void:
+	print("\n-- 11e: roll 9\" cannot reach a target 12\" away (needs 10\") --")
+	GameConstants.edition = 11  # ER = 2"
+	var state := _two_unit_state(12.0)
+	_setup_state(state)
+	_tm().terrain_features.clear()
+	var phase = _new_phase()
+	phase.pending_charges["U_CHG"] = {
+		"targets": ["U_TGT"],
+		"declared_targets": ["U_TGT"],
+		"distance": 9,
+		"dice_rolls": [4, 5],
+	}
+	var result = phase._resolve_charge_roll("U_CHG")
+	_check("charge FAILS (roll 9 vs 12\" − 2\" ER = 10\" needed)",
+		result.get("charge_failed", false) == true,
+		"charge_failed=%s" % str(result.get("charge_failed", "missing")))
+	phase.queue_free()

--- a/40k/tests/test_charge_roll_reachability_er.gd.uid
+++ b/40k/tests/test_charge_roll_reachability_er.gd.uid
@@ -1,0 +1,1 @@
+uid://kte4rkj0swh2


### PR DESCRIPTION
## Summary

A charge roll that could actually reach the enemy was being reported as failed. A charging model only has to close to within **engagement range** (2" in the 11e ruleset), not touch base-to-base — so a **9" roll against a target 9.6" away** should succeed (the model only needs to travel `9.6 − 2 = 7.6"`), but it was logged as:

> `[INSUFFICIENT_ROLL] Rolled 9" but nearest target is 9.6" away (need to close to within 2" engagement range)`

## Root cause

The 11e post-roll target-selection filter (`ChargeMove11e._targets_within`, driven from `ChargePhase._resolve_charge_roll`) kept only targets whose **raw base-to-base gap** was `<= min(12", roll)`, ignoring the engagement-range close-distance. With a gap of 9.6" and a roll of 9", `9.6 > 9` dropped the only target, leaving nothing selectable, so the charge was judged an insufficient roll.

## Fix

The reachable ceiling is now `min(12", roll + engagement_range)` — the 12" declaration range combined with the roll's reach to engagement range (`9 + 2 = 11"`, so a 9.6" target is reachable). Centralised in a new `ChargeMove11e.selectable_distance_ceiling()` and applied at all three call sites (`before_moving` plus the initial and post-reroll `_resolve_charge_roll` paths). Genuinely out-of-reach charges still fail (a 9" roll cannot reach a 12" target, which needs 10").

## Changes

- `40k/scripts/rules/movetypes/ChargeMove11e.gd` — add `selectable_distance_ceiling()`; use it in `before_moving`.
- `40k/phases/ChargePhase.gd` — use the new ceiling in both `_resolve_charge_roll` target-selection paths.
- `40k/tests/test_charge_roll_reachability_er.gd` — new regression suite pinning the reported case (succeeds) and the out-of-reach control (still fails).
- `40k/data/version_history.json` — 0.18.3 changelog entry.

## Verification

- New regression suite: **5/5** pass.
- No regressions: multitarget reachability **18/18**, charge-phase fixes **32/32**, engagement-range 11e **8/8**, Waaagh! advance-charge **17/17**.
- Live game (real running process, the reported scenario — Deffkoptas, roll 9, target 9.6" away, ER 2"): now logs `Deffkoptas charge roll: [4, 5] = 9" vs 9.6" needed - SUCCESS` with the target retained and zero errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NCYCJ4gMWfQ3ZHtQFCKC4z

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCYCJ4gMWfQ3ZHtQFCKC4z)_