### PR TITLE
Audit suite green on CI, AI turn-intent card + melee deployment roles, GUT runner -gexit

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -28,6 +28,8 @@ const MAX_BATTLE_ROUNDS: int = 5
 # Whitelisted exceptions (pre-game initialization only, before any actions):
 #   - ArmyListManager.gd (army load populates units/factions)
 #   - MultiplayerLobby.gd / WebLobby.gd (lobby resets meta before game start)
+#   - AIBenchmarkRunner.gd (--ai-benchmark harness stamps game_config on the
+#     freshly loaded fixture before kicking the first phase)
 # Enforced by tests/test_iss001_pipeline_mutations.gd (static scan).
 var state: Dictionary = {}
 

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -9173,7 +9173,7 @@ static func validate_charge_paths(unit_id: String, targets: Array, roll: int, pa
 		auto_fix_suggestions.append("Move models closer together to maintain coherency")
 
 	# 5. Validate base-to-base if possible
-	var base_to_base_validation = _validate_base_to_base_possible_rules(unit_id, paths, targets, board, roll)
+	var base_to_base_validation = validate_base_to_base_possible_rules(unit_id, paths, targets, board, roll)
 	if not base_to_base_validation.valid:
 		errors.append_array(base_to_base_validation.errors)
 		auto_fix_suggestions.append("Move models to achieve base-to-base contact when possible")
@@ -9555,7 +9555,7 @@ static func _validate_unit_coherency_for_charge_rules(unit_id: String, per_model
 # all-target coverage — MUST do so. Base-to-base contact (0") over-satisfies the
 # 1" band and is what the UI snap assist places models at. Function name kept for
 # call-site stability; it now enforces "within 1 inch", not literal base contact.
-static func _validate_base_to_base_possible_rules(unit_id: String, per_model_paths: Dictionary, target_ids: Array, board: Dictionary, rolled_distance: int = 0) -> Dictionary:
+static func validate_base_to_base_possible_rules(unit_id: String, per_model_paths: Dictionary, target_ids: Array, board: Dictionary, rolled_distance: int = 0) -> Dictionary:
 	var errors = []
 	var units = board.get("units", {})
 	var unit = units.get(unit_id, {})

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "0.21.0",
+      "date": "2026-07-12",
+      "summary": "The AI's game log now opens each turn with a single 'turn intent' card — its stance for the round (e.g. AGGRESSIVE / MELEE army), what the round is worth in VP, which enemies it plans to charge or tie up, and every unit's orders. Fast melee units (Stormboyz, Custodian Guard) also deploy like assault troops now instead of lining up as gunline shooters.",
+      "changes": [
+        "Game log: the movement-plan card is now a full turn-intent briefing — round stance (strategy + army archetype), 'Playing for:' VP stakes, named charge intents (\"Charge intent: Stormboyz → Custodian Guard (20.8\\\" away)\"), and shooters the AI plans to tie up in melee, followed by the per-unit orders.",
+        "AI deployment: units whose weapons make them melee-focused (Stormboyz with token pistols, Custodian Guard with guardian spears) now classify as melee and deploy forward for movement lanes; previously any unit carrying a ranged weapon deployed as a 'ranged unit positioning for firing lanes'. Uses the same melee-focus gate as the movement/charge logic so deployment and battle plans agree about a unit's role.",
+        "Fixed: secondary missions requiring a unit action are now scored impossible when the player has no units left."
+      ]
+    },
+    {
       "version": "0.20.0",
       "date": "2026-07-11",
       "summary": "The AI now fights to a single battle plan per turn — and the game log tells the truth about it. The movement plan the AI announces is the plan its units actually execute, melee hunts are declared up front (\"ATTACK Custodian Guard\"), spare units spread across objectives instead of piling onto one, and every decision card explains WHY (including when coordination overrides the raw scores).",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -2113,7 +2113,7 @@ func _validate_base_to_base_possible(unit_id: String, per_model_paths: Dictionar
 	# charge target MUST do so. Delegates to the single implementation in
 	# RulesEngine so the rule cannot drift between the two call sites (this was
 	# a ~200-line duplicate that had already diverged on tolerance).
-	return RulesEngine._validate_base_to_base_possible_rules(unit_id, per_model_paths, target_ids, game_state_snapshot, rolled_distance)
+	return RulesEngine.validate_base_to_base_possible_rules(unit_id, per_model_paths, target_ids, game_state_snapshot, rolled_distance)
 
 func _validate_must_end_closer(unit_id: String, per_model_paths: Dictionary, target_ids: Array) -> Dictionary:
 	# 10e Rule: Each model making a charge move must end that move closer to at

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -190,6 +190,10 @@ static var _config_overrides: Dictionary = {}
 static var _config_loaded: bool = false
 # Track whether the movement plan summary has been logged (reset per phase)
 static var _movement_plan_logged: bool = false
+# Most recent VP-stakes narration composed by _evaluate_all_objectives —
+# consumed by the turn-intent card so the "what we're playing for" line lives
+# in the announced plan, not buried in whichever unit happens to act first.
+static var _last_vp_stakes_line: String = ""
 # Track whether the focus fire summary has been logged (reset per phase)
 static var _focus_fire_plan_logged: bool = false
 # Track whether fight order summary has been logged (reset per phase)
@@ -2911,6 +2915,14 @@ static func _classify_deployment_role(unit: Dictionary) -> String:
 	if has_melee and not has_ranged:
 		return "melee"
 
+	# Mixed-weapon units whose OUTPUT is melee-dominated (Stormboyz with token
+	# pistols, choppa mobs with sluggas) are assault elements: deploy forward
+	# for movement lanes, not backfield for firing lanes. Uses the same
+	# _is_melee_focused_unit gate as the movement/charge seek logic so
+	# deployment and battle-plan behavior can't disagree about a unit's role.
+	if has_melee and _is_melee_focused_unit(unit):
+		return "melee"
+
 	# T-108: Anti-tank classifier — any high-S ranged weapon (S >= 9 or AP >= 3)
 	# qualifies the unit as anti-tank, useful for matchup-aware deployment.
 	if has_ranged:
@@ -4669,11 +4681,34 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 			snapshot, movable_units, obj_evaluations, objectives, enemies, friendly_units, player, battle_round, threat_data
 		)
 		var prior_replans = int(stored_plan.get("replans", -1))
+		# TURN-INTENT: capture the whole turn's context at plan time so the
+		# announced card can tell the full story in one place — stance, VP
+		# stakes, planned charges/lock targets — not just the unit moves.
+		var announce := {
+			"strategy_label": str(_get_round_strategy_modifiers(battle_round).get("label", "")),
+			"archetype_label": str(_get_army_strategy_modifiers(snapshot, player).get("label", "")),
+			"stakes": _last_vp_stakes_line,
+			"charge_lines": [],
+			"lock_line": "",
+		}
+		var plan_charge_intents = _get_phase_plan(player).get("charge_intent", {})
+		for ci_uid in plan_charge_intents:
+			var ci = plan_charge_intents[ci_uid]
+			var ci_name = snapshot.get("units", {}).get(ci_uid, {}).get("meta", {}).get("name", ci_uid)
+			announce.charge_lines.append("  Charge intent: %s → %s (%.1f\" away)" % [
+				ci_name, ci.get("target_name", "?"), float(ci.get("distance_inches", 0.0))])
+		var plan_lock_targets = _get_phase_plan(player).get("lock_targets", [])
+		if not plan_lock_targets.is_empty():
+			var lock_names: Array = []
+			for lt_id in plan_lock_targets:
+				lock_names.append(snapshot.get("units", {}).get(lt_id, {}).get("meta", {}).get("name", lt_id))
+			announce["lock_line"] = "  Tie up in melee: %s (dangerous shooters)" % ", ".join(lock_names.slice(0, 4))
 		_turn_movement_plan[player] = {
 			"round": battle_round,
 			"assignments": assignments,
 			"consumed": {},
 			"replans": prior_replans + 1,
+			"announce": announce,
 		}
 		if replan_reason != "":
 			_add_thinking_step("Re-planning movement: %s" % replan_reason)
@@ -4715,8 +4750,28 @@ static func _select_movement_action(snapshot: Dictionary, available_actions: Arr
 			plan_summary_parts.append(", ".join(move_parts))
 		if not threat_data.is_empty():
 			plan_summary_parts.append("avoiding %d threat zones" % threat_data.size())
-		if not plan_summary_parts.is_empty():
-			_add_thinking_step("Movement plan: %d units — %s" % [movable_units.size(), "; ".join(plan_summary_parts)])
+		# TURN-INTENT: the announced card carries the whole turn's intent — the
+		# army's stance this round, what the round is worth in VP, planned
+		# charges and shooters to tie up — followed by the per-unit orders.
+		# (Header must keep starting with "Movement plan" — AIPlayer's card
+		# slicer and the movement_plan_integrity() gate match on that.)
+		var turn_announce: Dictionary = _turn_movement_plan.get(player, {}).get("announce", {})
+		var stance_parts: Array = []
+		if str(turn_announce.get("strategy_label", "")) != "":
+			stance_parts.append(str(turn_announce.strategy_label))
+		if str(turn_announce.get("archetype_label", "")) != "":
+			stance_parts.append("%s army" % turn_announce.archetype_label)
+		var plan_header = "Movement plan (Round %d%s): %d units — %s" % [
+			battle_round,
+			(", " + " / ".join(stance_parts)) if not stance_parts.is_empty() else "",
+			movable_units.size(), "; ".join(plan_summary_parts)]
+		_add_thinking_step(plan_header)
+		if str(turn_announce.get("stakes", "")) != "":
+			_add_thinking_step("  Playing for: %s" % str(turn_announce.stakes).trim_prefix("VP stakes this round "))
+		for ci_line in turn_announce.get("charge_lines", []):
+			_add_thinking_step(str(ci_line))
+		if str(turn_announce.get("lock_line", "")) != "":
+			_add_thinking_step(str(turn_announce.lock_line))
 		# COORD-3: verbose army-level battle plan — one line per unit so the
 		# game log tells the WHOLE story of the turn up front, not just the
 		# unit currently acting. Sorted by assignment score (most important first).
@@ -6489,14 +6544,20 @@ static func _evaluate_all_objectives(
 		})
 
 	# Narrate the VP stakes once per evaluation (top objectives by VP), so the
-	# player sees WHAT the AI is playing for in mission terms.
+	# player sees WHAT the AI is playing for in mission terms. Also stash the
+	# line for the turn-intent card (the announced movement plan card leads
+	# with it, instead of it only appearing in the first acting unit's card).
 	if not vp_stake_notes.is_empty():
 		vp_stake_notes.sort_custom(func(a, b): return a.vp > b.vp)
 		var stake_parts: Array = []
 		for n in range(min(3, vp_stake_notes.size())):
 			var note = vp_stake_notes[n]
 			stake_parts.append("%s ~%.0f VP (%s)" % [note.id, note.vp, "; ".join(note.sources.slice(0, 2))])
-		_add_thinking_step("VP stakes this round (holding %d, enemy %d): %s" % [my_holds, their_holds, ", ".join(stake_parts)])
+		var stakes_line = "VP stakes this round (holding %d, enemy %d): %s" % [my_holds, their_holds, ", ".join(stake_parts)]
+		_last_vp_stakes_line = stakes_line
+		_add_thinking_step(stakes_line)
+	else:
+		_last_vp_stakes_line = ""
 
 	return evaluations
 
@@ -16368,6 +16429,9 @@ static func _assess_action_mission(units: Dictionary, player: int) -> float:
 	"""Generic assessment for action-based missions (Establish Locus, Cleanse, Deploy Teleport Homer).
 	These require performing actions during the shooting phase. The AI can perform these actions
 	by giving up shooting with a unit in a qualifying position."""
+	# No units means nobody can perform the action — flatly impossible.
+	if _count_alive_units_for_player(units, player) == 0:
+		return 0.0
 	# AI can now perform shooting-phase actions — moderate achievability
 	# Depends on having units in scoring positions (near center, in opponent zone, near objectives)
 	return 0.65  # Moderate achievability — AI can perform these if positioned well

--- a/40k/tests/run_multiplayer_tests.sh
+++ b/40k/tests/run_multiplayer_tests.sh
@@ -81,12 +81,17 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Build GUT command
+# -gexit is required: without it GUT prints its summary and then keeps the
+# process alive waiting for a manual window close, which on CI hangs the job
+# until timeout-minutes cancels it. With -gexit GUT quits nonzero when any
+# test fails (GutRunner._handle_quit), so the exit code stays meaningful.
 GUT_CMD=(
     godot
     --path "$PROJECT_ROOT"
     -s addons/gut/gut_cmdln.gd
     -gdir=res://tests/integration/
     -gprefix=test_multiplayer
+    -gexit
 )
 
 # Add specific test if requested
@@ -110,10 +115,10 @@ echo "  Starting Tests..."
 echo "=========================================="
 echo ""
 
-# Run the tests
-"${GUT_CMD[@]}"
-
-TEST_RESULT=$?
+# Run the tests. Guard against set -e: godot exits nonzero when tests fail
+# (via -gexit), and we still want the summary + exit-code passthrough below.
+TEST_RESULT=0
+"${GUT_CMD[@]}" || TEST_RESULT=$?
 
 echo ""
 echo "=========================================="

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -151,12 +151,14 @@ for test in "${TESTS[@]}"; do
     echo "Running: $test"
     echo "================================================"
 
-    # Capture output, filter for test result lines
-    OUTPUT=$(timeout 180 godot --headless --path . -s "$test" 2>&1 | grep -E "PASS|FAIL|Result|=== test" || true)
+    # Capture output, filter for test result lines. Summary formats vary:
+    # "=== Result: N passed, M failed ===", "=== Results: ...", and bare
+    # "=== N passed, M failed ===" — match on the counts, not the prefix.
+    OUTPUT=$(timeout 180 godot --headless --path . -s "$test" 2>&1 | grep -E "PASS|FAIL|Result|[0-9]+ passed, [0-9]+ failed|=== test" || true)
     echo "$OUTPUT"
 
     # Extract the final result line and parse pass/fail counts
-    RESULT_LINE=$(echo "$OUTPUT" | grep -E "Result:" | tail -1)
+    RESULT_LINE=$(echo "$OUTPUT" | grep -E "[0-9]+ passed, [0-9]+ failed" | tail -1)
     if [ -z "$RESULT_LINE" ]; then
         echo "  ERROR: no result line found for $test"
         FAILED=$((FAILED + 1))

--- a/40k/tests/test_hi_pretrigger.gd
+++ b/40k/tests/test_hi_pretrigger.gd
@@ -67,7 +67,12 @@ func _run_tests():
 		"actor_unit_id": "U_WARBOSS_B",
 		"payload": {"target_unit_ids": ["U_CUSTODIAN_GUARD_B"]}
 	})
