### PR TITLE
Fix Deep Strike exclusion missing on separated enemy clusters; add Reserves 6" band

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.19.0",
+			"date": "2026-07-11",
+			"summary": "Reinforcement placement helpers are clearer: the red 'must be >9\" from enemy models' no-deploy zone now shows around EVERY enemy cluster (not just the biggest one), and units arriving from Strategic Reserves now get a green band showing where they CAN be placed — within 6\" of a board edge.",
+			"changes": [
+				"Fixed: when placing a unit from Deep Strike or Strategic Reserves, the 9\" exclusion bubbles now render around all enemy models. Before, only the single largest connected clump of enemies drew its no-deploy zone; other enemy groups elsewhere on the board were left unmarked, making it look like you could legally arrive next to them. Each separate enemy cluster now gets its own labelled '9\" exclusion' zone.",
+				"New: units arriving from Strategic Reserves now show a green 'within 6\" of edge' band around the board perimeter — the area where they are allowed to be set up. (Deep Strike units, which may arrive anywhere >9\" from enemies, do not show this band.)",
+				"Under the hood: the enemy-exclusion overlay grouped models into connected clusters but only kept the largest merged shape after each step, silently discarding every other cluster; it now merges each cluster independently. The new Strategic Reserves band matches the placement validator exactly (model centre within 6\" of the nearest board edge)."
+			]
+		},
+		{
 			"version": "0.18.4",
 			"date": "2026-07-11",
 			"summary": "Fixed charge rolls being wrongly reported as failed when the roll would actually reach the enemy. A charging model only has to close to within engagement range (2\"), not touch base-to-base — e.g. a 9\" roll against a target 9.6\" away now succeeds (it only needs to travel 7.6\").",

--- a/40k/scripts/DeepStrikeExclusionVisual.gd
+++ b/40k/scripts/DeepStrikeExclusionVisual.gd
@@ -25,8 +25,7 @@ const FONT_SIZE: int = 13
 
 # Internal state
 var _exclusion_circles: Array = []  # Array of { center: Vector2, radius_px: float }
-var _merged_polygon: PackedVector2Array = PackedVector2Array()  # Union of all circles clipped to board
-var _merged_polygons: Array = []  # Multiple polygons after clipping
+var _merged_polygons: Array = []  # One clipped polygon per connected enemy cluster
 var _pulse_time: float = 0.0
 var _is_active: bool = false
 var _default_font: Font = null
@@ -74,7 +73,16 @@ func hide_exclusion() -> void:
 	queue_redraw()
 
 func _build_merged_polygon() -> void:
-	"""Merge all exclusion circles into polygon(s) clipped to the board."""
+	"""Merge exclusion circles into polygon(s) clipped to the board.
+
+	Enemy models frequently sit in several physically-separate clusters (e.g. a
+	block at the top of the board and another at the bottom). Each cluster must
+	produce its own exclusion polygon. The previous implementation progressively
+	merged every circle into one running polygon and, after each pairwise merge,
+	kept only the LARGEST resulting polygon — so any circle that did not touch the
+	largest connected blob was silently dropped and its exclusion zone never drew.
+	We now group circles into connected clusters first and merge each cluster on
+	its own, so every enemy group gets an exclusion zone."""
 	if _exclusion_circles.is_empty():
 		return
 
@@ -87,35 +95,132 @@ func _build_merged_polygon() -> void:
 		Vector2(0, board_height_px)
 	])
 
-	# Convert each circle to a polygon and progressively merge
-	var merged: PackedVector2Array = _circle_to_polygon(_exclusion_circles[0].center, _exclusion_circles[0].radius_px)
+	# Group circles into connected clusters (bubbles that overlap belong together),
+	# then merge each cluster independently and clip it to the board.
+	var clusters = _group_circles_into_clusters()
+	for cluster in clusters:
+		var merged = _merge_cluster(cluster)
+		if merged.size() < 3:
+			continue
+		var clipped = Geometry2D.intersect_polygons(merged, board_rect)
+		for poly in clipped:
+			if poly.size() >= 3:
+				_merged_polygons.append(poly)
 
