### PR TITLE
Add AI decision-flow explainer (docs/AI_DECISION_FLOW.html)

### DIFF
--- a/docs/AI_DECISION_FLOW.html
+++ b/docs/AI_DECISION_FLOW.html
@@ -1,0 +1,1213 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The Cogitator — How the AI Thinks</title>
+<style>
+/* ============================================================= *
+ *  THE COGITATOR — AI decision-flow explainer
+ *  Design language: a tactical targeting-computer readout.
+ *  Brass = the machine-spirit's decision glow. Steel = cold analysis.
+ *  Olive ✓ = chosen. Rust ✗ = rejected / reactive. (Mirrors the
+ *  real in-game "thought link" arrows.)
+ * ============================================================= */
+
+/* ---- Theme tokens ------------------------------------------- */
+:root, :root[data-theme="light"] {
+  --ground:      #e7e1d2;
+  --panel:       #f3eee2;
+  --panel-2:     #ece5d5;
+  --panel-3:     #e2dac6;
+  --ink:         #262a2e;
+  --ink-strong:  #14171b;
+  --muted:       #6e6a5c;
+  --faint:       #8b8676;
+  --line:        #cdc4ae;
+  --line-strong: #b7ac92;
+  --brass:       #8a5f16;
+  --brass-bright:#b07d1f;
+  --steel:       #216d76;
+  --confirm:     #4c7433;
+  --threat:      #a5402a;
+  --grid:        rgba(120,110,86,.10);
+  --glow:        rgba(176,125,31,.16);
+  --shadow:      rgba(40,34,20,.14);
+  color-scheme: light;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ground:      #0e1216;
+    --panel:       #151b21;
+    --panel-2:     #1b232b;
+    --panel-3:     #212b34;
+    --ink:         #d6d1c2;
+    --ink-strong:  #f1ede1;
+    --muted:       #8b93a0;
+    --faint:       #69707c;
+    --line:        #28313b;
+    --line-strong: #3a4653;
+    --brass:       #d9a94f;
+    --brass-bright:#e8bd66;
+    --steel:       #5fb0b8;
+    --confirm:     #8fb063;
+    --threat:      #d0694c;
+    --grid:        rgba(120,150,170,.06);
+    --glow:        rgba(217,169,79,.14);
+    --shadow:      rgba(0,0,0,.45);
+    color-scheme: dark;
+  }
+}
+:root[data-theme="dark"] {
+  --ground:      #0e1216;
+  --panel:       #151b21;
+  --panel-2:     #1b232b;
+  --panel-3:     #212b34;
+  --ink:         #d6d1c2;
+  --ink-strong:  #f1ede1;
+  --muted:       #8b93a0;
+  --faint:       #69707c;
+  --line:        #28313b;
+  --line-strong: #3a4653;
+  --brass:       #d9a94f;
+  --brass-bright:#e8bd66;
+  --steel:       #5fb0b8;
+  --confirm:     #8fb063;
+  --threat:      #d0694c;
+  --grid:        rgba(120,150,170,.06);
+  --glow:        rgba(217,169,79,.14);
+  --shadow:      rgba(0,0,0,.45);
+  color-scheme: dark;
+}
+
+/* ---- Fonts (system stacks; monospace carries the "console voice") */
+:root {
+  --font-body: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+  --wrap: 74ch;
+  --maxw: 1120px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html { -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+@media (prefers-reduced-motion: reduce) { html { scroll-behavior: auto; } }
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(1200px 600px at 50% -10%, var(--glow), transparent 60%),
+    linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 34px,
+    var(--ground);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 17px;
+  line-height: 1.62;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow-x: hidden;
+}
+
+/* ---- Layout primitives -------------------------------------- */
+.wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 clamp(18px, 4vw, 40px); }
+.prose { max-width: var(--wrap); }
+section { padding: clamp(48px, 7vw, 88px) 0; border-top: 1px solid var(--line); }
+section:first-of-type { border-top: none; }
+p { margin: 0 0 1.1em; }
+a { color: var(--brass); text-decoration-color: color-mix(in srgb, var(--brass) 40%, transparent); text-underline-offset: 3px; }
+a:hover { color: var(--brass-bright); }
+strong { color: var(--ink-strong); font-weight: 650; }
+
+/* ---- Type -------------------------------------------------- */
+h1, h2, h3 { color: var(--ink-strong); text-wrap: balance; line-height: 1.12; }
+h2 { font-size: clamp(1.55rem, 3.4vw, 2.15rem); margin: 0 0 .3em; letter-spacing: -.01em; }
+h3 { font-size: clamp(1.12rem, 2vw, 1.32rem); margin: 2em 0 .5em; letter-spacing: -.005em; }
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: .72rem;
+  letter-spacing: .26em;
+  text-transform: uppercase;
+  color: var(--brass);
+  display: inline-flex; align-items: center; gap: .6em;
+  margin: 0 0 1.1em;
+}
+.eyebrow::before { content: ""; width: 26px; height: 1px; background: var(--brass); opacity: .7; }
+.mono { font-family: var(--font-mono); }
+.k { /* inline code / symbol */
+  font-family: var(--font-mono);
+  font-size: .86em;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: .08em .42em;
+  color: var(--ink-strong);
+  white-space: nowrap;
+}
+.lede { font-size: clamp(1.08rem, 2vw, 1.28rem); color: var(--ink); line-height: 1.55; }
+.muted { color: var(--muted); }
+
+/* ---- Header ------------------------------------------------- */
+header.hero { padding: clamp(56px, 9vw, 116px) 0 clamp(40px, 6vw, 70px); position: relative; }
+.hero-tag {
+  font-family: var(--font-mono); font-size: .72rem; letter-spacing: .3em; text-transform: uppercase;
+  color: var(--muted); display: flex; flex-wrap: wrap; gap: .5em 1.4em; margin-bottom: 1.8em;
+}
+.hero-tag b { color: var(--steel); font-weight: 600; }
+h1 {
+  font-size: clamp(2.5rem, 7vw, 4.6rem);
+  margin: 0 0 .28em;
+  letter-spacing: -.02em;
+  font-weight: 720;
+}
+h1 .sub { display: block; color: var(--brass); }
+.hero .lede { max-width: 64ch; }
+.stat-row {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(128px, 1fr)); gap: 1px;
+  margin-top: 2.6em; background: var(--line); border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+}
+.stat { background: var(--panel); padding: 1.05em 1.15em; }
+.stat .n { font-family: var(--font-mono); font-size: 1.7rem; color: var(--ink-strong); font-variant-numeric: tabular-nums; line-height: 1; }
+.stat .l { font-size: .76rem; color: var(--muted); margin-top: .55em; letter-spacing: .02em; }
+
+/* ---- Panels / cards ---------------------------------------- */
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: clamp(20px, 3vw, 32px);
+  position: relative;
+  box-shadow: 0 1px 0 var(--shadow);
+}
+/* reticle corner brackets */
+.reticle::before, .reticle::after {
+  content: ""; position: absolute; width: 14px; height: 14px; pointer-events: none;
+  border: 1.5px solid var(--brass); opacity: .55;
+}
+.reticle::before { top: 9px; left: 9px; border-right: none; border-bottom: none; }
+.reticle::after  { bottom: 9px; right: 9px; border-left: none; border-top: none; }
+
+.callout {
+  border-left: 3px solid var(--brass);
+  background: linear-gradient(90deg, var(--glow), transparent 80%);
+  padding: 1em 1.2em; border-radius: 0 8px 8px 0; margin: 1.6em 0;
+}
+.callout.steel { border-left-color: var(--steel); background: linear-gradient(90deg, color-mix(in srgb, var(--steel) 12%, transparent), transparent 80%); }
+.callout.threat { border-left-color: var(--threat); background: linear-gradient(90deg, color-mix(in srgb, var(--threat) 12%, transparent), transparent 80%); }
+.callout p:last-child { margin-bottom: 0; }
+.callout .h { font-family: var(--font-mono); font-size: .74rem; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); display: block; margin-bottom: .4em; }
+
+.grid { display: grid; gap: 16px; }
+.grid.two { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+.grid.three { grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); }
+
+/* ---- Q&A answer chips (TL;DR) ------------------------------- */
+.qa { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); }
+.qa .card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 1.15em 1.25em; }
+.qa .q { font-family: var(--font-mono); font-size: .8rem; color: var(--steel); letter-spacing: .02em; margin-bottom: .5em; }
+.qa .a { color: var(--ink); font-size: .98rem; }
+.qa .a b { color: var(--ink-strong); }
+
+/* ---- Tables ------------------------------------------------- */
+.table-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 10px; margin: 1.4em 0; }
+table { border-collapse: collapse; width: 100%; font-size: .9rem; min-width: 560px; }
+th, td { text-align: left; padding: .68em .9em; border-bottom: 1px solid var(--line); vertical-align: top; }
+thead th { background: var(--panel-2); color: var(--ink-strong); font-family: var(--font-mono); font-size: .72rem; letter-spacing: .1em; text-transform: uppercase; position: sticky; top: 0; }
+tbody tr:last-child td { border-bottom: none; }
+tbody tr:hover td { background: color-mix(in srgb, var(--brass) 6%, transparent); }
+td.num, th.num { font-family: var(--font-mono); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.pill { display: inline-block; font-family: var(--font-mono); font-size: .72rem; padding: .12em .55em; border-radius: 20px; border: 1px solid; letter-spacing: .04em; }
+.pill.react { color: var(--threat); border-color: color-mix(in srgb, var(--threat) 45%, transparent); }
+.pill.proact { color: var(--steel); border-color: color-mix(in srgb, var(--steel) 45%, transparent); }
+.pill.free { color: var(--confirm); border-color: color-mix(in srgb, var(--confirm) 45%, transparent); }
+
+/* ---- Code readout ------------------------------------------ */
+pre {
+  margin: 1.4em 0; padding: 1.05em 1.2em; overflow-x: auto;
+  background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px;
+  font-family: var(--font-mono); font-size: .82rem; line-height: 1.55; color: var(--ink);
+}
+pre .c { color: var(--faint); }        /* comment */
+pre .kw { color: var(--steel); }        /* keyword */
+pre .fn { color: var(--brass); }        /* function */
+pre .st { color: var(--confirm); }      /* string / value */
+pre b { color: var(--ink-strong); font-weight: 600; }
+
+/* ---- Sticky mini-nav --------------------------------------- */
+nav.toc {
+  position: sticky; top: 0; z-index: 40;
+  backdrop-filter: blur(9px);
+  background: color-mix(in srgb, var(--ground) 82%, transparent);
+  border-bottom: 1px solid var(--line);
+}
+nav.toc .inner { max-width: var(--maxw); margin: 0 auto; padding: .55em clamp(18px,4vw,40px); display: flex; align-items: center; gap: .8em; overflow-x: auto; }
+nav.toc a { font-family: var(--font-mono); font-size: .74rem; color: var(--muted); text-decoration: none; white-space: nowrap; letter-spacing: .03em; padding: .3em .1em; border-bottom: 2px solid transparent; }
+nav.toc a:hover { color: var(--ink-strong); }
+nav.toc a.active { color: var(--brass); border-bottom-color: var(--brass); }
+nav.toc .brand { font-weight: 700; color: var(--ink-strong); letter-spacing: .12em; text-transform: uppercase; font-size: .74rem; margin-right: .4em; }
+.theme-btn { margin-left: auto; flex: none; background: var(--panel-2); border: 1px solid var(--line); color: var(--ink); font-family: var(--font-mono); font-size: .72rem; padding: .38em .7em; border-radius: 6px; cursor: pointer; letter-spacing: .06em; }
+.theme-btn:hover { border-color: var(--brass); color: var(--brass); }
+:focus-visible { outline: 2px solid var(--brass); outline-offset: 2px; border-radius: 3px; }
+
+/* ---- SVG diagram shells ------------------------------------ */
+.figure { margin: 1.8em 0; }
+.figure svg { display: block; width: 100%; height: auto; }
+figcaption { font-size: .82rem; color: var(--muted); margin-top: .8em; font-family: var(--font-mono); letter-spacing: .01em; }
+.svg-label { font-family: var(--font-mono); font-size: 12px; fill: var(--ink); }
+.svg-strong { fill: var(--ink-strong); font-weight: 600; }
+.svg-muted { fill: var(--muted); font-size: 11px; }
+.node-fill { fill: var(--panel); stroke: var(--line-strong); }
+.node-line { stroke: var(--line-strong); }
+
+/* ---- Loop pulse animation ---------------------------------- */
+.loop-path { fill: none; stroke: var(--brass); stroke-width: 2; opacity: .5; }
+.loop-pulse { fill: none; stroke: var(--brass-bright); stroke-width: 3.5; stroke-linecap: round; stroke-dasharray: 34 620; }
+@media (prefers-reduced-motion: no-preference) {
+  .loop-pulse { animation: run 4.4s linear infinite; }
+}
+@keyframes run { to { stroke-dashoffset: -654; } }
+
+/* ---- Phase timeline ---------------------------------------- */
+.phases { display: grid; gap: 10px; margin: 1.6em 0; }
+.phase-band { }
+.phase-band .band-label { font-family: var(--font-mono); font-size: .72rem; letter-spacing: .16em; text-transform: uppercase; color: var(--muted); margin-bottom: .7em; display: flex; align-items: center; gap: .6em; }
+.phase-band .band-label::after { content: ""; height: 1px; flex: 1; background: var(--line); }
+.phase-track { display: flex; flex-wrap: wrap; gap: 8px; }
+.chip {
+  --accent: var(--steel);
+  position: relative; flex: 1 1 130px; min-width: 118px;
+  background: var(--panel); border: 1px solid var(--line); border-top: 2px solid var(--accent);
+  border-radius: 8px; padding: .7em .8em .8em;
+}
+.chip .cn { font-family: var(--font-mono); font-size: .7rem; color: var(--faint); }
+.chip .ct { font-weight: 650; color: var(--ink-strong); font-size: .96rem; margin: .12em 0 .3em; }
+.chip .cd { font-size: .78rem; color: var(--muted); line-height: 1.4; }
+.chip.ai::after { content: "AI decides"; position: absolute; top: .6em; right: .6em; font-family: var(--font-mono); font-size: .58rem; letter-spacing: .06em; color: var(--brass); border: 1px solid color-mix(in srgb, var(--brass) 40%, transparent); border-radius: 10px; padding: .05em .4em; }
+.chip.brass { --accent: var(--brass); }
+
+/* ---- Ladder (per-phase priority steps) --------------------- */
+.ladder { counter-reset: step; margin: 1.5em 0; display: grid; gap: 2px; }
+.rung { display: grid; grid-template-columns: auto 1fr; gap: 1em; background: var(--panel); border: 1px solid var(--line); padding: .85em 1.1em; align-items: baseline; }
+.rung:first-child { border-radius: 10px 10px 0 0; }
+.rung:last-child { border-radius: 0 0 10px 10px; }
+.rung .idx { font-family: var(--font-mono); font-size: .78rem; color: var(--brass); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.rung .body { }
+.rung .body b { color: var(--ink-strong); }
+.rung .body .fn { font-family: var(--font-mono); font-size: .82rem; color: var(--steel); }
+.rung.final { border-color: color-mix(in srgb, var(--brass) 50%, var(--line)); background: linear-gradient(90deg, var(--glow), var(--panel) 70%); }
+.rung .tag { font-family: var(--font-mono); font-size: .64rem; text-transform: uppercase; letter-spacing: .1em; color: var(--muted); }
+
+/* ---- Scoring bars ------------------------------------------ */
+.score-demo { display: grid; grid-template-columns: 1fr; gap: 4px; margin: 1.4em 0; }
+.factor { display: grid; grid-template-columns: 190px 1fr 62px; gap: 14px; align-items: center; padding: .3em 0; }
+.factor .fl { font-size: .84rem; color: var(--ink); }
+.factor .fl small { color: var(--faint); font-family: var(--font-mono); font-size: .72rem; display: block; }
+.bar-track { height: 12px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 7px; overflow: hidden; position: relative; }
+.bar-fill { height: 100%; width: 0; border-radius: 6px; transition: width 1.1s cubic-bezier(.2,.7,.2,1); }
+.bar-fill.pos { background: linear-gradient(90deg, color-mix(in srgb,var(--confirm) 55%, var(--brass)), var(--confirm)); }
+.bar-fill.neg { background: linear-gradient(90deg, var(--threat), color-mix(in srgb,var(--threat) 60%, #000)); margin-left: auto; }
+.factor .fv { font-family: var(--font-mono); font-size: .84rem; text-align: right; font-variant-numeric: tabular-nums; }
+.factor .fv.pos { color: var(--confirm); }
+.factor .fv.neg { color: var(--threat); }
+.score-total { display: flex; justify-content: space-between; align-items: baseline; border-top: 1px dashed var(--line-strong); margin-top: .7em; padding-top: .8em; }
+.score-total .lab { font-family: var(--font-mono); font-size: .78rem; letter-spacing: .1em; text-transform: uppercase; color: var(--muted); }
+.score-total .val { font-family: var(--font-mono); font-size: 1.5rem; color: var(--brass); font-variant-numeric: tabular-nums; }
+
+/* ---- Thought-link interactive demo ------------------------- */
+.tl-wrap { display: grid; grid-template-columns: 1.4fr 1fr; gap: 20px; align-items: start; }
+@media (max-width: 760px) { .tl-wrap { grid-template-columns: 1fr; } }
+.tl-board { background:
+    radial-gradient(circle at 30% 30%, color-mix(in srgb,var(--steel) 8%, transparent), transparent 60%),
+    var(--panel-2); border: 1px solid var(--line); border-radius: 12px; position: relative; overflow: hidden; }
+.tl-board svg { display: block; width: 100%; height: auto; }
+.tl-side .row { display: flex; justify-content: space-between; gap: 1em; padding: .55em .1em; border-bottom: 1px solid var(--line); font-size: .88rem; align-items: baseline; }
+.tl-side .row:last-of-type { border-bottom: none; }
+.tl-side .row .nm { color: var(--ink); }
+.tl-side .row .sc { font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--muted); }
+.tl-side .row.win .nm { color: var(--confirm); font-weight: 600; }
+.tl-side .row.win .sc { color: var(--confirm); }
+.tl-btn { margin-top: 1em; width: 100%; background: var(--brass); color: #1a1206; border: none; font-family: var(--font-mono); font-size: .82rem; letter-spacing: .08em; text-transform: uppercase; padding: .7em 1em; border-radius: 8px; cursor: pointer; font-weight: 600; }
+.tl-btn:hover { background: var(--brass-bright); }
+:root[data-theme="dark"] .tl-btn, :root:not([data-theme="light"]) .tl-btn { color: #17110a; }
+.legend { display: flex; flex-wrap: wrap; gap: .4em 1.3em; margin-top: 1em; font-size: .78rem; color: var(--muted); }
+.legend span { display: inline-flex; align-items: center; gap: .5em; }
+.legend i { width: 22px; height: 0; display: inline-block; border-top-width: 3px; border-top-style: solid; }
+.legend .chosen i { border-color: var(--confirm); }
+.legend .rejected i { border-color: var(--threat); border-top-style: dashed; }
+
+/* ---- Surface cards (explainability) ------------------------ */
+.surface { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 1.15em 1.25em; }
+.surface .st { font-weight: 650; color: var(--ink-strong); display: flex; align-items: center; gap: .55em; margin-bottom: .35em; }
+.surface .st .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--brass); flex: none; }
+.surface .sk { font-family: var(--font-mono); font-size: .72rem; color: var(--steel); display: block; margin-bottom: .6em; }
+.surface p { font-size: .88rem; margin: 0; color: var(--ink); }
+
+/* ---- Reveal on scroll -------------------------------------- */
+.reveal { opacity: 0; transform: translateY(14px); transition: opacity .7s ease, transform .7s ease; }
+.reveal.in { opacity: 1; transform: none; }
+@media (prefers-reduced-motion: reduce) { .reveal { opacity: 1; transform: none; transition: none; } }
+
+/* ---- Footer ------------------------------------------------ */
+footer { border-top: 1px solid var(--line); padding: 3em 0 4em; color: var(--muted); font-size: .85rem; }
+footer .filemap { font-family: var(--font-mono); font-size: .8rem; }
+footer code { color: var(--steel); }
+hr.rule { border: none; border-top: 1px solid var(--line); margin: 2.4em 0; }
+.small { font-size: .82rem; color: var(--muted); }
+ul.clean { padding-left: 1.1em; }
+ul.clean li { margin: .35em 0; }
+</style>
+</head>
+<body>
+
+<nav class="toc" aria-label="Section navigation">
+  <div class="inner">
+    <span class="brand">◎ Cogitator</span>
+    <a href="#brief">Brief</a>
+    <a href="#loops">Two loops</a>
+    <a href="#turn">Turn order</a>
+    <a href="#control">Control flow</a>
+    <a href="#ladder">Decision tree</a>
+    <a href="#scoring">Scoring</a>
+    <a href="#reactive">Stratagems</a>
+    <a href="#difficulty">Difficulty</a>
+    <a href="#tuning">Tuning</a>
+    <a href="#see">What you see</a>
+    <a href="#limits">Honest limits</a>
+    <button class="theme-btn" id="themeBtn" type="button" aria-label="Toggle colour theme">◐ Theme</button>
+  </div>
+</nav>
+
+<header class="hero">
+  <div class="wrap">
+    <div class="hero-tag">
+      <span>Warhammer 40,000 · Godot 4</span>
+      <span>AI opponent architecture</span>
+      <span><b>Glass-box</b> heuristic engine</span>
+    </div>
+    <h1>How the AI thinks<span class="sub">— every decision, in order, and why.</span></h1>
+    <p class="lede">The computer opponent is not a neural network and not a language model. It is a
+    hand-built <strong>utility-scoring engine</strong>: on its turn it photographs the board, gives every
+    legal action a numeric score, and plays the highest one — narrating the options it rejected as it goes.
+    A second, signal-driven layer watches <em>your</em> turn for stratagem opportunities. This page walks the
+    whole flow, from the turn structure down to the exact weights, with the reasoning surfaced on screen.</p>
+
+    <div class="stat-row reveal">
+      <div class="stat"><div class="n">2</div><div class="l">decision loops — active&nbsp;+ reactive</div></div>
+      <div class="stat"><div class="n">6</div><div class="l">scored phases per turn</div></div>
+      <div class="stat"><div class="n">~91</div><div class="l">tunable weights, no code</div></div>
+      <div class="stat"><div class="n">4</div><div class="l">difficulty tiers</div></div>
+      <div class="stat"><div class="n">15+</div><div class="l">stratagems it can fire</div></div>
+      <div class="stat"><div class="n">7</div><div class="l">on-screen "why" surfaces</div></div>
+    </div>
+  </div>
+</header>
+
+<!-- ============================ BRIEF ============================ -->
+<section id="brief">
+  <div class="wrap">
+    <div class="eyebrow">The answer in brief</div>
+    <h2>Your questions, answered directly</h2>
+    <p class="prose muted">Four things you asked — is there a decision tree, is there an order, what is decided
+    where, and why — answered up front. The rest of the page is the evidence.</p>
+
+    <div class="qa reveal" style="margin-top:1.8em">
+      <div class="card">
+        <div class="q">// Is there a decision tree?</div>
+        <div class="a"><b>Yes — one per phase.</b> Each phase runs an ordered <em>priority ladder</em>
+        (handle mandatory sub-actions first), then falls through to a <em>utility-scoring</em> step that
+        picks the best tactical action. So: a short tree whose leaves are a scoring function.</div>
+      </div>
+      <div class="card">
+        <div class="q">// Is there an order?</div>
+        <div class="a"><b>Three nested orders.</b> The <em>phase sequence</em> (Command → Movement → Shooting →
+        Charge → Fight → Scoring), the <em>evaluate → decide → route → apply</em> loop that repeats inside each
+        phase, and the <em>step order</em> within a single phase's ladder.</div>
+      </div>
+      <div class="card">
+        <div class="q">// What is decided, and where?</div>
+        <div class="a"><b>One action at a time.</b> Where to move, who to shoot, whether to charge, who fights
+        first, which objective to grab — all in <span class="k">AIDecisionMaker.gd</span>. Reactive stratagems
+        (overwatch, re-rolls…) are decided in <span class="k">AIPlayer.gd</span> during your turn.</div>
+      </div>
+      <div class="card">
+        <div class="q">// Why each choice?</div>
+        <div class="a"><b>Highest score wins.</b> Every candidate gets <span class="k">score = Σ(weighted factors)</span>;
+        the max is chosen (plus a little difficulty "noise"). The rejected options and their scores are logged —
+        and drawn on the board — so you can see the reasoning.</div>
+      </div>
+    </div>
+
+    <div class="callout steel reveal">
+      <span class="h">One sentence to remember</span>
+      <p>The engine's core rule is <strong>"one action per call, recomputed from a fresh snapshot of the board."</strong>
+      It never trusts a stale plan — every decision starts by re-reading the current state, which is what makes it
+      robust to the thousands of rule interactions in 40k.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ TWO LOOPS ============================ -->
+<section id="loops">
+  <div class="wrap">
+    <div class="eyebrow">The big picture</div>
+    <h2>Two loops: one for its turn, one for yours</h2>
+    <p class="prose">Everything the AI does comes from one of two entry points. They are deliberately separate
+    pieces of machinery.</p>
+
+    <div class="grid two" style="margin-top:1.6em">
+      <div class="panel reticle reveal">
+        <div class="eyebrow" style="color:var(--brass)">Active loop · its turn</div>
+        <p style="margin-bottom:.6em"><strong>Pull model, frame-paced.</strong> A per-frame timer in
+        <span class="k">AIPlayer._process()</span> fires an evaluation, which asks the phase for the legal
+        actions, hands them to the decision engine, and routes the single best action back into the game —
+        then re-arms itself. This drives deploy, move, shoot, charge, fight, and score.</p>
+        <p class="small mono" style="margin:0">_evaluate_and_act → _execute_next_action → decide() → route_action → (repeat)</p>
+      </div>
+      <div class="panel reticle reveal">
+        <div class="eyebrow" style="color:var(--threat)">Reactive loop · your turn</div>
+        <p style="margin-bottom:.6em"><strong>Push model, signal-driven.</strong> When a phase begins,
+        <span class="k">_connect_phase_stratagem_signals()</span> wires the AI to that phase's reactive events.
+        When <em>you</em> move, charge, or roll dice, a signal wakes a handler that decides whether to spend CP on
+        a stratagem — Fire Overwatch, Command Re-roll, Heroic Intervention, and more.</p>
+        <p class="small mono" style="margin:0">phase signal → _on_*_opportunity → evaluate → maybe route_action</p>
+      </div>
+    </div>
+
+    <figure class="figure reveal">
+      <svg viewBox="0 0 900 300" role="img" aria-label="Diagram of the active decision loop cycling through evaluate, snapshot, decide, route, and apply, with a moving pulse.">
+        <!-- active loop ring -->
+        <path id="loopPath" class="loop-path" d="M 170 150 C 170 70, 320 55, 450 55 C 580 55, 730 70, 730 150 C 730 230, 580 245, 450 245 C 320 245, 170 230, 170 150 Z"/>
+        <path class="loop-pulse" d="M 170 150 C 170 70, 320 55, 450 55 C 580 55, 730 70, 730 150 C 730 230, 580 245, 450 245 C 320 245, 170 230, 170 150 Z"/>
+        <!-- nodes -->
+        <g class="svg-label">
+          <g transform="translate(170,150)">
+            <circle r="42" class="node-fill" stroke-width="1.5"/>
+            <text text-anchor="middle" y="-2" class="svg-strong">Snapshot</text>
+            <text text-anchor="middle" y="14" class="svg-muted">read board</text>
+          </g>
+          <g transform="translate(450,55)">
+            <circle r="42" class="node-fill" stroke-width="1.5"/>
+            <text text-anchor="middle" y="-2" class="svg-strong">decide()</text>
+            <text text-anchor="middle" y="14" class="svg-muted">score + pick</text>
+          </g>
+          <g transform="translate(730,150)">
+            <circle r="42" class="node-fill" stroke-width="1.5"/>
+            <text text-anchor="middle" y="-2" class="svg-strong">Route</text>
+            <text text-anchor="middle" y="14" class="svg-muted">one action</text>
+          </g>
+          <g transform="translate(450,245)">
+            <circle r="42" class="node-fill" stroke-width="1.5"/>
+            <text text-anchor="middle" y="-2" class="svg-strong">Apply</text>
+            <text text-anchor="middle" y="14" class="svg-muted">engine mutates</text>
+          </g>
+        </g>
+        <text x="450" y="155" text-anchor="middle" class="svg-muted" style="font-size:11px; letter-spacing:.2em; text-transform:uppercase">active loop</text>
+      </svg>
+      <figcaption>The active loop. Each pass produces exactly one action; the pulse is one action being chosen, applied, and the loop re-arming for the next.</figcaption>
+    </figure>
+
+    <div class="callout reveal">
+      <span class="h">Why it matters</span>
+      <p>Because the AI's action re-enters the <strong>same validate → process → apply pipeline as a human's</strong>
+      (<span class="k">execute_action()</span> in <span class="k">BasePhase.gd</span>), the AI is "just another action
+      source." It can never do something the rules engine wouldn't let you do.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ TURN ORDER ============================ -->
+<section id="turn">
+  <div class="wrap">
+    <div class="eyebrow">The order of things · part 1</div>
+    <h2>The turn structure it plays within</h2>
+    <p class="prose">A game is a one-time <strong>setup block</strong> followed by up to <strong>five battle
+    rounds</strong>. Each battle round is two player-turns, and each player-turn walks the same six phases. The
+    AI makes scored decisions in every phase tagged below; the phase state-machine lives in
+    <span class="k">PhaseManager.gd</span>, turn order in <span class="k">TurnManager.gd</span>.</p>
+
+    <div class="phases reveal">
+      <div class="phase-band">
+        <div class="band-label">Setup · runs once</div>
+        <div class="phase-track">
+          <div class="chip ai"><div class="cn">01</div><div class="ct">Formations</div><div class="cd">Attach leaders, embark, declare reserves</div></div>
+          <div class="chip ai"><div class="cn">02</div><div class="ct">Roll-off</div><div class="cd">Who deploys first (attacker / defender)</div></div>
+          <div class="chip ai"><div class="cn">03</div><div class="ct">Deployment</div><div class="cd">Place the army, terrain-aware, counter-deploy</div></div>
+          <div class="chip ai"><div class="cn">04</div><div class="ct">Redeployment</div><div class="cd">Scout & redeploy abilities</div></div>
+          <div class="chip ai"><div class="cn">05</div><div class="ct">First-turn roll</div><div class="cd">Who takes the first turn</div></div>
+          <div class="chip ai"><div class="cn">06</div><div class="ct">Scout</div><div class="cd">Pre-battle Scout moves</div></div>
+        </div>
+      </div>
+      <div class="phase-band" style="margin-top:1.2em">
+        <div class="band-label">Battle round · repeats, players alternate, ×5</div>
+        <div class="phase-track">
+          <div class="chip ai brass"><div class="cn">07</div><div class="ct">Command</div><div class="cd">Battle-shock, Oath / WAAAGH!, spend CP</div></div>
+          <div class="chip ai brass"><div class="cn">08</div><div class="ct">Movement</div><div class="cd">Move / advance / fall back / stay — scored</div></div>
+          <div class="chip ai brass"><div class="cn">09</div><div class="ct">Shooting</div><div class="cd">Army-wide focus-fire plan</div></div>
+          <div class="chip ai brass"><div class="cn">10</div><div class="ct">Charge</div><div class="cd">Declare & resolve charges</div></div>
+          <div class="chip ai brass"><div class="cn">11</div><div class="ct">Fight</div><div class="cd">Activation order, pile-in, consolidate</div></div>
+          <div class="chip ai brass"><div class="cn">12</div><div class="ct">Scoring</div><div class="cd">Score primary / secondary, end turn</div></div>
+        </div>
+      </div>
+    </div>
+    <p class="small muted">Two legacy enum slots — <span class="k">SCOUT_MOVES</span> and <span class="k">MORALE</span> —
+    are deprecated in 10th/11th edition (battle-shock folded into Command) and transparently remapped to Command.
+    Deployment is never re-entered after setup.</p>
+  </div>
+</section>
+
+<!-- ============================ CONTROL FLOW ============================ -->
+<section id="control">
+  <div class="wrap">
+    <div class="eyebrow">The order of things · part 2</div>
+    <h2>Inside one decision: the control flow</h2>
+    <p class="prose">Zoom into a single pass of the active loop. This is the exact chain from "it's the AI's turn"
+    to "an action changed the board." <span class="k">decide()</span> is the one entry point into the brain; it
+    dispatches to a per-phase function and returns one action, plus its reasoning.</p>
+
+    <figure class="figure reveal">
+      <svg viewBox="0 0 900 420" role="img" aria-label="Flowchart from AIPlayer through decide() dispatch to the per-phase deciders and back out to route_action.">
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--line-strong)"/>
+          </marker>
+          <marker id="arrowB" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0 0 L10 5 L0 10 z" fill="var(--brass)"/>
+          </marker>
+        </defs>
+        <g class="svg-label" font-size="12.5">
+          <!-- column 1: AIPlayer -->
+          <rect x="20" y="150" width="180" height="120" rx="10" class="node-fill" stroke-width="1.5"/>
+          <text x="110" y="178" text-anchor="middle" class="svg-strong">AIPlayer.gd</text>
+          <text x="110" y="200" text-anchor="middle" class="svg-muted">_process() timer</text>
+          <text x="110" y="218" text-anchor="middle" class="svg-muted">_evaluate_and_act()</text>
+          <text x="110" y="236" text-anchor="middle" class="svg-muted">get snapshot +</text>
+          <text x="110" y="252" text-anchor="middle" class="svg-muted">available actions</text>
+
+          <!-- column 2: decide dispatch -->
+          <rect x="300" y="30" width="300" height="360" rx="10" fill="var(--panel-2)" stroke="var(--line-strong)" stroke-width="1.5"/>
+          <text x="450" y="58" text-anchor="middle" class="svg-strong" style="font-size:13px">AIDecisionMaker.decide()</text>
+          <text x="450" y="77" text-anchor="middle" class="svg-muted">set difficulty · reset caches ·</text>
+          <text x="450" y="93" text-anchor="middle" class="svg-muted">detect army archetype · profile rules</text>
+          <line x1="320" y1="106" x2="580" y2="106" class="node-line" stroke-dasharray="3 3"/>
+          <text x="450" y="126" text-anchor="middle" class="svg-muted" style="font-size:11px; letter-spacing:.16em">match phase →</text>
+          <g style="font-family:var(--font-mono)">
+            <text x="330" y="150" class="svg-label">_decide_command()</text>
+            <text x="330" y="172" class="svg-label">_decide_movement()</text>
+            <text x="330" y="194" class="svg-label">_decide_shooting()</text>
+            <text x="330" y="216" class="svg-label">_decide_charge()</text>
+            <text x="330" y="238" class="svg-label">_decide_fight()</text>
+            <text x="330" y="260" class="svg-label">_decide_scoring()</text>
+            <text x="330" y="282" class="svg-muted" style="font-size:11px">…deployment, scout, roll-off</text>
+          </g>
+          <line x1="320" y1="300" x2="580" y2="300" class="node-line" stroke-dasharray="3 3"/>
+          <text x="450" y="322" text-anchor="middle" class="svg-muted" style="font-size:11px">attach to the returned action:</text>
+          <text x="450" y="342" text-anchor="middle" class="svg-label">_ai_thinking_steps</text>
+          <text x="450" y="360" text-anchor="middle" class="svg-label">_ai_decision_records</text>
+          <text x="450" y="378" text-anchor="middle" class="svg-label">_ai_thinking_context</text>
+
+          <!-- column 3: route + apply -->
+          <rect x="700" y="90" width="180" height="90" rx="10" class="node-fill" stroke-width="1.5"/>
+          <text x="790" y="120" text-anchor="middle" class="svg-strong">route_action()</text>
+          <text x="790" y="142" text-anchor="middle" class="svg-muted">the one chosen</text>
+          <text x="790" y="158" text-anchor="middle" class="svg-muted">action dict</text>
+
+          <rect x="700" y="240" width="180" height="110" rx="10" class="node-fill" stroke-width="1.5"/>
+          <text x="790" y="268" text-anchor="middle" class="svg-strong">execute_action()</text>
+          <text x="790" y="288" text-anchor="middle" class="svg-muted">validate →</text>
+          <text x="790" y="304" text-anchor="middle" class="svg-muted">process → apply</text>
+          <text x="790" y="324" text-anchor="middle" class="svg-muted">emit action_taken</text>
+          <text x="790" y="340" text-anchor="middle" class="svg-muted">(same as a human's)</text>
+        </g>
+        <!-- arrows -->
+        <path d="M200 210 L296 210" stroke="var(--line-strong)" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+        <path d="M600 135 L696 135" stroke="var(--brass)" stroke-width="2" fill="none" marker-end="url(#arrowB)"/>
+        <path d="M790 180 L790 236" stroke="var(--line-strong)" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+        <path d="M700 300 C 640 300, 190 320, 130 274" stroke="var(--line-strong)" stroke-width="1.5" fill="none" stroke-dasharray="4 4" marker-end="url(#arrow)"/>
+        <text x="430" y="418" text-anchor="middle" class="svg-muted" style="font-size:10.5px">action_taken re-arms the loop → next decision</text>
+      </svg>
+      <figcaption>One decision, end to end. The thinking payloads attached in <span class="mono">decide()</span> are what later light up the on-screen explanations.</figcaption>
+    </figure>
+  </div>
+</section>
+
+<!-- ============================ LADDER / DECISION TREE ============================ -->
+<section id="ladder">
+  <div class="wrap">
+    <div class="eyebrow">The order of things · part 3</div>
+    <h2>The decision tree, made concrete</h2>
+    <p class="prose">"Is there a decision tree?" — here it is. Every <span class="k">_decide_&lt;phase&gt;</span>
+    function is an <strong>ordered priority ladder</strong>: it resolves forced or special sub-actions first, in a
+    fixed order, and only reaches the <em>scoring</em> step for the real tactical choice. Below is the actual ladder
+    for the Movement phase (<span class="k">_decide_movement</span>), the richest one.</p>
+
+    <div class="ladder reveal">
+      <div class="rung"><div class="idx">step 0</div><div class="body"><span class="tag">forced first</span><br><b>Pending Command Re-roll?</b> Resolve the dice-reroll decision before anything else. <span class="fn">USE / DECLINE_COMMAND_REROLL</span></div></div>
+      <div class="rung"><div class="idx">step 0.5</div><div class="body"><span class="tag">free win</span><br><b>Healing available?</b> Always use free healing (Sawbonez) on the most-wounded model. <span class="fn">USE_SAWBONEZ</span></div></div>
+      <div class="rung"><div class="idx">step 1</div><div class="body"><span class="tag">bookkeeping</span><br><b>A move staged?</b> Confirm it. <span class="fn">CONFIRM_UNIT_MOVE</span></div></div>
+      <div class="rung"><div class="idx">step 1.5</div><div class="body"><span class="tag">reserves</span><br><b>Reinforcements can arrive?</b> Deploy them from reserves before moving anyone else. <span class="fn">PLACE_REINFORCEMENT</span></div></div>
+      <div class="rung"><div class="idx">step 1.75</div><div class="body"><span class="tag">transports</span><br><b>Should anyone disembark?</b> Unload before the transport moves. <span class="fn">CONFIRM_DISEMBARK</span></div></div>
+      <div class="rung final"><div class="idx">step 2 →</div><div class="body"><span class="tag" style="color:var(--brass)">the scoring step</span><br><b>Pick the best move for the next unit.</b> Score every (unit → objective) pairing and every candidate destination, then take the max. <span class="fn">_select_movement_action → BEGIN_NORMAL_MOVE / ADVANCE / FALL_BACK / REMAIN_STATIONARY</span></div></div>
+    </div>
+
+    <div class="callout reveal">
+      <span class="h">The pattern generalises</span>
+      <p>Every phase has this shape — a few guard rungs, then a scoring leaf. Shooting resolves grenades and
+      builds its focus-fire plan; Charge resolves overwatch/heroic-intervention windows then scores charge targets;
+      Fight resolves stances and picks the activation order then scores fight targets. <strong>The tree is shallow;
+      the intelligence is in the leaf.</strong> That leaf is next.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ SCORING ENGINE ============================ -->
+<section id="scoring">
+  <div class="wrap">
+    <div class="eyebrow">The "why" · the scoring engine</div>
+    <h2>How "best" is actually computed</h2>
+    <p class="prose">The leaf of every ladder is the same idea: <strong>enumerate the candidates, give each a
+    score, take the highest.</strong> A score is a sum of weighted factors — a utility function. Here is a
+    representative movement decision, scored the way the engine scores it (numbers are the real default weights).</p>
+
+    <div class="panel reveal" style="margin-top:1.4em">
+      <div style="display:flex; justify-content:space-between; flex-wrap:wrap; gap:.6em; align-items:baseline; margin-bottom:1em">
+        <div class="mono" style="color:var(--steel); font-size:.82rem">candidate: move Boyz → Objective 3 (contested, ~5 VP)</div>
+        <div class="mono muted" style="font-size:.75rem">scroll into view to compute →</div>
+      </div>
+      <div class="score-demo" id="scoreDemo">
+        <div class="factor"><div class="fl">Objective is contested<small>WEIGHT_CONTESTED_OBJ</small></div><div class="bar-track"><div class="bar-fill pos" data-w="53"></div></div><div class="fv pos">+8.0</div></div>
+        <div class="factor"><div class="fl">Worth ~5 VP next scoring<small>vp_value × 1.2/VP</small></div><div class="bar-track"><div class="bar-fill pos" data-w="40"></div></div><div class="fv pos">+6.0</div></div>
+        <div class="factor"><div class="fl">Reachable this turn<small>reach bonus</small></div><div class="bar-track"><div class="bar-fill pos" data-w="20"></div></div><div class="fv pos">+3.0</div></div>
+        <div class="factor"><div class="fl">Enough bodies to hold it<small>OC efficiency × 2.0</small></div><div class="bar-track"><div class="bar-fill pos" data-w="20"></div></div><div class="fv pos">+3.0</div></div>
+        <div class="factor"><div class="fl">Keeps its guns on target<small>WEIGHT_FIRING_POSITION_KEPT</small></div><div class="bar-track"><div class="bar-fill pos" data-w="13"></div></div><div class="fv pos">+2.0</div></div>
+        <div class="factor"><div class="fl">Walks into a charge threat<small>threat × survival</small></div><div class="bar-track"><div class="bar-fill neg" data-w="30"></div></div><div class="fv neg">−4.5</div></div>
+      </div>
+      <div class="score-total">
+        <span class="lab">Σ candidate score</span>
+        <span class="val" id="scoreVal">0.0</span>
+      </div>
+      <p class="small muted" style="margin:.9em 0 0">This one candidate scored <strong>17.5</strong>. The engine
+      does the same for the unit's other reachable objectives and destinations, sorts them, and greedily assigns
+      the best pairings across the whole army. A pinch of difficulty "noise" is added before the final sort so the
+      AI is not perfectly predictable.</p>
+    </div>
+
+    <h3>What feeds a score</h3>
+    <p class="prose">Different phases weigh different things, but they draw from the same palette of factors.
+    A selection of the real constants (all overridable — see <a href="#tuning">Tuning</a>):</p>
+
+    <div class="grid two reveal">
+      <div class="panel">
+        <div class="mono" style="color:var(--brass); font-size:.78rem; letter-spacing:.1em; margin-bottom:.7em">MOVEMENT — POSITIONAL</div>
+        <div class="table-scroll" style="margin:0; border:none">
+          <table style="min-width:0">
+            <tbody>
+              <tr><td>Uncontrolled objective</td><td class="num" style="color:var(--confirm)">+10.0</td></tr>
+              <tr><td>Contested objective</td><td class="num" style="color:var(--confirm)">+8.0</td></tr>
+              <tr><td>Home objective undefended</td><td class="num" style="color:var(--confirm)">+9.0</td></tr>
+              <tr><td>Behind-enemy-lines push (secondary)</td><td class="num" style="color:var(--confirm)">+7.0</td></tr>
+              <tr><td>Screen a deep-strike lane</td><td class="num" style="color:var(--confirm)">+8.0</td></tr>
+              <tr><td>Firing position lost by moving</td><td class="num" style="color:var(--threat)">−2.5</td></tr>
+              <tr><td>Per turn too far to reach</td><td class="num" style="color:var(--threat)">−2.0</td></tr>
+              <tr><td>Already sitting safe on it</td><td class="num" style="color:var(--threat)">−3.0</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+      <div class="panel">
+        <div class="mono" style="color:var(--brass); font-size:.78rem; letter-spacing:.1em; margin-bottom:.7em">TARGET VALUE — WHO TO KILL</div>
+        <div class="table-scroll" style="margin:0; border:none">
+          <table style="min-width:0">
+            <tbody>
+              <tr><td>Base, per point of cost</td><td class="num">×0.008</td></tr>
+              <tr><td>Carries an attached leader</td><td class="num" style="color:var(--confirm)">×1.5</td></tr>
+              <tr><td>Vehicle / Monster</td><td class="num" style="color:var(--confirm)">×1.2</td></tr>
+              <tr><td>Already below half strength</td><td class="num" style="color:var(--confirm)">×1.5</td></tr>
+              <tr><td>Standing on an objective</td><td class="num" style="color:var(--confirm)">×1.4</td></tr>
+              <tr><td>Flagged by a secondary mission</td><td class="num" style="color:var(--confirm)">×1.5</td></tr>
+              <tr><td>Hard to kill (survivability)</td><td class="num" style="color:var(--threat)">×0.85</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <h3>Target priority = expected damage × strategic value</h3>
+    <p class="prose">When choosing what to shoot, charge, or fight, the engine multiplies two independent
+    quantities. <strong>Expected damage</strong> is pure probability —
+    <span class="k">attacks × P(hit) × P(wound) × P(unsaved) × damage</span>, respecting cover and keywords.
+    <strong>Strategic value</strong> (above) is how badly it wants that unit <em>gone</em>, regardless of any one
+    weapon. A cheap weapon that reliably finishes a wounded, objective-holding character can out-score a big gun
+    aimed at a fresh tank.</p>
+
+    <div class="callout steel reveal">
+      <span class="h">The one true optimiser — focus fire</span>
+      <p>Shooting is the only phase that plans the <em>whole army at once</em>. <span class="k">_build_focus_fire_plan</span>
+      pools every ranged weapon, builds a weapon × target expected-damage matrix, computes each enemy's "kill
+      threshold" (its remaining wounds), then allocates fire by <strong>iterative marginal value</strong>: repeatedly
+      commit the single weapon-to-target pairing that buys the most useful damage right now — heavily rewarding the
+      shot that <em>crosses a kill threshold</em> (×2.5) and discounting overkill (×0.35). That is how it concentrates
+      fire instead of spreading it thin. Movement, charge and fight are per-unit greedy picks with coordination
+      <em>bonuses</em> layered on, rather than a single joint plan.</p>
+    </div>
+
+    <h3>Right tool for the job — weapon/target matching</h3>
+    <p class="prose">A multiplier nudges each weapon toward suitable prey. Weapons are classed
+    anti-tank / anti-infantry / general; targets are classed vehicle-monster / elite / horde.</p>
+    <div class="table-scroll reveal">
+      <table>
+        <thead><tr><th>Efficiency multiplier</th><th class="num">vs Vehicle / Monster</th><th class="num">vs Elite</th><th class="num">vs Horde</th></tr></thead>
+        <tbody>
+          <tr><td><b>Anti-tank weapon</b> <span class="muted">(S≥7, AP≥2, D≥3)</span></td><td class="num" style="color:var(--confirm)">×1.4 perfect</td><td class="num">×1.15</td><td class="num" style="color:var(--threat)">×0.6 wasteful</td></tr>
+          <tr><td><b>Anti-infantry weapon</b> <span class="muted">(S≤5)</span></td><td class="num" style="color:var(--threat)">×0.6</td><td class="num">×1.15</td><td class="num" style="color:var(--confirm)">×1.4 perfect</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="small muted">Plus a waste penalty for firing multi-damage weapons into 1-wound models (×0.4–0.7),
+    and a ×1.5 bonus when a weapon's "anti-X" special rule matches a target keyword.</p>
+
+    <h3>The modifiers that give it a personality</h3>
+    <p class="prose">Every raw score is finally scaled by a small stack of multipliers, so the same board can be
+    read aggressively or cagily depending on the situation:</p>
+    <div class="grid three reveal">
+      <div class="panel">
+        <div class="mono" style="color:var(--steel); font-size:.76rem; margin-bottom:.5em">TEMPO</div>
+        <p class="small" style="margin:0">Behind on VP → push harder (up to ×1.5, ×1.8 desperation from round 4).
+        Ahead → conserve toward ×0.8. Reads <span class="k">player VP − enemy VP</span>.</p>
+      </div>
+      <div class="panel">
+        <div class="mono" style="color:var(--steel); font-size:.76rem; margin-bottom:.5em">ARMY ARCHETYPE</div>
+        <p class="small" style="margin:0">Auto-detected once per game: <b>Melee / Shooting / Elite / Balanced</b>.
+        A melee army gets ×1.25 aggression and a lower charge bar; a gunline gets ×1.3 survival and holds back.</p>
+      </div>
+      <div class="panel">
+        <div class="mono" style="color:var(--steel); font-size:.76rem; margin-bottom:.5em">ROUND & FACTION</div>
+        <p class="small" style="margin:0">Rounds 1–2 aggressive, 3 neutral, 4–5 objective-hoarding. Faction flavour:
+        Orks, Custodes, Khorne and World Eaters charge more readily.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ REACTIVE / STRATAGEMS ============================ -->
+<section id="reactive">
+  <div class="wrap">
+    <div class="eyebrow">The reactive layer</div>
+    <h2>Stratagems: deciding on <em>your</em> turn</h2>
+    <p class="prose">The reactive loop is the AI spending Command Points in response to what you do. Each is a small
+    <strong>expected-value gate</strong>: estimate the payoff (expected mortal wounds, expected hits, damage ÷ target
+    health, probability of failure…), compare it to a threshold, and — crucially — <strong>refuse to spend the last
+    CP unless the payoff is high</strong>, keeping a point in reserve for emergencies. There is no deep look-ahead
+    here; it is disciplined heuristics.</p>
+
+    <div class="table-scroll reveal">
+      <table>
+        <thead><tr><th>Stratagem</th><th>Trigger</th><th>Kind</th><th>Uses it when…</th></tr></thead>
+        <tbody>
+          <tr><td><b>Fire Overwatch</b></td><td>You move / charge nearby</td><td><span class="pill react">reactive</span></td><td>Has ≥2 CP and expected hits ≥0.5 on a worthwhile (value ≥2) target. Hits only on unmodified 6s.</td></tr>
+          <tr><td><b>Command Re-roll</b></td><td>After a dice roll</td><td><span class="pill react">reactive</span></td><td>Failed charge it can still make, an Advance of 1 (or 2 with spare CP), or a battle-shock it's likely to pass on the re-roll.</td></tr>
+          <tr><td><b>Go to Ground / Smokescreen</b></td><td>Being shot at</td><td><span class="pill react">reactive</span></td><td>Defensive value (invuln / cover / −1 to be hit) on a valued unit clears <span class="k">1.5 × CP cost</span>.</td></tr>
+          <tr><td><b>Counter-Offensive</b> <span class="muted">(2 CP)</span></td><td>Enemy unit just fought</td><td><span class="pill react">reactive</span></td><td>A strong melee unit can fight back — score ≥3.0 (≥5.0 if it's the last 2 CP).</td></tr>
+          <tr><td><b>Heroic Intervention</b> <span class="muted">(1 CP)</span></td><td>Enemy ends a charge</td><td><span class="pill react">reactive</span></td><td>Has a melee counter-charger nearby — score ≥2.0 (≥4.0 if last CP).</td></tr>
+          <tr><td><b>Rapid Ingress</b></td><td>End of your Movement</td><td><span class="pill react">reactive</span></td><td>A reserve unit is worth dropping in early (≥3.0) and it won't burn its last CP before round 4.</td></tr>
+          <tr><td><b>Tank Shock</b> <span class="muted">(1 CP)</span></td><td>After its own vehicle charges</td><td><span class="pill proact">proactive</span></td><td>Expected mortal wounds from the slam clear the bar (≥1.0; ≥2.0 if last CP).</td></tr>
+          <tr><td><b>Grenade</b></td><td>Its own Shooting</td><td><span class="pill proact">proactive</span></td><td>A poor-shooting unit sits within 8″ of a target the ~3 MW could meaningfully hurt (≥2.0).</td></tr>
+          <tr><td><b>Epic Challenge</b> <span class="muted">(1 CP)</span></td><td>Its character fights</td><td><span class="pill proact">proactive</span></td><td>Its champion can reliably threaten an enemy character (damage ÷ HP ≥0.8 and ≥2 damage).</td></tr>
+          <tr><td><b>Insane Bravery</b> <span class="muted">(1 CP)</span></td><td>A battle-shock test</td><td><span class="pill proact">proactive</span></td><td>Auto-pass is worth it: P(fail) × unit value ≥1.2.</td></tr>
+          <tr><td><b>Distraction Grot · Bomb Squigs · Ka'tah · ability re-rolls</b></td><td>Various</td><td><span class="pill free">free</span></td><td>Free effects — taken automatically whenever legal (no CP, no difficulty gate).</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="small muted">Reactive reasoning is drained back into the game log via <span class="k">_flush_reactive_thinking</span>,
+    so even a <em>declined</em> stratagem ("saving CP") shows up in the on-screen log. Reactive stratagem evaluation is
+    on at Normal difficulty and above; Easy plays random legal actions and skips them entirely.</p>
+  </div>
+</section>
+
+<!-- ============================ DIFFICULTY ============================ -->
+<section id="difficulty">
+  <div class="wrap">
+    <div class="eyebrow">Turning the dial</div>
+    <h2>Four difficulty tiers</h2>
+    <p class="prose">Difficulty is not a stat bonus — it gates <em>which behaviours run</em> and how much random
+    "noise" is stirred into the scores. Easy short-circuits the whole engine to random legal actions; each tier up
+    unlocks more of the machinery and tightens the optimisation.</p>
+
+    <div class="table-scroll reveal">
+      <table>
+        <thead>
+          <tr><th>Behaviour</th><th>Easy</th><th>Normal</th><th>Hard</th><th>Competitive</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Decision method</td><td>random legal</td><td>full scoring</td><td>full scoring</td><td>full scoring</td></tr>
+          <tr><td class="num">Score noise (± randomness)</td><td class="num">100.0</td><td class="num">1.5</td><td class="num">0.5</td><td class="num" style="color:var(--brass)">0.0</td></tr>
+          <tr><td class="num">Positioning search depth</td><td class="num">1</td><td class="num">3</td><td class="num">5</td><td class="num" style="color:var(--brass)">8</td></tr>
+          <tr><td>Stratagems, focus fire, threat sense</td><td>—</td><td>✓</td><td>✓</td><td>✓</td></tr>
+          <tr><td>Weapon/target matching, fall-back sense</td><td>—</td><td>✓</td><td>✓</td><td>✓</td></tr>
+          <tr><td>Multi-phase planning, screening</td><td>—</td><td>—</td><td>✓</td><td>✓</td></tr>
+          <tr><td>Trade analysis, opponent look-ahead</td><td>—</td><td>—</td><td>—</td><td>✓</td></tr>
+          <tr><td class="num">Charge willingness (lower = bolder)</td><td class="num">×2.0</td><td class="num">×1.0</td><td class="num">×0.85</td><td class="num" style="color:var(--brass)">×0.7</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="grid two reveal">
+      <div class="callout" style="margin:0"><span class="h">Easy — a learning aid</span><p>Random valid moves with noise so high (100) it swamps any real score. Good for learning the rules; it barely charges.</p></div>
+      <div class="callout" style="margin:0"><span class="h">Competitive — pure optimiser</span><p>Zero noise, deepest positioning search, trade math and a 1-ply look-ahead. It takes the mathematically best action every time.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ TUNING ============================ -->
+<section id="tuning">
+  <div class="wrap">
+    <div class="eyebrow">Reshaping it without code</div>
+    <h2>Weights, profiles & conditional rules</h2>
+    <p class="prose">Every number on this page is a <em>default</em>. The engine reads each weight through
+    <span class="k">get_param(name, default)</span>, which resolves an override chain — so you can give Player 1 and
+    Player 2 entirely different personalities, or make the AI change its mind mid-game, all from JSON.</p>
+
+    <figure class="figure reveal">
+      <svg viewBox="0 0 900 210" role="img" aria-label="Override layering from code defaults up through config files, profiles, and conditional rules.">
+        <defs>
+          <marker id="up" viewBox="0 0 10 10" refX="5" refY="2" markerWidth="8" markerHeight="8" orient="auto"><path d="M0 8 L5 0 L10 8" fill="none" stroke="var(--brass)" stroke-width="1.6"/></marker>
+        </defs>
+        <g class="svg-label" font-size="12.5">
+          <g>
+            <rect x="60" y="150" width="780" height="44" rx="7" fill="var(--panel)" stroke="var(--line-strong)"/>
+            <text x="78" y="177" class="svg-strong">1 · Code defaults</text>
+            <text x="822" y="177" text-anchor="end" class="svg-muted mono" style="font-size:11px">const in AIDecisionMaker.gd</text>
+          </g>
+          <g>
+            <rect x="90" y="108" width="720" height="40" rx="7" fill="var(--panel-2)" stroke="var(--line-strong)"/>
+            <text x="108" y="133" class="svg-strong">2 · Shipped + machine config</text>
+            <text x="792" y="133" text-anchor="end" class="svg-muted mono" style="font-size:11px">data/ai_config.json · user://ai_config.json</text>
+          </g>
+          <g>
+            <rect x="120" y="66" width="660" height="40" rx="7" fill="var(--panel-3)" stroke="var(--line-strong)"/>
+            <text x="138" y="91" class="svg-strong">3 · Per-player profile</text>
+            <text x="762" y="91" text-anchor="end" class="svg-muted mono" style="font-size:11px">user://ai_profiles/&lt;name&gt;.json</text>
+          </g>
+          <g>
+            <rect x="150" y="24" width="600" height="40" rx="7" fill="var(--panel-3)" stroke="var(--brass)"/>
+            <text x="168" y="49" class="svg-strong" style="fill:var(--brass)">4 · Conditional rules (highest priority)</text>
+            <text x="732" y="49" text-anchor="end" class="svg-muted mono" style="font-size:11px">profile.rules[ ]</text>
+          </g>
+          <path d="M450 150 L450 66" stroke="var(--brass)" stroke-width="1.5" fill="none" marker-end="url(#up)" opacity=".7"/>
+          <text x="465" y="120" class="svg-muted" style="font-size:10.5px">later layer wins</text>
+        </g>
+      </svg>
+      <figcaption>Higher layers override lower ones. A profile can retune the weights; a conditional rule can retune them <em>situationally</em>.</figcaption>
+    </figure>
+
+    <div class="grid two reveal">
+      <div>
+        <h3 style="margin-top:.2em">A conditional rule</h3>
+        <p class="small">A rule fires when its conditions (ANDed) match the live context — phase, round, VP gap,
+        health, distance to enemy, on-objective, unit type… — and then <span class="k">override</span>,
+        <span class="k">multiply</span> or <span class="k">add</span> to any weight.</p>
+        <pre><span class="c">// "When behind on VP in round 4+,</span>
+<span class="c">//  push objectives 50% harder."</span>
+{
+  <span class="kw">"conditions"</span>: [
+    { <span class="kw">"type"</span>: <span class="st">"round_gte"</span>, <span class="kw">"value"</span>: <span class="st">4</span> },
+    { <span class="kw">"type"</span>: <span class="st">"vp_behind"</span> }
+  ],
+  <span class="kw">"actions"</span>: [
+    { <span class="kw">"type"</span>: <span class="st">"multiply"</span>,
+      <span class="kw">"param"</span>: <span class="st">"URGENCY_LATE_GAME_PUSH"</span>,
+      <span class="kw">"value"</span>: <span class="st">1.5</span> }
+  ]
+}</pre>
+      </div>
+      <div>
+        <h3 style="margin-top:.2em">The supporting cast</h3>
+        <ul class="clean small">
+          <li><b>ProfileManager.gd</b> — loads / validates the JSON personality files (a visual editor ships as <span class="k">ai-creator/index.html</span>).</li>
+          <li><b>AIAbilityAnalyzer.gd</b> — reads each unit's special rules and turns them into offensive / defensive multipliers the scorer can use (e.g. an aura leader raises a target's value; a Feel-No-Pain unit is discounted as harder to kill).</li>
+          <li><b>AIDifficultyConfig.gd</b> — the tier gates and noise levels from the previous section (code, not JSON).</li>
+          <li><b>The decision log</b> — press F10 to export every scored decision with its full breakdown, for the external AI Gameplay Visualizer.</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ WHAT YOU SEE ============================ -->
+<section id="see">
+  <div class="wrap">
+    <div class="eyebrow">The glass box</div>
+    <h2>How the reasoning is shown to you</h2>
+    <p class="prose">Because <span class="k">decide()</span> attaches its thinking to every action, the game can
+    put the "why" on screen — live, spatially, and after the fact. The centrepiece is the <strong>thought link</strong>:
+    hover an AI decision in the log and it draws, on the board, a solid green arrow to the option it
+    <em>chose</em> and dashed red arrows to the options it <em>rejected</em> — each labelled with its score.
+    Here is a faithful re-creation.</p>
+
+    <div class="tl-wrap reveal">
+      <div class="tl-board">
+        <svg id="tlSvg" viewBox="0 0 460 300" role="img" aria-label="A board showing the AI unit and four candidate targets, with a green arrow to the chosen target and dashed red arrows to the rejected ones.">
+          <defs>
+            <marker id="mChosen" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="var(--confirm)"/></marker>
+            <marker id="mRej" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="var(--threat)"/></marker>
+          </defs>
+          <g id="tlLinks"></g>
+          <g id="tlNodes"></g>
+        </svg>
+      </div>
+      <div class="tl-side">
+        <div class="mono" style="color:var(--steel); font-size:.76rem; letter-spacing:.08em; margin-bottom:.6em">TARGET SCORES — this activation</div>
+        <div id="tlRows"></div>
+        <button class="tl-btn" id="tlBtn" type="button">↻ Re-run the cogitator</button>
+        <div class="legend">
+          <span class="chosen"><i></i> chosen (highest)</span>
+          <span class="rejected"><i></i> rejected</span>
+        </div>
+        <p class="small muted" style="margin:.9em 0 0">Same data the real game draws — <span class="k">_ai_thinking_context</span>:
+        the unit, each candidate's position, its score, and which one won.</p>
+      </div>
+    </div>
+
+    <h3>The seven surfaces</h3>
+    <div class="grid three reveal">
+      <div class="surface"><div class="st"><span class="dot"></span>Thinking indicator</div><span class="sk">a pulsing banner</span><p>"AI is thinking…" so you always know the game hasn't frozen — it's deliberating.</p></div>
+      <div class="surface"><div class="st"><span class="dot"></span>Live action log</div><span class="sk">AIActionLogOverlay</span><p>A streaming ticker of what the AI is doing and its reasoning, right now, colour-coded by player.</p></div>
+      <div class="surface"><div class="st"><span class="dot" style="background:var(--confirm)"></span>Thought links</div><span class="sk">AIThoughtLinkVisual</span><p>The green-chosen / red-rejected scored arrows above — hover a log card, click to pin.</p></div>
+      <div class="surface"><div class="st"><span class="dot" style="background:var(--steel)"></span>Unit highlight</div><span class="sk">AIUnitHighlight</span><p>A pulsing ring on the active unit — blue = moving, red = shooting, orange = charging / fighting.</p></div>
+      <div class="surface"><div class="st"><span class="dot" style="background:var(--steel)"></span>Movement trails</div><span class="sk">AIMovementPathVisual</span><p>Fading dashed arrows showing exactly where each model just moved, and from where.</p></div>
+      <div class="surface"><div class="st"><span class="dot"></span>Turn summary</div><span class="sk">AITurnSummaryPanel</span><p>A post-turn digest: what happened each phase, plus the notable moments (charges, stratagems).</p></div>
+      <div class="surface"><div class="st"><span class="dot"></span>Turn replay <span class="k" style="font-size:.8em">R</span></div><span class="sk">AITurnReplayPanel</span><p>Scrub back through any earlier round to review what the AI did — history survives save/load.</p></div>
+      <div class="surface"><div class="st"><span class="dot" style="background:var(--steel)"></span>On-demand hint</div><span class="sk">request_suggestion()</span><p>Ask "what would you do here?" — it runs a side-effect-free preview and draws the same arrows, without acting.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- ============================ HONEST LIMITS ============================ -->
+<section id="limits">
+  <div class="wrap">
+    <div class="eyebrow">Straight talk</div>
+    <h2>What it is, what it isn't</h2>
+    <p class="prose">To set expectations honestly — and because you asked what's really going on:</p>
+
+    <div class="grid two">
+      <div class="callout steel" style="margin-top:0"><span class="h">It is</span>
+        <p>A layered, deterministic <strong>heuristic engine</strong> with genuine army-level coordination:
+        focus-fire planning, a per-turn multi-phase plan, mission-card awareness, archetype detection and
+        round/tempo pivots. Fully offline, instant, and always rule-legal because the game engine — not the AI —
+        is the source of truth.</p>
+      </div>
+      <div class="callout threat" style="margin-top:0"><span class="h">It isn't</span>
+        <p>A machine-learning model. There is <strong>no neural network, no training, no LLM</strong>. A per-action
+        language model was explicitly rejected by the project: 50–200 engine actions per turn would mean minutes and
+        real money per game, and it would break determinism, offline play and rules-legality. A turn-level "strategist"
+        LLM that merely nudges these existing parameters is noted as a possible future experiment behind a flag.</p>
+      </div>
+    </div>
+
+    <h3>Known rough edges</h3>
+    <p class="prose small">From the project's own architecture review — worth knowing when the AI does something odd:</p>
+    <ul class="clean small">
+      <li><strong>Save/load can shift its behaviour.</strong> The engine keeps eight planning caches (the multi-phase plan, focus-fire plan, archetype…) that aren't serialised, so a reloaded game re-derives them.</li>
+      <li><strong>Its damage math is a private copy.</strong> The AI reimplements hit/wound/save probability rather than calling the shared rules engine, so its expectations can drift slightly from what the dice actually do.</li>
+      <li><strong>Deployment is reactive, not a master plan</strong> — it places units one at a time without an army-wide deployment posture, and those weights aren't yet tunable.</li>
+      <li><strong>It's a big monolith</strong> — ~19,700 lines of scoring in one file. The roadmap is to split it per phase, point its math at the shared engine, and add CP-budget planning and a deeper look-ahead at the top tier.</li>
+    </ul>
+
+    <hr class="rule">
+    <div class="filemap small">
+      <div class="eyebrow" style="margin-bottom:1.2em">The code, if you want to read along</div>
+      <div class="table-scroll" style="border:none; margin:0">
+        <table style="min-width:0">
+          <tbody>
+            <tr><td><code>autoloads/AIPlayer.gd</code></td><td class="muted">the controller — both loops, reactive handlers, pacing</td><td class="num muted">~3,470 ln</td></tr>
+            <tr><td><code>scripts/AIDecisionMaker.gd</code></td><td class="muted">the brain — <code>decide()</code>, every phase, all scoring</td><td class="num muted">~19,700 ln</td></tr>
+            <tr><td><code>scripts/AIDifficultyConfig.gd</code></td><td class="muted">the four tier gates & noise levels</td><td class="num muted">~165 ln</td></tr>
+            <tr><td><code>scripts/AIAbilityAnalyzer.gd</code></td><td class="muted">special-rules → scoring multipliers</td><td class="num muted">~670 ln</td></tr>
+            <tr><td><code>scripts/ProfileManager.gd</code></td><td class="muted">personality profiles & conditional rules</td><td class="num muted">~145 ln</td></tr>
+            <tr><td><code>data/ai_config.json</code> · <code>docs/AI_TUNING.md</code></td><td class="muted">the 91 tunable weights and how to change them</td><td class="num muted">—</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <p style="max-width:70ch">A map of the computer opponent in the Warhammer&nbsp;40,000 Godot project — how it decides,
+    in what order, and why, with the reasoning it already shows you on the board. Every weight and function name here
+    is drawn from the live source; the numbers are defaults you can override without touching code.</p>
+    <p class="small">◎ Generated as a living document — regenerate it whenever the scoring weights or phase flow change.</p>
+  </div>
+</footer>
+
+<script>
+(function () {
+  "use strict";
+  var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  /* ---- Theme toggle ---------------------------------------- */
+  var root = document.documentElement;
+  var btn = document.getElementById("themeBtn");
+  function setTheme(t) { root.setAttribute("data-theme", t); }
+  btn.addEventListener("click", function () {
+    var cur = root.getAttribute("data-theme") || "dark";
+    setTheme(cur === "dark" ? "light" : "dark");
+  });
+
+  /* ---- Reveal on scroll ------------------------------------ */
+  var reveals = [].slice.call(document.querySelectorAll(".reveal"));
+  if (reduce || !("IntersectionObserver" in window)) {
+    reveals.forEach(function (el) { el.classList.add("in"); });
+  } else {
+    var io = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); }
+      });
+    }, { threshold: 0.12 });
+    reveals.forEach(function (el) { io.observe(el); });
+  }
+
+  /* ---- Scoring bars: fill + count up when in view ---------- */
+  var demo = document.getElementById("scoreDemo");
+  var scoreVal = document.getElementById("scoreVal");
+  var scored = false;
+  function runScore() {
+    if (scored) return; scored = true;
+    var fills = [].slice.call(demo.querySelectorAll(".bar-fill"));
+    fills.forEach(function (f) {
+      var w = f.getAttribute("data-w");
+      if (reduce) { f.style.transition = "none"; }
+      requestAnimationFrame(function () { f.style.width = w + "%"; });
+    });
+    var target = 17.5, t0 = null, dur = reduce ? 0 : 1100;
+    function step(ts) {
+      if (t0 === null) t0 = ts;
+      var p = dur ? Math.min((ts - t0) / dur, 1) : 1;
+      scoreVal.textContent = (target * (0.15 + 0.85 * p)).toFixed(1);
+      if (p < 1) requestAnimationFrame(step); else scoreVal.textContent = target.toFixed(1);
+    }
+    requestAnimationFrame(step);
+  }
+  if (demo) {
+    if (reduce || !("IntersectionObserver" in window)) { runScore(); }
+    else {
+      var sio = new IntersectionObserver(function (es) {
+        es.forEach(function (e) { if (e.isIntersecting) { runScore(); sio.disconnect(); } });
+      }, { threshold: 0.4 });
+      sio.observe(demo);
+    }
+  }
+
+  /* ---- Active section in the top nav ----------------------- */
+  var navLinks = [].slice.call(document.querySelectorAll("nav.toc a"));
+  var map = {};
+  navLinks.forEach(function (a) {
+    var id = a.getAttribute("href").slice(1);
+    var sec = document.getElementById(id);
+    if (sec) map[id] = a;
+  });
+  if ("IntersectionObserver" in window) {
+    var nio = new IntersectionObserver(function (entries) {
+      entries.forEach(function (e) {
+        if (e.isIntersecting) {
+          navLinks.forEach(function (a) { a.classList.remove("active"); });
+          if (map[e.target.id]) map[e.target.id].classList.add("active");
+        }
+      });
+    }, { rootMargin: "-45% 0px -50% 0px" });
+    [].slice.call(document.querySelectorAll("section[id]")).forEach(function (s) { nio.observe(s); });
+  }
+
+  /* ---- Interactive thought-link demo ----------------------- */
+  var svgNS = "http://www.w3.org/2000/svg";
+  var unit = { x: 70, y: 150, name: "Intercessors" };
+  var targets = [
+    { name: "Warboss (char)",   x: 360, y: 62,  base: 15 },
+    { name: "Boyz on Obj 3",    x: 380, y: 150, base: 12 },
+    { name: "Gretchin screen",  x: 350, y: 238, base: 5  },
+    { name: "Deffkopta",        x: 220, y: 205, base: 8  }
+  ];
+  var linksG = document.getElementById("tlLinks");
+  var nodesG = document.getElementById("tlNodes");
+  var rowsEl = document.getElementById("tlRows");
+
+  function el(name, attrs) {
+    var e = document.createElementNS(svgNS, name);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+  function jitter(base) {
+    // vary scores a little each run so the "winner" can change, like real noise
+    return Math.max(1, base + (Math.random() - 0.45) * 7);
+  }
+  function render() {
+    while (linksG.firstChild) linksG.removeChild(linksG.firstChild);
+    while (nodesG.firstChild) nodesG.removeChild(nodesG.firstChild);
+    rowsEl.innerHTML = "";
+
+    var scores = targets.map(function (t) { return { t: t, s: jitter(t.base) }; });
+    var maxS = -1, win = 0;
+    scores.forEach(function (o, i) { if (o.s > maxS) { maxS = o.s; win = i; } });
+
+    // links first (so nodes sit on top)
+    scores.forEach(function (o, i) {
+      var chosen = (i === win);
+      var mid = "M" + unit.x + " " + unit.y + " L" + o.t.x + " " + o.t.y;
+      var line = el("path", {
+        d: mid, fill: "none",
+        stroke: chosen ? "var(--confirm)" : "var(--threat)",
+        "stroke-width": chosen ? 3 : 1.6,
+        "stroke-dasharray": chosen ? "0" : "6 5",
+        "marker-end": chosen ? "url(#mChosen)" : "url(#mRej)",
+        opacity: chosen ? "1" : "0.75"
+      });
+      linksG.appendChild(line);
+      // score label at midpoint
+      var lx = (unit.x + o.t.x) / 2, ly = (unit.y + o.t.y) / 2 - 5;
+      var badge = el("text", {
+        x: lx, y: ly, "text-anchor": "middle",
+        "font-family": "var(--font-mono)", "font-size": "11",
+        fill: chosen ? "var(--confirm)" : "var(--threat)", "font-weight": chosen ? "700" : "400"
+      });
+      badge.textContent = (chosen ? "✓ " : "✗ ") + o.s.toFixed(1);
+      linksG.appendChild(badge);
+    });
+
+    // AI unit node
+    var ur = el("circle", { cx: unit.x, cy: unit.y, r: 16, fill: "var(--panel)", stroke: "var(--steel)", "stroke-width": 2 });
+    nodesG.appendChild(ur);
+    if (!reduce) {
+      var pulse = el("circle", { cx: unit.x, cy: unit.y, r: 16, fill: "none", stroke: "var(--steel)", "stroke-width": 2, opacity: .6 });
+      var an = el("animate", { attributeName: "r", values: "16;26;16", dur: "2.2s", repeatCount: "indefinite" });
+      var an2 = el("animate", { attributeName: "opacity", values: ".6;0;.6", dur: "2.2s", repeatCount: "indefinite" });
+      pulse.appendChild(an); pulse.appendChild(an2); nodesG.appendChild(pulse);
+    }
+    var ut = el("text", { x: unit.x, y: unit.y + 34, "text-anchor": "middle", "font-family": "var(--font-mono)", "font-size": "11", fill: "var(--ink)" });
+    ut.textContent = unit.name; nodesG.appendChild(ut);
+
+    // target nodes
+    scores.forEach(function (o, i) {
+      var chosen = (i === win);
+      var c = el("circle", {
+        cx: o.t.x, cy: o.t.y, r: chosen ? 13 : 10,
+        fill: chosen ? "color-mix(in srgb, var(--confirm) 26%, var(--panel))" : "var(--panel)",
+        stroke: chosen ? "var(--confirm)" : "var(--line-strong)", "stroke-width": chosen ? 2.4 : 1.5
+      });
+      nodesG.appendChild(c);
+    });
+
+    // side rows
+    var sorted = scores.slice().sort(function (a, b) { return b.s - a.s; });
+    sorted.forEach(function (o) {
+      var isWin = (o.t === scores[win].t);
+      var row = document.createElement("div");
+      row.className = "row" + (isWin ? " win" : "");
+      var nm = document.createElement("span"); nm.className = "nm"; nm.textContent = (isWin ? "▸ " : "") + o.t.name;
+      var sc = document.createElement("span"); sc.className = "sc"; sc.textContent = o.s.toFixed(1);
+      row.appendChild(nm); row.appendChild(sc); rowsEl.appendChild(row);
+    });
+  }
+  var tlBtn = document.getElementById("tlBtn");
+  if (tlBtn) { tlBtn.addEventListener("click", render); render(); }
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a single self-contained, interactive HTML document — `docs/AI_DECISION_FLOW.html` — that explains how the computer opponent makes decisions: **what** is decided, **where**, in **what order**, and **why**. Everything in it is sourced from the live code.

## What it covers

- **The two loops** — the active, frame-paced loop on the AI's turn (`AIPlayer._process → _evaluate_and_act → _execute_next_action`) and the signal-driven reactive loop on the opponent's turn (`_connect_phase_stratagem_signals` → `_on_*_opportunity`).
- **Turn / phase order** — the one-time setup block and the six-phase battle round, marking where the AI makes scored decisions.
- **Control flow** — `AIPlayer` → `AIDecisionMaker.decide()` → per-phase dispatch → `route_action` → the same `execute_action` validate/process/apply pipeline a human uses.
- **The decision tree** — each `_decide_<phase>` as an ordered priority ladder that falls through to a utility-scoring leaf, with Movement as the worked example.
- **The scoring engine** — `score = Σ(weighted factors)` → argmax + difficulty noise, with the real default weights; target priority (expected damage × strategic value), the focus-fire marginal-value allocator, weapon/target efficiency matching, and the tempo / archetype / round / faction modifiers.
- **Reactive stratagems** — the catalog with triggers, plus the EV-threshold + "keep a CP in reserve" discipline.
- **Difficulty tiers** — Easy → Competitive and what each unlocks (feature gates + score noise).
- **Tuning & profiles** — the code-default → config → profile → conditional-rule override layering.
- **The seven on-screen "why" surfaces**, including a live re-creation of the in-game thought link (green chosen / red rejected scored arrows).
- **Honest limits** — it is a deterministic heuristic engine, not ML/LLM (a per-action LLM was explicitly rejected), plus known rough edges from the architecture review.

## Implementation notes

- Pure static asset: inline SVG diagrams, inline CSS/JS, no external requests.
- Light and dark themes (token-based), `prefers-reduced-motion` respected, responsive with horizontal-scroll containers for wide content.
- Documentation only — no gameplay code changed, so no `version_history.json` entry.

## Verification

Rendered with headless Chromium in both themes — hero, scoring readout (bar fills + Σ count-up), the interactive thought-link board, and the control-flow flowchart all render correctly with **zero JS console errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVnxZeg54nGjDN65SEFGkH

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVnxZeg54nGjDN65SEFGkH)_