-	# (Fire Overwatch is auto-declined by AI logic when no eligible shooter)
+	# The defender's Fire Overwatch window must be declined by the DEFENDER.
+	# The AI used to auto-decline it even for a human defender (the "AI
+	# hijacking the human defender's window" bug fixed in #563); with that
+	# gone, this headless test plays the defender's part explicitly.
+	if phase.awaiting_fire_overwatch:
+		phase.execute_action({"type": "DECLINE_FIRE_OVERWATCH", "player": 1})
 
 	# Issue #329: pass deterministic rng_seed so the 2D6 charge roll never flakes.
 	# Warboss only needs ~1.75" to reach engagement range, so any seed works for

--- a/40k/tests/test_iss001_pipeline_mutations.gd
+++ b/40k/tests/test_iss001_pipeline_mutations.gd
@@ -27,6 +27,7 @@ const WRITE_WHITELIST = [
 	"ArmyListManager.gd",
 	"MultiplayerLobby.gd",
 	"WebLobby.gd",
+	"AIBenchmarkRunner.gd",
 ]
 
 const SCAN_DIRS = ["res://phases", "res://scripts", "res://autoloads", "res://dialogs"]

--- a/40k/tests/test_iss032_ai_cache_policy.gd
+++ b/40k/tests/test_iss032_ai_cache_policy.gd
@@ -28,11 +28,14 @@ func _run_tests():
 	var slm = root.get_node_or_null("SaveLoadManager")
 	var aidm = load("res://scripts/AIDecisionMaker.gd")
 