-	for i in range(1, _exclusion_circles.size()):
-		var circle_poly = _circle_to_polygon(_exclusion_circles[i].center, _exclusion_circles[i].radius_px)
-		var union_result = Geometry2D.merge_polygons(merged, circle_poly)
-		if union_result.size() > 0:
-			# Take the largest polygon as the merged result
-			var largest_idx = 0
-			var largest_area = 0.0
-			for j in range(union_result.size()):
-				var area = abs(_polygon_area(union_result[j]))
-				if area > largest_area:
-					largest_area = area
-					largest_idx = j
-			merged = union_result[largest_idx]
+func _group_circles_into_clusters() -> Array:
+	"""Union-find grouping of exclusion circles whose bubbles overlap.
+	Returns an Array of clusters; each cluster is an Array of circle dictionaries."""
+	var n = _exclusion_circles.size()
+	var parent: Array = []
+	parent.resize(n)
+	for i in range(n):
+		parent[i] = i
 
-	# Clip to board boundaries
-	var clipped = Geometry2D.intersect_polygons(merged, board_rect)
-	for poly in clipped:
-		if poly.size() >= 3:
-			_merged_polygons.append(poly)
+	# Two circles are connected when their bubbles overlap (edge distance < 0).
+	for i in range(n):
+		var ci = _exclusion_circles[i]
+		for j in range(i + 1, n):
+			var cj = _exclusion_circles[j]
+			if ci.center.distance_to(cj.center) < ci.radius_px + cj.radius_px:
+				_union(parent, i, j)
+
+	var groups: Dictionary = {}
+	for i in range(n):
+		var root = _find(parent, i)
+		if not groups.has(root):
+			groups[root] = []
+		groups[root].append(_exclusion_circles[i])
+	return groups.values()
+
+func _find(parent: Array, i: int) -> int:
+	while parent[i] != i:
+		parent[i] = parent[parent[i]]  # path halving
+		i = parent[i]
+	return i
+
+func _union(parent: Array, a: int, b: int) -> void:
+	var ra = _find(parent, a)
+	var rb = _find(parent, b)
+	if ra != rb:
+		parent[rb] = ra
+
+func _merge_cluster(cluster: Array) -> PackedVector2Array:
+	"""Merge all circles in a connected cluster into its outer boundary polygon.
+
+	Circles are folded in connectivity order (only a circle that overlaps something
+	already merged is folded in), so the accumulating shape always stays one connected
+	blob and _largest_polygon reliably returns the outer boundary ring.
+
+	KNOWN LIMITATION: if a cluster forms a ring of enemies with an uncovered gap in the
+	middle (a legal deep-strike pocket >9\" from every model), that gap is an interior
+	'hole' ring in the union. We keep only the outer boundary here, and the fill in _draw
+	uses draw_colored_polygon which cannot express holes, so such a pocket is drawn as
+	excluded. This is a rare, purely-cosmetic over-exclusion — the authoritative legality
+	check is DeploymentController._validate_reinforcement_position, not this overlay — so
+	it never permits or blocks an actual placement. Punching the hole out would require
+	hole-aware triangulation of the fill and is deliberately out of scope."""
+	if cluster.is_empty():
+		return PackedVector2Array()
+
+	var merged: PackedVector2Array = _circle_to_polygon(cluster[0].center, cluster[0].radius_px)
+	var merged_circles: Array = [cluster[0]]
+	var pending: Array = []
+	for i in range(1, cluster.size()):
+		pending.append(cluster[i])
+
+	# Repeatedly fold in a pending circle that overlaps something already merged.
+	# Because the cluster is connected, every circle is eventually reachable.
+	var progress = true
+	while not pending.is_empty() and progress:
+		progress = false
+		var i = 0
+		while i < pending.size():
+			var pc = pending[i]
+			var overlaps = false
+			for mc in merged_circles:
+				if pc.center.distance_to(mc.center) < pc.radius_px + mc.radius_px:
+					overlaps = true
+					break
+			if overlaps:
+				var circle_poly = _circle_to_polygon(pc.center, pc.radius_px)
+				var union_result = Geometry2D.merge_polygons(merged, circle_poly)
+				merged = _largest_polygon(union_result)
+				merged_circles.append(pc)
+				pending.remove_at(i)
+				progress = true
+			else:
+				i += 1
+
+	return merged
+
+func _largest_polygon(polys: Array) -> PackedVector2Array:
+	"""Return the polygon with the greatest absolute area (the outer ring)."""
+	var largest := PackedVector2Array()
+	var largest_area := -1.0
+	for poly in polys:
+		var area = abs(_polygon_area(poly))
+		if area > largest_area:
+			largest_area = area
+			largest = poly
+	return largest
 
 func _circle_to_polygon(center: Vector2, radius: float) -> PackedVector2Array:
-	"""Convert a circle to a polygon approximation."""
+	"""Convert a circle to a polygon approximation.
+
+	The polygon is CIRCUMSCRIBED (vertices pushed out by 1/cos(PI/segments)) so it
+	fully contains the true circle instead of being inscribed inside it. This matters
+	because clustering and the fold-in test (_group_circles_into_clusters / _merge_cluster)
+	decide overlap from the TRUE circle radii, while the actual union is computed on these
+	polygons. An inscribed polygon can fall a fraction of a pixel short of the true circle,
+	so two barely-overlapping bubbles could pass the radius test yet produce disjoint
+	polygons — which merge_polygons would then leave unmerged and _largest_polygon would
+	silently drop. Circumscribing guarantees polygon overlap whenever the circles overlap.
+	The cost is enlarging every drawn bubble by ~0.2% (about 1px at these radii)."""
+	var effective_radius = radius / cos(PI / float(CIRCLE_SEGMENTS))
 	var points = PackedVector2Array()
 	for i in range(CIRCLE_SEGMENTS):
 		var angle = TAU * float(i) / float(CIRCLE_SEGMENTS)
-		points.append(center + Vector2(cos(angle), sin(angle)) * radius)
+		points.append(center + Vector2(cos(angle), sin(angle)) * effective_radius)
 	return points
 
 func _process(delta: float) -> void:
@@ -158,9 +263,9 @@ func _draw() -> void:
 			# Draw dashed line
 			_draw_dashed_line(p1, p2, pulse_alpha, march_offset)
 
-	# Draw a single label near the center of the screen-visible portion
-	if _merged_polygons.size() > 0:
-		_draw_exclusion_label(_merged_polygons[0], board_width_px, board_height_px, edge_threshold, pulse_alpha)
+	# Label every disjoint exclusion zone so each enemy cluster is annotated.
+	for poly in _merged_polygons:
+		_draw_exclusion_label(poly, board_width_px, board_height_px, edge_threshold, pulse_alpha)
 
 func _is_board_edge(p1: Vector2, p2: Vector2, board_w: float, board_h: float, threshold: float) -> bool:
 	"""Check if both points of an edge lie on the same board boundary."""

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -180,6 +180,7 @@ var reinforcements_button: Button = null
 var _selected_unit_for_reserves: String = ""
 var _reinforcement_placement_type: String = ""  # P2-80: chosen placement type (deep_strike or strategic_reserves)
 var _deep_strike_exclusion_visual: Node2D = null  # 9" exclusion bubble around enemy models
+var _strategic_reserves_zone_visual: Node2D = null  # 6"-from-edge valid band for Strategic Reserves
 
 # Deployment zone toggle (Z key) - allows viewing zones after deployment phase
 var _deployment_zones_toggled_on: bool = false
@@ -2520,25 +2521,66 @@ func _on_scout_reserves_confirmed() -> void:
 	update_ui()
 
 func _show_deep_strike_exclusion() -> void:
-	"""Show 9-inch exclusion bubbles around all enemy models for reinforcement placement."""
+	"""Show placement helpers for reinforcement placement: the 9\" exclusion
+	bubbles around all enemy models, plus — when the unit is arriving from
+	Strategic Reserves — the valid 6\"-from-board-edge band it must be set up in."""
 	_hide_deep_strike_exclusion()  # Clean up any existing visual
 	var active_player = GameState.get_active_player()
 	var enemy_positions = GameState.get_enemy_model_positions(active_player)
-	if enemy_positions.is_empty():
-		return
-	_deep_strike_exclusion_visual = load("res://scripts/DeepStrikeExclusionVisual.gd").new()
-	if ghost_layer:
-		ghost_layer.add_child(_deep_strike_exclusion_visual)
-	else:
-		add_child(_deep_strike_exclusion_visual)
-	_deep_strike_exclusion_visual.show_exclusion(enemy_positions)
+	if not enemy_positions.is_empty():
+		_deep_strike_exclusion_visual = load("res://scripts/DeepStrikeExclusionVisual.gd").new()
+		if ghost_layer:
+			ghost_layer.add_child(_deep_strike_exclusion_visual)
+		else:
+			add_child(_deep_strike_exclusion_visual)
+		_deep_strike_exclusion_visual.show_exclusion(enemy_positions)
+	# Strategic Reserves also constrains placement to within 6" of a board edge.
+	# Show that valid band regardless of whether any enemies are on the board.
+	if _is_strategic_reserves_placement():
+		_show_strategic_reserves_zone()
 
 func _hide_deep_strike_exclusion() -> void:
-	"""Hide and free the deep strike exclusion visual."""
+	"""Hide and free the reinforcement placement helper visuals."""
 	if _deep_strike_exclusion_visual and is_instance_valid(_deep_strike_exclusion_visual):
 		_deep_strike_exclusion_visual.hide_exclusion()
 		_deep_strike_exclusion_visual.queue_free()
 		_deep_strike_exclusion_visual = null
+	_hide_strategic_reserves_zone()
+
+func _is_strategic_reserves_placement() -> bool:
+	"""True when the unit currently being placed is arriving via Strategic Reserves
+	(so the 6\"-from-edge constraint applies). Mirrors the effective placement type
+	used by DeploymentController._validate_reinforcement_position: the placement-type
+	override wins, otherwise the unit's own reserve_type (default strategic_reserves)."""
+	if not deployment_controller:
+		return false
+	var uid = deployment_controller.unit_id
+	if uid == "":
+		return false
+	var override_type = deployment_controller.reinforcement_placement_type
+	if override_type != "":
+		return override_type == "strategic_reserves"
+	var unit = GameState.get_unit(uid)
+	if unit.is_empty():
+		return false
+	return unit.get("reserve_type", "strategic_reserves") == "strategic_reserves"
+
+func _show_strategic_reserves_zone() -> void:
+	"""Show the within-6\"-of-edge valid placement band for Strategic Reserves."""
+	_hide_strategic_reserves_zone()
+	_strategic_reserves_zone_visual = load("res://scripts/StrategicReservesZoneVisual.gd").new()
+	if ghost_layer:
+		ghost_layer.add_child(_strategic_reserves_zone_visual)
+	else:
+		add_child(_strategic_reserves_zone_visual)
+	_strategic_reserves_zone_visual.show_zone()
+
+func _hide_strategic_reserves_zone() -> void:
+	"""Hide and free the Strategic Reserves valid-zone visual."""
+	if _strategic_reserves_zone_visual and is_instance_valid(_strategic_reserves_zone_visual):
+		_strategic_reserves_zone_visual.hide_zone()
+		_strategic_reserves_zone_visual.queue_free()
+		_strategic_reserves_zone_visual = null
 
 # T4-7: Rapid Ingress placement — same as reinforcement but uses PLACE_RAPID_INGRESS_REINFORCEMENT
 var _rapid_ingress_unit_id: String = ""
@@ -8790,6 +8832,10 @@ func _on_phase_changed(new_phase: GameStateData.Phase) -> void:
 
 	# Hide deep strike exclusion bubbles on phase change
 	_hide_deep_strike_exclusion()
