### PR TITLE
Fix history view: click another log entry to switch steps without Esc

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.18.5",
+			"date": "2026-07-11",
+			"summary": "History view: jump straight between game-log steps — while viewing a past step you can now click any other log entry to show that one, no need to press Esc first.",
+			"changes": [
+				"While viewing a past board state (after clicking a game-log entry), clicking a different log entry now switches the view directly to that step. Previously the read-only overlay silently swallowed clicks on the log, so you had to press Esc (Return to Live Game) before picking another step.",
+				"The game log stays fully usable while viewing history — scrolling the list and expanding card details work too, and the banner always names the step being shown.",
+				"Hardened the history board rebuild against two step clicks landing in the same frame, which could have created duplicate model tokens."
+			]
+		},
+		{
 			"version": "0.18.4",
 			"date": "2026-07-11",
 			"summary": "Fixed charge rolls being wrongly reported as failed when the roll would actually reach the enemy. A charging model only has to close to within engagement range (2\"), not touch base-to-base — e.g. a 9\" roll against a target 9.6\" away now succeeds (it only needs to travel 7.6\").",

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -1675,19 +1675,68 @@ func debug_click_history_card_matching(substring: String) -> bool:
 	"""Test hook (windowed scenarios): drive the exact same code path as a real
 	left-click on the first clickable log card whose text contains `substring`.
 	Returns false if no matching clickable card exists."""
-	if _card_container == null:
+	var card := _find_history_card_matching(substring)
+	if card == null:
 		return false
+	_set_active_history_card(card)
+	emit_signal("history_step_requested", int(card.get_meta("history_index")), _card_history_description(card))
+	return true
+
+func _find_history_card_matching(substring: String) -> Control:
+	"""First clickable (history-stamped) log card whose entry text contains
+	`substring`; null if none."""
+	if _card_container == null:
+		return null
 	for card in _card_container.get_children():
 		if not is_instance_valid(card):
 			continue
 		if not card.has_meta("history_index"):
 			continue
-		var txt := str(card.get_meta("history_desc", ""))
-		if substring in txt:
-			_set_active_history_card(card)
-			emit_signal("history_step_requested", int(card.get_meta("history_index")), _card_history_description(card))
-			return true
-	return false
+		if substring in str(card.get_meta("history_desc", "")):
+			return card
+	return null
+
+func scroll_history_card_into_view(substring: String) -> bool:
+	"""Test hook: scroll the log so the first clickable card whose text contains
+	`substring` sits inside the scroll viewport, so a synthesized pointer click
+	can land on it. Returns false if no matching clickable card exists."""
+	var card := _find_history_card_matching(substring)
+	if card == null or _scroll == null:
+		return false
+	_scroll.ensure_control_visible(card)
+	return true
+
+func real_click_history_card_matching(substring: String) -> bool:
+	"""Test hook: synthesize a REAL mouse press+release (via Input.parse_input_event,
+	so normal viewport GUI picking decides who receives it) at the on-screen position
+	of the first clickable log card whose text contains `substring`. Unlike
+	debug_click_history_card_matching — which emits the signal directly — this
+	proves the card is actually reachable by the pointer (e.g. not covered by the
+	history overlay). Returns true when the card was found and the events were
+	injected; whether the click LANDED on the card is for the caller to assert."""
+	var card := _find_history_card_matching(substring)
+	if card == null:
+		return false
+	var r := card.get_global_rect()
+	# Aim at the card's left edge, vertically centred: that region is the icon
+	# badge / accent strip (non-Button, mouse-ignored) so the event falls through
+	# to the card itself even on cards that contain real Buttons (detail toggles).
+	var pos := Vector2(r.position.x + minf(16.0, r.size.x * 0.5), r.position.y + r.size.y * 0.5)
+	var press := InputEventMouseButton.new()
+	press.button_index = MOUSE_BUTTON_LEFT
+	press.pressed = true
+	press.button_mask = MOUSE_BUTTON_MASK_LEFT
+	press.position = pos
+	press.global_position = pos
+	Input.parse_input_event(press)
+	var release := InputEventMouseButton.new()
+	release.button_index = MOUSE_BUTTON_LEFT
+	release.pressed = false
+	release.button_mask = 0
+	release.position = pos
+	release.global_position = pos
+	Input.parse_input_event(release)
+	return true
 
 func _on_ai_filter_pressed() -> void:
 	# The header 'AI' shortcut drives the same state as the AI chip.

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -247,6 +247,8 @@ var _history_live_state: Dictionary = {}      # the real, live GameState.state (
 var _history_overlay: Control = null          # blocks input on the board while viewing
 var _history_banner_label: RichTextLabel = null
 var _history_saved_ai_enabled: bool = false   # AI enabled flag to restore on exit
+var _history_saved_log_panel_index: int = -1  # log panel's child index to restore on exit
+var _history_refresh_running: bool = false    # drops overlapping history board rebuilds
 
 # P3-117: Dice Roll History panel UI elements
 var _dice_history_panel: PanelContainer = null
@@ -10634,6 +10636,16 @@ func _enter_history_view_mode() -> void:
 
 	_build_history_overlay()
 
+	# Godot routes mouse input by TREE order, not z_index (z_index affects drawing
+	# only) — so raising the log panel's z_index alone still left the overlay (a
+	# later sibling) eating every click aimed at the panel, forcing the player to
+	# press Esc before picking another step. Move the panel after the overlay in
+	# the tree so log cards stay genuinely clickable and the player can switch
+	# straight to a different step while viewing. Original index restored on exit.
+	if game_log_panel and is_instance_valid(game_log_panel) and game_log_panel.get_parent() == self:
+		_history_saved_log_panel_index = game_log_panel.get_index()
+		move_child(game_log_panel, get_child_count() - 1)
+
 func _set_controllers_input_enabled(enabled: bool) -> void:
 	"""Enable/disable input processing on every phase controller — used to make the
 	board fully inert while the player browses a past step."""
@@ -10648,8 +10660,10 @@ func _build_history_overlay() -> void:
 		_history_overlay.visible = true
 		return
 
-	# Full-screen input blocker. Sits above the board/HUD but BELOW the game log
-	# panel (whose z is raised) so the player can keep clicking other log entries.
+	# Full-screen input blocker. The game log panel is kept usable on top of it by
+	# _enter_history_view_mode moving the panel AFTER this overlay in the tree
+	# (input picking follows tree order; the raised z_index below only handles
+	# draw order) so the player can keep clicking other log entries.
 	var overlay := Control.new()
 	overlay.name = "HistoryViewOverlay"
 	overlay.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)