-	# Seed some strategy caches as a mid-game AI would
+	# Seed some strategy caches as a mid-game AI would.
+	# _phase_plan / _phase_plan_built became per-player dictionaries (SOAK-3);
+	# the old bool assignment stopped this script from compiling, which made
+	# the test hang to the runner timeout instead of reporting.
 	aidm._focus_fire_plan["U_X"] = {"target": "U_Y"}
 	aidm._focus_fire_plan_built = true
-	aidm._phase_plan["move"] = ["U_X"]
-	aidm._phase_plan_built = true
+	aidm._phase_plan[2] = {"charge_intent": {"U_X": {"target_id": "U_Y"}}}
+	aidm._phase_plan_built = {2: true}
 	_check("caches seeded", aidm._focus_fire_plan_built and not aidm._focus_fire_plan.is_empty())
 
 	# Policy is wired: AIPlayer listens to load_completed directly
@@ -45,7 +48,7 @@ func _run_tests():
 	_check("focus-fire cache cleared on load",
 		aidm._focus_fire_plan.is_empty() and aidm._focus_fire_plan_built == false)
 	_check("phase plan cleared on load",
-		aidm._phase_plan.is_empty() and aidm._phase_plan_built == false)
+		aidm._phase_plan.is_empty() and aidm._phase_plan_built.is_empty())
 
 	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
 	quit(0 if failed == 0 else 1)