+	# Abandon any in-progress reinforcement placement: clear the P2-80 placement-type
+	# choice so a stale Deep Strike / Strategic Reserves selection cannot leak into the
+	# next placement started in a later phase.
+	_reinforcement_placement_type = ""
 
 	# Clear transport panel when phase changes
 	update_transport_panel("")

--- a/40k/scripts/StrategicReservesZoneVisual.gd
+++ b/40k/scripts/StrategicReservesZoneVisual.gd
@@ -1,0 +1,170 @@
+extends Node2D
+
+# StrategicReservesZoneVisual - Highlights the VALID placement band for a unit
+# arriving from Strategic Reserves. Such a unit must be set up wholly within 6"
+# of a battlefield edge (and, separately, >9" from enemy models — that exclusion
+# is drawn by DeepStrikeExclusionVisual). This visual paints the 6"-from-edge
+# "frame" band around the board perimeter in green ("you can deploy here"),
+# complementing the red enemy-exclusion bubbles.
+#
+# The 6" rule is measured from the model's centre to the nearest board edge, to
+# match DeploymentController._validate_reinforcement_position exactly.
+
+const PX_PER_INCH: float = 40.0
+const EDGE_DISTANCE_INCHES: float = 6.0
+const DEFAULT_BOARD_W_INCHES: float = 44.0
+const DEFAULT_BOARD_H_INCHES: float = 60.0
+
+# Dashed line style (matches the other placement visuals)
+const DASH_LENGTH: float = 12.0
+const GAP_LENGTH: float = 8.0
+const LINE_WIDTH: float = 2.5
+const MARCH_SPEED: float = 25.0
+
+# Colors - green to signal a permitted area (contrast with the red exclusion visual)
+const LINE_COLOR: Color = Color(0.3, 1.0, 0.45, 0.85)
+const GLOW_COLOR: Color = Color(0.3, 1.0, 0.45, 0.15)
+const GLOW_WIDTH: float = 8.0
+const FILL_COLOR: Color = Color(0.3, 1.0, 0.45, 0.07)
+const LABEL_BG_COLOR: Color = Color(0.05, 0.1, 0.06, 0.85)
+const LABEL_BG_PADDING: Vector2 = Vector2(6, 3)
+const FONT_SIZE: int = 13
+
+var _board_w_px: float = DEFAULT_BOARD_W_INCHES * PX_PER_INCH
+var _board_h_px: float = DEFAULT_BOARD_H_INCHES * PX_PER_INCH
+var _band_px: float = EDGE_DISTANCE_INCHES * PX_PER_INCH
+var _pulse_time: float = 0.0
+var _is_active: bool = false
+var _default_font: Font = null
+
+func _ready() -> void:
+	z_index = -4  # Same layer as the exclusion visuals
+	_default_font = FactionPalettes.FONT_RAJDHANI_SEMIBOLD
+	set_process(false)
+
+func show_zone() -> void:
+	"""Show the within-6\"-of-edge valid placement band. Reads the current board
+	dimensions from GameState so the band always matches the real board."""
+	_resolve_board_size()
+	_is_active = true
+	_pulse_time = 0.0
+	set_process(true)
+	visible = true
+	queue_redraw()
+	print("[StrategicReservesZoneVisual] Showing 6\" board-edge placement band (board %.0fx%.0f px)" % [_board_w_px, _board_h_px])
+
+func hide_zone() -> void:
+	"""Hide the valid placement band."""
+	_is_active = false
+	set_process(false)
+	visible = false
+	queue_redraw()
+
+func _resolve_board_size() -> void:
+	_board_w_px = DEFAULT_BOARD_W_INCHES * PX_PER_INCH
+	_board_h_px = DEFAULT_BOARD_H_INCHES * PX_PER_INCH
+	var gs = get_node_or_null("/root/GameState")
+	if gs and gs.state.has("board"):
+		var size = gs.state.board.get("size", null)
+		if size != null:
+			var w = size.get("width", DEFAULT_BOARD_W_INCHES)
+			var h = size.get("height", DEFAULT_BOARD_H_INCHES)
+			if w > 0 and h > 0:
+				_board_w_px = float(w) * PX_PER_INCH
+				_board_h_px = float(h) * PX_PER_INCH
+	# Never let the band exceed half the board (degenerate on tiny boards)
+	_band_px = min(EDGE_DISTANCE_INCHES * PX_PER_INCH, min(_board_w_px, _board_h_px) / 2.0)
+
+func _process(delta: float) -> void:
+	if _is_active:
+		_pulse_time += delta
+		queue_redraw()
+
+func _draw() -> void:
+	if not _is_active:
+		return
+
+	var pulse_alpha = 0.7 + 0.3 * (1.0 + sin(_pulse_time * 2.0)) / 2.0
+	var march_offset = fmod(_pulse_time * MARCH_SPEED, DASH_LENGTH + GAP_LENGTH)
+
+	var w = _board_w_px
+	var h = _board_h_px
+	var b = _band_px
+
+	# Fill the perimeter frame as four non-overlapping rectangles so the alpha
+	# does not double up where bands meet at the corners.
+	var fill = Color(FILL_COLOR.r, FILL_COLOR.g, FILL_COLOR.b, FILL_COLOR.a * pulse_alpha)
+	draw_rect(Rect2(0, 0, w, b), fill, true)                 # top band
+	draw_rect(Rect2(0, h - b, w, b), fill, true)             # bottom band
+	draw_rect(Rect2(0, b, b, h - 2.0 * b), fill, true)       # left band
+	draw_rect(Rect2(w - b, b, b, h - 2.0 * b), fill, true)   # right band
+
+	# Draw the inner boundary (the 6" line) as an animated dashed rectangle.
+	# Anything inside this rectangle (toward the board centre) is NOT a legal
+	# Strategic Reserves position.
+	var inner = [
+		Vector2(b, b),
+		Vector2(w - b, b),
+		Vector2(w - b, h - b),
+		Vector2(b, h - b),
+	]
+	for i in range(inner.size()):
+		var p1 = inner[i]
+		var p2 = inner[(i + 1) % inner.size()]
+		var glow_color = Color(GLOW_COLOR.r, GLOW_COLOR.g, GLOW_COLOR.b, GLOW_COLOR.a * pulse_alpha)
+		draw_line(p1, p2, glow_color, GLOW_WIDTH, true)
+		_draw_dashed_line(p1, p2, pulse_alpha, march_offset)
+
+	_draw_zone_label(pulse_alpha)
+
+func _draw_dashed_line(p1: Vector2, p2: Vector2, pulse_alpha: float, march_offset: float) -> void:
+	"""Draw a marching-ants dashed line between two points."""
+	var direction = (p2 - p1).normalized()
+	var total_length = p1.distance_to(p2)
+	var segment_length = DASH_LENGTH + GAP_LENGTH
+
+	if total_length < 1.0:
+		return
+
+	var line_color = Color(LINE_COLOR.r, LINE_COLOR.g, LINE_COLOR.b, LINE_COLOR.a * pulse_alpha)
+
+	var pos = -march_offset
+	while pos < total_length:
+		var dash_start = max(pos, 0.0)
+		var dash_end = min(pos + DASH_LENGTH, total_length)
+
+		if dash_start < dash_end:
+			var start_pt = p1 + direction * dash_start
+			var end_pt = p1 + direction * dash_end
+			draw_line(start_pt, end_pt, line_color, LINE_WIDTH, true)
+
+		pos += segment_length
+
+func _draw_zone_label(pulse_alpha: float) -> void:
+	"""Draw a 'Reserves: within 6\" of edge' label centred on the top band."""
+	if not _default_font:
+		return
+
+	var label_text = "Reserves: within 6\" of edge"
+	var text_size = _default_font.get_string_size(label_text, HORIZONTAL_ALIGNMENT_LEFT, -1, FONT_SIZE)
+
+	# Centre horizontally, sit vertically in the middle of the top band.
+	var label_pos = Vector2(_board_w_px / 2.0, _band_px / 2.0)
+
+	var bg_rect = Rect2(
+		label_pos - LABEL_BG_PADDING - Vector2(text_size.x / 2.0, text_size.y / 2.0),
+		text_size + LABEL_BG_PADDING * 2
+	)
+	var bg_color = Color(LABEL_BG_COLOR.r, LABEL_BG_COLOR.g, LABEL_BG_COLOR.b, LABEL_BG_COLOR.a * pulse_alpha)
+	draw_rect(bg_rect, bg_color, true)
+
+	var text_color = Color(LINE_COLOR.r, LINE_COLOR.g, LINE_COLOR.b, pulse_alpha)
+	draw_string(
+		_default_font,
+		label_pos - Vector2(text_size.x / 2.0, -text_size.y / 4.0),
+		label_text,
+		HORIZONTAL_ALIGNMENT_LEFT,
+		-1,
+		FONT_SIZE,
+		text_color
+	)