@@ -10728,11 +10742,20 @@ func _history_refresh_visuals() -> void:
 	"""Rebuild the board tokens from the (historical) GameState.state. Deliberately
 	minimal: it recreates unit tokens and updates score/round labels only. It does
 	NOT rebuild phase controllers or run any phase logic — this is a passive view."""
+	# Guard against overlapping runs (same duplicate-token hazard as
+	# _recreate_unit_visuals): two log-card clicks landing within one frame would
+	# each rebuild the full token set after the await below. Dropping the second
+	# call is safe — this run reads GameState fresh AFTER the await, so it already
+	# renders the step of the latest click.
+	if _history_refresh_running:
+		return
+	_history_refresh_running = true
 	# Clear existing tokens
 	for child in token_layer.get_children():
 		child.queue_free()
 	await get_tree().process_frame
 	if not _history_view_active:
+		_history_refresh_running = false
 		return  # exited while we were awaiting
 
 	var units = GameState.state.get("units", {})
@@ -10764,6 +10787,7 @@ func _history_refresh_visuals() -> void:
 		_update_round_indicator()
 	if active_player_badge:
 		active_player_badge.text = "P%d" % GameState.get_active_player()
+	_history_refresh_running = false
 
 func _exit_history_view() -> void:
 	if not _history_view_active:
@@ -10781,13 +10805,18 @@ func _exit_history_view() -> void:
 	if game_log_panel and is_instance_valid(game_log_panel) and game_log_panel.has_method("clear_active_history"):
 		game_log_panel.clear_active_history()
 
-	# Remove the overlay and restore the log panel's normal z.
+	# Remove the overlay and restore the log panel's normal z + tree position
+	# (it was moved after the overlay so it could receive clicks — see
+	# _enter_history_view_mode; leaving it last would draw it above dialogs).
 	if _history_overlay and is_instance_valid(_history_overlay):
 		_history_overlay.queue_free()
 	_history_overlay = null
 	_history_banner_label = null
 	if game_log_panel and is_instance_valid(game_log_panel):
 		game_log_panel.z_index = UI_PANEL_Z
+		if _history_saved_log_panel_index >= 0 and game_log_panel.get_parent() == self:
+			move_child(game_log_panel, mini(_history_saved_log_panel_index, get_child_count() - 1))
+	_history_saved_log_panel_index = -1
 
 	# Rebuild the live board and re-run normal UI refresh.
 	_recreate_unit_visuals()

--- a/40k/tests/scenarios/sp/game_log_switch_step_no_escape.json
+++ b/40k/tests/scenarios/sp/game_log_switch_step_no_escape.json
@@ -1,0 +1,81 @@
+{
+  "id": "game_log_switch_step_no_escape",
+  "covers": [
+    "ui.GameLogPanel.history_step_click",
+    "ui.GameLogPanel.real_click_history_card",
+    "ui.Main.history_view",
+    "ui.Main.history_overlay_input_order",
+    "replay.ReplayManager.build_recorded_state_at"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "History view: switch to another log step WITHOUT pressing Escape. Makes two real confirmed moves (Blade Champion, then Shield Captain) so two log cards carry recording markers, then opens history view by REAL-clicking the 'Shield Captain' moved card — synthesized mouse press/release through Input.parse_input_event, so normal viewport GUI picking decides what is hit. While the read-only overlay is still up, REAL-clicks the 'Blade Champion' card and asserts the view switches to that earlier step (Shield Captain back at its pre-move y=100) with history view still active, the same overlay still alive, and no duplicate tokens from the back-to-back board rebuilds. Guards the regression where the full-screen history overlay ate log-panel clicks — Godot routes mouse input by tree order, not z_index, so raising the panel's z_index alone left the overlay (a later sibling) swallowing clicks and forced players to press Esc before choosing another step. Finally exits with a real Escape key press and asserts the live state is restored.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "ReplayManager.cleanup()" },
+    { "act": "execute_script", "script": "ReplayManager.start_recording(false)" },
+    { "act": "execute_script", "script": "ReplayManager.is_recording", "equals": true },
+
+    { "act": "execute_script", "script": "main.movement_controller._select_unit_in_list_by_id(\"U_BLADE_CHAMPION_A\")", "equals": true },
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_BLADE_CHAMPION_A",
+      "payload": { "model_id": "m1", "dest": [120, 320], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script", "script": "main.movement_controller._select_unit_in_list_by_id(\"U_SHIELD_CAPTAIN_A\")", "equals": true },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"flags\", {}).get(\"moved\", false)", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "STAGE_MODEL_MOVE",
+      "actor_unit_id": "U_SHIELD_CAPTAIN_A",
+      "payload": { "model_id": "m1", "dest": [50, 280], "rotation": 0.0 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script", "script": "main.phase_action_button.emit_signal(\"pressed\")" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"flags\", {}).get(\"moved\", false)", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 280 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "execute_script", "script": "main.game_log_panel.count_history_cards()", "expect_min": 2 },
+    { "act": "screenshot", "label": "01_live_both_units_moved" },
+
+    { "act": "execute_script", "script": "main.game_log_panel.scroll_history_card_into_view(\"Shield-Captain\")", "equals": true },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "main.game_log_panel.real_click_history_card_matching(\"Shield-Captain\")", "equals": true },
+    { "act": "wait_frames", "frames": 4 },
+
+    { "act": "execute_script", "script": "main.is_history_view_active()", "equals": true },
+    { "act": "execute_script", "script": "main._history_overlay != null", "equals": true },
+    { "act": "execute_script", "script": "main.game_log_panel.has_active_history()", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 280 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "screenshot", "label": "02_history_view_on_shield_captain_step" },
+
+    { "act": "execute_script", "script": "main.game_log_panel.scroll_history_card_into_view(\"Blade Champion\")", "equals": true },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "execute_script", "script": "main.game_log_panel.real_click_history_card_matching(\"Blade Champion\")", "equals": true },
+    { "act": "wait_frames", "frames": 4 },
+
+    { "act": "execute_script", "script": "main.is_history_view_active()", "equals": true },
+    { "act": "execute_script", "script": "main._history_overlay != null", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 100 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "execute_script", "script": "max_tokens_per_model()", "expect_max": 1 },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "screenshot", "label": "03_switched_to_blade_champion_step_no_escape" },
+
+    { "act": "simulate_key", "keycode": "Escape" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script", "script": "main.is_history_view_active()", "equals": false },
+    { "act": "execute_script", "script": "main.game_log_panel.has_active_history()", "equals": false },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_SHIELD_CAPTAIN_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 280 },
+    { "act": "execute_script", "script": "int(GameState.get_unit(\"U_BLADE_CHAMPION_A\").get(\"models\")[0].get(\"position\").get(\"y\"))", "equals": 320 },
+    { "act": "screenshot", "label": "04_returned_to_live_game" }
+  ]
+}