--- a/40k/tests/unit/test_ai_movement_decisions.gd
+++ b/40k/tests/unit/test_ai_movement_decisions.gd
@@ -154,7 +154,13 @@ func test_objective_evaluation_held_safe():
 	var evals = AIDecisionMaker._evaluate_all_objectives(snapshot, objectives, 2, enemies, friendlies, 1)
 	var home_eval = _find_eval(evals, "obj_home_2")
 	_assert(home_eval.state == "held_safe", "Home objective held safe (state=%s)" % home_eval.state)
-	_assert(home_eval.priority < 0, "Held safe objective has low priority (%.1f)" % home_eval.priority)
+	# Held-safe must rank BELOW an uncontrolled objective so spare units grab
+	# new ground first. The old `priority < 0` pin broke every time the held
+	# weight was retuned (-8.0 -> -3.0 plus retention bonuses); the relative
+	# ordering is the actual design intent and survives tuning.
+	var center_uncontrolled = _find_eval(evals, "obj_center")
+	_assert(home_eval.priority < center_uncontrolled.priority,
+		"Held safe (%.1f) ranks below uncontrolled (%.1f)" % [home_eval.priority, center_uncontrolled.priority])
 
 func test_objective_evaluation_contested():
 	print("\n--- test_objective_evaluation_contested ---")