--- a/40k/tests/test_deep_strike_exclusion_clusters.gd
+++ b/40k/tests/test_deep_strike_exclusion_clusters.gd
@@ -1,0 +1,89 @@
+extends SceneTree
+
+# Regression test for DeepStrikeExclusionVisual cluster merging.
+#
+# Bug (fixed): when enemy models formed several physically-separate clusters,
+# the exclusion overlay merged every circle into one running polygon and kept
+# only the LARGEST result after each pairwise merge — silently dropping the
+# exclusion zone of every cluster that was not connected to the largest one.
+# The player saw a red "9\" exclusion" zone around one enemy group and nothing
+# around the others (see the reported top-vs-bottom screenshot).
+#
+# This is a pure-geometry check (no window needed): it drives show_exclusion()
+# and asserts _merged_polygons contains one polygon per connected cluster.
+#
+# Usage: godot --headless --path 40k -s tests/test_deep_strike_exclusion_clusters.gd
+
+var passed := 0
+var failed := 0
+
+const PX_PER_INCH := 40.0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init() -> void:
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _make_visual() -> Node2D:
+	var v: Node2D = load("res://scripts/DeepStrikeExclusionVisual.gd").new()
+	root.add_child(v)
+	return v
+
+func _model(x: float, y: float, base_mm: int = 32) -> Dictionary:
+	return {"x": x, "y": y, "base_mm": base_mm}
+
+func _poly_count(v: Node2D, positions: Array) -> int:
+	v.show_exclusion(positions)
+	return v._merged_polygons.size()
+
+func _run_tests() -> void:
+	if passed > 0 or failed > 0:
+		return  # guard against double invocation (ready signal + timer)
+	print("\n=== test_deep_strike_exclusion_clusters ===\n")
+
+	var v := _make_visual()
+
+	# A single enemy model -> exactly one exclusion polygon.
+	print("-- single model --")
+	_check("one model -> 1 polygon", _poly_count(v, [_model(880, 1200)]) == 1)
+
+	# Two models whose 9\" bubbles overlap (close together) -> one merged polygon.
+	print("-- one tight cluster --")
+	_check("two overlapping models -> 1 polygon",
+		_poly_count(v, [_model(880, 1200), _model(920, 1200)]) == 1)
+
+	# Two clusters far apart (top vs bottom of a 44x60\" board) -> TWO polygons.
+	# This is the exact regression: before the fix only the larger one survived.
+	print("-- two separated clusters (the reported bug) --")
+	var top_bottom := [
+		_model(880, 160), _model(940, 160), _model(1000, 160),   # top row cluster
+		_model(880, 2240), _model(940, 2240), _model(1000, 2240), # bottom row cluster
+	]
+	_check("top + bottom clusters -> 2 polygons", _poly_count(v, top_bottom) == 2,
+		"got %d" % v._merged_polygons.size())
+
+	# Three separated clusters (top, bottom-left, bottom-right) -> THREE polygons.
+	print("-- three separated clusters --")
+	var three := [
+		_model(880, 160), _model(940, 160),        # top
+		_model(160, 2240), _model(220, 2240),      # bottom-left
+		_model(1600, 2240), _model(1660, 2240),    # bottom-right
+	]
+	_check("three clusters -> 3 polygons", _poly_count(v, three) == 3,
+		"got %d" % v._merged_polygons.size())
+
+	# Empty input -> no polygons, no crash.
+	print("-- empty --")
+	_check("no models -> 0 polygons", _poly_count(v, []) == 0)
+
+	v.queue_free()
+
+	print("\n=== RESULT: %d passed, %d failed ===\n" % [passed, failed])
+	quit(1 if failed > 0 else 0)