### PR DESCRIPTION
## Summary

When viewing a past board state (history view, entered by clicking a game-log card), clicking a **different** log card did nothing — the player had to press Esc back to the live game before picking another step. This makes the log directly switchable while viewing.

## Root cause

The history view builds a full-screen input-blocking overlay, and the code raised the log panel's `z_index` assuming that kept it clickable. But Godot routes mouse input by **tree order**, not `z_index` (z only affects drawing) — so the panel rendered above the overlay and looked clickable, while every click actually landed on the overlay (`MOUSE_FILTER_STOP`) and was swallowed. The step-switching logic in `_show_history_state` already supported repeated clicks; the clicks just never arrived.

## The fix

- **`Main.gd`**: on entering history view, move the log panel after the overlay in the scene tree (input picking + draw order both follow it there); restore its original child index on exit so save/load dialogs keep rendering above the log in normal play.
- Added a re-entrancy guard to `_history_refresh_visuals`, because two step clicks landing in the same frame would double-build the token set (same duplicate-token hazard fixed for live play in 0.18.2).
- Side benefit: scrolling the log and expanding card details now also work while viewing history.

## Validation (windowed, per the project gate)

- Added `GameLogPanel` test hooks that synthesize a **real** mouse click through viewport picking at a log card's screen position (`scroll_history_card_into_view` / `real_click_history_card_matching`) — unlike the existing `debug_click_history_card_matching`, which emits the signal directly and is exactly why this bug was invisible to the old scenario.
- New scenario `tests/scenarios/sp/game_log_switch_step_no_escape.json`: two real confirmed moves, real-click the "Shield-Captain moved" card to enter history view, then real-click the "Blade Champion moved" card **while the overlay is up**, and assert the board switched to that earlier step (Shield-Captain back at y=100), the overlay stayed up, no duplicate tokens, then a real Escape restores the live state.
- Runs **pre-fix**: fails at exactly the switch assertion (clean reproduction). **Post-fix: 47/47 pass.** Screenshots show the banner changing from "Viewing: P1: Shield-Captain moved" to "Viewing: P1: Blade Champion moved" with the card highlight following.
- Neighbors still pass: `game_log_step_replay`, `save_load_dialog_above_log`, `game_log_ability_filter`, `game_log_clarity_filters`. No ERROR lines in the debug log.

Version bumped to **0.18.5** with a player-facing changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019BkKoWw3eaUMdSGmkhUxv5

---
_Generated by [Claude Code](https://claude.ai/code/session_019BkKoWw3eaUMdSGmkhUxv5)_