@@ -440,40 +446,47 @@ func test_movement_toward_assigned_objective():
 
 func test_hold_for_shooting_enemies_in_range():
 	print("\n--- test_hold_for_shooting_enemies_in_range ---")
-	# Ranged unit with enemy in weapon range, objective is far away
-	# Should remain stationary to maintain shooting capability
+	# _should_hold_for_shooting contract (T7-14 era, still current):
+	#   * moving that KEEPS at least one target in weapon range -> move
+	#     (move-and-shoot strictly beats castling)
+	#   * moving that would LOSE every target, toward a low-priority objective
+	#     more than a turn away -> hold and shoot
+	# The old end-to-end version of this test pinned pre-T7-14 castling
+	# behavior ("hold whenever enemies are in range"), which the AI
+	# deliberately no longer does.
 	var snapshot = _create_test_snapshot()
-	snapshot.battle_round = 3  # Not round 1 (no urgency to rush forward)
+	snapshot.battle_round = 3
 
-	# Place one unit holding home so it doesn't interfere
-	_add_unit(snapshot, "u_home", 2, Vector2(880, 2160), "Home Holder", 2, 6, 5, ["INFANTRY"], [])
-
-	# Ranged unit at y=1600, enemy at y=1000 = 600px = 15" (within 24" range)
-	# Nearest objective is obj_nml_2 at (1360, 1680) or obj_center at (880, 1200)
 	_add_unit(snapshot, "u1", 2, Vector2(880, 1600), "Shooty Boyz", 2, 6, 5, ["INFANTRY"], [
 		{"name": "Bolt rifle", "type": "Ranged", "range": "24", "attacks": "2", "skill": "3",
 		 "strength": "4", "ap": "1", "damage": "1", "keywords": []}
 	])