### PR DESCRIPTION
## Summary

Two fixes to the reinforcement placement helper (Deep Strike / Strategic Reserves arrival):

### 1. Deep Strike exclusion zone was missing on some enemy clusters (reported bug)
The red ">9\" from enemy models" no-deploy zone only rendered around the **single largest** connected clump of enemies. `DeepStrikeExclusionVisual._build_merged_polygon()` merged every enemy 9" bubble into one running polygon and, after each pairwise merge, kept only the **largest** resulting polygon — silently discarding any enemy cluster not physically connected to it. Enemy groups elsewhere on the board showed no exclusion zone (the reported "red at the top but not the bottom" screenshot).

**Fix:** group bubbles into connected clusters (union-find on true-circle overlap) and merge **each cluster independently**, so every enemy group draws its own labelled zone. Bubble polygons are now **circumscribed** so a near-tangent pair can no longer produce disjoint polygons that get dropped.

### 2. Strategic Reserves now shows where you *can* deploy (follow-up request)
New `StrategicReservesZoneVisual` paints a green "within 6\" of edge" band around the board perimeter — the area a Strategic Reserves unit may be set up in. It matches `DeploymentController._validate_reinforcement_position` exactly (model centre within 6" of the nearest board edge) and is shown only for Strategic Reserves arrivals, **not** Deep Strike (which may arrive anywhere >9" from enemies). Wired into both the normal reinforcement flow and Rapid Ingress via `_is_strategic_reserves_placement()`, which mirrors the validator's effective-placement-type logic.

