### PR TITLE
Stage fight-phase dice like shooting: hit/wound pauses + Command Re-roll

### DIFF
--- a/40k/autoloads/GameManager.gd
+++ b/40k/autoloads/GameManager.gd
@@ -189,6 +189,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _delegate_to_current_phase(action)
 		"BATCH_FIGHT_ACTIONS":
 			return _delegate_to_current_phase(action)
+		"USE_FIGHT_REROLL":  # Staged fight: Command Re-roll a hit/wound die
+			return _delegate_to_current_phase(action)
 
 		# Roll-off actions — deployment-order roll-off (pre-deployment) and the
 		# separate first-turn roll-off (post-deployment).

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -970,6 +970,8 @@ static func resolve_shoot_wounds(hit_context: Dictionary, board: Dictionary, rng
 # Only the chosen die is re-rolled; the untouched dice keep their result. A die
 # re-rolled here is not auto-re-rolled again (re-roll modifiers masked off — a
 # dice can only be re-rolled once). Returns an updated to_hit display block.
+# Works for BOTH ranged and melee hit contexts (melee stores WS under "bs" and
+# sets is_melee, which routes the display block context + skips DAKKASTORM).
 static func reroll_hit_die(hit_context: Dictionary, die_index: int, rng_service: RNGService = null) -> Dictionary:
 	if not rng_service:
 		rng_service = make_rng()
@@ -1000,7 +1002,8 @@ static func reroll_hit_die(hit_context: Dictionary, die_index: int, rng_service:
 				crits += 1
 			else:
 				regular += 1
-	if has_dakkastorm(hit_context.get("actor_unit", {})) and regular > 0:
+	# DAKKASTORM converts hits to crits for RANGED attacks only — never melee.
+	if not hit_context.get("is_melee", false) and has_dakkastorm(hit_context.get("actor_unit", {})) and regular > 0:
 		crits += regular
 		regular = 0
 	hit_context["hits"] = hits
@@ -1015,7 +1018,7 @@ static func reroll_hit_die(hit_context: Dictionary, die_index: int, rng_service:
 	hit_context["total_hits_for_wounds"] = hits + int(hit_context.get("sustained_bonus_hits", 0))
 
 	var block = {
-		"context": "to_hit",
+		"context": "hit_roll_melee" if hit_context.get("is_melee", false) else "to_hit",
 		"threshold": str(hit_context.get("bs", 4)) + "+",
 		"rolls_raw": hit_context["hit_rolls"],
 		"rolls_modified": hit_context["modified_rolls"],
@@ -1056,11 +1059,14 @@ static func reroll_wound_die(wound_context: Dictionary, die_index: int, board: D
 	var wounds_from_rolls = 0
 	var crit_wounds = 0
 	var regular_wounds = 0
+	var all_crit_wounds = 0  # ALL critical wounds regardless of DW (melee Hold Still)
 	for e in evals:
 		if e.get("auto_fail", false):
 			continue
 		if e.get("is_wound", false):
 			wounds_from_rolls += 1
+			if e.get("is_crit", false):
+				all_crit_wounds += 1
 			if has_dev and e.get("is_crit", false):
 				crit_wounds += 1
 			else:
@@ -1083,18 +1089,31 @@ static func reroll_wound_die(wound_context: Dictionary, die_index: int, board: D
 		}
 	var save_data = {}
 	if wounds_caused > 0:
-		save_data = prepare_save_resolution(
-			wounds_caused,
-			wound_context.get("target_unit_id", ""),
-			wound_context.get("actor_unit_id", ""),
-			wound_context.get("weapon_profile", {}),
-			board,
-			dev_data,
-			wound_context.get("melta_data", {}),
-			precision_data
-		)
+		# Melee wound contexts rebuild save data via the melee AP-modifier chain
+		# (no cover / melta in melee) — same overlay format either way.
+		if wound_context.get("is_melee", false):
+			save_data = prepare_melee_save_resolution(
+				wounds_caused,
+				wound_context.get("target_unit_id", ""),
+				wound_context.get("actor_unit_id", ""),
+				wound_context.get("weapon_profile", {}),
+				board,
+				dev_data,
+				precision_data
+			)
+		else:
+			save_data = prepare_save_resolution(
+				wounds_caused,
+				wound_context.get("target_unit_id", ""),
+				wound_context.get("actor_unit_id", ""),
+				wound_context.get("weapon_profile", {}),
+				board,
+				dev_data,
+				wound_context.get("melta_data", {}),
+				precision_data
+			)
 	var block = {
-		"context": "to_wound",
+		"context": "wound_roll_melee" if wound_context.get("is_melee", false) else "to_wound",
 		"threshold": str(wound_context.get("wound_threshold", 4)) + "+",
 		"rolls_raw": wound_context["wound_rolls"],
 		"successes": wounds_caused,
@@ -1107,6 +1126,9 @@ static func reroll_wound_die(wound_context: Dictionary, die_index: int, board: D
 		"wound_context": wound_context,
 		"dice_block": block,
 		"wounds_caused": wounds_caused,
+		"critical_wounds": crit_wounds,
+		"regular_wounds": regular_wounds,
+		"all_critical_wounds": all_crit_wounds,
 		"save_data": save_data,
 		"old_value": old_eval.get("raw", 0),
 		"new_value": new_raw
@@ -10477,17 +10499,234 @@ static func resolve_melee_attacks_interactive(action: Dictionary, board: Diction
 
 	return result
 
+# ==========================================
+# STAGED FIGHT (interactive Command Re-roll between hit and wound rolls)
+# resolve_melee_hits() rolls ONLY the hit roll for a single melee assignment and
+# returns a hit_context; the caller may pause (offer Command Re-roll on a hit die
+# via reroll_hit_die), then call resolve_melee_wounds(hit_context) which rolls the
+# wound roll and prepares save data. resolve_melee_saves_auto() runs the saving
+# throw + damage tail for the auto-allocate path. Mirrors the staged shooting API
+# (resolve_shoot_hits / resolve_shoot_wounds); the composed
+# _resolve_melee_assignment stays behaviour-identical for the fast paths.
+# ==========================================
+
+static func resolve_melee_hits(action: Dictionary, board: Dictionary, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var result = {"success": true, "phase": "FIGHT", "dice": [], "log_text": "", "no_hits": true, "early_exit": false}
+	var actor_unit_id = action.get("actor_unit_id", "")
+	var assignments = action.get("payload", {}).get("assignments", [])
+	if assignments.is_empty():
+		result.success = false
+		result.log_text = "No attack assignments provided"
+		return result
+	# Staged path resolves ONE assignment at a time.
+	var assignment = assignments[0]
+	var h = _resolve_melee_assignment_hits(assignment, actor_unit_id, board, rng_service)
+	result.dice = h.get("dice", [])
+	result.log_text = h.get("log_text", "")
+	result.no_hits = h.get("no_hits", false)
+	result.early_exit = h.get("early_exit", false)
+	# Always propagate hit_context (present even on a miss) so the staged path can
+	# Command Re-roll a missed die and continue to wounds if it becomes a hit.
+	result["hit_context"] = h.get("hit_context", {})
+	return result
+
+# include_hold_still: pass true when the caller will resolve saves interactively
+# (Hold Still MW ride on the save_data, matching resolve_melee_attacks_interactive);
+# pass false when resolve_melee_saves_auto will run — its tail rolls Hold Still
+# itself, exactly like the auto monolith.
+static func resolve_melee_wounds(hit_context: Dictionary, board: Dictionary, rng_service: RNGService = null, include_hold_still: bool = true) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var w = _resolve_melee_assignment_wounds(hit_context, board, rng_service)
+	var result = {
+		"success": true,
+		"phase": "FIGHT",
+		"dice": w.get("dice", []),
+		"log_text": w.get("log_text", ""),
+		"no_wounds": w.get("no_wounds", false),
+		"wounds_caused": w.get("wounds_caused", 0),
+		"all_critical_wound_count": w.get("all_critical_wound_count", 0),
+		"wound_context": w.get("wound_context", {}),
+		"wound_result": w,
+		"save_data_list": [],
+		"hold_still_mortal_wounds": 0
+	}
+	if w.get("no_wounds", false):
+		return result
+	# Package interactive-save data exactly like resolve_melee_attacks_interactive
+	# (dev wounds / precision / Hold Still), so the same overlay flow works.
+	var packaged = {"log_text": ""}
+	_build_melee_stop_before_saves(packaged, hit_context, w, rng_service, include_hold_still)
+	result["hold_still_mortal_wounds"] = packaged.get("hold_still_mortal_wounds", 0)
+	result["log_text"] = packaged.get("log_text", result["log_text"])
+	var dw_data = {
+		"has_devastating_wounds": hit_context.get("weapon_has_devastating_wounds", false),
+		"critical_wounds": w.get("critical_wound_count", 0),
+		"regular_wounds": w.get("regular_wound_count", 0)
+	}
+	var prec_data = {
+		"has_precision": hit_context.get("weapon_has_precision", false),
+		"precision_wounds": hit_context.get("critical_hits", 0) if hit_context.get("weapon_has_precision", false) else 0,
+		"critical_hits": hit_context.get("critical_hits", 0)
+	}
+	var save_data = prepare_melee_save_resolution(
+		w.get("wounds_caused", 0),
+		hit_context.get("target_id", ""),
+		hit_context.get("attacker_id", ""),
+		hit_context.get("weapon_profile", {}),
+		board,
+		dw_data,
+		prec_data
+	)
+	if save_data.get("success", false):
+		var hs_mw = int(result["hold_still_mortal_wounds"])
+		if hs_mw > 0:
+			save_data["hold_still_mortal_wounds"] = hs_mw
+		result["save_data_list"] = [save_data]
+	return result
+
+# Staged fight auto-allocate tail: run the PHASE 6-7 saving throws + damage for
+# one assignment whose hits/wounds were rolled via the staged calls above.
+static func resolve_melee_saves_auto(hit_context: Dictionary, wound_result: Dictionary, board: Dictionary, rng_service: RNGService = null) -> Dictionary:
+	if not rng_service:
+		rng_service = make_rng()
+	var s = _resolve_melee_assignment_saves(hit_context, wound_result, board, rng_service)
+	return {
+		"success": true,
+		"phase": "FIGHT",
+		"diffs": s.get("diffs", []),
+		"dice": s.get("dice", []),
+		"log_text": s.get("log_text", "")
+	}
+
 # Resolve a single melee assignment (models with weapon -> target)
 # Full pipeline mirroring shooting: hit rolls (with critical tracking, Sustained Hits),
 # wound rolls (with Lethal Hits, Devastating Wounds), save rolls (with invulnerable saves),
 # FNP, and damage application.
 # P0-58: When stop_before_saves=true, stops after wound rolls and returns save prep data
 # for interactive wound allocation overlay (defender-controlled wound allocation).
+#
+# STAGED FIGHT: composed from the hits / wounds / saves thirds below so the staged
+# fight path (resolve_melee_hits / resolve_melee_wounds / resolve_melee_saves_auto)
+# can pause between the hit roll and the wound roll for Command Re-roll — exactly
+# mirroring the ranged _resolve_assignment_until_wounds split. Behaviour and RNG
+# order are identical to the original monolith.
 static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: String, board: Dictionary, rng: RNGService, stop_before_saves: bool = false) -> Dictionary:
+	var h = _resolve_melee_assignment_hits(assignment, actor_unit_id, board, rng)
+	var result = {
+		"diffs": [],
+		"dice": (h.get("dice", []) as Array).duplicate(),
+		"log_text": h.get("log_text", "")
+	}
+	if h.get("early_exit", false) or h.get("no_hits", false):
+		return result
+
+	var hit_context = h.get("hit_context", {})
+	var w = _resolve_melee_assignment_wounds(hit_context, board, rng)
+	for wdb in w.get("dice", []):
+		result.dice.append(wdb)
+	if w.get("no_wounds", false):
+		result.log_text = w.get("log_text", "")
+		return result
+
+	# P0-58: When stop_before_saves=true, return wound data for interactive save allocation
+	if stop_before_saves:
+		_build_melee_stop_before_saves(result, hit_context, w, rng)
+		return result
+
+	var s = _resolve_melee_assignment_saves(hit_context, w, board, rng)
+	result.diffs.append_array(s.get("diffs", []))
+	for sdb in s.get("dice", []):
+		result.dice.append(sdb)
+	result.log_text = s.get("log_text", "")
+	return result
+
+# OA-19: HOLD STILL AND SAY 'AARGH!' — roll D6 mortal wounds per critical wound
+# for the 'urty syringe (non-VEHICLE targets). Shared between the interactive
+# (stop_before_saves) packaging and the staged fight path so the roll happens at
+# the same point relative to the wound roll in both.
+static func _roll_hold_still_mortal_wounds(hit_context: Dictionary, all_critical_wound_count: int, rng: RNGService) -> int:
+	if all_critical_wound_count <= 0:
+		return 0
+	var attacker_unit = hit_context.get("actor_unit", {})
+	var target_unit = hit_context.get("target_unit", {})
+	var weapon_name = str(hit_context.get("weapon_name", ""))
+	if not _has_hold_still_ability(attacker_unit):
+		return 0
+	if not weapon_name.to_lower().contains("urty syringe"):
+		return 0
+	if unit_has_keyword(target_unit, "VEHICLE"):
+		print("RulesEngine: HOLD STILL AND SAY 'AARGH!' (interactive) — target %s is VEHICLE, excluded" % hit_context.get("target_name", ""))
+		return 0
+	var hs_mw_count = 0
+	for _hs_i in range(all_critical_wound_count):
+		hs_mw_count += rng.roll_d6(1)[0]
+	print("RulesEngine: HOLD STILL AND SAY 'AARGH!' (interactive) — %d critical wound(s), %d mortal wounds pending" % [all_critical_wound_count, hs_mw_count])
+	return hs_mw_count
+
+# P0-58 packaging shared by the interactive monolith path and the staged fight
+# path: stamps the hit/wound tallies + Hold Still mortal wounds onto `result`
+# and builds the awaiting-saves log line. Set include_hold_still=false when the
+# save/damage tail (_resolve_melee_assignment_saves) will run afterwards — it
+# rolls and applies Hold Still itself, and rolling here too would double it.
+static func _build_melee_stop_before_saves(result: Dictionary, hit_context: Dictionary, w: Dictionary, rng: RNGService, include_hold_still: bool = true) -> void:
+	var is_torrent = hit_context.get("is_torrent", false)
+	var hits = int(hit_context.get("hits", 0))
+	var critical_hits = int(hit_context.get("critical_hits", 0))
+	var sustained_bonus_hits = int(hit_context.get("sustained_bonus_hits", 0))
+	var total_attacks = int(hit_context.get("total_attacks", 0))
+	var total_hits_for_wounds = int(hit_context.get("total_hits_for_wounds", 0))
+	var wounds_caused = int(w.get("wounds_caused", 0))
+	var auto_wounds = int(w.get("auto_wounds", 0))
+	result["wounds_caused"] = wounds_caused
+	result["critical_wound_count"] = w.get("critical_wound_count", 0)
+	result["regular_wound_count"] = w.get("regular_wound_count", 0)
+	result["weapon_has_devastating_wounds"] = hit_context.get("weapon_has_devastating_wounds", false)
+	result["weapon_has_precision"] = hit_context.get("weapon_has_precision", false)
+	result["critical_hits"] = critical_hits
+	result["weapon_profile"] = hit_context.get("weapon_profile", {})
+	result["target_id"] = hit_context.get("target_id", "")
+	result["attacker_id"] = hit_context.get("attacker_id", "")
+	result["target_name"] = hit_context.get("target_name", "")
+	result["attacker_name"] = hit_context.get("attacker_name", "")
+	result["weapon_name"] = hit_context.get("weapon_name", "")
+	result["stop_before_saves"] = true
+	# OA-19: Compute Hold Still mortal wound count for interactive path
+	result["hold_still_mortal_wounds"] = _roll_hold_still_mortal_wounds(hit_context, int(w.get("all_critical_wound_count", 0)), rng) if include_hold_still else 0
+	# Build log text for the hit/wound portion
+	var hw_parts = []
+	hw_parts.append("Melee: %s (%s) → %s" % [result["attacker_name"], result["weapon_name"], result["target_name"]])
+	if is_torrent:
+		hw_parts.append("Torrent: %d auto-hits" % hits)
+	else:
+		var hw_hit_detail = "Hit: %d/%d" % [hits, total_attacks]
+		if critical_hits > 0:
+			hw_hit_detail += " [%d crit]" % critical_hits
+		hw_parts.append(hw_hit_detail)
+	if sustained_bonus_hits > 0:
+		hw_parts.append("+%d Sustained Hits" % sustained_bonus_hits)
+	var hw_wound_detail = "Wound: %d/%d" % [wounds_caused, total_hits_for_wounds]
+	if auto_wounds > 0:
+		hw_wound_detail += " (%d Lethal)" % auto_wounds
+	hw_parts.append(hw_wound_detail)
+	hw_parts.append("Awaiting defender save allocation...")
+	result.log_text = " - ".join(hw_parts)
+	print("RulesEngine: P0-58 — Melee hits/wounds resolved, %d wounds caused, returning for interactive saves" % wounds_caused)
+
+# Melee hits third: PHASES 1-4 of the original monolith (attack counting, combat
+# stats, weapon abilities, hit rolls). Returns {dice, log_text, early_exit,
+# no_hits, hit_context}. The hit_context carries per-die evals (reroll_hit_die
+# support) and every stat the wounds/saves thirds need. WS is ALSO stored under
+# the ranged "bs"/"bs_per_attack" keys so reroll_hit_die works unchanged.
+static func _resolve_melee_assignment_hits(assignment: Dictionary, actor_unit_id: String, board: Dictionary, rng: RNGService) -> Dictionary:
 	var result = {
 		"diffs": [],
 		"dice": [],
-		"log_text": ""
+		"log_text": "",
+		"early_exit": false,
+		"no_hits": false
 	}
 
 	var attacker_id = assignment.get("attacker", "")
@@ -10497,12 +10736,14 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 
 	if weapon_id.is_empty():
 		result.log_text = "No weapon specified for melee attack"
+		result.early_exit = true
 		return result
 
 	# Get weapon profile (melee weapons use same format as ranged)
 	var weapon_profile = get_weapon_profile(weapon_id, board)
 	if weapon_profile.is_empty():
 		result.log_text = "Weapon profile not found: " + weapon_id
+		result.early_exit = true
 		return result
 
 	var units = board.get("units", {})
@@ -10511,6 +10752,7 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 
 	if attacker_unit.is_empty() or target_unit.is_empty():
 		result.log_text = "Attacker or target unit not found"
+		result.early_exit = true
 		return result
 
 	var attacker_name = attacker_unit.get("meta", {}).get("name", attacker_id)
@@ -10689,6 +10931,7 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 
 	if total_attacks == 0:
 		result.log_text = "No valid attacking models (0/%d in engagement range)" % total_alive_models
+		result.early_exit = true
 		return result
 
 	# ===== PHASE 2: GET COMBAT STATS =====
@@ -10890,6 +11133,14 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 	var sustained_result = {"bonus_hits": 0, "rolls": []}
 	var total_hits_for_wounds = 0
 	var hit_rolls = []
+	# STAGED FIGHT: per-die records for Command Re-roll (mirrors the ranged path).
+	# Declarations hoisted out of the non-torrent branch so the hit_context can be
+	# built unconditionally; behaviour is unchanged (torrent makes no hit roll).
+	var hit_evals = []
+	var modified_rolls = []
+	var melee_hit_reroll_data = []
+	var melee_crit_threshold = 6  # Default: only unmodified 6s are critical hits
+	var melee_hit_modifiers = HitModifier.NONE
 
 	if is_torrent:
 		# TORRENT: All attacks automatically hit - no roll needed
@@ -10911,7 +11162,6 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 		hit_rolls = rng.roll_d6(total_attacks)
 
 		# MARTIAL MASTERY — CRIT ON 5+ (P2-27): Shield Host detachment
-		var melee_crit_threshold = 6  # Default: only unmodified 6s are critical hits
 		if melee_attacker_flags.get("martial_mastery_crit_5", false):
 			melee_crit_threshold = 5
 			print("RulesEngine: Martial Mastery (Crit on 5+) — melee critical hit threshold lowered to 5+")
@@ -10929,8 +11179,6 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 				print("RulesEngine: DRAG IT DOWN — melee critical hits on 5+ (target is Prey)")
 
 		# Build melee hit modifiers using the HitModifier system
-		var melee_hit_modifiers = HitModifier.NONE
-
 		# Get hit modifiers from assignment
 		if assignment.has("modifiers") and assignment.modifiers.has("hit"):
 			var hit_mods = assignment.modifiers.hit
@@ -11005,7 +11253,6 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 			melee_hit_modifiers = melee_hit_modifiers & ~HitModifier.MINUS_ONE
 			print("RulesEngine: [PSYCHIC] (melee) — ignoring hit-roll penalties for %s" % weapon_name)
 
-		var melee_hit_reroll_data = []
 		# ISS-012: per-roll evaluation shared with the ranged paths
 		# (AttackSequence.evaluate_hit_roll). melee_crit_threshold covers
 		# Martial Mastery (5+); it is always <= 6, so the legacy redundant
@@ -11015,6 +11262,8 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 			# MA-11: Use per-model WS for this attack's threshold
 			var attack_ws = ws_per_attack[i] if i < ws_per_attack.size() else ws
 			var hit_eval = AttackSequence.evaluate_hit_roll(roll, attack_ws, melee_hit_modifiers, melee_crit_threshold, rng)
+			modified_rolls.append(hit_eval.final_roll)
+			hit_evals.append({"raw": roll, "final": hit_eval.final_roll, "is_hit": hit_eval.is_hit, "is_crit": hit_eval.is_crit})
 			if hit_eval.rerolled:
 				melee_hit_reroll_data.append({
 					"original": hit_eval.reroll_from,
@@ -11036,6 +11285,9 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 		# (If Lethal Hits: critical hits auto-wound, but sustained bonus hits still roll)
 		total_hits_for_wounds = hits + sustained_bonus_hits
 
+		# NOTE: the block shape is pinned by tests/fixtures/attack_goldens.json —
+		# per-die modified rolls / reroll data live in hit_context (and flow to the
+		# staged dialog via fight_stage_paused), not here.
 		result.dice.append({
 			"context": "hit_roll_melee",
 			"threshold": str(ws) + "+",
@@ -11058,12 +11310,104 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 			"precision_weapon": weapon_has_precision
 		})
 
+	# Build the hit context up-front so it is available even on a full miss —
+	# the staged fight path may Command Re-roll a MISSED die (turning it into a
+	# hit), which needs the per-die evals/modifiers preserved here. WS values are
+	# duplicated under the ranged "bs"/"bs_per_attack" keys for reroll_hit_die.
+	var hit_context = {
+		"is_melee": true,
+		"assignment": assignment,
+		"actor_unit_id": actor_unit_id,
+		"attacker_id": attacker_id,
+		"target_id": target_id,
+		"target_unit_id": target_id,
+		"weapon_id": weapon_id,
+		"weapon_profile": weapon_profile,
+		"weapon_name": weapon_name,
+		"attacker_name": attacker_name,
+		"target_name": target_name,
+		"actor_unit": attacker_unit,
+		"target_unit": target_unit,
+		# Combat stats (post-modifier) needed by the wounds / saves thirds
+		"ws": ws,
+		"strength": strength,
+		"toughness": toughness,
+		"ap": ap,
+		"damage": damage,
+		"base_save": base_save,
+		"has_dead_brutal": has_dead_brutal,
+		"model_count": model_count,
+		"total_alive_models": total_alive_models,
+		# Weapon abilities
+		"weapon_has_lethal_hits": weapon_has_lethal_hits,
+		"weapon_has_devastating_wounds": weapon_has_devastating_wounds,
+		"weapon_has_precision": weapon_has_precision,
+		"sustained_data": sustained_data,
+		"is_torrent": is_torrent,
+		# Hit tallies + per-die records
+		"hits": hits,
+		"critical_hits": critical_hits,
+		"regular_hits": regular_hits,
+		"sustained_bonus_hits": sustained_bonus_hits,
+		"total_hits_for_wounds": total_hits_for_wounds,
+		"total_attacks": total_attacks,
+		"hit_rolls": hit_rolls,
+		"modified_rolls": modified_rolls,
+		"hit_evals": hit_evals,
+		"reroll_data": melee_hit_reroll_data,
+		# reroll_hit_die compatibility (ranged field names)
+		"bs": ws,
+		"bs_per_attack": ws_per_attack,
+		"hit_modifiers": melee_hit_modifiers,
+		"critical_hit_threshold": melee_crit_threshold,
+		"hit_fail_band": 1,
+	}
+	result["hit_context"] = hit_context
+
 	if hits == 0 and sustained_bonus_hits == 0:
 		var melee_miss_log = "Melee: %s (%s) → %s: %d attacks, 0 hits" % [attacker_name, weapon_name, target_name, total_attacks]
 		if not hit_rolls.is_empty():
 			melee_miss_log += " [%s] vs %s+" % [", ".join(hit_rolls.map(func(r): return str(r))), str(ws)]
 		result.log_text = melee_miss_log
+		result.no_hits = true
 		return result
+
+	return result
+
+# Melee wounds third: PHASE 5 of the original monolith (wound rolls with Lethal
+# Hits / Devastating Wounds / Anti-Keyword / Twin-linked). Takes the hit_context
+# from _resolve_melee_assignment_hits; returns {dice, log_text, no_wounds,
+# wounds_caused, critical_wound_count, regular_wound_count,
+# all_critical_wound_count, auto_wounds, wound_rolls, wound_threshold,
+# melee_wound_modifier_net, wound_context}. wound_context carries per-die evals
+# so reroll_wound_die works for melee.
+static func _resolve_melee_assignment_wounds(hit_context: Dictionary, board: Dictionary, rng: RNGService) -> Dictionary:
+	var result = {
+		"dice": [],
+		"log_text": "",
+		"no_wounds": false
+	}
+	var assignment = hit_context["assignment"]
+	var attacker_id = hit_context["attacker_id"]
+	var target_id = hit_context["target_id"]
+	var weapon_id = hit_context["weapon_id"]
+	var weapon_name = hit_context["weapon_name"]
+	var attacker_name = hit_context["attacker_name"]
+	var target_name = hit_context["target_name"]
+	var units = board.get("units", {})
+	var attacker_unit = units.get(attacker_id, {})
+	var target_unit = units.get(target_id, {})
+	var strength = hit_context["strength"]
+	var toughness = hit_context["toughness"]
+	var weapon_has_lethal_hits = hit_context["weapon_has_lethal_hits"]
+	var weapon_has_devastating_wounds = hit_context["weapon_has_devastating_wounds"]
+	var is_torrent = hit_context["is_torrent"]
+	var hits = int(hit_context["hits"])
+	var critical_hits = int(hit_context["critical_hits"])
+	var regular_hits = int(hit_context["regular_hits"])
+	var sustained_bonus_hits = int(hit_context["sustained_bonus_hits"])
+	var total_hits_for_wounds = int(hit_context["total_hits_for_wounds"])
+	var total_attacks = int(hit_context["total_attacks"])
 
 	# ===== PHASE 5: WOUND ROLLS =====
 	# With Lethal Hits, Sustained Hits, Devastating Wounds, and Anti-Keyword interactions
@@ -11195,6 +11539,7 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 	var regular_wound_count = 0
 	var all_critical_wound_count = 0  # OA-19: Track ALL critical wounds (for Hold Still and Say 'Aargh!')
 	var melee_wound_reroll_data = []  # Track twin-linked / modifier re-rolls
+	var wound_evals = []  # STAGED FIGHT: per-die records for reroll_wound_die
 
 	if weapon_has_lethal_hits and not is_torrent and lethal_hits_auto_wound_11e(weapon_id, board, assignment):
 		# Lethal Hits: Critical hits (unmodified 6s to hit) automatically wound - no wound roll
@@ -11209,6 +11554,7 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 			for roll in wound_rolls:
 				# ISS-012: shared per-roll evaluation (AttackSequence.evaluate_wound_roll)
 				var wound_eval = AttackSequence.evaluate_wound_roll(roll, melee_wound_modifiers, wound_threshold, melee_critical_wound_threshold, rng)
+				wound_evals.append({"raw": roll, "is_wound": wound_eval.is_wound, "is_crit": wound_eval.is_crit, "auto_fail": wound_eval.auto_fail})
 				if wound_eval.rerolled:
 					melee_wound_reroll_data.append({"original": wound_eval.reroll_from, "rerolled_to": wound_eval.reroll_to})
 				if wound_eval.auto_fail:
@@ -11232,6 +11578,7 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 			for roll in wound_rolls:
 				# ISS-012: shared per-roll evaluation (AttackSequence.evaluate_wound_roll)
 				var wound_eval = AttackSequence.evaluate_wound_roll(roll, melee_wound_modifiers, wound_threshold, melee_critical_wound_threshold, rng)
+				wound_evals.append({"raw": roll, "is_wound": wound_eval.is_wound, "is_crit": wound_eval.is_crit, "auto_fail": wound_eval.auto_fail})
 				if wound_eval.rerolled:
 					melee_wound_reroll_data.append({"original": wound_eval.reroll_from, "rerolled_to": wound_eval.reroll_to})
 				if wound_eval.auto_fail:
@@ -11282,59 +11629,89 @@ static func _resolve_melee_assignment(assignment: Dictionary, actor_unit_id: Str
 		"wound_modifiers_applied": melee_wound_modifiers
 	})
 
+	# Package the wound stage for the composer / staged fight path. wound_context
+	# mirrors the ranged wound_context field names so reroll_wound_die works.
+	result["wounds_caused"] = wounds_caused
+	result["critical_wound_count"] = critical_wound_count
+	result["regular_wound_count"] = regular_wound_count
+	result["all_critical_wound_count"] = all_critical_wound_count
+	result["auto_wounds"] = auto_wounds
+	result["wound_rolls"] = wound_rolls
+	result["wound_threshold"] = wound_threshold
+	result["melee_wound_modifier_net"] = melee_wound_modifier_net
+	result["wound_context"] = {
+		"is_melee": true,
+		"wound_evals": wound_evals,
+		"wound_rolls": wound_rolls,
+		"wound_modifiers": melee_wound_modifiers,
+		"wound_threshold": wound_threshold,
+		"critical_wound_threshold": melee_critical_wound_threshold,
+		"weapon_has_devastating_wounds": weapon_has_devastating_wounds,
+		"weapon_has_precision": hit_context.get("weapon_has_precision", false),
+		"auto_wounds": auto_wounds,
+		"critical_hits": critical_hits,
+		"target_unit_id": target_id,
+		"actor_unit_id": attacker_id,
+		"weapon_profile": hit_context.get("weapon_profile", {}),
+		"melta_data": {},
+	}
+
 	if wounds_caused == 0:
 		var hit_text = "%d hits" % hits
 		if sustained_bonus_hits > 0:
 			hit_text += " (+%d sustained)" % sustained_bonus_hits
 		result.log_text = "Melee: %s (%s) → %s: %d attacks, %s, 0 wounds" % [attacker_name, weapon_name, target_name, total_attacks, hit_text]
+		result.no_wounds = true
 		return result
 
-	# P0-58: When stop_before_saves=true, return wound data for interactive save allocation
-	if stop_before_saves:
-		result["wounds_caused"] = wounds_caused
-		result["critical_wound_count"] = critical_wound_count
-		result["regular_wound_count"] = regular_wound_count
-		result["weapon_has_devastating_wounds"] = weapon_has_devastating_wounds
-		result["weapon_has_precision"] = weapon_has_precision
-		result["critical_hits"] = critical_hits
-		result["weapon_profile"] = weapon_profile
-		result["target_id"] = target_id
-		result["attacker_id"] = attacker_id
-		result["target_name"] = target_name
-		result["attacker_name"] = attacker_name
-		result["weapon_name"] = weapon_name
-		result["stop_before_saves"] = true
-		# OA-19: Compute Hold Still mortal wound count for interactive path
-		var hs_mw_count = 0
-		if all_critical_wound_count > 0 and _has_hold_still_ability(attacker_unit):
-			if weapon_name.to_lower().contains("urty syringe"):
-				if not unit_has_keyword(target_unit, "VEHICLE"):
-					for _hs_i in range(all_critical_wound_count):
-						hs_mw_count += rng.roll_d6(1)[0]
-					print("RulesEngine: HOLD STILL AND SAY 'AARGH!' (interactive) — %d critical wound(s), %d mortal wounds pending" % [all_critical_wound_count, hs_mw_count])
-				else:
-					print("RulesEngine: HOLD STILL AND SAY 'AARGH!' (interactive) — target %s is VEHICLE, excluded" % target_name)
-		result["hold_still_mortal_wounds"] = hs_mw_count
-		# Build log text for the hit/wound portion
-		var hw_parts = []
-		hw_parts.append("Melee: %s (%s) → %s" % [attacker_name, weapon_name, target_name])
-		if is_torrent:
-			hw_parts.append("Torrent: %d auto-hits" % hits)
-		else:
-			var hw_hit_detail = "Hit: %d/%d" % [hits, total_attacks]
-			if critical_hits > 0:
-				hw_hit_detail += " [%d crit]" % critical_hits
-			hw_parts.append(hw_hit_detail)
-		if sustained_bonus_hits > 0:
-			hw_parts.append("+%d Sustained Hits" % sustained_bonus_hits)
-		var hw_wound_detail = "Wound: %d/%d" % [wounds_caused, total_hits_for_wounds]
-		if auto_wounds > 0:
-			hw_wound_detail += " (%d Lethal)" % auto_wounds
-		hw_parts.append(hw_wound_detail)
-		hw_parts.append("Awaiting defender save allocation...")
-		result.log_text = " - ".join(hw_parts)
-		print("RulesEngine: P0-58 — Melee hits/wounds resolved, %d wounds caused, returning for interactive saves" % wounds_caused)
-		return result
+	return result
+
+# Melee saves third: PHASES 6-7 of the original monolith (saving throws, FNP,
+# damage application, Hold Still mortal wounds). Takes the hit_context and the
+# wounds-third result; returns {diffs, dice, log_text}. Only the auto-resolve
+# path reaches this — the interactive path stops before saves.
+static func _resolve_melee_assignment_saves(hit_context: Dictionary, w: Dictionary, board: Dictionary, rng: RNGService) -> Dictionary:
+	var result = {
+		"diffs": [],
+		"dice": [],
+		"log_text": ""
+	}
+	var assignment = hit_context["assignment"]
+	var actor_unit_id = hit_context["actor_unit_id"]
+	var attacker_id = hit_context["attacker_id"]
+	var target_id = hit_context["target_id"]
+	var weapon_id = hit_context["weapon_id"]
+	var weapon_name = hit_context["weapon_name"]
+	var weapon_profile = hit_context["weapon_profile"]
+	var attacker_name = hit_context["attacker_name"]
+	var target_name = hit_context["target_name"]
+	var units = board.get("units", {})
+	var attacker_unit = units.get(attacker_id, {})
+	var target_unit = units.get(target_id, {})
+	var ws = hit_context["ws"]
+	var ap = hit_context["ap"]
+	var damage = hit_context["damage"]
+	var base_save = hit_context["base_save"]
+	var has_dead_brutal = hit_context["has_dead_brutal"]
+	var model_count = int(hit_context["model_count"])
+	var total_alive_models = int(hit_context["total_alive_models"])
+	var weapon_has_devastating_wounds = hit_context["weapon_has_devastating_wounds"]
+	var weapon_has_precision = hit_context["weapon_has_precision"]
+	var is_torrent = hit_context["is_torrent"]
+	var hits = int(hit_context["hits"])
+	var critical_hits = int(hit_context["critical_hits"])
+	var sustained_bonus_hits = int(hit_context["sustained_bonus_hits"])
+	var total_attacks = int(hit_context["total_attacks"])
+	var total_hits_for_wounds = int(hit_context["total_hits_for_wounds"])
+	var hit_rolls = hit_context["hit_rolls"]
+	var wounds_caused = int(w["wounds_caused"])
+	var critical_wound_count = int(w["critical_wound_count"])
+	var regular_wound_count = int(w["regular_wound_count"])
+	var all_critical_wound_count = int(w["all_critical_wound_count"])
+	var auto_wounds = int(w["auto_wounds"])
+	var wound_rolls = w["wound_rolls"]
+	var wound_threshold = w["wound_threshold"]
+	var melee_wound_modifier_net = int(w["melee_wound_modifier_net"])
 
 	# ===== PHASE 6: SAVE ROLLS =====
 	# A1 (11e): melee saves/damage via the SAME defender allocation-group path as
@@ -14005,6 +14382,18 @@ static func check_units_in_engagement_range(unit1: Dictionary, unit2: Dictionary
 ## type-aware format).
 static func generate_weapon_id(weapon_name: String, weapon_type: String = "") -> String:
 	return _generate_weapon_id(weapon_name, weapon_type)
+
+## Staged fight: re-roll Hold Still (OA-19) mortal wounds for a melee
+## hit_context after a Command Re-roll changed the critical-wound tally.
+static func roll_hold_still_mortal_wounds(hit_context: Dictionary, all_critical_wound_count: int, rng_service: RNGService = null) -> int:
+	if not rng_service:
+		rng_service = make_rng()
+	return _roll_hold_still_mortal_wounds(hit_context, all_critical_wound_count, rng_service)
+
+## 11.04 WHILE MOVING (11e): charging models that CAN end within 1" of a charge
+## target MUST do so. Public delegate for ChargePhase (single implementation).
+static func validate_base_to_base_possible_rules(unit_id: String, per_model_paths: Dictionary, target_ids: Array, board: Dictionary, rolled_distance: int = 0) -> Dictionary:
+	return _validate_base_to_base_possible_rules(unit_id, per_model_paths, target_ids, board, rolled_distance)
 
 ## Allocate `total_damage` into the target unit's model pool; returns the
 ## damage-application result (diffs, casualties).

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -14390,11 +14390,6 @@ static func roll_hold_still_mortal_wounds(hit_context: Dictionary, all_critical_
 		rng_service = make_rng()
 	return _roll_hold_still_mortal_wounds(hit_context, all_critical_wound_count, rng_service)
 
-## 11.04 WHILE MOVING (11e): charging models that CAN end within 1" of a charge
-## target MUST do so. Public delegate for ChargePhase (single implementation).
-static func validate_base_to_base_possible_rules(unit_id: String, per_model_paths: Dictionary, target_ids: Array, board: Dictionary, rolled_distance: int = 0) -> Dictionary:
-	return _validate_base_to_base_possible_rules(unit_id, per_model_paths, target_ids, board, rolled_distance)
-
 ## Allocate `total_damage` into the target unit's model pool; returns the
 ## damage-application result (diffs, casualties).
 static func apply_damage_to_unit_pool(target_unit_id: String, total_damage: int, models: Array, board: Dictionary) -> Dictionary:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "0.24.0",
+      "date": "2026-07-12",
+      "summary": "The Fight phase no longer jumps straight through the dice: melee attacks now resolve weapon by weapon with a visible pause after the hit roll and after the wound roll — just like staged shooting — including a Command Re-roll (1 CP) button on each die.",
+      "changes": [
+        "Clicking Fight! now opens a Melee Resolution window that walks through each weapon in turn: the hit roll is shown and PAUSES ('Roll to Wound' button), then the wound roll is shown and pauses ('Continue to Saving Throws'), then saves resolve — so you can actually read what happened at every stage.",
+        "Command Re-roll (1 CP) is now available in melee: while paused after a hit or wound roll, click any die to re-roll it (once per phase, attacker's CP), exactly like the staged shooting flow.",
+        "Each weapon (e.g. Big choppa, Power klaw, and auto-included Extra Attacks weapons) resolves as its own step with a named 'Weapon X of Y' header and a running combat log inside the window.",
+        "A summary ('Melee attacks resolved — N enemy models destroyed') with a Close button ends the sequence; the next fighter selection then continues as before.",
+        "AI activations and multiplayer games keep the previous one-shot resolution (no pauses), matching how staged shooting behaves."
+      ]
+    },
+    {
       "version": "0.23.0",
       "date": "2026-07-11",
       "summary": "Made the online Save & Load screen far more reliable when the cloud server is slow or waking up. Instead of silently showing an empty 'Existing Saves' list (which looked like your saved games had vanished), it now retries automatically, shows a clear message if it still can't reach the server, and has a new ⟳ Refresh button to reload the list by hand.",

--- a/40k/dialogs/FightSequenceDialog.gd
+++ b/40k/dialogs/FightSequenceDialog.gd
@@ -1,0 +1,357 @@
+extends AcceptDialog
+
+const _WhiteDwarfTheme = preload("res://scripts/WhiteDwarfTheme.gd")
+
+# FightSequenceDialog — staged melee resolution UI (mirrors WeaponOrderDialog's
+# staged section for shooting). Stays open through the whole fight sequence:
+#   hit roll  -> pause: dice shown, optional per-die Command Re-roll,
+#                "Roll to Wound ▶"
+#   wound roll-> pause: dice shown, optional per-die Command Re-roll,
+#                "Continue to Saving Throws ▶"
+#   saves     -> auto-allocated results appended (or the dialog hides while the
+#                defender uses the WoundAllocationOverlay, then re-shows)
+#   complete  -> summary + Close
+#
+# The dialog connects directly to FightPhase signals (dice_rolled,
+# fight_stage_paused, saves_required) — same pattern as WeaponOrderDialog.
+
+signal staged_continue_requested(next_step: String)      # "wounds" or "saves"
+signal staged_reroll_requested(stage: String, die_index: int)  # Command Re-roll a hit/wound die
+
+var current_phase = null
+var current_stage: String = ""       # "hits" | "wounds" while paused
+
+# UI nodes
+var vbox: VBoxContainer
+var header_label: Label
+var progress_label: Label
+var dice_log_rich_text: RichTextLabel
+var staged_continue_button: Button
+var close_button: Button
+var reroll_label: Label
+var reroll_row: HBoxContainer
+
+func _ready() -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	# Stable node name so windowed scenarios can address the dialog + buttons.
+	name = "FightSequenceDialog"
+	title = "Fight — Melee Resolution"
+	dialog_hide_on_ok = false
+	min_size = DialogConstants.LARGE
+	get_ok_button().hide()
+
+	vbox = VBoxContainer.new()
+	vbox.name = "Content"
+	vbox.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 20, 0)
+	add_child(vbox)
+
+	header_label = Label.new()
+	header_label.name = "HeaderLabel"
+	header_label.text = "Resolving melee attacks..."
+	header_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	header_label.add_theme_font_size_override("font_size", 14)
+	header_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	vbox.add_child(header_label)
+
+	progress_label = Label.new()
+	progress_label.name = "ProgressLabel"
+	progress_label.text = ""
+	progress_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	progress_label.add_theme_font_size_override("font_size", 12)
+	progress_label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.8))
+	vbox.add_child(progress_label)
+
+	_add_gold_separator(vbox)
+
+	# Command Re-roll affordance: a row of per-die buttons the attacker can
+	# click to re-roll a single hit/wound die with Command Re-roll (1 CP).
+	reroll_label = Label.new()
+	reroll_label.name = "RerollLabel"
+	reroll_label.add_theme_font_size_override("font_size", 12)
+	reroll_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	reroll_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	reroll_label.visible = false
+	vbox.add_child(reroll_label)
+
+	reroll_row = HBoxContainer.new()
+	reroll_row.name = "RerollRow"
+	reroll_row.visible = false
+	var reroll_scroll = ScrollContainer.new()
+	reroll_scroll.name = "RerollScroll"
+	reroll_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 44)
+	reroll_scroll.add_child(reroll_row)
+	vbox.add_child(reroll_scroll)
+
+	# Action buttons
+	var button_hbox = HBoxContainer.new()
+	button_hbox.name = "Buttons"
+	button_hbox.alignment = BoxContainer.ALIGNMENT_CENTER
+	vbox.add_child(button_hbox)
+
+	staged_continue_button = Button.new()
+	staged_continue_button.name = "StagedContinueButton"
+	staged_continue_button.text = "Continue ▶"
+	staged_continue_button.pressed.connect(_on_staged_continue_pressed)
+	staged_continue_button.custom_minimum_size = Vector2(260, 42)
+	WhiteDwarfTheme.apply_primary_button(staged_continue_button)
+	button_hbox.add_child(staged_continue_button)
+	staged_continue_button.visible = false
+
+	close_button = Button.new()
+	close_button.name = "CloseButton"
+	close_button.text = "Close"
+	close_button.pressed.connect(_on_close_pressed)
+	close_button.custom_minimum_size = Vector2(100, 42)
+	close_button.visible = false
+	WhiteDwarfTheme.apply_secondary_button(close_button)
+	button_hbox.add_child(close_button)
+
+	_add_gold_separator(vbox)
+
+	var log_label = Label.new()
+	log_label.text = "Combat Log:"
+	log_label.add_theme_font_size_override("font_size", 12)
+	vbox.add_child(log_label)
+
+	dice_log_rich_text = RichTextLabel.new()
+	dice_log_rich_text.name = "DiceLog"
+	dice_log_rich_text.set_custom_minimum_size(Vector2(DialogConstants.LARGE.x - 40, 200))
+	dice_log_rich_text.bbcode_enabled = true
+	dice_log_rich_text.scroll_following = true
+	vbox.add_child(dice_log_rich_text)
+
+	print("FightSequenceDialog initialized")
+
+func setup(phase, fighter_name: String) -> void:
+	current_phase = phase
+	header_label.text = "%s — melee attacks" % fighter_name
+	if current_phase == null:
+		return
+	if current_phase.has_signal("dice_rolled") and not current_phase.dice_rolled.is_connected(_on_dice_rolled):
+		current_phase.dice_rolled.connect(_on_dice_rolled)
+	if current_phase.has_signal("fight_stage_paused") and not current_phase.fight_stage_paused.is_connected(_on_stage_paused):
+		current_phase.fight_stage_paused.connect(_on_stage_paused)
+	# Hide while the defender allocates wounds in the overlay; the next
+	# fight_stage_paused re-shows the dialog.
+	if current_phase.has_signal("saves_required") and not current_phase.saves_required.is_connected(_on_saves_required):
+		current_phase.saves_required.connect(_on_saves_required)
+
+# --- dice log rendering ---------------------------------------------------
+
+func _on_dice_rolled(dice_data: Dictionary) -> void:
+	var context = dice_data.get("context", "")
+	match context:
+		"weapon_progress":
+			_add_to_dice_log("", Color.WHITE)
+			_add_to_dice_log("[b]━━━ %s ━━━[/b]" % dice_data.get("message", ""), WhiteDwarfTheme.WH_GOLD)
+			if dice_data.get("total_weapons", 0):
+				progress_label.text = dice_data.get("message", "")
+		"resolution_start":
+			_add_to_dice_log(dice_data.get("message", "Beginning melee resolution..."), Color.CYAN)
+		"reroll_note":
+			_add_to_dice_log("[b][color=orange]↻ %s[/color][/b]" % dice_data.get("message", "Re-roll"), Color.ORANGE)
+		"auto_hit_melee", "auto_hit":
+			var total = dice_data.get("total_attacks", dice_data.get("successes", 0))
+			_add_to_dice_log("[b]Rolling to Hit:[/b] [color=cyan]%d automatic hits[/color]" % total, Color.WHITE)
+		"hit_roll_melee", "to_hit":
+			_add_to_dice_log(_format_roll_line("hit", dice_data), Color.WHITE)
+		"wound_roll_melee", "to_wound":
+			_add_to_dice_log(_format_roll_line("wound", dice_data), Color.WHITE)
+		"save_roll_melee", "save_roll", "save":
+			_add_to_dice_log(_format_save_line(dice_data), Color.WHITE)
+		"feel_no_pain":
+			var prevented = dice_data.get("wounds_prevented", 0)
+			_add_to_dice_log("[b]Feel No Pain[/b] (need %s): %s → [color=cyan]%d prevented[/color]" % [
+				dice_data.get("threshold", "?"), _dice_str(dice_data.get("rolls_raw", [])), prevented], Color.WHITE)
+		"hazardous_check", "hazardous":
+			_add_to_dice_log("[b][color=red]Hazardous:[/color][/b] %s" % dice_data.get("message", str(dice_data.get("rolls_raw", []))), Color.WHITE)
+		_:
+			# Fallback for any other dice block with rolls.
+			var rolls = dice_data.get("rolls_raw", dice_data.get("rolls", []))
+			if not (rolls as Array).is_empty():
+				var line = "[b]%s[/b]" % context.capitalize().replace("_", " ")
+				if dice_data.has("threshold"):
+					line += " (need %s)" % dice_data.get("threshold", "")
+				line += ": %s" % _dice_str(rolls)
+				if dice_data.has("successes"):
+					line += " → [b][color=green]%d[/color][/b]" % int(dice_data.get("successes", 0))
+				_add_to_dice_log(line, Color.WHITE)
+
+func _format_roll_line(kind: String, dice_data: Dictionary) -> String:
+	var threshold = str(dice_data.get("threshold", ""))
+	var rolls_raw = dice_data.get("rolls_raw", [])
+	var rolls_modified = dice_data.get("rolls_modified", [])
+	var display_rolls = rolls_modified if not (rolls_modified as Array).is_empty() else rolls_raw
+	var total = (display_rolls as Array).size()
+	var successes = int(dice_data.get("successes", 0))
+
+	var label = "Rolling to Hit" if kind == "hit" else "Rolling to Wound"
+	var line = "[b]%s[/b] (need %s): %s" % [label, threshold, _dice_str(display_rolls)]
+	var rerolls = dice_data.get("rerolls", dice_data.get("wound_rerolls", []))
+	if not (rerolls as Array).is_empty():
+		line += "  [color=orange]("
+		for rr in rerolls:
+			line += "%d→%d " % [rr.get("original", 0), rr.get("rerolled_to", 0)]
+		line = line.strip_edges() + ")[/color]"
+	var fails = max(0, total - successes)
+	var noun = kind if successes == 1 else kind + "s"
+	line += " → [b][color=green]%d %s[/color][/b]" % [successes, noun]
+	if kind == "hit" and total > 0:
+		var miss_word = "miss" if fails == 1 else "misses"
+		line += "[color=gray], %d %s[/color]" % [fails, miss_word]
+	var crits = int(dice_data.get("critical_hits", dice_data.get("critical_wounds", 0)))
+	if crits > 0:
+		var crit_kind = "critical hit" if kind == "hit" else "critical wound"
+		line += "  [color=#c8a24a](%d %s%s)[/color]" % [crits, crit_kind, "" if crits == 1 else "s"]
+	var sustained = int(dice_data.get("sustained_bonus_hits", 0))
+	if kind == "hit" and sustained > 0:
+		line += "  [color=#c8a24a](+%d Sustained)[/color]" % sustained
+	var lethal_autos = int(dice_data.get("lethal_hits_auto_wounds", 0))
+	if kind == "wound" and lethal_autos > 0:
+		line += "  [color=#c8a24a](%d Lethal auto-wound%s)[/color]" % [lethal_autos, "" if lethal_autos == 1 else "s"]
+	return line
+
+func _format_save_line(dice_data: Dictionary) -> String:
+	var threshold = str(dice_data.get("threshold", "?"))
+	var rolls = dice_data.get("rolls_raw", [])
+	var saved = int(dice_data.get("successes", 0))
+	var failed = int(dice_data.get("failed", max(0, (rolls as Array).size() - saved)))
+	var line = "[b]Saving Throws[/b] (need %s): %s → [color=green]%d saved[/color], [color=red]%d failed[/color]" % [
+		threshold, _dice_str(rolls), saved, failed]
+	var dev = int(dice_data.get("devastating_wounds_bypassed", 0))
+	if dev > 0:
+		line += "  [color=#c8a24a](%d DEVASTATING — no save)[/color]" % dev
+	return line
+
+func _dice_str(rolls: Array) -> String:
+	if rolls.is_empty():
+		return "[color=gray]—[/color]"
+	var parts = []
+	for r in rolls:
+		var v = int(r)
+		if v == 6:
+			parts.append("[color=#d4af37]6[/color]")
+		elif v == 1:
+			parts.append("[color=#a04040]1[/color]")
+		else:
+			parts.append(str(v))
+	return "[ " + " ".join(parts) + " ]"
+
+func _add_to_dice_log(text: String, color: Color) -> void:
+	if not dice_log_rich_text:
+		return
+	var color_hex = color.to_html(false)
+	dice_log_rich_text.append_text("[color=#%s]%s[/color]\n" % [color_hex, text])
+
+# --- staged pauses ----------------------------------------------------------
+
+func _on_stage_paused(stage: String, info: Dictionary) -> void:
+	current_stage = stage
+	if not visible:
+		popup_centered()
+	if stage == "complete":
+		staged_continue_button.visible = false
+		reroll_label.visible = false
+		reroll_row.visible = false
+		_clear_reroll_row()
+		var casualties = int(info.get("casualties", 0))
+		var cas_label = "model" if casualties == 1 else "models"
+		_add_to_dice_log("", Color.WHITE)
+		_add_to_dice_log("[b]Melee attacks resolved — %d enemy %s destroyed.[/b]" % [casualties, cas_label], WhiteDwarfTheme.WH_GOLD)
+		progress_label.text = "Attacks complete"
+		close_button.visible = true
+		return
+
+	var reroll_available = bool(info.get("reroll_available", false))
+	if stage == "hits":
+		staged_continue_button.text = "Roll to Wound ▶"
+		staged_continue_button.tooltip_text = "Proceed to the wound roll for this weapon"
+	elif stage == "wounds":
+		staged_continue_button.text = "Continue to Saving Throws ▶"
+		staged_continue_button.tooltip_text = "Resolve the defender's saving throws"
+	staged_continue_button.visible = true
+	close_button.visible = false
+
+	if reroll_available:
+		var rolls = info.get("modified_rolls", [])
+		if (rolls as Array).is_empty():
+			rolls = info.get("hit_rolls", info.get("wound_rolls", []))
+		_populate_reroll_row(stage, rolls)
+	else:
+		reroll_label.visible = false
+		reroll_row.visible = false
+		_clear_reroll_row()
+
+func _populate_reroll_row(stage: String, rolls: Array) -> void:
+	_clear_reroll_row()
+	if rolls.is_empty():
+		reroll_label.visible = false
+		reroll_row.visible = false
+		return
+	reroll_label.text = "Command Re-roll (1 CP) — click a %s die to re-roll it (once per phase):" % ("hit" if stage == "hits" else "wound")
+	reroll_label.visible = true
+	reroll_row.visible = true
+	for i in range(rolls.size()):
+		var die_btn = Button.new()
+		die_btn.name = "Die%d" % i
+		die_btn.text = str(int(rolls[i]))
+		die_btn.custom_minimum_size = Vector2(38, 38)
+		die_btn.tooltip_text = "Re-roll this die with Command Re-roll (1 CP)"
+		_WhiteDwarfTheme.apply_to_button(die_btn)
+		die_btn.pressed.connect(_on_reroll_die_pressed.bind(i))
+		reroll_row.add_child(die_btn)
+
+func _clear_reroll_row() -> void:
+	if not reroll_row:
+		return
+	for child in reroll_row.get_children():
+		child.queue_free()
+
+func _on_reroll_die_pressed(die_index: int) -> void:
+	print("FightSequenceDialog: re-roll %s die %d requested" % [current_stage, die_index])
+	# Disable further clicks immediately (once per phase); the phase confirms.
+	reroll_label.visible = false
+	reroll_row.visible = false
+	_clear_reroll_row()
+	emit_signal("staged_reroll_requested", current_stage, die_index)
+
+func _on_staged_continue_pressed() -> void:
+	staged_continue_button.visible = false
+	reroll_label.visible = false
+	reroll_row.visible = false
+	_clear_reroll_row()
+	if current_stage == "hits":
+		emit_signal("staged_continue_requested", "wounds")
+	elif current_stage == "wounds":
+		emit_signal("staged_continue_requested", "saves")
+
+func _on_saves_required(_save_data_list: Array) -> void:
+	# Defender's WoundAllocationOverlay takes over — get out of the way.
+	# The next fight_stage_paused (next weapon / complete) re-shows us.
+	hide()
+
+func _on_close_pressed() -> void:
+	hide()
+	queue_free()
+
+# Windowed-scenario helper: ScenarioRunner's execute_script is Expression-only
+# (no loops/statements), so the "click continue until the sequence completes"
+# loop lives here. Clicks the staged continue button through the remaining
+# stages and stops at the completion summary (Close visible). Returns a short
+# status string; the scenario asserts/screenshots, then clicks CloseButton.
+func debug_click_through(max_clicks: int = 12) -> String:
+	var clicks = 0
+	while clicks < max_clicks and not close_button.visible:
+		if staged_continue_button.visible:
+			_on_staged_continue_pressed()
+		clicks += 1
+	if close_button.visible:
+		return "complete after %d step(s)" % clicks
+	return "not complete after %d step(s)" % clicks
+
+func _add_gold_separator(parent: Control) -> void:
+	var sep = ColorRect.new()
+	sep.custom_minimum_size = Vector2(0, 2)
+	sep.color = Color(WhiteDwarfTheme.WH_GOLD.r, WhiteDwarfTheme.WH_GOLD.g, WhiteDwarfTheme.WH_GOLD.b, 0.4)
+	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	parent.add_child(sep)

--- a/40k/dialogs/FightSequenceDialog.gd.uid
+++ b/40k/dialogs/FightSequenceDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://4eikc2qvd8fn

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -43,6 +43,11 @@ signal pile_in_step_required(data: Dictionary)  # 11e 12.02: global Pile In step
 # analogue of ShootingPhase.shooting_begun — remote/visual feedback hook).
 # Was emitted UNDECLARED, raising a runtime error on every melee confirm.
 signal fighting_begun(unit_id: String)
+# STAGED FIGHT: paused after the hit roll ("hits") or wound roll ("wounds") of
+# the current weapon so the attacker can read the dice / use Command Re-roll;
+# "complete" fires when the whole staged sequence finishes. Mirrors
+# ShootingPhase.shooting_stage_paused.
+signal fight_stage_paused(stage: String, info: Dictionary)
 
 # Fight state tracking
 var active_fighter_id: String = ""
@@ -60,6 +65,14 @@ var units_that_piled_in: Dictionary = {}  # unit_id -> true, tracks which units 
 var pending_melee_save_data: Array = []  # Save data list for WoundAllocationOverlay
 var pending_melee_hit_wound_result: Dictionary = {}  # Dice/log from hit+wound resolution
 var awaiting_melee_saves: bool = false  # True while waiting for defender to allocate wounds
+
+# STAGED FIGHT (non-networked, human attacker): assignment-by-assignment melee
+# resolution with pauses after the hit roll and the wound roll (Command Re-roll
+# windows) — mirrors ShootingPhase's sequential_staged mode. Empty = inactive.
+# Keys: assignments, current_index, stage ("hits_pending"/"wounds_pending"/
+# "saves_pending"), hit_context, wound_result, wound_context, save_data_list,
+# assignment_dice, interactive_saves, total_casualties, reroll flags.
+var staged_fight_state: Dictionary = {}
 
 # New subphase tracking
 var fights_first_sequence: Dictionary = {"1": [], "2": []}  # Player -> Array of unit IDs
@@ -154,6 +167,7 @@ func _on_phase_enter() -> void:
 	pending_attacks.clear()
 	confirmed_attacks.clear()
 	resolution_state.clear()
+	staged_fight_state.clear()
 	dice_log.clear()
 	units_that_fought.clear()
 	units_that_piled_in.clear()
@@ -560,6 +574,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _validate_apply_melee_saves(action)
+		"CONTINUE_TO_WOUNDS", "CONTINUE_TO_SAVES", "USE_FIGHT_REROLL":  # Staged sequential steps
+			return _validate_staged_fight_continue(action)
 		"USE_MOMENT_SHACKLE":
 			var ms_uid = action.get("unit_id", "")
 			if ms_uid not in _moment_shackle_pending_units:
@@ -631,6 +647,12 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_batch_fight_actions(action)
 		"APPLY_MELEE_SAVES":
 			return _process_apply_melee_saves(action)
+		"CONTINUE_TO_WOUNDS":  # Staged: roll the wound roll for the paused weapon
+			return _staged_fight_continue_to_wounds()
+		"CONTINUE_TO_SAVES":  # Staged: hand the paused weapon's wounds to saves
+			return _staged_fight_continue_to_saves()
+		"USE_FIGHT_REROLL":  # Staged: Command Re-roll a hit or wound die
+			return _process_use_fight_reroll(action)
 		"USE_MOMENT_SHACKLE":
 			return _process_use_moment_shackle(action)
 		"DECLINE_MOMENT_SHACKLE":
@@ -1534,7 +1556,15 @@ func _process_roll_dice(action: Dictionary) -> Dictionary:
 		var _ss = get_node_or_null("/root/SettingsService")
 		_auto_alloc_11e = _ss == null or _ss.get_auto_allocate_wounds()
 
-	if defender_is_human and not _auto_alloc_11e:
+	# STAGED FIGHT: in non-networked play a HUMAN attacker resolves weapon by
+	# weapon with pauses after the hit roll and the wound roll (Command Re-roll
+	# windows) — mirrors ShootingPhase's sequential_staged mode. AI attackers,
+	# networked games and explicit fast_roll keep the one-shot paths below.
+	var interactive_saves = defender_is_human and not _auto_alloc_11e
+	if _should_stage_fight(action):
+		return _staged_fight_begin(interactive_saves)
+
+	if interactive_saves:
 		# P0-58: Interactive path — resolve hits+wounds only, then let defender allocate wounds
 		return _process_roll_dice_interactive(melee_action)
 	else:
@@ -1718,6 +1748,443 @@ func _process_roll_dice_auto(melee_action: Dictionary) -> Dictionary:
 	final_result["consolidate_distance"] = consol_dist
 
 	return final_result
+
+# =============================================================================
+# STAGED FIGHT RESOLUTION (mirrors ShootingPhase's sequential_staged mode)
+#
+# In non-networked play a HUMAN attacker resolves melee weapon by weapon:
+#   ROLL_DICE            -> roll hits for weapon 1, PAUSE (fight_stage_paused "hits")
+#   CONTINUE_TO_WOUNDS   -> roll wounds, PAUSE (fight_stage_paused "wounds")
+#   CONTINUE_TO_SAVES    -> saving throws (auto-allocate or WoundAllocationOverlay),
+#                           then next weapon's hits or finish the activation
+#   USE_FIGHT_REROLL     -> Command Re-roll one hit/wound die at either pause
+#
+# Networked games and AI attackers keep the one-shot paths above (mirrors how
+# staged shooting / Command Re-roll are host/SP only elsewhere).
+# =============================================================================
+
+func create_result(success: bool, changes: Array = [], error: String = "", additional_data: Dictionary = {}) -> Dictionary:
+	var result = {
+		"success": success,
+		"phase": phase_type,
+		"timestamp": Time.get_unix_time_from_system()
+	}
+	if success:
+		result["changes"] = changes
+		for key in additional_data:
+			result[key] = additional_data[key]
+	else:
+		result["error"] = error
+	return result
+
+func _should_stage_fight(action: Dictionary) -> bool:
+	if action.get("payload", {}).get("fast_roll", false):
+		return false
+	if NetworkManager.is_networked():
+		return false
+	# Only stage for human attackers — AI activations must not pause.
+	var fighter_owner = get_unit(active_fighter_id).get("owner", get_current_player())
+	var ai_player = get_node_or_null("/root/AIPlayer")
+	if ai_player and ai_player.get("enabled") and ai_player.has_method("is_ai_player") and ai_player.is_ai_player(fighter_owner):
+		return false
+	return true
+
+func _fight_reroll_available() -> bool:
+	# A staged hit/wound Command Re-roll is offered when the ATTACKING player has
+	# not already used Command Re-roll this phase and can pay the CP.
+	var sm = get_node_or_null("/root/StratagemManager")
+	if sm == null or not sm.has_method("is_command_reroll_available"):
+		return false
+	var fighter_owner = get_unit(active_fighter_id).get("owner", get_current_player())
+	var chk = sm.is_command_reroll_available(fighter_owner)
+	return chk.get("available", false)
+
+func _staged_fight_begin(interactive_saves: bool) -> Dictionary:
+	staged_fight_state = {
+		"assignments": confirmed_attacks.duplicate(true),
+		"current_index": 0,
+		"stage": "",
+		"hit_context": {},
+		"wound_result": {},
+		"wound_context": {},
+		"save_data_list": [],
+		"interactive_saves": interactive_saves,
+		"total_casualties": 0,
+		"completed": []
+	}
+	log_phase_message("Starting staged fight resolution (%d weapon assignment(s))" % staged_fight_state.assignments.size())
+	return _staged_fight_roll_hits([])
+
+func _staged_fight_target_destroyed(target_id: String) -> bool:
+	var unit = get_unit(target_id)
+	if unit.is_empty():
+		return true
+	for model in unit.get("models", []):
+		if model.get("alive", true):
+			return false
+	return true
+
+func _staged_fight_roll_hits(carry_changes: Array) -> Dictionary:
+	var assignments = staged_fight_state.get("assignments", [])
+	var idx = int(staged_fight_state.get("current_index", 0))
+
+	# Skip assignments whose target has been destroyed by an earlier weapon.
+	while idx < assignments.size():
+		var target_id = assignments[idx].get("target", "")
+		if target_id != "" and not _staged_fight_target_destroyed(target_id):
+			break
+		var skipped_weapon = RulesEngine.get_weapon_profile(assignments[idx].get("weapon", ""), game_state_snapshot).get("name", assignments[idx].get("weapon", ""))
+		log_phase_message("Skipped %s — target destroyed" % skipped_weapon)
+		emit_signal("dice_rolled", {"context": "weapon_progress",
+			"message": "Skipped %s — target destroyed" % skipped_weapon})
+		idx += 1
+		staged_fight_state.current_index = idx
+
+	if idx >= assignments.size():
+		return _staged_fight_finish(carry_changes)
+
+	var assignment = assignments[idx]
+	var weapon_id = assignment.get("weapon", "")
+	var target_id = assignment.get("target", "")
+	var weapon_name = RulesEngine.get_weapon_profile(weapon_id, game_state_snapshot).get("name", weapon_id)
+	var target_name = get_unit(target_id).get("meta", {}).get("name", target_id)
+	var fighter_name = get_unit(active_fighter_id).get("meta", {}).get("name", active_fighter_id)
+
+	GameEventLog.add_combat_header("P%d: %s → %s with %s (weapon %d/%d)" % [
+		get_unit(active_fighter_id).get("owner", get_current_player()), fighter_name, target_name, weapon_name,
+		idx + 1, assignments.size()])
+
+	var progress = {
+		"context": "weapon_progress",
+		"message": "Weapon %d of %d — %s → %s" % [idx + 1, assignments.size(), weapon_name, target_name],
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"current_index": idx,
+		"total_weapons": assignments.size(),
+		"stage": "hits"
+	}
+	emit_signal("dice_rolled", progress)
+
+	var melee_action = {"type": "FIGHT", "actor_unit_id": active_fighter_id, "payload": {"assignments": [assignment]}}
+	var rng = RulesEngine.make_rng()
+	var hres = RulesEngine.resolve_melee_hits(melee_action, game_state_snapshot, rng)
+	if not hres.get("success", false):
+		return create_result(false, [], hres.get("log_text", "Melee hit resolution failed"))
+
+	for db in hres.get("dice", []):
+		dice_log.append(db)
+		emit_signal("dice_rolled", db)
+		if db.get("context", "") == "hit_roll_melee":
+			_emit_melee_hit_detail(db)
+	if hres.get("log_text", "") != "":
+		log_phase_message(hres.get("log_text", ""))
+
+	if hres.get("early_exit", false):
+		# No eligible models / bad assignment — skip to the next weapon.
+		staged_fight_state.current_index = idx + 1
+		return _staged_fight_roll_hits(carry_changes)
+
+	var hc = hres.get("hit_context", {})
+	staged_fight_state.stage = "hits_pending"
+	staged_fight_state.hit_context = hc
+	staged_fight_state.wound_result = {}
+	staged_fight_state.wound_context = {}
+	staged_fight_state.save_data_list = []
+
+	var can_reroll = _fight_reroll_available() and not hc.get("is_torrent", false) and not (hc.get("hit_rolls", []) as Array).is_empty()
+	var pause_info = {
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"unit_name": fighter_name,
+		"current_index": idx,
+		"total_weapons": assignments.size(),
+		"reroll_available": can_reroll,
+		"hit_rolls": hc.get("hit_rolls", []),
+		"modified_rolls": hc.get("modified_rolls", []),
+		"hits": hc.get("hits", 0),
+		"threshold": str(hc.get("ws", hc.get("bs", 4))) + "+"
+	}
+	emit_signal("fight_stage_paused", "hits", pause_info)
+	log_phase_message("Weapon %d of %d hit roll complete — awaiting attacker to continue to wound roll" % [idx + 1, assignments.size()])
+	return create_result(true, carry_changes, "", {
+		"staged_pause": "hits",
+		"current_weapon_index": idx,
+		"total_weapons": assignments.size(),
+		"weapon_name": weapon_name,
+		"target_name": target_name,
+		"reroll_available": can_reroll,
+		"hit_rolls": hc.get("hit_rolls", []),
+		"hits": hc.get("hits", 0),
+		"dice": hres.get("dice", [])
+	})
+
+func _staged_fight_continue_to_wounds() -> Dictionary:
+	if staged_fight_state.get("stage", "") != "hits_pending":
+		return create_result(false, [], "Not awaiting continue-to-wounds")
+	var hc = staged_fight_state.get("hit_context", {})
+	var idx = int(staged_fight_state.get("current_index", 0))
+	var assignments = staged_fight_state.get("assignments", [])
+	var interactive_saves = staged_fight_state.get("interactive_saves", false)
+
+	var rng = RulesEngine.make_rng()
+	# Hold Still MW ride on the interactive save_data; the auto tail rolls its own.
+	var wres = RulesEngine.resolve_melee_wounds(hc, game_state_snapshot, rng, interactive_saves)
+
+	for db in wres.get("dice", []):
+		dice_log.append(db)
+		emit_signal("dice_rolled", db)
+		if db.get("context", "") == "wound_roll_melee":
+			_emit_melee_wound_detail(db)
+	if wres.get("log_text", "") != "":
+		log_phase_message(wres.get("log_text", ""))
+
+	staged_fight_state.wound_result = wres.get("wound_result", {})
+	staged_fight_state.wound_context = wres.get("wound_context", {})
+	staged_fight_state.save_data_list = wres.get("save_data_list", [])
+
+	if wres.get("no_wounds", false):
+		# No wounds — this weapon is done; hazardous check, then next weapon.
+		staged_fight_state.stage = ""
+		return _staged_fight_assignment_complete([])
+
+	staged_fight_state.stage = "wounds_pending"
+	var wc = wres.get("wound_context", {})
+	var can_reroll = _fight_reroll_available() and not (wc.get("wound_evals", []) as Array).is_empty()
+	var wounds = 0
+	var sdl = wres.get("save_data_list", [])
+	if not sdl.is_empty():
+		wounds = int(sdl[0].get("wounds_to_save", wres.get("wounds_caused", 0)))
+	else:
+		wounds = int(wres.get("wounds_caused", 0))
+	var pause_info = {
+		"current_index": idx,
+		"total_weapons": assignments.size(),
+		"reroll_available": can_reroll,
+		"wound_rolls": wc.get("wound_rolls", []),
+		"wounds": wounds,
+		"target_name": get_unit(assignments[idx].get("target", "")).get("meta", {}).get("name", ""),
+		"threshold": str(wc.get("wound_threshold", 4)) + "+"
+	}
+	emit_signal("fight_stage_paused", "wounds", pause_info)
+	log_phase_message("Weapon %d of %d wound roll complete — awaiting attacker to continue to saving throws" % [idx + 1, assignments.size()])
+	return create_result(true, [], "", {
+		"staged_pause": "wounds",
+		"current_weapon_index": idx,
+		"total_weapons": assignments.size(),
+		"reroll_available": can_reroll,
+		"wounds": wounds,
+		"dice": wres.get("dice", [])
+	})
+
+func _staged_fight_continue_to_saves() -> Dictionary:
+	if staged_fight_state.get("stage", "") != "wounds_pending":
+		return create_result(false, [], "Not awaiting continue-to-saves")
+	var hc = staged_fight_state.get("hit_context", {})
+	var wound_result = staged_fight_state.get("wound_result", {})
+	var save_data_list = staged_fight_state.get("save_data_list", [])
+
+	if staged_fight_state.get("interactive_saves", false) and not save_data_list.is_empty():
+		# Defender allocates wounds via WoundAllocationOverlay; the staged
+		# sequence resumes in _process_apply_melee_saves.
+		staged_fight_state.stage = "saves_pending"
+		pending_melee_save_data = save_data_list
+		pending_melee_hit_wound_result = {"diffs": [], "dice": []}
+		awaiting_melee_saves = true
+		emit_signal("saves_required", save_data_list)
+		log_phase_message("Awaiting defender wound allocation for melee combat (staged)...")
+		return create_result(true, [], "", {
+			"awaiting_melee_saves": true,
+			"save_data_list": save_data_list
+		})
+
+	# Auto-allocate: run the save/damage tail synchronously (rolls Hold Still
+	# itself, exactly like the one-shot monolith path).
+	var rng = RulesEngine.make_rng()
+	var sres = RulesEngine.resolve_melee_saves_auto(hc, wound_result, game_state_snapshot, rng)
+	var changes = sres.get("diffs", [])
+	var save_blocks = []
+	for db in sres.get("dice", []):
+		dice_log.append(db)
+		emit_signal("dice_rolled", db)
+		save_blocks.append(db)
+	if sres.get("log_text", "") != "":
+		log_phase_message(sres.get("log_text", ""))
+
+	var casualties = 0
+	for diff in changes:
+		if str(diff.get("path", "")).ends_with(".alive") and diff.get("value") == false:
+			casualties += 1
+	staged_fight_state.total_casualties = int(staged_fight_state.get("total_casualties", 0)) + casualties
+
+	# Verbose save/FNP log lines (normalize save_roll_melee -> save_roll)
+	for sb in save_blocks:
+		var ctx = sb.get("context", "")
+		if ctx == "save_roll_melee" or ctx == "save_roll" or ctx == "save":
+			var nsb = sb.duplicate()
+			nsb["context"] = "save_roll"
+			_emit_melee_save_detail(nsb)
+		elif ctx == "feel_no_pain":
+			_emit_melee_fnp_detail(sb)
+	if casualties > 0:
+		var cas_label = "model" if casualties == 1 else "models"
+		GameEventLog.add_combat_result("  Result: %d %s destroyed" % [casualties, cas_label])
+	else:
+		GameEventLog.add_combat_result("  Result: No models destroyed")
+
+	staged_fight_state.stage = ""
+	return _staged_fight_assignment_complete(changes)
+
+# One weapon fully resolved (saves applied or no wounds) — run its Hazardous
+# check, advance to the next weapon or finish the activation.
+func _staged_fight_assignment_complete(changes: Array) -> Dictionary:
+	var assignments = staged_fight_state.get("assignments", [])
+	var idx = int(staged_fight_state.get("current_index", 0))
+	if idx < assignments.size():
+		var assignment = assignments[idx]
+		var weapon_id = assignment.get("weapon", "")
+		var fighter_unit = get_unit(active_fighter_id)
+		if RulesEngine.is_hazardous_weapon(weapon_id, game_state_snapshot) \
+				or fighter_unit.get("flags", {}).get("effect_grant_hazardous_melee", false):
+			var models_that_fought = assignment.get("models", []).size()
+			var rng = RulesEngine.make_rng()
+			var hazard = RulesEngine.resolve_hazardous_check(active_fighter_id, weapon_id, models_that_fought, game_state_snapshot, rng)
+			if hazard.get("hazardous_triggered", false):
+				changes = changes + hazard.get("diffs", [])
+			for db in hazard.get("dice", []):
+				dice_log.append(db)
+				emit_signal("dice_rolled", db)
+			if hazard.get("log_text", "") != "":
+				log_phase_message(hazard.get("log_text", ""))
+		staged_fight_state.completed.append(assignment)
+	staged_fight_state.current_index = idx + 1
+	return _staged_fight_roll_hits(changes)
+
+func _staged_fight_finish(changes: Array) -> Dictionary:
+	var total_casualties = int(staged_fight_state.get("total_casualties", 0))
+	var fighter_name = get_unit(active_fighter_id).get("meta", {}).get("name", active_fighter_id)
+	var summary = {"success": true, "diffs": changes, "casualties": total_casualties}
+
+	emit_signal("fight_stage_paused", "complete", {
+		"unit_name": fighter_name,
+		"casualties": total_casualties,
+		"total_weapons": staged_fight_state.get("assignments", []).size()
+	})
+
+	# Emit resolution signals for each target (mirrors _process_roll_dice_auto)
+	for assignment in staged_fight_state.get("assignments", []):
+		emit_signal("attacks_resolved", active_fighter_id, assignment.get("target", ""), summary)
+		emit_signal("fight_resolved", active_fighter_id, summary)
+
+	staged_fight_state.clear()
+	confirmed_attacks.clear()
+	_trigger_unit_animation(active_fighter_id, "idle")
+	log_phase_message("Melee combat resolved for %s (staged)" % active_fighter_id)
+
+	var final_result = create_result(true, changes)
+	final_result["log_text"] = "Melee combat resolved for %s" % fighter_name
+
+	# 11e: no per-fighter consolidation — the activation ends when the
+	# attacks are resolved (consolidation is the global 12.07 step).
+	if GameConstants.edition >= 11:
+		return _finish_fight_activation_11e(final_result)
+
+	var consol_dist = _get_consolidation_distance(active_fighter_id)
+	emit_signal("consolidate_required", active_fighter_id, consol_dist)
+	final_result["trigger_consolidate"] = true
+	final_result["consolidate_unit_id"] = active_fighter_id
+	final_result["consolidate_distance"] = consol_dist
+	return final_result
+
+func _process_use_fight_reroll(action: Dictionary) -> Dictionary:
+	var payload = action.get("payload", {})
+	var stage = str(payload.get("stage", ""))
+	var die_index = int(payload.get("die_index", -1))
+	var expected = "hits_pending" if stage == "hits" else ("wounds_pending" if stage == "wounds" else "")
+	if expected == "" or staged_fight_state.get("stage", "") != expected:
+		return create_result(false, [], "No re-roll available at this stage")
+
+	# Spend the CP + record the once-per-phase Command Re-roll usage (attacker).
+	var sm = get_node_or_null("/root/StratagemManager")
+	if sm == null or not sm.has_method("execute_command_reroll"):
+		return create_result(false, [], "Command Re-roll unavailable")
+	var fighter_owner = get_unit(active_fighter_id).get("owner", get_current_player())
+	var strat_result = sm.execute_command_reroll(fighter_owner, active_fighter_id, {"roll_type": stage + "_roll"})
+	if not strat_result.get("success", false):
+		return create_result(false, [], str(strat_result.get("reason", "Cannot use Command Re-roll")))
+
+	var rng = RulesEngine.make_rng()
+	if stage == "hits":
+		var hc = staged_fight_state.get("hit_context", {})
+		var rr = RulesEngine.reroll_hit_die(hc, die_index, rng)
+		if not rr.get("success", false):
+			return create_result(false, [], str(rr.get("error", "Re-roll failed")))
+		emit_signal("dice_rolled", {"context": "reroll_note",
+			"message": "Command Re-roll (1 CP): hit die %d → %d" % [rr.get("old_display", rr.get("old_value", 0)), rr.get("new_display", rr.get("new_value", 0))]})
+		emit_signal("dice_rolled", rr.get("dice_block", {}))
+		dice_log.append(rr.get("dice_block", {}))
+		var uhc = rr.get("hit_context", {})
+		staged_fight_state.hit_context = uhc
+		emit_signal("fight_stage_paused", "hits", {
+			"reroll_available": false,
+			"hit_rolls": uhc.get("hit_rolls", []),
+			"modified_rolls": uhc.get("modified_rolls", []),
+			"hits": uhc.get("hits", 0)
+		})
+		return create_result(true, [], "", {
+			"staged_pause": "hits", "reroll_used": true, "reroll_available": false,
+			"dice_block": rr.get("dice_block", {}), "hits": uhc.get("hits", 0)
+		})
+	else:
+		var wc = staged_fight_state.get("wound_context", {})
+		var rr = RulesEngine.reroll_wound_die(wc, die_index, game_state_snapshot, rng)
+		if not rr.get("success", false):
+			return create_result(false, [], str(rr.get("error", "Re-roll failed")))
+		var new_wounds = int(rr.get("wounds_caused", 0))
+		# Keep the wound_result tallies in sync — the auto save tail reads them.
+		var wres = staged_fight_state.get("wound_result", {})
+		wres["wounds_caused"] = new_wounds
+		wres["critical_wound_count"] = rr.get("critical_wounds", 0)
+		wres["regular_wound_count"] = rr.get("regular_wounds", 0)
+		wres["all_critical_wound_count"] = rr.get("all_critical_wounds", 0)
+		# Rebuild the pending save list (may now have more/fewer wounds).
+		if new_wounds > 0:
+			var sd = rr.get("save_data", {})
+			if staged_fight_state.get("interactive_saves", false):
+				var hs_mw = RulesEngine.roll_hold_still_mortal_wounds(
+					staged_fight_state.get("hit_context", {}), int(rr.get("all_critical_wounds", 0)), rng)
+				if hs_mw > 0:
+					sd["hold_still_mortal_wounds"] = hs_mw
+			staged_fight_state.save_data_list = [sd]
+		else:
+			staged_fight_state.save_data_list = []
+		emit_signal("dice_rolled", {"context": "reroll_note",
+			"message": "Command Re-roll (1 CP): wound die %d → %d" % [rr.get("old_value", 0), rr.get("new_value", 0)]})
+		emit_signal("dice_rolled", rr.get("dice_block", {}))
+		dice_log.append(rr.get("dice_block", {}))
+		emit_signal("fight_stage_paused", "wounds", {
+			"reroll_available": false,
+			"wound_rolls": rr.get("wound_context", {}).get("wound_rolls", []),
+			"wounds": new_wounds
+		})
+		return create_result(true, [], "", {
+			"staged_pause": "wounds", "reroll_used": true, "reroll_available": false,
+			"dice_block": rr.get("dice_block", {}), "wounds": new_wounds
+		})
+
+func _validate_staged_fight_continue(action: Dictionary) -> Dictionary:
+	var t = action.get("type", "")
+	if t == "CONTINUE_TO_WOUNDS":
+		if staged_fight_state.get("stage", "") != "hits_pending":
+			return {"valid": false, "errors": ["Not awaiting continue-to-wounds"]}
+	elif t == "CONTINUE_TO_SAVES":
+		if staged_fight_state.get("stage", "") != "wounds_pending":
+			return {"valid": false, "errors": ["Not awaiting continue-to-saves"]}
+	elif t == "USE_FIGHT_REROLL":
+		var stage = str(action.get("payload", {}).get("stage", ""))
+		var expected = "hits_pending" if stage == "hits" else ("wounds_pending" if stage == "wounds" else "")
+		if expected == "" or staged_fight_state.get("stage", "") != expected:
+			return {"valid": false, "errors": ["No re-roll available at this stage"]}
+	return {"valid": true, "errors": []}
 
 # T3-12: Batch fight actions to avoid multiplayer race conditions
 # Instead of sending individual ASSIGN_ATTACKS + CONFIRM + ROLL_DICE with fixed delays,
@@ -1985,6 +2452,18 @@ func _process_apply_melee_saves(action: Dictionary) -> Dictionary:
 			total_casualties += hs_casualties
 			GameEventLog.add_combat_result("  Hold Still and Say 'Aargh!': %d mortal wounds → %s (%d slain)" % [hs_mw, hs_target_name, hs_casualties])
 			log_phase_message("Hold Still and Say 'Aargh!': %d mortal wounds → %s (%d casualties)" % [hs_mw, hs_target_name, hs_casualties])
+
+	# STAGED FIGHT: these saves belong to ONE weapon of a staged sequence —
+	# advance to the next weapon (or finish the activation) instead of ending
+	# the activation here.
+	if not staged_fight_state.is_empty() and staged_fight_state.get("stage", "") == "saves_pending":
+		awaiting_melee_saves = false
+		pending_melee_save_data.clear()
+		pending_melee_hit_wound_result.clear()
+		staged_fight_state.total_casualties = int(staged_fight_state.get("total_casualties", 0)) + total_casualties
+		staged_fight_state.stage = ""
+		log_phase_message("Staged melee saves applied (%d casualties) — continuing sequence" % total_casualties)
+		return _staged_fight_assignment_complete(all_diffs)
 
 	# Clear pending state
 	awaiting_melee_saves = false
@@ -3399,6 +3878,34 @@ func get_available_actions() -> Array:
 			"description": "Apply melee saves (interactive wound allocation)"
 		})
 		log_phase_message("P0-58: Awaiting melee saves — returning APPLY_MELEE_SAVES only")
+		return actions
+
+	# STAGED FIGHT: while paused after a hit/wound roll, the attacker's options
+	# are exactly: continue to the next stage, or Command Re-roll one die.
+	var staged_stage = staged_fight_state.get("stage", "")
+	if staged_stage == "hits_pending":
+		actions.append({
+			"type": "CONTINUE_TO_WOUNDS",
+			"description": "Roll to wound for the paused weapon"
+		})
+		if _fight_reroll_available():
+			actions.append({
+				"type": "USE_FIGHT_REROLL",
+				"payload": {"stage": "hits", "die_index": 0},
+				"description": "Command Re-roll (1 CP) — re-roll one hit die"
+			})
+		return actions
+	elif staged_stage == "wounds_pending":
+		actions.append({
+			"type": "CONTINUE_TO_SAVES",
+			"description": "Continue to saving throws for the paused weapon"
+		})
+		if _fight_reroll_available():
+			actions.append({
+				"type": "USE_FIGHT_REROLL",
+				"payload": {"stage": "wounds", "die_index": 0},
+				"description": "Command Re-roll (1 CP) — re-roll one wound die"
+			})
 		return actions
 
 	# 11e 12.02: during the global Pile In step, the piling-in player's

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -61,6 +61,9 @@ var current_fighter_owner: int = -1
 var active_melee_allocation_overlay: WoundAllocationOverlay = null
 var processing_melee_saves_signal: bool = false
 
+# STAGED FIGHT: the sequence dialog showing hit/wound pauses + Command Re-roll
+var active_fight_sequence_dialog = null
+
 # UI Elements
 var unit_selector: ItemList
 var attack_tree: Tree
@@ -472,6 +475,11 @@ func set_phase(phase: BasePhase) -> void:
 		# Acrobatic Escape signal
 		if phase.has_signal("acrobatic_escape_available") and not phase.acrobatic_escape_available.is_connected(_on_acrobatic_escape_available):
 			phase.acrobatic_escape_available.connect(_on_acrobatic_escape_available)
+		# STAGED FIGHT: open the sequence dialog when a fighter's attacks are
+		# confirmed (before ROLL_DICE in the same batch), so the dialog catches
+		# every dice_rolled / fight_stage_paused emission.
+		if phase.has_signal("fighting_begun") and not phase.fighting_begun.is_connected(_on_fighting_begun_staged):
+			phase.fighting_begun.connect(_on_fighting_begun_staged)
 
 		print("DEBUG: FightController signals connected, setting up UI")
 
@@ -1922,6 +1930,56 @@ func _on_attacks_confirmed(assignments: Array) -> void:
 	}
 	print("[FightController] Sending BATCH_FIGHT_ACTIONS with %d sub-actions" % sub_actions.size())
 	emit_signal("fight_action_requested", batch_action)
+
+# =============================================================================
+# STAGED FIGHT: sequence dialog (hit pause / wound pause / Command Re-roll)
+# =============================================================================
+
+func _on_fighting_begun_staged(unit_id: String) -> void:
+	# The staged sequence only runs in non-networked play for human attackers —
+	# mirror FightPhase._should_stage_fight so we never open a dialog that will
+	# get no pause events.
+	if NetworkManager.is_networked():
+		return
+	var fighter_owner = GameState.get_unit(unit_id).get("owner", -1)
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.get("enabled") and ai_player_node.is_ai_player(fighter_owner):
+		return
+
+	# Replace any dialog left over from a previous activation.
+	if active_fight_sequence_dialog != null and is_instance_valid(active_fight_sequence_dialog):
+		active_fight_sequence_dialog.queue_free()
+		active_fight_sequence_dialog = null
+
+	var dialog_script = load("res://dialogs/FightSequenceDialog.gd")
+	if not dialog_script:
+		push_error("FightController: Failed to load FightSequenceDialog.gd")
+		return
+	var dialog = AcceptDialog.new()
+	dialog.set_script(dialog_script)
+	var fighter_name = GameState.get_unit(unit_id).get("meta", {}).get("name", unit_id)
+	# Add to the tree FIRST (_ready builds the UI nodes), THEN setup() — which
+	# connects the phase signals. Both happen during CONFIRM processing, before
+	# ROLL_DICE runs in the same batch, so no dice/pause event is missed.
+	get_tree().root.add_child(dialog)
+	dialog.setup(current_phase, fighter_name)
+	dialog.staged_continue_requested.connect(_on_fight_staged_continue_requested)
+	dialog.staged_reroll_requested.connect(_on_fight_staged_reroll_requested)
+	dialog.popup_centered()
+	active_fight_sequence_dialog = dialog
+	print("[FightController] FightSequenceDialog opened for %s" % fighter_name)
+
+func _on_fight_staged_continue_requested(next_step: String) -> void:
+	var action_type = "CONTINUE_TO_WOUNDS" if next_step == "wounds" else "CONTINUE_TO_SAVES"
+	print("[FightController] Staged continue: %s" % action_type)
+	emit_signal("fight_action_requested", {"type": action_type})
+
+func _on_fight_staged_reroll_requested(stage: String, die_index: int) -> void:
+	print("[FightController] Staged Command Re-roll: %s die %d" % [stage, die_index])
+	emit_signal("fight_action_requested", {
+		"type": "USE_FIGHT_REROLL",
+		"payload": {"stage": stage, "die_index": die_index}
+	})
 
 func _on_consolidate_required(unit_id: String, max_distance: float) -> void:
 	"""Show consolidate dialog and enable interactive movement"""

--- a/40k/tests/scenarios/sp/fight_dialogs_single_confirm_11e.json
+++ b/40k/tests/scenarios/sp/fight_dialogs_single_confirm_11e.json
@@ -11,7 +11,7 @@
   "rng_seed": 42,
   "transition_to_phase": 10,
   "disable_ai": true,
-  "description": "UX guard: the fight-flow dialogs must expose exactly ONE confirm affordance. Previously the AttackAssignmentDialog showed both its own 'Fight!' button and the AcceptDialog built-in 'OK' button, wired to the same handler — confusing, and the OK path auto-hid the dialog even when the confirm was rejected (no assignments). Same for FightSelectionDialog, where unit choice is a single click and OK could only dismiss the picker without selecting. This scenario drives the real player path: pass both Pile In halves, assert the FightSelectionDialog has NO visible built-in OK button, pick the Warboss, assert the AttackAssignmentDialog has NO visible built-in OK button while its 'Fight!' ConfirmButton IS visible, then assign all weapons and resolve the fight through that single button, proving the picker re-pops for the next activation. Setup-only privileges: CP zeroed to suppress stratagem prompts not under test; model wounds inflated so no unit dies mid-scenario.",
+  "description": "UX guard: the fight-flow dialogs must expose exactly ONE confirm affordance. Previously the AttackAssignmentDialog showed both its own 'Fight!' button and the AcceptDialog built-in 'OK' button, wired to the same handler — confusing, and the OK path auto-hid the dialog even when the confirm was rejected (no assignments). Same for FightSelectionDialog, where unit choice is a single click and OK could only dismiss the picker without selecting. This scenario drives the real player path: pass both Pile In halves, assert the FightSelectionDialog has NO visible built-in OK button, pick the Warboss, assert the AttackAssignmentDialog has NO visible built-in OK button while its 'Fight!' ConfirmButton IS visible, then assign all weapons and resolve the fight through that single button, proving the picker re-pops for the next activation. Setup-only privileges: CP zeroed to suppress stratagem prompts not under test; model wounds inflated so no unit dies mid-scenario. STAGED FIGHT: after each Fight! click the FightSequenceDialog pauses at the hit and wound rolls — the scenario clicks through the staged continue buttons to complete each activation.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.8 },
     { "act": "expect_state", "path": "meta.phase", "equals": 10 },
@@ -43,6 +43,10 @@
     { "act": "screenshot", "label": "02_attack_assignment_single_fight_button" },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").debug_click_through(12)" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/CloseButton", "emit_pressed": true },
     { "act": "wait_seconds", "seconds": 1.0 },
 
     { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },

--- a/40k/tests/scenarios/sp/global_consolidation_step_11e.json
+++ b/40k/tests/scenarios/sp/global_consolidation_step_11e.json
@@ -68,6 +68,10 @@
     { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog", "timeout_s": 5.0 },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").debug_click_through(12)" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/CloseButton", "emit_pressed": true },
     { "act": "wait_seconds", "seconds": 1.0 },
 
     { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },
@@ -79,6 +83,10 @@
     { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog", "timeout_s": 5.0 },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").debug_click_through(12)" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/CloseButton", "emit_pressed": true },
     { "act": "wait_seconds", "seconds": 1.0 },
 
     { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },
@@ -90,6 +98,10 @@
     { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog", "timeout_s": 5.0 },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
     { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").debug_click_through(12)" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/CloseButton", "emit_pressed": true },
     { "act": "wait_seconds", "seconds": 1.0 },
 
     { "act": "expect_phase_property", "property": "consolidation_step_11e", "equals": 0 },

--- a/40k/tests/scenarios/sp/staged_fight_reroll_ui.json
+++ b/40k/tests/scenarios/sp/staged_fight_reroll_ui.json
@@ -1,0 +1,109 @@
+{
+  "id": "staged_fight_reroll_ui",
+  "covers": [
+    "ui.fight.staged_hit_wound_pause",
+    "ui.fight.command_reroll",
+    "ui.fight.continue_buttons",
+    "dialogs.FightSequenceDialog"
+  ],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 7,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Drives the non-networked STAGED fight sequence through the real player path: pile-in halves passed, Warboss selected, attacks assigned, Fight! clicked -> FightSequenceDialog pauses after the hit roll ('Roll to Wound' + per-die Command Re-roll), a hit die is Command Re-rolled (CP spent), then the sequence continues stage by stage until the summary + Close. Verifies the fight no longer jumps straight through hit/wound rolls. Setup-only privileges: CP zeroed during selection to suppress the Epic Challenge prompt (not under test), then granted before Fight! so the Command Re-roll affordance appears; defender wounds inflated so the target survives all weapons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[1].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[2].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CUSTODIAN_GUARD_B\"].models[3].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_TELEMON_HEAVY_DREADNOUGHT_I\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/FightSelectionDialog/Content/UnitScroll/UnitList/Fight_U_WARBOSS_B", "emit_pressed": true },
+
+    { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/AllToTargetButton", "emit_pressed": true },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 2}, true)" },
+    { "act": "screenshot", "label": "01_attacks_assigned_before_fight" },
+    { "act": "click_node", "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSequenceDialog", "timeout_s": 5.0 },
+    { "act": "expect_node_visible", "node": "/root/FightSequenceDialog/Content/Buttons/StagedContinueButton", "timeout_s": 3.0 },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").staged_continue_button.text.begins_with(\"Roll to Wound\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").reroll_row.visible",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"Rolling to Hit\")",
+      "equals": true
+    },
+    { "act": "screenshot", "label": "02_hits_pause_with_reroll_row" },
+
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/RerollScroll/RerollRow/Die0", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "expect_state", "path": "players.2.cp", "equals": 1 },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"Command Re-roll\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").reroll_row.visible",
+      "equals": false
+    },
+    { "act": "screenshot", "label": "03_after_hit_command_reroll" },
+
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/StagedContinueButton", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 6 },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"Rolling to Wound\") or main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"0 wounds\")",
+      "equals": true
+    },
+    { "act": "screenshot", "label": "04_after_continue_to_wounds" },
+
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").debug_click_through(12)"
+    },
+    { "act": "wait_frames", "frames": 4 },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").close_button.visible",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"Melee attacks resolved\")",
+      "equals": true
+    },
+    { "act": "screenshot", "label": "05_sequence_complete_summary" },
+    { "act": "click_node", "node": "/root/FightSequenceDialog/Content/Buttons/CloseButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "units.U_WARBOSS_B.flags.has_fought", "equals": true },
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },
+    { "act": "screenshot", "label": "06_next_fighter_selection_repops" }
+  ]
+}

