### PR TITLE
Fix the L key LoS overlay: sight lines in every phase, not just shooting

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "0.22.0",
+      "date": "2026-07-12",
+      "summary": "Hold L to see lines of sight in ANY phase — solid green lines to enemies your units can see, dashed red to the ones they can't. Previously the L overlay only existed during the shooting phase (and even there usually drew nothing), so it looked broken. The left roster strip hotkey moved to B.",
+      "changes": [
+        "Hold L: draws a sight line from each of your units to every enemy unit — solid green when a clear line of sight exists (drawn along the actual sighting line, base-edge aware), dashed red between the nearest models when the view is blocked. Works in every phase now, not just shooting.",
+        "With a unit selected (mover, shooter, charger or fighter), holding L shows just that unit's lines of sight, checked with the same rules the shooting phase uses for target eligibility (including 11e hidden/obscuring visibility).",
+        "In the shooting phase with a shooter selected, L still shows the detailed per-model debug view (sample points, blocked attempts, terrain highlights).",
+        "The overlay refreshes automatically while held, so lines follow models as they move and no longer fade out after a few seconds.",
+        "Left roster strip hotkey is now B (was L, which the LoS overlay always captured first, so it never worked); the '?' shortcut overlay lists both keys."
+      ]
+    },
+    {
       "version": "0.21.0",
       "date": "2026-07-12",
       "summary": "The AI's game log now opens each turn with a single 'turn intent' card — its stance for the round (e.g. AGGRESSIVE / MELEE army), what the round is worth in VP, which enemies it plans to charge or tie up, and every unit's orders. Fast melee units (Stormboyz, Custodian Guard) also deploy like assault troops now instead of lining up as gunline shooters.",

--- a/40k/scripts/LeftRosterStrip.gd
+++ b/40k/scripts/LeftRosterStrip.gd
@@ -26,9 +26,11 @@ func _ready() -> void:
 	name = "LeftRoster"
 	mouse_filter = Control.MOUSE_FILTER_PASS
 	# Hidden by default — HUD_Right already lists every unit, and the
-	# left-edge strip was overlapping GameLogPanel. Press L (or hit the
+	# left-edge strip was overlapping GameLogPanel. Press B (or hit the
 	# toolbar toggle Main wires in _install_design_guidelines_overlays)
-	# to bring it in.
+	# to bring it in. (Was L, but Main._input consumes L for the LoS
+	# overlay before _unhandled_key_input ever runs, so an L binding here
+	# can never fire.)
 	visible = false
 	_sync_viewport_size()
 	var vp := get_viewport()
@@ -62,7 +64,7 @@ func _unhandled_key_input(event: InputEvent) -> void:
 	if not (event is InputEventKey):
 		return
 	var k := event as InputEventKey
-	if k.pressed and not k.echo and k.keycode == KEY_L:
+	if k.pressed and not k.echo and k.keycode == KEY_B:
 		toggle_visible()
 		get_viewport().set_input_as_handled()
 

--- a/40k/scripts/LoSDebugVisual.gd
+++ b/40k/scripts/LoSDebugVisual.gd
@@ -23,15 +23,53 @@ const TERRAIN_HIGHLIGHT_COLOR = Color(1.0, 0.5, 0.0, 0.8)  # Orange
 const TERRAIN_BLOCKED_COLOR = Color(1.0, 0.0, 0.0, 0.8)  # Red
 const TERRAIN_COVER_COLOR = Color(1.0, 1.0, 0.0, 0.8)  # Yellow
 
+# ===== L-KEY SIGHT-LINE OVERVIEW (phase-independent) =====
+# While the L overlay is held, draw one sight line per (friendly unit ->
+# enemy unit) pair: solid green when a clear line exists, dashed red between
+# the nearest models when the pair budget found none. Unlike los_lines
+# (5-second expiry, fed by the shooting controller's per-model debug), these
+# persist until the overlay turns off and auto-refresh while models move.
+const OVERVIEW_REFRESH_INTERVAL := 0.5
+const OVERVIEW_CLEAR_COLOR := Color(0.25, 1.0, 0.35, 0.9)
+const OVERVIEW_BLOCKED_COLOR := Color(1.0, 0.3, 0.25, 0.7)
+const OVERVIEW_LINE_WIDTH := 2.5
+# Nearest model pairs tried per unit pair before declaring it blocked.
+# check_enhanced_visibility already samples base-edge points per pair, so a
+# small pair budget keeps the all-units sweep inside a frame budget while a
+# selected unit gets extra pairs for "only the flank model can see" layouts.
+const OVERVIEW_MAX_PAIRS_SELECTED := 3
+const OVERVIEW_MAX_PAIRS_ALL := 1
+
+var overview_active: bool = false
+var overview_source_unit_id: String = ""  # "" -> every unit of the active player
+var overview_lines: Array = []  # {from: Vector2, to: Vector2, is_clear: bool}
+var _overview_accum: float = 0.0
+var _overview_sig: int = 0
+
 func _ready() -> void:
 	z_index = 10  # Above most things for visibility
 	name = "LoSDebugVisual"
+	set_process(false)  # only ticks while the L overview is active
 	print("[LoSDebugVisual] Initialized")
 
 func _draw() -> void:
 	if not debug_enabled:
 		return
-	
+
+	# Overview sight lines (L overlay): green solid = clear, red dashed = blocked
+	# (key is "is_clear" — "clear" would collide with Dictionary.clear())
+	for ol in overview_lines:
+		var oc: Color = OVERVIEW_CLEAR_COLOR if ol["is_clear"] else OVERVIEW_BLOCKED_COLOR
+		if ol["is_clear"]:
+			draw_line(ol["from"], ol["to"], oc, OVERVIEW_LINE_WIDTH)
+		else:
+			draw_dashed_line(ol["from"], ol["to"], oc, OVERVIEW_LINE_WIDTH, 14.0)
+		draw_circle(ol["from"], OVERVIEW_LINE_WIDTH * 1.8, oc)
+		# Arrowhead at the target end so direction reads at a glance
+		var odir = (ol["to"] - ol["from"]).normalized()
+		draw_line(ol["to"], ol["to"] - odir.rotated(0.45) * 13.0, oc, OVERVIEW_LINE_WIDTH)
+		draw_line(ol["to"], ol["to"] - odir.rotated(-0.45) * 13.0, oc, OVERVIEW_LINE_WIDTH)
+
 	# Draw all LoS lines
 	for los_data in los_lines:
 		var from_pos = los_data.from
@@ -170,6 +208,7 @@ func clear_all_highlights() -> void:
 
 func clear_all_debug_visuals() -> void:
 	# Comprehensive cleanup method for all LoS debug visualizations
+	hide_overview()
 	clear_los_lines()
 	clear_all_highlights()
 	_remove_all_child_visuals()  # NEW: Remove child nodes
@@ -225,6 +264,7 @@ func _point_in_polygon(point: Vector2, polygon: PackedVector2Array) -> bool:
 func set_debug_enabled(enabled: bool) -> void:
 	debug_enabled = enabled
 	if not enabled:
+		hide_overview()
 		clear_los_lines()
 		clear_all_highlights()
 		_remove_all_child_visuals()  # NEW: Remove child Node2D objects
@@ -232,6 +272,154 @@ func set_debug_enabled(enabled: bool) -> void:
 
 func toggle_debug() -> void:
 	set_debug_enabled(not debug_enabled)
+
+
+# ===== L-KEY SIGHT-LINE OVERVIEW =====
+
+# Show unit->unit sight lines from `source_unit_id` (or from every unit of
+# the active player when "") to all enemy units. Requires debug_enabled.
+func show_overview(source_unit_id: String = "") -> void:
+	overview_active = true
+	overview_source_unit_id = source_unit_id
+	_overview_accum = 0.0
+	_overview_sig = 0
+	# Drop any stale shooter-mode drawings so the overlay reads clean.
+	clear_los_lines()
+	clear_all_highlights()
+	_remove_all_child_visuals()
+	_rebuild_overview()
+	set_process(true)
+	print("[LoSDebugVisual] Overview ON (source=%s, %d lines)" % [
+		source_unit_id if source_unit_id != "" else "<active player>", overview_lines.size()])
+
+
+func hide_overview() -> void:
+	if not overview_active and overview_lines.is_empty():
+		return
+	overview_active = false
+	overview_source_unit_id = ""
+	overview_lines.clear()
+	set_process(false)
+	queue_redraw()
+	print("[LoSDebugVisual] Overview OFF")
+
+
+# Auto-refresh while active so the lines track model moves / selection, and
+# never silently go stale. Cheap signature check gates the actual rebuild.
+func _process(delta: float) -> void:
+	if not overview_active or not debug_enabled:
+		return
+	_overview_accum += delta
+	if _overview_accum < OVERVIEW_REFRESH_INTERVAL:
+		return
+	_overview_accum = 0.0
+	var sig := _overview_state_signature()
+	if sig != _overview_sig:
+		_rebuild_overview()
+
+
+func _overview_state_signature() -> int:
+	var parts: Array = [overview_source_unit_id]
+	var units: Dictionary = GameState.state.get("units", {})
+	parts.append(int(GameState.state.get("meta", {}).get("active_player", 0)))
+	for uid in units:
+		var u = units[uid]
+		if typeof(u) != TYPE_DICTIONARY:
+			continue
+		for m in u.get("models", []):
+			if typeof(m) != TYPE_DICTIONARY or not m.get("alive", true):
+				continue
+			var p := _get_model_position_from_dict(m)
+			parts.append(int(p.x))
+			parts.append(int(p.y))
+	return hash(parts)
+
+
+func _rebuild_overview() -> void:
+	overview_lines.clear()
+	_overview_sig = _overview_state_signature()
+	var board = GameState.create_snapshot()
+	var units: Dictionary = board.get("units", {})
+
+	var sources: Array = []
+	if overview_source_unit_id != "" and units.has(overview_source_unit_id):
+		sources.append(overview_source_unit_id)
+	else:
+		var active_player := int(board.get("meta", {}).get("active_player", 1))
+		for uid in units:
+			var u = units[uid]
+			if typeof(u) != TYPE_DICTIONARY:
+				continue
+			if int(u.get("owner", 0)) == active_player:
+				sources.append(uid)
+
+	var max_pairs: int = OVERVIEW_MAX_PAIRS_SELECTED if overview_source_unit_id != "" else OVERVIEW_MAX_PAIRS_ALL
+	for src_id in sources:
+		var src = units[src_id]
+		var src_owner := int(src.get("owner", 0))
+		for tgt_id in units:
+			if str(tgt_id) == str(src_id):
+				continue
+			var tgt = units[tgt_id]
+			if typeof(tgt) != TYPE_DICTIONARY:
+				continue
+			if int(tgt.get("owner", 0)) == src_owner:
+				continue
+			var line := _unit_pair_sight_line(src, tgt, board, max_pairs)
+			if not line.is_empty():
+				overview_lines.append(line)
+	queue_redraw()
+
+
+# Best sight line between two units, mirroring the shooting-eligibility LoS
+# path (11e hidden/obscuring gates + EnhancedLineOfSight), tried over the
+# `max_pairs` nearest model pairs. Blocked pairs fall back to a nearest-model
+# center line so the player still sees WHICH pair was judged.
+func _unit_pair_sight_line(src: Dictionary, tgt: Dictionary, board: Dictionary, max_pairs: int) -> Dictionary:
+	var src_models := _alive_positioned_models(src)
+	var tgt_models := _alive_positioned_models(tgt)
+	if src_models.is_empty() or tgt_models.is_empty():
+		return {}
+
+	var pairs: Array = []
+	for a in src_models:
+		for t in tgt_models:
+			pairs.append([a.pos.distance_squared_to(t.pos), a, t])
+	pairs.sort_custom(func(x, y): return x[0] < y[0])
+
+	# 11e visibility gates (13.09 HIDDEN detection / 13.10-13.11 obscuring)
+	# to match RulesEngine._check_target_visibility.
+	var tm = null
+	if GameConstants.edition >= 11:
+		tm = Engine.get_main_loop().root.get_node_or_null("TerrainManager")
+
+	var budget: int = mini(max_pairs, pairs.size())
+	for i in range(budget):
+		var a = pairs[i][1]
+		var t = pairs[i][2]
+		if tm != null:
+			if not tm.hidden_model_visible_to(t.model, tgt, a.model):
+				continue
+			if not tm.model_visible_11e(a.model, t.model):
+				continue
+		var r = EnhancedLineOfSight.check_enhanced_visibility(a.model, t.model, board)
+		if r.has_los and r.sight_line.size() >= 2:
+			return {"from": r.sight_line[0], "to": r.sight_line[1], "is_clear": true}
+
+	var nearest = pairs[0]
+	return {"from": nearest[1].pos, "to": nearest[2].pos, "is_clear": false}
+
+
+func _alive_positioned_models(unit: Dictionary) -> Array:
+	var out: Array = []
+	for m in unit.get("models", []):
+		if typeof(m) != TYPE_DICTIONARY or not m.get("alive", true):
+			continue
+		var p := _get_model_position_from_dict(m)
+		if p == Vector2.ZERO:
+			continue
+		out.append({"pos": p, "model": m})
+	return out
 
 func _remove_all_child_visuals() -> void:
 	# Remove all child Node2D objects created for debug visualization

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2904,7 +2904,8 @@ func _setup_dashboard_toggle_buttons() -> void:
 	#   • Missions — opens / closes SecondaryMissionPanel (now hidden by
 	#     default, anchored top-center under the HUD bar).
 	#   • Roster — toggles the LeftRoster card strip (hidden by default,
-	#     also bound to KEY_L by the panel itself).
+	#     also bound to KEY_B by the panel itself; KEY_L belongs to the
+	#     LoS overlay).
 	var hud_container = get_node_or_null("HUD_Bottom/HBoxContainer")
 	if hud_container == null:
 		return
@@ -2921,7 +2922,7 @@ func _setup_dashboard_toggle_buttons() -> void:
 		var roster_btn := Button.new()
 		roster_btn.name = "RosterToggle"
 		roster_btn.text = "Roster"
-		roster_btn.tooltip_text = "Show / hide the left-side unit roster strip (L)"
+		roster_btn.tooltip_text = "Show / hide the left-side unit roster strip (B)"
 		roster_btn.pressed.connect(_on_roster_toggle_pressed)
 		hud_container.add_child(roster_btn)
 
@@ -4077,6 +4078,17 @@ func _setup_terrain() -> void:
 	print("Added LineOfSightVisual to BoardRoot")
 	print("Line of Sight: Hold 'V' to check what models can see the cursor position")
 
+	# Persistent L-overlay layer (2026-07-12): previously only
+	# ShootingController created LoSDebugVisual (and freed it on phase exit),
+	# so holding L silently did nothing in every other phase. Creating it here
+	# makes the L sight-line overlay work all game long; ShootingController
+	# now reuses this node instead of owning its own.
+	if not $BoardRoot.has_node("LoSDebugVisual"):
+		var los_dbg = preload("res://scripts/LoSDebugVisual.gd").new()
+		los_dbg.name = "LoSDebugVisual"
+		$BoardRoot.add_child(los_dbg)
+		print("Added persistent LoSDebugVisual to BoardRoot")
+
 	# Dev tools — hidden by default, toggled with Shift+D
 	var hud_container2 = $HUD_Bottom/HBoxContainer
 	if hud_container2:
@@ -4372,6 +4384,15 @@ func _toggle_los_debug() -> void:
 		los_debug = get_node_or_null("BoardRoot/LoSDebugVisual")
 		print("LoS debug: Using BoardRoot instance (fallback)")
 
+	# 2026-07-12: L must work in EVERY phase — if no instance exists yet
+	# (e.g. a save loaded straight into a non-shooting phase before
+	# _setup_terrain ran, or an old save flow), create the persistent one.
+	if not los_debug and has_node("BoardRoot"):
+		los_debug = preload("res://scripts/LoSDebugVisual.gd").new()
+		los_debug.name = "LoSDebugVisual"
+		$BoardRoot.add_child(los_debug)
+		print("LoS debug: Created persistent BoardRoot instance on demand")
+
 	if los_debug:
 		var was_enabled = los_debug.debug_enabled
 		print("LoS debug: Was enabled: ", was_enabled)
@@ -4385,12 +4406,21 @@ func _toggle_los_debug() -> void:
 		if los_button:
 			los_button.set_pressed_no_signal(is_now_enabled)
 
-		# If we just turned debug ON, refresh visuals if shooting phase is active
-		if not was_enabled and is_now_enabled and shooting_controller:
-			print("LoS debug: Calling refresh on ShootingController")
-			if shooting_controller.has_method("refresh_los_debug_visuals"):
-				shooting_controller.refresh_los_debug_visuals()
-				print("LoS debug: Refreshed visuals for active shooter")
+		# If we just turned debug ON, show sight lines in every phase:
+		# active shooter selected -> the shooting controller's per-model
+		# enhanced debug; otherwise -> the unit->unit sight-line overview
+		# (from the selected unit, or every active-player unit).
+		if not was_enabled and is_now_enabled:
+			var shooter_mode := false
+			if shooting_controller and "active_shooter_id" in shooting_controller \
+					and shooting_controller.active_shooter_id != "":
+				print("LoS debug: Calling refresh on ShootingController")
+				if shooting_controller.has_method("refresh_los_debug_visuals"):
+					shooting_controller.refresh_los_debug_visuals()
+					shooter_mode = true
+					print("LoS debug: Refreshed visuals for active shooter")
+			if not shooter_mode and los_debug.has_method("show_overview"):
+				los_debug.show_overview(_selected_unit_id_or_empty())
 	else:
 		print("LoS debug visual not found")
 
@@ -5273,8 +5303,13 @@ func _input(event: InputEvent) -> void:
 		get_viewport().set_input_as_handled()
 		return
 	
-	# T32: LoS debug — held-key power-user mode (was: persistent top-bar toggle)
-	if event is InputEventKey and event.keycode == KEY_L and not event.echo:
+	# T32: LoS debug — held-key power-user mode (was: persistent top-bar toggle).
+	# 2026-07-12: shows the sight-line overview in every phase (see
+	# LoSDebugVisual.show_overview). Chorded PRESSES (Ctrl+L = load, etc.) are
+	# not ours; releases always count so the held overlay can't get stuck ON
+	# when a modifier happens to be down at release time.
+	if event is InputEventKey and event.keycode == KEY_L and not event.echo \
+			and not (event.pressed and (event.shift_pressed or event.ctrl_pressed or event.meta_pressed)):
 		var want_on: bool = event.pressed
 		if want_on != los_debug_active:
 			_toggle_los_debug()
@@ -11845,7 +11880,8 @@ func _toggle_hotkey_help_overlay() -> void:
 		["U", "Toggle army panel"],
 		["S", "Toggle stratagems panel"],
 		["M", "Show secondary missions"],
-		["L", "Toggle LoS debug overlay"],
+		["L (hold)", "Show lines of sight (green clear / red blocked)"],
+		["B", "Toggle left roster strip"],
 		["G", "Toggle 1\" tactical grid overlay"],
 		["8", "Toggle visual style (letter / enhanced)"],
 		["9", "Toggle debug mode"],

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -285,10 +285,12 @@ func _exit_tree() -> void:
 	if target_highlights and is_instance_valid(target_highlights):
 		target_highlights.queue_free()
 
-	# Clean up LoS debug visualization
+	# Clean up LoS debug drawings but do NOT free the node — it is the
+	# persistent BoardRoot layer shared with Main's phase-independent L
+	# overlay (2026-07-12); freeing it here is what used to kill the L key
+	# for the rest of the game.
 	if los_debug_visual and is_instance_valid(los_debug_visual):
 		los_debug_visual.clear_all_debug_visuals()
-		los_debug_visual.queue_free()
 
 	# T5-MP3: Clean up shooting lines container
 	if shooting_lines_container and is_instance_valid(shooting_lines_container):
@@ -337,11 +339,17 @@ func _create_shooting_visuals() -> void:
 	los_visual.clear_points()
 	board_root.add_child(los_visual)
 	
-	# Create LoS debug visualization
-	los_debug_visual = preload("res://scripts/LoSDebugVisual.gd").new()
-	los_debug_visual.name = "LoSDebugVisual"
-	board_root.add_child(los_debug_visual)
-	print("ShootingController: Added LoS debug visualization")
+	# LoS debug visualization — reuse the persistent BoardRoot node Main
+	# creates (2026-07-12) so the L overlay works outside the shooting phase
+	# too; only create one here if it is somehow missing.
+	los_debug_visual = board_root.get_node_or_null("LoSDebugVisual")
+	if los_debug_visual:
+		print("ShootingController: Reusing persistent LoS debug visualization")
+	else:
+		los_debug_visual = preload("res://scripts/LoSDebugVisual.gd").new()
+		los_debug_visual.name = "LoSDebugVisual"
+		board_root.add_child(los_debug_visual)
+		print("ShootingController: Added LoS debug visualization")
 	
 	# Create range visualization node
 	range_visual = Node2D.new()

--- a/40k/tests/scenarios/sp/los_overlay_l_key.json
+++ b/40k/tests/scenarios/sp/los_overlay_l_key.json
@@ -1,0 +1,56 @@
+{
+  "id": "los_overlay_l_key",
+  "covers": [
+    "scripts/LoSDebugVisual.gd",
+    "scripts/LeftRosterStrip.gd",
+    "Main._toggle_los_debug",
+    "ShootingController._create_shooting_visuals"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "description": "Hold-L lines-of-sight overlay works in EVERY phase (regression: the LoSDebugVisual node only existed while ShootingController was alive, so L silently did nothing outside the shooting phase, and drew nothing inside it without an active shooter). Holding L in the Movement phase draws unit->unit sight lines (solid green clear / dashed red blocked) for the active player; releasing L clears them; the same works in the Shooting phase with no shooter selected. Also covers the roster strip hotkey move L->B (its old L binding was permanently shadowed by Main's L handler).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\") != null",
+      "equals": true },
+    { "act": "screenshot", "label": "01_movement_before_L" },
+
+    { "act": "execute_script", "script": "main.t32_synthesize_l(true)", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\").debug_enabled",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\").overview_lines.size()",
+      "expect_min": 1 },
+    { "act": "screenshot", "label": "02_movement_L_held_sight_lines" },
+
+    { "act": "execute_script", "script": "main.t32_synthesize_l(false)", "equals": false },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\").overview_lines.size()",
+      "equals": 0 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\").debug_enabled",
+      "equals": false },
+    { "act": "screenshot", "label": "03_movement_L_released_cleared" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(8)" },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "execute_script", "script": "main.t32_synthesize_l(true)", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/LoSDebugVisual\").overview_lines.size()",
+      "expect_min": 1 },
+    { "act": "screenshot", "label": "04_shooting_L_no_shooter_still_draws" },
+    { "act": "execute_script", "script": "main.t32_synthesize_l(false)", "equals": false },
+
+    { "act": "simulate_key", "keycode": "B" },
+    { "act": "expect_node_visible", "node": "/root/Main/LeftRoster" },
+    { "act": "simulate_key", "keycode": "B" },
+    { "act": "expect_node_property", "node": "/root/Main/LeftRoster", "property": "visible", "equals": false }
+  ]
+}