+	var unit = snapshot.units["u1"]
+	var centroid = AIDecisionMaker._get_unit_centroid(unit)
+
+	# Case 1: enemy 15" ahead; objective further along the same axis. Moving
+	# 6" toward it keeps the enemy well inside 24" -> should NOT hold.
 	_add_unit(snapshot, "e1", 1, Vector2(880, 1000), "Enemy Guard", 2, 6, 5, ["INFANTRY"], [])
+	var enemies = {"e1": snapshot.units["e1"]}
+	var toward_enemy_obj = Vector2(880, 1200)  # 10" away, same direction as enemy
+	var hold_keeps = AIDecisionMaker._should_hold_for_shooting(
+		unit, centroid, toward_enemy_obj, 24.0, enemies, 6.0, {"score": 5.0})
+	_assert(hold_keeps == false,
+		"move keeps target in range -> move-and-shoot, not hold (got hold=%s)" % hold_keeps)
 
-	var actions = _make_available_actions(["u_home", "u1"])
-	# Process first decision (home unit holds)
-	var decision = AIDecisionMaker._decide_movement(snapshot, actions, 2)
-	var actor = decision.get("actor_unit_id", "")
-	if actor == "u_home":
-		# Remove home unit and get decision for u1
-		var remaining = []
-		for a in actions:
-			if a.get("actor_unit_id", "") != "u_home":
-				remaining.append(a)
-		snapshot.units["u_home"]["flags"]["moved"] = true
-		decision = AIDecisionMaker._decide_movement(snapshot, remaining, 2)
-
-	# The ranged unit should hold for shooting since enemies are in range
-	# and the objective is more than 1 turn away
-	var move_type = decision.get("type", "")
-	_assert(move_type == "REMAIN_STATIONARY",
-		"Ranged unit with enemies in range holds for shooting (type=%s)" % move_type)
+	# Case 2: enemy at ~23" (near max range); low-priority objective directly
+	# AWAY from it, 20"+ off (3+ turns). Moving 6" away pushes the enemy to
+	# ~29" — every target lost — so the unit should hold and shoot instead.
+	# (Reposition EVERY model — the range check uses the unit centroid.)
+	for m_i in range(snapshot.units["e1"]["models"].size()):
+		var em = snapshot.units["e1"]["models"][m_i]
+		em["position"] = Vector2(880 + m_i * 40, 1600 - 23 * 40)
+	enemies = {"e1": snapshot.units["e1"]}
+	var away_obj = Vector2(880, 1600 + 22 * 40)  # 22" away, opposite the enemy
+	var hold_loses = AIDecisionMaker._should_hold_for_shooting(
+		unit, centroid, away_obj, 24.0, enemies, 6.0, {"score": 5.0})
+	_assert(hold_loses == true,
+		"move loses ALL targets toward far low-priority objective -> hold (got hold=%s)" % hold_loses)
 
 func test_move_when_no_enemies_in_range():
 	print("\n--- test_move_when_no_enemies_in_range ---")

--- a/40k/tests/unit/test_ai_scoring_discard.gd
+++ b/40k/tests/unit/test_ai_scoring_discard.gd
@@ -279,4 +279,7 @@ func test_while_active_with_enemies():
 		"scoring": {"when": "while_active"},
 	}
 	var score = AIDecisionMaker._evaluate_mission_achievability(snapshot, mission, 2, 2)
-	_assert(score == 1.0, "While-active always achievable with enemies alive (got: %.1f)" % score)
+	# The exact value is tiered by round/kill progress (T19-4: 0.75 in R1-2,
+	# staged later) — the design intent is simply "comfortably above the 0.20
+	# discard bar while enemies are alive", so pin that instead of == 1.0.
+	_assert(score >= 0.5, "While-active clearly keepable with enemies alive (got: %.2f)" % score)

--- a/40k/tests/unit/test_base_contact_enforcement.gd
+++ b/40k/tests/unit/test_base_contact_enforcement.gd
@@ -75,7 +75,7 @@ func test_model_in_b2b_is_valid():
 		"marine_1": [[0, 0], [touching_x, 0]]
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 7
 	)
 
@@ -106,7 +106,7 @@ func test_model_could_reach_within_1in_but_didnt():
 		"marine_1": [[0, 0], [stop_x, 0]]
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 7
 	)
 