--- a/40k/tests/test_staged_fight_phase_flow.gd
+++ b/40k/tests/test_staged_fight_phase_flow.gd
@@ -1,0 +1,187 @@
+extends SceneTree
+
+# Staged fight phase flow (FightPhase action machine).
+#
+# Drives a FightPhase instance through the STAGED melee sequence:
+#   ROLL_DICE                  -> staged_pause "hits" (fight_stage_paused fired)
+#   USE_FIGHT_REROLL (hits)    -> one die re-rolled, CP spent
+#   CONTINUE_TO_WOUNDS         -> staged_pause "wounds" (or advance on 0 wounds)
+#   CONTINUE_TO_SAVES          -> saves auto-resolved, next weapon or activation end
+# and asserts: pause signals fire with dice payloads, out-of-order continues are
+# rejected, damage lands on the target, has_fought is set at the end.
+#
+# Usage: godot --headless --path . -s tests/test_staged_fight_phase_flow.gd
+
+var passed := 0
+var failed := 0
+var pauses: Array = []
+var dice_events: Array = []
+var _gs = null
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run"))
+	create_timer(0.2).timeout.connect(_run)
+
+func _make_state() -> Dictionary:
+	var fighter_models = []
+	for i in range(3):
+		fighter_models.append({
+			"id": "mf%d" % i, "position": {"x": 0, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 2, "current_wounds": 2
+		})
+	var target_models = []
+	for i in range(6):
+		target_models.append({
+			"id": "mt%d" % i, "position": {"x": 40, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1,
+			"stats": {"toughness": 4, "save": 5}
+		})
+	return {
+		"meta": {"phase": 10, "active_player": 1, "battle_round": 2, "turn": 2},
+		"board": {"size": {"width": 1760, "height": 2400}, "objectives": []},
+		"players": {
+			"1": {"cp": 3, "vp": 0},
+			"2": {"cp": 3, "vp": 0}
+		},
+		"units": {
+			"U_FIGHTER": {
+				"id": "U_FIGHTER", "owner": 1, "flags": {"charged_this_turn": true},
+				"meta": {"name": "Fighters", "keywords": ["INFANTRY"],
+					"stats": {"toughness": 4, "save": 3, "wounds": 2},
+					"weapons": [{
+						"name": "Test Choppa", "type": "Melee", "range": "Melee",
+						"attacks": "3", "weapon_skill": "3", "strength": "5",
+						"ap": "-1", "damage": "1", "special_rules": ""
+					}]},
+				"models": fighter_models
+			},
+			"U_TARGET": {
+				"id": "U_TARGET", "owner": 2, "flags": {},
+				"meta": {"name": "Targets", "keywords": ["INFANTRY"],
+					"stats": {"toughness": 4, "save": 5, "wounds": 1}},
+				"models": target_models
+			}
+		}
+	}
+
+func _alive_count(unit_id: String) -> int:
+	var n = 0
+	for m in _gs.state.units[unit_id].models:
+		if m.get("alive", true):
+			n += 1
+	return n
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_staged_fight_phase_flow ===\n")
+
+	var game_state = root.get_node_or_null("GameState")
+	_gs = game_state
+	if game_state == null:
+		_check("GameState autoload reachable", false)
+		_finish()
+		return
+	GameConstants.edition = 11
+	game_state.state = _make_state()
+
+	# load() at runtime — naming the FightPhase class at parse time would force
+	# an eager compile before autoloads register and spam a startup script error.
+	var phase = load("res://phases/FightPhase.gd").new()
+	root.add_child(phase)
+	phase.enter_phase(game_state.state)
+
+	phase.fight_stage_paused.connect(func(stage, info): pauses.append({"stage": stage, "info": info}))
+	phase.dice_rolled.connect(func(d): dice_events.append(d))
+
+	# Bypass the selection dialog plumbing: activate the fighter directly and
+	# stage its attack assignment (the AttackAssignmentDialog path ends in the
+	# same phase state).
+	phase.active_fighter_id = "U_FIGHTER"
+	if phase.sequencer_11e != null:
+		phase.sequencer_11e.select_to_fight("U_FIGHTER", game_state.state)
+	phase.pending_attacks = [{
+		"attacker": "U_FIGHTER",
+		"target": "U_TARGET",
+		"weapon": "test_choppa_melee",
+		"models": ["0", "1", "2"]
+	}]
+
+	var confirm = phase.process_action({"type": "CONFIRM_AND_RESOLVE_ATTACKS", "player": 1})
+	_check("CONFIRM_AND_RESOLVE_ATTACKS succeeded", confirm.get("success", false), str(confirm))
+
+	# Out-of-order continue must be rejected before ROLL_DICE
+	var early = phase.execute_action({"type": "CONTINUE_TO_WOUNDS", "player": 1})
+	_check("CONTINUE_TO_WOUNDS rejected before ROLL_DICE", not early.get("success", true))
+
+	var roll = phase.execute_action({"type": "ROLL_DICE", "player": 1})
+	_check("ROLL_DICE succeeded", roll.get("success", false), str(roll.get("error", "")))
+	_check("ROLL_DICE paused at hits", roll.get("staged_pause", "") == "hits", str(roll))
+	_check("fight_stage_paused('hits') fired", pauses.size() >= 1 and pauses[0].stage == "hits")
+	_check("hits pause carries hit_rolls", not (pauses[0].info.get("hit_rolls", []) as Array).is_empty() if pauses.size() >= 1 else false)
+	_check("hits pause offers Command Re-roll (3 CP available)", pauses[0].info.get("reroll_available", false) if pauses.size() >= 1 else false)
+	var hit_block_found = false
+	for d in dice_events:
+		if d.get("context", "") == "hit_roll_melee":
+			hit_block_found = true
+	_check("hit_roll_melee dice block emitted", hit_block_found)
+
+	# Wrong-stage reroll and continue are rejected
+	var bad_continue = phase.execute_action({"type": "CONTINUE_TO_SAVES", "player": 1})
+	_check("CONTINUE_TO_SAVES rejected at hits stage", not bad_continue.get("success", true))
+	var bad_reroll = phase.execute_action({"type": "USE_FIGHT_REROLL", "player": 1, "payload": {"stage": "wounds", "die_index": 0}})
+	_check("USE_FIGHT_REROLL(wounds) rejected at hits stage", not bad_reroll.get("success", true))
+
+	# Command Re-roll a hit die (die 0) — costs 1 CP
+	var cp_before = int(game_state.state.players["1"]["cp"])
+	var rr = phase.execute_action({"type": "USE_FIGHT_REROLL", "player": 1, "payload": {"stage": "hits", "die_index": 0}})
+	_check("USE_FIGHT_REROLL(hits) succeeded", rr.get("success", false), str(rr.get("error", "")))
+	var cp_after = int(game_state.state.players["1"]["cp"])
+	_check("Command Re-roll spent 1 CP", cp_after == cp_before - 1, "cp %d -> %d" % [cp_before, cp_after])
+	_check("re-roll reports reroll_used", rr.get("reroll_used", false))
+	# Re-emitted pause shows reroll no longer available
+	_check("pause re-emitted with reroll_available=false",
+		pauses.size() >= 2 and pauses[-1].stage == "hits" and not pauses[-1].info.get("reroll_available", true))
+
+	# Second reroll must be refused (once per phase)
+	var rr2 = phase.execute_action({"type": "USE_FIGHT_REROLL", "player": 1, "payload": {"stage": "hits", "die_index": 1}})
+	_check("second Command Re-roll refused (once per phase)", not rr2.get("success", true))
+
+	var targets_before = _alive_count("U_TARGET")
+	var wounds_step = phase.execute_action({"type": "CONTINUE_TO_WOUNDS", "player": 1})
+	_check("CONTINUE_TO_WOUNDS succeeded", wounds_step.get("success", false), str(wounds_step.get("error", "")))
+
+	var finished = false
+	if wounds_step.get("staged_pause", "") == "wounds":
+		_check("fight_stage_paused('wounds') fired", pauses[-1].stage == "wounds")
+		_check("wounds pause carries wound_rolls", not (pauses[-1].info.get("wound_rolls", []) as Array).is_empty())
+		var saves_step = phase.execute_action({"type": "CONTINUE_TO_SAVES", "player": 1})
+		_check("CONTINUE_TO_SAVES succeeded", saves_step.get("success", false), str(saves_step.get("error", "")))
+		finished = true
+	else:
+		# 0 wounds → the phase advanced/finished on its own; still a valid staged run.
+		print("    (wound roll caused 0 wounds — sequence auto-advanced)")
+		finished = true
+
+	_check("staged state cleared after sequence", phase.staged_fight_state.is_empty())
+	_check("sequence completion pause fired", pauses[-1].stage == "complete", "last=%s" % str(pauses[-1].stage if pauses.size() > 0 else "none"))
+	_check("fighter flagged has_fought", game_state.state.units["U_FIGHTER"].get("flags", {}).get("has_fought", false))
+	var targets_after = _alive_count("U_TARGET")
+	print("    (target models alive: %d -> %d)" % [targets_before, targets_after])
+	_check("no further staged actions accepted", not phase.execute_action({"type": "CONTINUE_TO_WOUNDS", "player": 1}).get("success", true))
+
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_staged_fight_phase_flow.gd.uid
+++ b/40k/tests/test_staged_fight_phase_flow.gd.uid
@@ -1,0 +1,1 @@
+uid://jmeptun6cenq

--- a/40k/tests/test_staged_fight_reroll.gd
+++ b/40k/tests/test_staged_fight_reroll.gd
@@ -1,0 +1,279 @@
+extends SceneTree
+
+# Staged fight resolution + Command Re-roll (RulesEngine).
+#
+# Proves:
+#   A) resolve_melee_hits() + resolve_melee_wounds() + resolve_melee_saves_auto()
+#      driven with the SAME rng as resolve_melee_attacks() consumes dice in the
+#      identical order and produces identical hit_roll_melee / wound_roll_melee /
+#      save dice records and diffs (the split is a pure re-shape of the monolith).
+#   B) resolve_melee_hits() returns ONLY the hit roll (no wound record) + a
+#      hit_context; resolve_melee_wounds(hit_context) returns the wound record.
+#   C) reroll_hit_die() works on a MELEE hit_context: re-rolls exactly one die,
+#      recomputes hits and total_hits_for_wounds, leaves untouched dice unchanged.
+#   D) reroll_wound_die() works on a MELEE wound_context and rebuilds save_data
+#      via the melee save-resolution path.
+#   E) resolve_melee_attacks_interactive() (P0-58 path) produces the same
+#      save_data wounds as the staged hits+wounds calls with the same seed.
+#
+# Usage: godot --headless --path . -s tests/test_staged_fight_reroll.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run"))
+	create_timer(0.1).timeout.connect(_run)
+
+func _make_board() -> Dictionary:
+	# Attacker and target columns 40px (1") apart — every model in engagement range.
+	var attacker_models = []
+	for i in range(5):
+		attacker_models.append({
+			"id": "ma%d" % i,
+			"position": {"x": 0, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 2, "current_wounds": 2
+		})
+	var target_models = []
+	for i in range(10):
+		target_models.append({
+			"id": "mt%d" % i,
+			"position": {"x": 40, "y": float(i * 35)},
+			"base_mm": 32, "base_type": "circular",
+			"alive": true, "wounds": 1, "current_wounds": 1,
+			"stats": {"toughness": 4, "save": 4}
+		})
+	return {
+		"units": {
+			"U_FIGHTER": {
+				"id": "U_FIGHTER", "owner": 1,
+				"meta": {"name": "Fighters", "keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 3}},
+				"models": attacker_models, "flags": {}
+			},
+			"U_TARGET": {
+				"id": "U_TARGET", "owner": 2,
+				"meta": {"name": "Targets", "keywords": ["INFANTRY"], "stats": {"toughness": 4, "save": 4}},
+				"models": target_models, "flags": {}
+			}
+		}
+	}
+
+func _action() -> Dictionary:
+	return {
+		"type": "FIGHT",
+		"actor_unit_id": "U_FIGHTER",
+		"payload": {"assignments": [{
+			"attacker": "U_FIGHTER",
+			"target": "U_TARGET",
+			"weapon": "lance_melee",
+			"models": ["0", "1", "2", "3", "4"]
+		}]}
+	}
+
+func _find(dice: Array, ctx: String) -> Dictionary:
+	for d in dice:
+		if d.get("context", "") == ctx:
+			return d
+	return {}
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_staged_fight_reroll ===\n")
+	var rules = root.get_node_or_null("RulesEngine")
+	if rules == null:
+		_check("RulesEngine autoload reachable", false)
+		_finish()
+		return
+
+	var SEED := 424242
+
+	# --- A) Equivalence: monolith vs staged thirds with the same seed ---
+	var mono = rules.resolve_melee_attacks(_action(), _make_board(), rules.RNGService.new(SEED))
+	var mono_hit = _find(mono.get("dice", []), "hit_roll_melee")
+	var mono_wound = _find(mono.get("dice", []), "wound_roll_melee")
+
+	var staged_rng = rules.RNGService.new(SEED)
+	var board2 = _make_board()
+	var hits_res = rules.resolve_melee_hits(_action(), board2, staged_rng)
+	var staged_hit = _find(hits_res.get("dice", []), "hit_roll_melee")
+	_check("A: monolith produced a hit_roll_melee record", not mono_hit.is_empty())
+	_check("A: staged hit rolls == monolith hit rolls",
+		str(staged_hit.get("rolls_raw", [])) == str(mono_hit.get("rolls_raw", [])),
+		"staged=%s mono=%s" % [str(staged_hit.get("rolls_raw", [])), str(mono_hit.get("rolls_raw", []))])
+	_check("A: staged hit successes == monolith",
+		staged_hit.get("successes", -1) == mono_hit.get("successes", -2))
+
+	if not hits_res.get("no_hits", true):
+		var wounds_res = rules.resolve_melee_wounds(hits_res.get("hit_context", {}), board2, staged_rng)
+		var staged_wound = _find(wounds_res.get("dice", []), "wound_roll_melee")
+		_check("A: monolith produced a wound_roll_melee record", not mono_wound.is_empty())
+		_check("A: staged wound rolls == monolith wound rolls",
+			str(staged_wound.get("rolls_raw", [])) == str(mono_wound.get("rolls_raw", [])),
+			"staged=%s mono=%s" % [str(staged_wound.get("rolls_raw", [])), str(mono_wound.get("rolls_raw", []))])
+		_check("A: staged wound successes == monolith",
+			staged_wound.get("successes", -1) == mono_wound.get("successes", -2))
+
+		# NOTE: resolve_melee_wounds rolls Hold Still MW (0 here — no Painboy) and
+		# does NOT consume rng otherwise; saves_auto must then match the monolith's
+		# save/damage tail dice.
+		if not wounds_res.get("no_wounds", true):
+			var saves_res = rules.resolve_melee_saves_auto(hits_res.get("hit_context", {}), wounds_res.get("wound_result", {}), board2, staged_rng)
+			var mono_save_ctxs = []
+			for db in mono.get("dice", []):
+				var c = db.get("context", "")
+				if c != "hit_roll_melee" and c != "wound_roll_melee":
+					mono_save_ctxs.append([c, str(db.get("rolls_raw", db.get("rolls", [])))])
+			var staged_save_ctxs = []
+			for db in saves_res.get("dice", []):
+				staged_save_ctxs.append([db.get("context", ""), str(db.get("rolls_raw", db.get("rolls", [])))])
+			_check("A: staged save/damage dice == monolith tail dice",
+				str(staged_save_ctxs) == str(mono_save_ctxs),
+				"staged=%s mono=%s" % [str(staged_save_ctxs), str(mono_save_ctxs)])
+			_check("A: staged diffs count == monolith diffs count",
+				saves_res.get("diffs", []).size() == mono.get("diffs", []).size(),
+				"staged=%d mono=%d" % [saves_res.get("diffs", []).size(), mono.get("diffs", []).size()])
+
+	# --- B) hits stage returns ONLY the hit roll + a hit_context ---
+	var hits_only = rules.resolve_melee_hits(_action(), _make_board(), rules.RNGService.new(SEED))
+	_check("B: hits stage has hit_roll_melee record", not _find(hits_only.get("dice", []), "hit_roll_melee").is_empty())
+	_check("B: hits stage has NO wound_roll_melee record", _find(hits_only.get("dice", []), "wound_roll_melee").is_empty())
+	_check("B: hits stage returns a hit_context", hits_only.has("hit_context") and not hits_only.hit_context.is_empty())
+	_check("B: melee hit_context flagged is_melee", hits_only.get("hit_context", {}).get("is_melee", false))
+
+	# --- C) reroll_hit_die on the melee context ---
+	var hc = hits_only.get("hit_context", {})
+	var evals_before = (hc.get("hit_evals", []) as Array).duplicate(true)
+	var hits_before = int(hc.get("hits", 0))
+	var idx := 0  # pick a failed die if present, else 0
+	for i in range(evals_before.size()):
+		if not evals_before[i].get("is_hit", false):
+			idx = i
+			break
+	var rr = rules.reroll_hit_die(hc, idx, rules.RNGService.new(99))
+	_check("C: reroll_hit_die succeeded on melee context", rr.get("success", false), str(rr.get("error", "")))
+	_check("C: exactly one hit die changed",
+		_count_diff(evals_before, hc.get("hit_evals", [])) == 1,
+		"diffs=%d" % _count_diff(evals_before, hc.get("hit_evals", [])))
+	_check("C: total_hits_for_wounds == hits + sustained",
+		int(hc.get("total_hits_for_wounds", -1)) == int(hc.get("hits", 0)) + int(hc.get("sustained_bonus_hits", 0)))
+	_check("C: hits recomputed consistently with evals",
+		int(hc.get("hits", -1)) == _count_hits(hc.get("hit_evals", [])),
+		"hits=%d evals_hits=%d" % [int(hc.get("hits", -1)), _count_hits(hc.get("hit_evals", []))])
+	_check("C: reroll dice block uses melee context name",
+		rr.get("dice_block", {}).get("context", "") == "hit_roll_melee",
+		"ctx=%s" % rr.get("dice_block", {}).get("context", ""))
+	print("    (hits %d -> %d after re-rolling die %d)" % [hits_before, int(hc.get("hits", 0)), idx])
+
+	# --- D) reroll_wound_die on the melee wound_context ---
+	var d_rng = rules.RNGService.new(SEED)
+	var d_board = _make_board()
+	var d_hits = rules.resolve_melee_hits(_action(), d_board, d_rng)
+	var d_wounds = rules.resolve_melee_wounds(d_hits.get("hit_context", {}), d_board, d_rng)
+	if not d_wounds.get("wound_context", {}).is_empty() and not d_wounds.get("save_data_list", []).is_empty():
+		var wc = d_wounds.get("wound_context", {})
+		_check("D: melee wound_context flagged is_melee", wc.get("is_melee", false))
+		var wev_before = (wc.get("wound_evals", []) as Array).duplicate(true)
+		var w_rr = rules.reroll_wound_die(wc, 0, d_board, rules.RNGService.new(7))
+		_check("D: reroll_wound_die succeeded on melee context", w_rr.get("success", false), str(w_rr.get("error", "")))
+		_check("D: exactly one wound die changed",
+			_count_diff(wev_before, wc.get("wound_evals", [])) == 1)
+		_check("D: rebuilt save_data has wounds_to_save == wounds_caused",
+			int(w_rr.get("save_data", {}).get("wounds_to_save", -1)) == int(w_rr.get("wounds_caused", -2))
+				or int(w_rr.get("wounds_caused", 0)) == 0)
+		_check("D: reroll dice block uses melee context name",
+			w_rr.get("dice_block", {}).get("context", "") == "wound_roll_melee",
+			"ctx=%s" % w_rr.get("dice_block", {}).get("context", ""))
+	else:
+		print("    (no wounds this seed — D skipped, not a failure)")
+
+	# --- E) interactive path (P0-58) matches staged save_data with same seed ---
+	var e_int = rules.resolve_melee_attacks_interactive(_action(), _make_board(), rules.RNGService.new(SEED))
+	var e_rng = rules.RNGService.new(SEED)
+	var e_board = _make_board()
+	var e_hits = rules.resolve_melee_hits(_action(), e_board, e_rng)
+	var e_wounds = rules.resolve_melee_wounds(e_hits.get("hit_context", {}), e_board, e_rng)
+	var int_sd = e_int.get("save_data_list", [])
+	var staged_sd = e_wounds.get("save_data_list", [])
+	_check("E: interactive and staged agree on save_data presence",
+		int_sd.is_empty() == staged_sd.is_empty())
+	if not int_sd.is_empty() and not staged_sd.is_empty():
+		_check("E: interactive and staged agree on wounds_to_save",
+			int(int_sd[0].get("wounds_to_save", -1)) == int(staged_sd[0].get("wounds_to_save", -2)),
+			"int=%d staged=%d" % [int(int_sd[0].get("wounds_to_save", -1)), int(staged_sd[0].get("wounds_to_save", -2))])
+
+	# --- F) Hold Still (OA-19) — the extracted helper matches the interactive
+	#        monolith with the same seed (Painboy 'Urty Syringe, crit wounds) ---
+	var hs_seed := 0
+	var hs_int = {}
+	var hs_found := false
+	for try_seed in range(1, 60):
+		hs_int = rules.resolve_melee_attacks_interactive(_hs_action(), _hs_board(), rules.RNGService.new(try_seed))
+		var sdl = hs_int.get("save_data_list", [])
+		if not sdl.is_empty() and int(sdl[0].get("hold_still_mortal_wounds", 0)) > 0:
+			hs_seed = try_seed
+			hs_found = true
+			break
+	if hs_found:
+		var f_rng = rules.RNGService.new(hs_seed)
+		var f_board = _hs_board()
+		var f_hits = rules.resolve_melee_hits(_hs_action(), f_board, f_rng)
+		var f_wounds = rules.resolve_melee_wounds(f_hits.get("hit_context", {}), f_board, f_rng)
+		var int_hs = int(hs_int.get("save_data_list", [])[0].get("hold_still_mortal_wounds", -1))
+		var staged_hs_sd = f_wounds.get("save_data_list", [])
+		var staged_hs = int(staged_hs_sd[0].get("hold_still_mortal_wounds", -2)) if not staged_hs_sd.is_empty() else -2
+		_check("F: Hold Still MW identical between interactive and staged (seed %d)" % hs_seed,
+			int_hs == staged_hs, "int=%d staged=%d" % [int_hs, staged_hs])
+	else:
+		_check("F: found a seed producing Hold Still mortal wounds", false, "no crit wounds in 60 seeds?")
+
+	_finish()
+
+func _hs_board() -> Dictionary:
+	var b = _make_board()
+	b.units.U_FIGHTER.meta["abilities"] = [{"name": "Hold Still and Say 'Aargh!'", "description": "test"}]
+	b.units.U_FIGHTER.meta["weapons"] = [{
+		"name": "'Urty Syringe", "type": "Melee", "range": "Melee",
+		"attacks": "4", "weapon_skill": "3", "strength": "4",
+		"ap": "0", "damage": "1", "special_rules": ""
+	}]
+	return b
+
+func _hs_action() -> Dictionary:
+	return {
+		"type": "FIGHT",
+		"actor_unit_id": "U_FIGHTER",
+		"payload": {"assignments": [{
+			"attacker": "U_FIGHTER",
+			"target": "U_TARGET",
+			"weapon": "'Urty Syringe",
+			"models": ["0", "1", "2", "3", "4"]
+		}]}
+	}
+
+func _count_diff(a: Array, b: Array) -> int:
+	var n = 0
+	for i in range(min(a.size(), b.size())):
+		if str(a[i]) != str(b[i]):
+			n += 1
+	return n
+
+func _count_hits(evals: Array) -> int:
+	var n = 0
+	for e in evals:
+		if e.get("is_hit", false):
+			n += 1
+	return n
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit()

--- a/40k/tests/test_staged_fight_reroll.gd.uid
+++ b/40k/tests/test_staged_fight_reroll.gd.uid
@@ -1,0 +1,1 @@
+uid://d28hxaomw6emn


### PR DESCRIPTION
# Summary

The Fight phase resolved hits, wounds, saves and damage in one synchronous RulesEngine call, so clicking **Fight!** jumped straight to the outcome with no chance to read the rolls or spend CP. Melee now mirrors the staged shooting flow end to end: a **Melee Resolution window** walks through each weapon — hit roll shown and **paused** ("Roll to Wound ▶", per-die **Command Re-roll (1 CP)** buttons), then the wound roll pauses the same way ("Continue to Saving Throws ▶"), then saves resolve and the next weapon repeats until a summary + Close. AI activations, multiplayer games and `fast_roll` keep the previous one-shot resolution, matching how staged shooting is single-player/host-only.

## RulesEngine

- Split the ~1300-line `_resolve_melee_assignment` monolith into composable thirds: `_resolve_melee_assignment_hits` (attack count / stats / abilities / hit rolls, builds a melee `hit_context` with per-die evals), `_resolve_melee_assignment_wounds` (wound rolls, builds a `wound_context`), `_resolve_melee_assignment_saves` (saves / FNP / damage / Hold Still). The recomposed monolith is behaviour-identical — **all 63 attack goldens match byte-for-byte** and the P0-58 interactive path is unchanged.
- New staged API mirroring `resolve_shoot_hits` / `resolve_shoot_wounds`: `resolve_melee_hits`, `resolve_melee_wounds`, `resolve_melee_saves_auto`. Hold Still (OA-19) rolls exactly once per path via a shared helper.
- `reroll_hit_die` / `reroll_wound_die` now work on melee contexts (WS stored under the ranged `bs` keys; DAKKASTORM guarded to ranged only; melee save data rebuilt via `prepare_melee_save_resolution`; melee dice-block contexts).

## FightPhase

- `ROLL_DICE` in non-networked play with a human attacker resolves weapon by weapon: hit roll → PAUSE (`fight_stage_paused "hits"`) → `CONTINUE_TO_WOUNDS` → PAUSE (`"wounds"`) → `CONTINUE_TO_SAVES` → saves (auto-allocate tail or the existing WoundAllocationOverlay) → next weapon or activation end. `USE_FIGHT_REROLL` Command Re-rolls one hit or wound die at either pause (1 CP, once per phase, attacker's CP). Action names deliberately match ShootingPhase's staged vocabulary.
- Interactive saves resume the staged sequence from `APPLY_MELEE_SAVES`; per-weapon Hazardous checks preserved; `get_available_actions` exposes the staged continues while paused (MCP/AI drivable).

## UI

- New `FightSequenceDialog` (modeled on WeaponOrderDialog's staged section): per-weapon progress header, verbose dice log, per-die Command Re-roll buttons, staged continue button, completion summary + Close. Hides while the wound-allocation overlay is up and re-shows on the next pause.

## Validation

- `tests/test_staged_fight_reroll.gd` (25 checks): staged == monolith with the same seed (dice + diffs), melee rerolls, Hold Still parity, interactive parity.
- `tests/test_staged_fight_phase_flow.gd` (23 checks): pauses fire, CP spend + once-per-phase gating, out-of-order rejection, damage lands, activation finishes.
- Windowed scenario `staged_fight_reroll_ui` (50 checks) drives the real dialogs with screenshots of every stage; live MCP session `verify_delivery` → **PASS** with zero log errors.
- `fight_dialogs_single_confirm_11e` + `global_consolidation_step_11e` updated to click through the staged pauses; 7 fight-adjacent scenarios re-run green.
- Full pretrigger suite: 98 tests — the only failures (`test_hi_pretrigger`, `test_iss001_pipeline_mutations`) reproduce identically on `origin/main` (pre-existing). Also fixed a pre-existing `test_iss020_public_api` violation in ChargePhase (direct `_resolve_melee_assignment` call → public wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Dva8VodL68tktNLjGreD9

---
_Generated by [Claude Code](https://claude.ai/code/session_015Dva8VodL68tktNLjGreD9)_