### PR DESCRIPTION
## Problem

Holding **L** ("show all lines of sight") was effectively dead:

- The `LoSDebugVisual` node only existed while `ShootingController` was alive — created on shooting-phase entry, **freed on phase exit** — so in every other phase `_toggle_los_debug()` found nothing and silently no-opped (the "LoS Debug: ON" toast showed over an empty board).
- Even inside the shooting phase it drew nothing unless a shooter with eligible targets was already selected, and the visuals self-expired after 3–5 seconds while the key was still held.
- The left roster strip also bound L, a binding that could never fire (Main consumes L in `_input` before `_unhandled_key_input` runs).

## Fix

- **Persistent overlay node**: Main creates `BoardRoot/LoSDebugVisual` at terrain setup (with an on-demand fallback in `_toggle_los_debug`); `ShootingController` reuses that node and no longer frees it on exit.
- **New sight-line overview** (`LoSDebugVisual.show_overview`): holding L draws one line per friendly-unit → enemy-unit pair — **solid green** along the actual sighting line when LoS exists, **dashed red** between nearest models when blocked. With a unit selected it shows just that unit's lines; otherwise every active-player unit. Checks mirror shooting eligibility (`EnhancedLineOfSight` + 11e hidden/obscuring gates) over the nearest model pairs, and the overlay auto-refreshes while held instead of fading out.
- Shooting phase with an active shooter keeps the detailed per-model debug view.
- Chorded presses (Ctrl+L = load, etc.) are ignored, but releases always count so the held overlay can't stick on.
- **Roster strip hotkey moved L → B**; tooltip, comments, and the `?` hotkey overlay updated.
- Changelog entry 0.22.0 added to `version_history.json`.

## Validation

- New windowed scenario `tests/scenarios/sp/los_overlay_l_key.json` (25/25 steps): drives L through the real input path in the **movement** and **shooting** phases, asserts overview lines appear and clear, and covers the B roster toggle.
- Existing shooting scenarios re-run green: `383_battleshock_can_shoot`, `click_select_shooter_shooting`, `shooting_no_targets_feedback`.
- Live MCP-bridge checks: single shared node in the shooting phase, node survives shooting → charge transition (the old kill-path), L draws in the charge phase, `verify_delivery` → PASS with zero log errors, screenshots confirm green/red lines rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WcMCnf6NbbNCoM2inzd73a

---
_Generated by [Claude Code](https://claude.ai/code/session_01WcMCnf6NbbNCoM2inzd73a)_