### Also
- Clear the P2-80 placement-type override on phase change so an abandoned placement cannot leak a stale Deep Strike / Strategic Reserves choice into a later one.
- Add headless regression test `test_deep_strike_exclusion_clusters.gd` asserting one exclusion polygon per connected cluster.
- Changelog entry v0.19.0.

## Files
- `40k/scripts/DeepStrikeExclusionVisual.gd` — cluster-aware merge + circumscribe.
- `40k/scripts/StrategicReservesZoneVisual.gd` — new green 6"-from-edge band.
- `40k/scripts/Main.gd` — wiring + placement-type parity + phase-change cleanup.
- `40k/tests/test_deep_strike_exclusion_clusters.gd` — regression test.
- `40k/data/version_history.json` — v0.19.0.

## Validation
- Faithful port of both algorithms using real polygon-boolean ops (shapely) **reproduced the bug** (only 1 of 3 zones drawn, 51.5% of exclusion area missing) and **confirmed the fix** (all 3 zones), plus a near-tangent regression.
- Two independent adversarial code reviews: circumscribe fix → ship-ready; new visual + wiring → no blockers, validator parity confirmed.
- Every draw call in the new visual cross-referenced against the shipping `DeepStrikeExclusionVisual.gd`.
- **Not run in-container:** the live windowed scenario / in-game screenshot and the new headless test could not be executed here (no Godot binary in this remote container and egress policy blocks downloading one). These should be run on a machine with Godot before relying on the visual end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nYDMt2f1fNpo99or5p9Mk

---
_Generated by [Claude Code](https://claude.ai/code/session_012nYDMt2f1fNpo99or5p9Mk)_