@@ -138,7 +138,7 @@ func test_per_model_second_model_must_close():
 		"marine_b": [[0, 80], [150, 80]]         # stops ~2.5" from ork_2
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 10
 	)
 
@@ -162,7 +162,7 @@ func test_per_model_both_models_close_is_valid():
 		"marine_a": [[0, 0], [300 - 50.4, 0]],   # base contact with ork_1
 		"marine_b": [[0, 80], [300 - 50.4, 80]]  # base contact with ork_2
 	}
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 10
 	)
 	assert_true(result.valid, "Both models in contact should be valid: %s" % str(result.errors))
@@ -192,7 +192,7 @@ func test_model_cannot_reach_b2b_is_valid():
 		"marine_1": [[0, 0], [stop_x, 0]]
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 12
 	)
 
@@ -223,7 +223,7 @@ func test_multiple_models_mixed_reachability():
 		"marine_2": [[-340, 0], [-60, 0]]  # Moves but can't reach b2b
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 7
 	)
 
@@ -253,7 +253,7 @@ func test_dead_target_models_ignored():
 		"marine_1": [[0, 0], [stop_x, 0]]
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 12
 	)
 
@@ -270,7 +270,7 @@ func test_empty_paths_handled_gracefully():
 	})
 
 	# Empty per_model_paths
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", {}, ["target_unit"], board, 7
 	)
 
@@ -298,7 +298,7 @@ func test_model_within_tolerance_is_b2b():
 		"marine_1": [[0, 0], [almost_touching_x, 0]]
 	}
 
-	var result = RulesEngineScript._validate_base_to_base_possible_rules(
+	var result = RulesEngineScript.validate_base_to_base_possible_rules(
 		"charger_unit", per_model_paths, ["target_unit"], board, 7
 	)
 


### PR DESCRIPTION
Batch 2 of the AI review follow-ups. Three commits, each independently verified:

## 1. Headless audit suite: all 11 CI failures fixed (`a8f08e5`)
The "Headless audit suite" job had been red on main with 11 failures (plus 3 suites whose results the runner failed to parse). Fixes span the runner's result parsing (`run_pretrigger_tests.sh`), a Fire Overwatch pause in `test_hi_pretrigger.gd`, stale cache-shape assumptions in `test_iss032_ai_cache_policy.gd`, the ISS-001 write whitelist, making `RulesEngine.validate_base_to_base_possible_rules` public (it was called cross-class), and rewriting two AI movement assertions that pinned incidental behavior. **Confirmed green on CI's Godot 4.4.1 twice** (runs 29176401829, 29194737046).

## 2. AI: turn-intent card + melee-focused deployment roles (`4d89dca`)
- The game log now opens each AI movement phase with a combined turn-intent card: strategy stance/archetype header, "Playing for:" VP stakes, charge intents with distances, and tie-up-in-melee intents.
- Deployment role classifier: mixed-weapon units whose output is melee-dominated (Stormboyz with token pistols, choppa mobs) now classify as assault elements and deploy forward for movement lanes instead of "positioning for firing lanes".
- Guard in `_assess_action_mission` for the zero-units edge case.
Both features live-validated through the MCP bridge plus the `ai_battle_plan_log_integrity` windowed scenario. Version history bumped to 0.21.0.

## 3. CI: `-gexit` for the multi-peer GUT runner (`b673fb3`)
The "Multi-peer integration (GUT)" job was added 2026-07-05 by the same commit that broke the audit suite it `needs:` — so it had been skipped on every CI run of its life. Once unblocked by fix #1, its first-ever execution timed out at `timeout-minutes: 20`: `run_multiplayer_tests.sh` never passed `-gexit`, so GUT prints its summary and then keeps the process alive indefinitely. Reproduced locally at both the batch head and the pre-batch merge commit (identical hang). With the fix the job completes in ~7 minutes and reports honestly — currently `failure`, because the multiplayer suite has pre-existing flaky test failures (7–11 per run with a shifting set across three local runs). Surfacing that debt is the point; fixing those tests is follow-up work.

Known-red CI that this PR does not touch: the coverage-matrix job (main's pre-existing 151 uncovered tags) and the newly-honest multiplayer failures above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5DrSz8VK6NR9WWetZHs1H

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5DrSz8VK6NR9WWetZHs1H)_