### PR TITLE
Fix: engaged units skipped in Fight phase when the AI can't select a fighter

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -28,6 +28,7 @@ var _failed_deploy_unit_ids: Array = []  # Units that failed both deployment and
 var _failed_reinforcement_unit_ids: Array = []  # Units that failed reinforcement placement — skip to avoid infinite loop
 var _failed_transport_ids: Array = []  # Transports that completed or failed embarkation — skip to avoid re-embarkation
 var _pile_in_retry_units: Array = []  # Units that already had an empty pile-in retry — next failure sends CONSOLIDATE
+var _select_fighter_retry_count: int = 0  # Consecutive SELECT_FIGHTER failures — reset on any success; escalates to END_FIGHT only after 3
 var _pending_advance_moves: Dictionary = {}  # unit_id -> decision — awaiting advance roll resolution before staging moves
 var _last_thinking_phase: int = -1  # Track which phase we last logged a "thinking" message for
 var _last_thinking_round: int = -1  # Track which round we last logged a "thinking" message for
@@ -242,6 +243,7 @@ func configure(player_types: Dictionary, difficulty_levels: Dictionary = {}) -> 
 	_failed_reinforcement_unit_ids.clear()
 	_failed_transport_ids.clear()
 	_pile_in_retry_units.clear()
+	_select_fighter_retry_count = 0
 	_pending_advance_moves.clear()
 	_last_thinking_phase = -1
 	_last_thinking_round = -1
@@ -374,6 +376,23 @@ func _get_fight_phase_selecting_player() -> int:
 		return fight_phase.current_selecting_player
 	return -1
 
+func _fight_step_over() -> bool:
+	"""True when the fight phase reports no unit is eligible to fight any more —
+	the only state where the SELECT_FIGHTER failure fallback may safely send
+	END_FIGHT (at 11e END_FIGHT forfeits every remaining fight via the 12.07
+	forfeit loop). Defensive default is true so an unreadable phase keeps the
+	old escape-hatch behavior instead of looping."""
+	if not _phase_manager_ref:
+		_phase_manager_ref = get_node_or_null("/root/PhaseManager")
+	if not _phase_manager_ref or not _phase_manager_ref.current_phase_instance:
+		return true
+	var phase = _phase_manager_ref.current_phase_instance
+	if "sequencer_11e" in phase and phase.sequencer_11e != null:
+		return not phase.sequencer_11e.has_eligible(GameState.state)
+	if phase.has_method("_all_eligible_units_have_fought"):
+		return phase._all_eligible_units_have_fought()
+	return true
+
 func _get_pending_reactive_window_player() -> int:
 	"""Owner of the reactive decision window the current phase is blocked on,
 	or 0 when none is pending. Covers the ChargePhase windows that
@@ -419,6 +438,7 @@ func reset_runtime_state() -> void:
 	_failed_reinforcement_unit_ids.clear()
 	_failed_transport_ids.clear()
 	_pile_in_retry_units.clear()
+	_select_fighter_retry_count = 0
 	_pending_advance_moves.clear()
 	_last_thinking_phase = -1
 	_last_thinking_round = -1
@@ -1808,18 +1828,36 @@ func _execute_next_action(player: int) -> void:
 		push_error("AIPlayer: Action failed: %s - Error: %s" % [decision.get("type", "?"), error_msg])
 		print("AIPlayer: Failed action details: %s" % str(decision))
 
-		# Handle failed SELECT_FIGHTER — unit no longer in engagement range, send END_FIGHT
+		# Handle failed SELECT_FIGHTER. A rejected selection does NOT mean the
+		# unit left combat — it usually means the offer was stale (the other
+		# player's pick, or eligibility shifted). END_FIGHT here is
+		# catastrophic at 11e: the 12.07 forfeit loop marks EVERY remaining
+		# unit as fought (2026-07-12 report: an engaged Stompa never got to
+		# fight). Re-evaluate against fresh offers while fighting continues;
+		# END_FIGHT only when the phase says nobody is eligible, or as a
+		# last-resort escape after repeated consecutive failures.
 		if decision.get("type") == "SELECT_FIGHTER":
 			var failed_unit_id = decision.get("unit_id", "")
 			var fight_unit_name = _get_unit_name(failed_unit_id)
-			print("AIPlayer: SELECT_FIGHTER failed for %s, sending END_FIGHT" % failed_unit_id)
-			_log_ai_event(player, "%s no longer in combat — ending fight" % fight_unit_name)
-			_current_phase_actions += 1
-			NetworkIntegration.route_action({
-				"type": "END_FIGHT",
-				"player": player,
-				"_ai_description": "End fight — %s not in engagement range" % fight_unit_name
-			})
+			_select_fighter_retry_count += 1
+			if not _fight_step_over() and _select_fighter_retry_count <= 3:
+				print("AIPlayer: SELECT_FIGHTER failed for %s (%s) — re-evaluating (retry %d/3)" % [
+					failed_unit_id, str(error_msg), _select_fighter_retry_count])
+				_log_ai_event(player, "%s selection rejected (%s) — re-checking fight order" % [
+					fight_unit_name, _format_error_concise(error_msg)])
+				_request_evaluation()
+			else:
+				print("AIPlayer: SELECT_FIGHTER failed for %s, sending END_FIGHT (fight step over: %s, retries: %d)" % [
+					failed_unit_id, str(_fight_step_over()), _select_fighter_retry_count])
+				_select_fighter_retry_count = 0
+				_log_ai_event(player, "%s could not be selected (%s) — ending fight" % [
+					fight_unit_name, _format_error_concise(error_msg)])
+				_current_phase_actions += 1
+				NetworkIntegration.route_action({
+					"type": "END_FIGHT",
+					"player": player,
+					"_ai_description": "End fight — %s could not be selected" % fight_unit_name
+				})
 
 		# Handle failed deployment specifically
 		elif decision.get("type") == "DEPLOY_UNIT":
@@ -2020,6 +2058,10 @@ func _execute_next_action(player: int) -> void:
 			_log_ai_event(player, "%s reinforcement failed (%s) — retrying" % [reinf_unit_name, _format_error_concise(error_msg)])
 			_handle_failed_reinforcement(player, decision)
 	else:
+		# Any successful action means the loop is progressing — clear the
+		# consecutive SELECT_FIGHTER failure counter.
+		_select_fighter_retry_count = 0
+
 		# Track successful transport embarkation to prevent re-embarkation of same transport
 		if decision.get("type") == "DECLARE_TRANSPORT_EMBARKATION":
 			var transport_id = decision.get("transport_id", "")

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.31.0",
+			"date": "2026-07-12",
+			"summary": "Fixed a Fight phase bug where one of your units in combat could be skipped entirely when playing against the AI. If the AI reached a point where it couldn't select one of its own units, it would end the whole Fight phase — forfeiting every remaining fight, including yours (e.g. a Stompa in base contact that never got to swing).",
+			"changes": [
+				"Fight phase: the list of units offered the 'select to fight' action is now driven by the real 11th-edition fight sequencer, tagged with the correct player, instead of a legacy queue that drifted out of order once fights happened out of sequence. Your engaged units are now always offered their fight in the right order.",
+				"AI: when the AI can't select a fighter it now re-checks the fight order and continues, instead of ending the entire Fight phase and forfeiting every remaining fight (yours included). It only ends the fight when the sequencer confirms no unit on either side is still eligible.",
+				"AI: the AI no longer tries to pick your units to fight during the alternating fight sequence — it only considers selection offers addressed to it."
+			]
+		},
+		{
 			"version": "0.30.0",
 			"date": "2026-07-12",
 			"summary": "Removed the legacy hand-made terrain layouts (Chapter Approved 1-8 and the parse-test boards). The game now plays exclusively on the converted official 11e tournament layouts, and the main menu defaults to the current matchup's first official variant with its paired deployment.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -3946,9 +3946,34 @@ func get_available_actions() -> Array:
 		log_phase_message("[11e 12.07] Consolidate step — returning %d consolidation action(s)" % actions.size())
 		return actions
 
-	# If no active fighter, need to select one
-	# Skip units that are no longer in engagement range (enemies may have been destroyed during earlier fights)
-	if active_fighter_id == "" and current_fight_index < fight_sequence.size():
+	# If no active fighter, need to select one.
+	# 11e (12.04): the sequencer is the selection AUTHORITY — offer exactly ITS
+	# candidates, tagged with the picking player. The legacy fight_sequence
+	# queue assumes fights happen in its precomputed order: current_fight_index
+	# advances by one per fight no matter WHICH unit fought, so as soon as a
+	# player legally picks any candidate other than the queue head, the queue
+	# desyncs and this getter used to offer a unit _validate_select_fighter
+	# then rejects ("Not your selection"). The AI submitted that stale offer,
+	# hit the failure fallback, and END_FIGHT forfeited every remaining fight
+	# (2026-07-12 report: an engaged Stompa never got to fight).
+	if GameConstants.edition >= 11 and sequencer_11e != null:
+		if active_fighter_id == "":
+			var sel_11e = sequencer_11e.peek_selection(GameState.state)
+			if not sel_11e.done:
+				for cand_id in sel_11e.candidates:
+					actions.append({
+						"type": "SELECT_FIGHTER",
+						"unit_id": cand_id,
+						"player": sel_11e.player,
+						"description": "Select %s to fight (%s step, 12.04)" % [cand_id, sel_11e.step]
+					})
+				log_phase_message("[11e 12.04] Sequencer offers %d SELECT_FIGHTER candidate(s) for Player %d (%s step)" % [
+					sel_11e.candidates.size(), sel_11e.player, sel_11e.step])
+		else:
+			log_phase_message("NOT adding SELECT_FIGHTER: active_fighter_id='%s'" % active_fighter_id)
+	# 10e: legacy queue-driven offer. Skip units that are no longer in
+	# engagement range (enemies may have been destroyed during earlier fights).
+	elif active_fighter_id == "" and current_fight_index < fight_sequence.size():
 		while current_fight_index < fight_sequence.size():
 			var candidate_unit_id = fight_sequence[current_fight_index]
 			var candidate_unit = game_state_snapshot.get("units", {}).get(candidate_unit_id, {})
@@ -3968,31 +3993,6 @@ func get_available_actions() -> Array:
 	else:
 		log_phase_message("NOT adding SELECT_FIGHTER: active_fighter_id='%s', index=%d, size=%d" % [active_fighter_id, current_fight_index, fight_sequence.size()])
 
-	# ISS-050 / AI-vs-AI benchmark finding: at 11e the sequencer (12.04) is the
-	# selection authority — _validate_select_fighter accepts its candidates even
-	# when the legacy fight_sequence queue is empty (e.g. a Fights-First unit
-	# with no queued fights). If the queue-based branch above offered nothing
-	# while a selection is actually pending, surface the sequencer's candidates
-	# so action-driven players (the AI) can answer instead of hanging.
-	if GameConstants.edition >= 11 and active_fighter_id == "" and sequencer_11e != null:
-		var has_select := false
-		for a in actions:
-			if a.get("type", "") == "SELECT_FIGHTER":
-				has_select = true
-				break
-		if not has_select:
-			var sel_11e = sequencer_11e.next_selection(GameState.state)
-			if not sel_11e.done:
-				for cand_id in sel_11e.candidates:
-					actions.append({
-						"type": "SELECT_FIGHTER",
-						"unit_id": cand_id,
-						"player": sel_11e.player,
-						"description": "Select %s to fight (%s step, 12.04)" % [cand_id, sel_11e.step]
-					})
-				log_phase_message("[11e 12.04] Sequencer offers %d SELECT_FIGHTER candidate(s) for Player %d (%s step)" % [
-					sel_11e.candidates.size(), sel_11e.player, sel_11e.step])
-	
 	# If active fighter is selected, show simple control actions
 	if active_fighter_id != "":
 		if pending_attacks.is_empty():

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -13543,14 +13543,24 @@ static func _decide_fight(snapshot: Dictionary, available_actions: Array, player
 
 	# Step 4: If we need to select a fighter, select one
 	# T7-46: Use fight order optimization to pick the best unit to activate first
-	if action_types.has("SELECT_FIGHTER"):
-		var offered_action = action_types["SELECT_FIGHTER"][0]
+	# 2026-07-12: only consider offers addressed to the player we are evaluating
+	# for — 11e offers carry the sequencer's picking player. When the pending
+	# selection belongs to the opponent (a human mid-alternation), submitting
+	# their unit as ours fails validation and the failure fallback used to end
+	# the whole fight phase. Offers without a player field (10e legacy queue)
+	# pass through unchanged.
+	var my_select_offers: Array = []
+	for ofa_check in action_types.get("SELECT_FIGHTER", []):
+		if int(ofa_check.get("player", player)) == player:
+			my_select_offers.append(ofa_check)
+	if not my_select_offers.is_empty():
+		var offered_action = my_select_offers[0]
 		var offered_uid = offered_action.get("unit_id", "")
 		# SOAK-3: all unit ids actually offered — the engine may offer exactly
 		# one (the sequenced unit); a plan pick outside this set gets rejected
 		# and the failure fallback ends the whole fight phase.
 		var offered_ids: Array = []
-		for ofa in action_types["SELECT_FIGHTER"]:
+		for ofa in my_select_offers:
 			var ouid = ofa.get("unit_id", "")
 			if ouid != "":
 				offered_ids.append(ouid)

--- a/40k/scripts/rules/FightSequencer.gd
+++ b/40k/scripts/rules/FightSequencer.gd
@@ -112,6 +112,34 @@ func next_selection(board: Dictionary) -> Dictionary:
 	return {"done": true, "player": 0, "step": step, "candidates": []}
 
 
+## Pure preview of next_selection(): who would select next, and from which
+## candidates — WITHOUT advancing picker/step. get_available_actions polls
+## this every UI/AI refresh, so the poll must not mutate alternation state;
+## the walk is re-derived from (picker, step) + board each call and always
+## converges to the same answer next_selection() would return.
+func peek_selection(board: Dictionary) -> Dictionary:
+	var p := picker
+	var s := step
+	while true:
+		if s == "fights_first":
+			var mine = eligible_units(board, p, true)
+			if not mine.is_empty():
+				return {"done": false, "player": p, "step": s, "candidates": mine}
+			var theirs = eligible_units(board, _other(p), true)
+			if not theirs.is_empty():
+				return {"done": false, "player": _other(p), "step": s, "candidates": theirs}
+			s = "remaining"
+		else:
+			var mine = eligible_units(board, p, false)
+			if not mine.is_empty():
+				return {"done": false, "player": p, "step": s, "candidates": mine}
+			var theirs = eligible_units(board, _other(p), false)
+			if not theirs.is_empty():
+				return {"done": false, "player": _other(p), "step": s, "candidates": theirs}
+			return {"done": true, "player": 0, "step": s, "candidates": []}
+	return {"done": true, "player": 0, "step": s, "candidates": []}
+
+
 ## Mark the unit as selected to fight and report its available fight
 ## types (12.05/12.06): {fight_types: Array, fight_type: String}.
 ## Alternation passes to the other player (12.04).

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2709,6 +2709,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "fight.select_fighter_offer_11e",
+      "description": "FIGHT phase (11e 12.04): get_available_actions offers SELECT_FIGHTER for exactly the FightSequencer's current candidates, tagged with the picking player, instead of the legacy fight_sequence queue that desynced once fights happened out of order. Regression for the 2026-07-12 report where an engaged Stompa was never offered its fight (the AI acted on a stale offer and END_FIGHT forfeited every remaining fight). Validated by 'stompa_gets_to_fight_11e'.",
+      "scenarios": [
+        "stompa_gets_to_fight_11e"
+      ],
+      "last_verified_commit": "4abfc9b",
+      "status": "covered"
+    },
+    {
+      "id": "scripts.rules.FightSequencer.peek_selection",
+      "description": "FightSequencer.peek_selection() \u2014 a pure, non-mutating preview of next_selection() used by get_available_actions on every UI/AI poll; must not advance picker/step. Validated by 'stompa_gets_to_fight_11e' (live) and test_iss050_fight_phase_11e.gd (headless purity/parity).",
+      "scenarios": [
+        "stompa_gets_to_fight_11e"
+      ],
+      "last_verified_commit": "4abfc9b",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/saves/stompa_fight_11e.meta
+++ b/40k/tests/saves/stompa_fight_11e.meta
@@ -1,0 +1,24 @@
+{
+	"created_at": 1777928072.0,
+	"game_state": {
+		"active_player": 2,
+		"game_id": "stompa-fight-11e",
+		"is_multiplayer": false,
+		"phase": 9,
+		"player1_difficulty": 1,
+		"player1_type": "AI",
+		"player2_difficulty": -1,
+		"player2_type": "HUMAN",
+		"turn": 4
+	},
+	"preview": {
+		"battle_round": 4.0,
+		"players": {}
+	},
+	"save_info": {
+		"description": "Stompa fight 11e regression fixture",
+		"save_type": "manual",
+		"tags": []
+	},
+	"version": "1.1.0"
+}

--- a/40k/tests/saves/stompa_fight_11e.w40ksave
+++ b/40k/tests/saves/stompa_fight_11e.w40ksave
@@ -1,0 +1,6453 @@
+{
+	"_serialization": {
+		"game_version": "1.1.0",
+		"serializer": "StateSerializer",
+		"timestamp": 1777928072.4749,
+		"version": "1.1.0"
+	},
+	"board": {
+		"deployment_zones": [
+			{
+				"player": 1.0,
+				"poly": [
+					{
+						"x": 0.0,
+						"y": 0.0
+					},
+					{
+						"x": 44.0,
+						"y": 0.0
+					},
+					{
+						"x": 44.0,
+						"y": 8.0
+					},
+					{
+						"x": 34.0,
+						"y": 8.0
+					},
+					{
+						"x": 34.0,
+						"y": 14.0
+					},
+					{
+						"x": 10.0,
+						"y": 14.0
+					},
+					{
+						"x": 10.0,
+						"y": 8.0
+					},
+					{
+						"x": 0.0,
+						"y": 8.0
+					}
+				]
+			},
+			{
+				"player": 2.0,
+				"poly": [
+					{
+						"x": 0.0,
+						"y": 52.0
+					},
+					{
+						"x": 10.0,
+						"y": 52.0
+					},
+					{
+						"x": 10.0,
+						"y": 46.0
+					},
+					{
+						"x": 34.0,
+						"y": 46.0
+					},
+					{
+						"x": 34.0,
+						"y": 52.0
+					},
+					{
+						"x": 44.0,
+						"y": 52.0
+					},
+					{
+						"x": 44.0,
+						"y": 60.0
+					},
+					{
+						"x": 0.0,
+						"y": 60.0
+					}
+				]
+			}
+		],
+		"objectives": [
+			{
+				"id": "obj_center",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 1200.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_nml_1",
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 880.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_nml_2",
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 1520.0
+				},
+				"radius_mm": 40.0,
+				"zone": "no_mans_land"
+			},
+			{
+				"id": "obj_home_1",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 160.0
+				},
+				"radius_mm": 40.0,
+				"zone": "player1"
+			},
+			{
+				"id": "obj_home_2",
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 2240.0
+				},
+				"radius_mm": 40.0,
+				"zone": "player2"
+			}
+		],
+		"size": {
+			"height": 60.0,
+			"width": 44.0
+		},
+		"terrain": [],
+		"terrain_features": [
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_1",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 80.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 720.0,
+					"y": 200.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 320.0
+						},
+						"id": "ruins_1_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 680.0,
+							"y": 80.0
+						},
+						"id": "ruins_1_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 800.0,
+							"y": 80.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_2",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2080.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2080.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1040.0,
+					"y": 2200.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						"id": "ruins_2_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2080.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 960.0,
+							"y": 2320.0
+						},
+						"id": "ruins_2_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 1080.0,
+							"y": 2320.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_3",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 960.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 440.0,
+					"y": 1080.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						"id": "ruins_3_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 1200.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_4",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1320.0,
+					"y": 1320.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 240.0,
+					"y": 160.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1240.0,
+							"y": 1200.0
+						},
+						"id": "ruins_4_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_5",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 260.0,
+					"y": 1400.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 200.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1600.0
+						},
+						"id": "ruins_5_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 1600.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_6",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 800.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 1200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 800.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1500.0,
+					"y": 1000.0
+				},
+				"rotation": 90.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 200.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1400.0,
+							"y": 800.0
+						},
+						"id": "ruins_6_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 800.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_7",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 440.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 440.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 320.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 200.0
+						},
+						"id": "ruins_7_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 200.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 440.0
+						},
+						"id": "ruins_7_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 440.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 360.0
+						},
+						"id": "ruins_7_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 280.0
+						},
+						"type": "door"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 390.0
+						},
+						"id": "ruins_7_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 250.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "medium",
+				"id": "ruins_8",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 560.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 560.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 440.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 560.0
+						},
+						"id": "ruins_8_wall_east",
+						"start": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 320.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": false,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 520.0,
+							"y": 440.0
+						},
+						"id": "ruins_8_wall_center",
+						"start": {
+							"_type": "Vector2",
+							"x": 280.0,
+							"y": 440.0
+						},
+						"type": "window"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "ruins_9",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 1840.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 1840.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 2080.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1120.0,
+							"y": 2080.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1360.0,
+					"y": 1960.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins"
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_10",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 1960.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 2200.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 2200.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 400.0,
+					"y": 2080.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 640.0,
+							"y": 1960.0
+						},
+						"id": "ruins_10_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						"type": "solid"
+					},
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 2200.0
+						},
+						"id": "ruins_10_wall_west",
+						"start": {
+							"_type": "Vector2",
+							"x": 160.0,
+							"y": 1960.0
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "medium",
+				"id": "ruins_11",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 844.852783203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 505.441558837891
+						},
+						{
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 675.147216796875
+						},
+						{
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1014.55847167969
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 760.0
+				},
+				"rotation": -45.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 505.441558837891
+						},
+						"id": "ruins_11_wall_north",
+						"start": {
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 844.852783203125
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "tall",
+				"id": "ruins_12",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 625.441528320312,
+							"y": 1724.85278320312
+						},
+						{
+							"_type": "Vector2",
+							"x": 964.852783203125,
+							"y": 1385.44152832031
+						},
+						{
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 1555.14721679688
+						},
+						{
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1894.55847167969
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 880.0,
+					"y": 1640.0
+				},
+				"rotation": -45.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 480.0,
+					"y": 240.0
+				},
+				"traits": [
+					"obscuring"
+				],
+				"type": "ruins",
+				"walls": [
+					{
+						"blocks_los": true,
+						"blocks_movement": {
+							"INFANTRY": false,
+							"MONSTER": true,
+							"VEHICLE": true
+						},
+						"end": {
+							"_type": "Vector2",
+							"x": 1134.55847167969,
+							"y": 1555.14721679688
+						},
+						"id": "ruins_12_wall_south",
+						"start": {
+							"_type": "Vector2",
+							"x": 795.147216796875,
+							"y": 1894.55847167969
+						},
+						"type": "solid"
+					}
+				]
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "woods_1",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 80.0,
+							"y": 640.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 240.0,
+							"y": 640.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 240.0,
+							"y": 800.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 80.0,
+							"y": 800.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 720.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 160.0
+				},
+				"traits": [
+					"difficult_ground"
+				],
+				"type": "woods"
+			},
+			{
+				"can_move_through": {
+					"INFANTRY": true,
+					"MONSTER": false,
+					"VEHICLE": false
+				},
+				"height_category": "low",
+				"id": "woods_2",
+				"polygon": {
+					"_type": "PackedVector2Array",
+					"data": [
+						{
+							"_type": "Vector2",
+							"x": 1520.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1680.0,
+							"y": 1600.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1680.0,
+							"y": 1760.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1520.0,
+							"y": 1760.0
+						}
+					]
+				},
+				"position": {
+					"_type": "Vector2",
+					"x": 1600.0,
+					"y": 1680.0
+				},
+				"rotation": 0.0,
+				"size": {
+					"_type": "Vector2",
+					"x": 160.0,
+					"y": 160.0
+				},
+				"traits": [
+					"difficult_ground"
+				],
+				"type": "woods"
+			}
+		],
+		"terrain_layout": "layout_2"
+	},
+	"faction_ability_manager": {
+		"active_doctrine": {
+			"1": "",
+			"2": ""
+		},
+		"active_effects": {
+			"1": {},
+			"2": {}
+		},
+		"active_mastery": {
+			"1": "",
+			"2": ""
+		},
+		"bionik_workshop_resolved": false,
+		"bionik_workshop_results": {},
+		"da_kaptin_used_round": {
+			"1": 0,
+			"2": 0
+		},
+		"doctrines_used": {
+			"1": [],
+			"2": []
+		},
+		"loot_objective": {
+			"1": "",
+			"2": ""
+		},
+		"loot_objective_round": {
+			"1": 0,
+			"2": 0
+		},
+		"mastery_selected_round": {
+			"1": 0,
+			"2": 0
+		},
+		"plant_waaagh_banner_used": {},
+		"player_abilities": {
+			"1": [],
+			"2": []
+		},
+		"player_detachment": {
+			"1": "",
+			"2": ""
+		},
+		"razgit_redeploys_used": {
+			"1": 0,
+			"2": 0
+		},
+		"razgit_resolved": false,
+		"waaagh_active": {
+			"1": false,
+			"2": false
+		},
+		"waaagh_used": {
+			"1": false,
+			"2": false
+		}
+	},
+	"factions": {
+		"1": {
+			"created_date": "2025-03-01",
+			"detachment": "Shield Host",
+			"name": "Adeptus Custodes",
+			"player_name": "",
+			"points": 1000.0,
+			"team_name": ""
+		},
+		"2": {
+			"created_date": "2025-02-20",
+			"detachment": "War Horde",
+			"name": "Orks",
+			"player_name": "",
+			"points": 2000.0,
+			"team_name": ""
+		}
+	},
+	"history": [
+		{
+			"actions": [
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.formations_p1_confirmed",
+							"value": true
+						},
+						{
+							"op": "set",
+							"path": "meta.active_player",
+							"value": 2.0
+						}
+					],
+					"player": 1.0,
+					"type": "CONFIRM_FORMATIONS"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.formations_p2_confirmed",
+							"value": true
+						}
+					],
+					"player": 2.0,
+					"type": "CONFIRM_FORMATIONS"
+				}
+			],
+			"phase": 0.0,
+			"turn": 1.0
+		},
+		{
+			"actions": [
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_A.models.0.position",
+							"value": {
+								"x": 50.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 50.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_SHIELD_CAPTAIN_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_C.models.0.position",
+							"value": {
+								"x": 120.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_C.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 120.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_C"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_BLADE_CHAMPION_A.models.0.position",
+							"value": {
+								"x": 120.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_BLADE_CHAMPION_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 120.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BLADE_CHAMPION_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_B.models.0.position",
+							"value": {
+								"x": 50.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_B.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 50.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_B"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.0.position",
+							"value": {
+								"x": 200.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.1.position",
+							"value": {
+								"x": 280.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.2.position",
+							"value": {
+								"x": 360.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.models.3.position",
+							"value": {
+								"x": 440.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CUSTODIAN_GUARD_B.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 200.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 280.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 360.0,
+							"y": 100.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 440.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CUSTODIAN_GUARD_B"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_IN_MEGA_ARMOUR_D.models.0.position",
+							"value": {
+								"x": 200.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WARBOSS_IN_MEGA_ARMOUR_D.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 200.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_IN_MEGA_ARMOUR_D"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.0.position",
+							"value": {
+								"x": 850.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.1.position",
+							"value": {
+								"x": 910.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.2.position",
+							"value": {
+								"x": 970.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.models.3.position",
+							"value": {
+								"x": 1030.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_C.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 850.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 910.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 970.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1030.0,
+							"y": 50.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_C"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WEIRDBOY_J.models.0.position",
+							"value": {
+								"x": 400.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WEIRDBOY_J.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 400.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WEIRDBOY_J"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.0.position",
+							"value": {
+								"x": 1100.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.1.position",
+							"value": {
+								"x": 1160.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.2.position",
+							"value": {
+								"x": 1220.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.models.3.position",
+							"value": {
+								"x": 1280.0,
+								"y": 50.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_WITCHSEEKERS_D.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1100.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1160.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1220.0,
+							"y": 50.0
+						},
+						{
+							"_type": "Vector2",
+							"x": 1280.0,
+							"y": 50.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_D"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_PAINBOSS_I.models.0.position",
+							"value": {
+								"x": 300.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_PAINBOSS_I.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 300.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_PAINBOSS_I"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H.models.0.position",
+							"value": {
+								"x": 400.0,
+								"y": 250.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 400.0,
+							"y": 250.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_KAPTIN_BADRUKK_A.models.0.position",
+							"value": {
+								"x": 500.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_KAPTIN_BADRUKK_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 500.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_KAPTIN_BADRUKK_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_TELEMON_HEAVY_DREADNOUGHT_I.models.0.position",
+							"value": {
+								"x": 600.0,
+								"y": 250.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_TELEMON_HEAVY_DREADNOUGHT_I.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 600.0,
+							"y": 250.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_TELEMON_HEAVY_DREADNOUGHT_I"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_NOB_WAAAGH_BANNER_A.models.0.position",
+							"value": {
+								"x": 720.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_NOB_WAAAGH_BANNER_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 720.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_NOB_WAAAGH_BANNER_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_JETBIKE_A.models.0.position",
+							"value": {
+								"x": 1600.0,
+								"y": 100.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_SHIELD_CAPTAIN_JETBIKE_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1600.0,
+							"y": 100.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_SHIELD_CAPTAIN_JETBIKE_A"
+				},
+				{
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "units.U_STRIKE_FORCE_A.models.0.position",
+							"value": {
+								"x": 1200.0,
+								"y": 2330.0
+							}
+						},
+						{
+							"op": "set",
+							"path": "units.U_STRIKE_FORCE_A.status",
+							"value": 2.0
+						}
+					],
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1200.0,
+							"y": 2330.0
+						}
+					],
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_STRIKE_FORCE_A"
+				}
+			],
+			"phase": 1.0,
+			"turn": 1.0
+		},
+		{
+			"actions": [
+				{
+					"_replay_diffs": [],
+					"type": "END_DEPLOYMENT"
+				}
+			],
+			"phase": 2.0,
+			"turn": 1.0
+		},
+		{
+			"actions": [
+				{
+					"_log_text": "Roll-off: Player 1 = 3, Player 2 = 6 \u2014 Player 2 wins!",
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.roll_off_player1_roll",
+							"value": 3.0
+						},
+						{
+							"op": "set",
+							"path": "meta.roll_off_player2_roll",
+							"value": 6.0
+						},
+						{
+							"op": "set",
+							"path": "meta.roll_off_winner",
+							"value": 2.0
+						}
+					],
+					"player": 1.0,
+					"type": "ROLL_FOR_FIRST_TURN"
+				},
+				{
+					"_log_text": "Player 2 chose second \u2014 Player 1 takes the first turn",
+					"_replay_diffs": [
+						{
+							"op": "set",
+							"path": "meta.roll_off_choice",
+							"value": "second"
+						},
+						{
+							"op": "set",
+							"path": "meta.first_turn_player",
+							"value": 1.0
+						},
+						{
+							"op": "set",
+							"path": "meta.active_player",
+							"value": 1.0
+						}
+					],
+					"choice": "second",
+					"player": 2.0,
+					"type": "CHOOSE_TURN_ORDER"
+				}
+			],
+			"phase": 3.0,
+			"turn": 1.0
+		}
+	],
+	"meta": {
+		"active_player": 2,
+		"battle_round": 4,
+		"created_at": 1777894246.48332,
+		"deployment_type": "crucible_of_battle",
+		"first_turn_player": 1.0,
+		"formations": {
+			"1": {
+				"leader_attachments": {},
+				"reserves": [],
+				"transport_embarkations": {}
+			},
+			"2": {
+				"leader_attachments": {},
+				"reserves": [],
+				"transport_embarkations": {}
+			}
+		},
+		"formations_declared": true,
+		"formations_p1_confirmed": true,
+		"formations_p2_confirmed": true,
+		"game_id": "c02b1ee3-2b22-48a0-b65b-3033f9c810e94c65",
+		"phase": 9,
+		"roll_off_choice": "second",
+		"roll_off_player1_roll": 3.0,
+		"roll_off_player2_roll": 6.0,
+		"roll_off_winner": 2.0,
+		"turn_number": 1.0,
+		"version": "1.1.0",
+		"game_config": {
+			"player1_type": "AI",
+			"player2_type": "HUMAN",
+			"player1_difficulty": 1,
+			"player2_difficulty": -1
+		}
+	},
+	"phase_log": [],
+	"players": {
+		"1": {
+			"bonus_cp_gained_this_round": 0.0,
+			"cp": 1,
+			"primary_vp": 0.0,
+			"secondary_vp": 0.0,
+			"vp": 0.0
+		},
+		"2": {
+			"bonus_cp_gained_this_round": 0.0,
+			"cp": 4,
+			"primary_vp": 0.0,
+			"secondary_vp": 0.0,
+			"vp": 0.0
+		}
+	},
+	"secondary_missions": {
+		"active_actions": {
+			"1": [],
+			"2": []
+		},
+		"objective_control_at_turn_start": {
+			"obj_center": 0.0,
+			"obj_home_1": 0.0,
+			"obj_home_2": 0.0,
+			"obj_nml_1": 0.0,
+			"obj_nml_2": 0.0
+		},
+		"player_state": {
+			"1": {
+				"active": [
+					{
+						"achieved": false,
+						"action": {},
+						"category": "Purge the Enemy",
+						"id": "no_prisoners",
+						"interaction_details": {},
+						"interaction_type": "",
+						"mission_data": {},
+						"name": "No Prisoners",
+						"number": 14.0,
+						"pending_interaction": false,
+						"requires_action": false,
+						"scoring": {
+							"conditions": [
+								{
+									"check": "enemy_unit_destroyed",
+									"params": {},
+									"vp": 2.0
+								}
+							],
+							"max_vp_per_score": 5.0,
+							"when": "while_active"
+						},
+						"vp_scored": 0.0
+					},
+					{
+						"achieved": false,
+						"action": {},
+						"category": "Battlefield Supremacy",
+						"id": "display_of_might",
+						"interaction_details": {},
+						"interaction_type": "",
+						"mission_data": {},
+						"name": "Display of Might",
+						"number": 4.0,
+						"pending_interaction": false,
+						"requires_action": false,
+						"scoring": {
+							"conditions": [
+								{
+									"check": "more_units_wholly_in_no_mans_land_than_opponent",
+									"params": {},
+									"vp": 5.0
+								}
+							],
+							"when": "end_of_your_turn"
+						},
+						"vp_scored": 0.0
+					}
+				],
+				"deck": [
+					"secure_no_mans_land",
+					"extend_battle_lines",
+					"a_tempting_target",
+					"bring_it_down",
+					"behind_enemy_lines",
+					"overwhelming_force",
+					"area_denial",
+					"assassination",
+					"deploy_teleport_homer",
+					"defend_stronghold",
+					"storm_hostile_objective",
+					"establish_locus",
+					"marked_for_death",
+					"cull_the_horde",
+					"cleanse",
+					"engage_on_all_fronts"
+				],
+				"discard": [],
+				"initialized": true,
+				"mode": "tactical",
+				"secondary_vp": 0.0
+			},
+			"2": {
+				"active": [],
+				"deck": [
+					"display_of_might",
+					"bring_it_down",
+					"assassination",
+					"cleanse",
+					"deploy_teleport_homer",
+					"extend_battle_lines",
+					"engage_on_all_fronts",
+					"behind_enemy_lines",
+					"overwhelming_force",
+					"defend_stronghold",
+					"a_tempting_target",
+					"marked_for_death",
+					"secure_no_mans_land",
+					"storm_hostile_objective",
+					"no_prisoners",
+					"area_denial",
+					"cull_the_horde",
+					"establish_locus"
+				],
+				"discard": [],
+				"initialized": true,
+				"mode": "tactical",
+				"secondary_vp": 0.0
+			}
+		},
+		"units_destroyed_this_turn": []
+	},
+	"stratagem_manager": {
+		"active_effects": [],
+		"player_faction_stratagems": {
+			"1": [
+				"faction_ac_shield_host_archeotech_munitions",
+				"faction_ac_shield_host_arcane_genetic_alchemy",
+				"faction_ac_shield_host_unwavering_sentinels",
+				"faction_ac_shield_host_avenge_the_fallen",
+				"faction_ac_shield_host_multipotentiality",
+				"faction_ac_shield_host_vigilance_eternal"
+			],
+			"2": [
+				"faction_ork_war_horde_unbridled_carnage",
+				"faction_ork_war_horde_\u2019ard_as_nails",
+				"faction_ork_war_horde_mob_rule",
+				"faction_ork_war_horde_ere_we_go",
+				"faction_ork_war_horde_careen",
+				"faction_ork_war_horde_orks_is_never_beaten"
+			]
+		},
+		"usage_history": {
+			"1": [],
+			"2": []
+		}
+	},
+	"unit_visuals": {},
+	"units": {
+		"U_BATTLEWAGON_G": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BATTLEWAGON_G",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D6 mortal wounds.",
+						"name": "Deadly Demise D6",
+						"type": "Core"
+					},
+					{
+						"description": "Firing Deck 11. Each time this transport shoots, up to 11 models embarked within it can be selected to shoot as well. Each time such a model makes a ranged attack, it is treated as if it were not embarked, except that it cannot use any abilities that require it to be on the battlefield.",
+						"name": "FIRING DECK",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model loses one or more wounds, roll one D6: on a 6, this model does not lose a wound.",
+						"name": "Ramshackle",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-5 Wounds Remaining",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Add 2 to this model's Toughness characteristic. If this model is equipped with this wargear, it loses the Firing Deck ability.",
+						"name": "'Ard Case",
+						"type": "Wargear"
+					},
+					{
+						"description": "This model has a transport capacity of 22 ORKS INFANTRY models. Each MEGA ARMOUR model takes up the space of 2 models. This model cannot transport models that are JUMP PACK models.",
+						"name": "TRANSPORT",
+						"type": "Special"
+					}
+				],
+				"display_name": "Battlewagon",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLEWAGON",
+					"ORKS",
+					"TRANSPORT",
+					"VEHICLE"
+				],
+				"name": "Battlewagon",
+				"points": 160.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 10.0,
+					"objective_control": 5.0,
+					"save": 3.0,
+					"toughness": 12.0,
+					"wounds": 16.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Battlewagon",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Deff rolla",
+					"1x Grabbin' klaw",
+					"1x Kannon",
+					"1x Lobba",
+					"1x Wreckin' ball",
+					"1x 'Ard Case"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "D6+3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kannon \u2013 frag",
+						"range": "36",
+						"special_rules": "blast",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "D6",
+						"name": "Kannon \u2013 shell",
+						"range": "36",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D6+1",
+						"ballistic_skill": "5",
+						"damage": "2",
+						"name": "Killkannon",
+						"range": "24",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Lobba",
+						"range": "48",
+						"special_rules": "blast, indirect fire",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "5",
+						"name": "Zzap gun",
+						"range": "36",
+						"special_rules": "anti-vehicle 4+",
+						"strength": "D6+6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Deff rolla",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "2",
+						"damage": "2",
+						"name": "Grabbin' klaw",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "6",
+						"damage": "1",
+						"name": "Tracks and wheels",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"damage": "D6",
+						"name": "Wreckin' ball",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 180.0,
+						"width": 110.0
+					},
+					"base_mm": 180.0,
+					"base_type": "rectangular",
+					"current_wounds": 16.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 16.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_BATTLEWAGON_G",
+			"status": 7.0,
+			"transport_data": {
+				"capacity": 22.0,
+				"capacity_keywords": [
+					"ORKS",
+					"INFANTRY"
+				],
+				"capacity_multipliers": {
+					"MEGA ARMOUR": 2.0
+				},
+				"embarked_units": [],
+				"excluded_keywords": [
+					"JUMP PACK"
+				],
+				"firing_deck": 0.0
+			}
+		},
+		"U_BLADE_CHAMPION_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BLADE_CHAMPION_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, you can re-roll Charge rolls made for that unit",
+						"name": "Swift Onslaught",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Charge phase, this model's unit is eligible to declare a charge in a turn which it Advanced.",
+						"name": "Martial Inspiration",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Blade Champion",
+				"enhancements": [
+					"Adamantine Talisman (+25 pts)"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BLADE CHAMPION",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"leader_data": {
+					"can_lead": [
+						"CUSTODIAN GUARD"
+					]
+				},
+				"name": "Blade Champion",
+				"points": 145.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Blade Champion",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Vaultswords \u2013 Behemor",
+						"range": "Melee",
+						"special_rules": "precision",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "9",
+						"damage": "1",
+						"name": "Vaultswords \u2013 Hurricanus",
+						"range": "Melee",
+						"special_rules": "sustained hits 1",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-3",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Vaultswords \u2013 Victus",
+						"range": "Melee",
+						"special_rules": "devastating wounds",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_BLADE_CHAMPION_A",
+			"status": 2.0
+		},
+		"U_BOYZ_E": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_E",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "If this unit has a Starting Strength of 20, you can attach up to two Leader units to it instead of one (but only if one of those is a WARBOSS model). If you do, and this unit is destroyed, the Leader units attached to it become separate units with their original Starting Strengths.",
+						"name": "BODYGUARD",
+						"type": "Special (\u043f\u0440\u0430\u0432\u0430\u044f \u043a\u043e\u043b\u043e\u043d\u043a\u0430)"
+					}
+				],
+				"display_name": "Boyz Alpha",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9-19 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m12",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m13",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m14",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m15",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m16",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m17",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m18",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m19",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m20",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_BOYZ_E",
+			"status": 7.0
+		},
+		"U_BOYZ_F": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_F",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "If this unit has a Starting Strength of 20, you can attach up to two Leader units to it instead of one (but only if one of those is a WARBOSS model). If you do, and this unit is destroyed, the Leader units attached to it become separate units with their original Starting Strengths.",
+						"name": "BODYGUARD",
+						"type": "Special (\u043f\u0440\u0430\u0432\u0430\u044f \u043a\u043e\u043b\u043e\u043d\u043a\u0430)"
+					}
+				],
+				"display_name": "Boyz Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"model_profiles": {
+					"boss_nob": {
+						"label": "Boss Nob",
+						"stats_override": {
+							"save": 4.0,
+							"weapon_skill": 3.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Big choppa",
+							"Choppa",
+							"Power klaw",
+							"Slugga",
+							"Kombi-weapon"
+						]
+					},
+					"boy": {
+						"label": "Boy",
+						"stats_override": {
+							"weapon_skill": 4.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Choppa",
+							"Close combat weapon",
+							"Shoota",
+							"Slugga",
+							"Big shoota",
+							"Rokkit launcha"
+						]
+					}
+				},
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9-19 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"model_type": "boss_nob",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m12",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m13",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m14",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m15",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m16",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m17",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m18",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m19",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m20",
+					"model_type": "boy",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_BOYZ_F",
+			"status": 7.0
+		},
+		"U_BOYZ_K": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_BOYZ_K",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the end of your Command phase, if this unit is within range of an objective marker you control, that objective marker remains under your control, even if you have no models within range of it, until your opponent controls it at the start or end of any turn.",
+						"name": "Get Da Good Bitz",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Boyz Gamma",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"BATTLELINE",
+					"BOYZ",
+					"GRENADES",
+					"INFANTRY",
+					"MOB",
+					"ORKS"
+				],
+				"name": "Boyz",
+				"points": 80.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9 Boyz",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"9x Slugga",
+					"1x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "5",
+						"damage": "3",
+						"name": "Rokkit launcha",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Shoota",
+						"range": "18",
+						"special_rules": "rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_BOYZ_K",
+			"status": 7.0
+		},
+		"U_CALADIUS_GRAV-TANK_E": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_CALADIUS_GRAV-TANK_E",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model makes an attack with its twin iliastus accelerator cannon that targets an enemy unit (excluding MONSTERS and VEHICLES), that attack has the [LETHAL HITS] ability. Each time this model makes an attack with its twin arachnus heavy blaze cannon that targets an enemy MONSTER or VEHICLE unit, that attack has the [LETHAL HITS] ability.",
+						"name": "Advanced Firepower",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-5 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-5 Wounds Remaining",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Caladius Grav-tank",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CALADIUS GRAV-TANK",
+					"FLY",
+					"IMPERIUM",
+					"VEHICLE"
+				],
+				"name": "Caladius Grav-tank",
+				"points": 215.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 10.0,
+					"objective_control": 4.0,
+					"save": 2.0,
+					"toughness": 11.0,
+					"wounds": 14.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Caladius Grav-tank",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "4",
+						"ballistic_skill": "2",
+						"damage": "D6+2",
+						"name": "Twin arachnus heavy blaze cannon",
+						"range": "48",
+						"special_rules": "twin-linked",
+						"strength": "12",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "4",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Twin iliastus accelerator cannon",
+						"range": "48",
+						"special_rules": "rapid fire 4, twin-linked",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Twin lastrum bolt cannon",
+						"range": "36",
+						"special_rules": "sustained hits 1",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "4",
+						"damage": "1",
+						"name": "Armoured hull",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 170.0,
+						"width": 105.0
+					},
+					"base_mm": 170.0,
+					"base_type": "oval",
+					"current_wounds": 14.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 14.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_CALADIUS_GRAV-TANK_E",
+			"status": 7.0
+		},
+		"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers 1 mortal wound.",
+						"name": "Deadly Demise 1",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model is selected to fight, you can select one enemy unit within Engagement Range of it and roll one D6, adding 2 to the result if this model made a Charge move this turn: on a 4-5, that enemy unit suffers D3 mortal wounds; on a 6+, that enemy unit suffers 3 mortal wounds.",
+						"name": "Dread Foe",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Contemptor-Achillus Dreadnought",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CONTEMPTOR-ACHILLUS DREADNOUGHT",
+					"IMPERIUM",
+					"VEHICLE",
+					"WALKER"
+				],
+				"name": "Contemptor-Achillus Dreadnought",
+				"points": 155.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 3.0,
+					"save": 2.0,
+					"toughness": 9.0,
+					"wounds": 10.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Contemptor-Achillus Dreadnought",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Achillus dreadspear",
+						"range": "12",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Infernus incinerator",
+						"range": "12",
+						"special_rules": "torrent, ignores cover",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "3",
+						"name": "Twin adrathic destructor",
+						"range": "18",
+						"special_rules": "twin-linked",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "D6+1",
+						"name": "Achillus dreadspear",
+						"range": "Melee",
+						"special_rules": "lance",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 60.0,
+					"current_wounds": 10.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 10.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H",
+			"status": 2.0
+		},
+		"U_CUSTODIAN_GUARD_B": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {
+				"charged_this_turn": true,
+				"fights_first": true
+			},
+			"id": "U_CUSTODIAN_GUARD_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					},
+					{
+						"description": "Add 1 to the Objective Control characteristic of models in the bearer's unit.",
+						"name": "Vexilla",
+						"type": "Wargear"
+					},
+					{
+						"description": "Each time a model in this unit makes an attack, re-roll a Wound roll of 1. While this unit is within range of an objective marker you control, you can re-roll the Wound roll instead.",
+						"name": "Stand Vigil",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Shooting phase, after this unit has shot, it can shoot again.",
+						"name": "Sentinel Storm",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Custodian Guard",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BATTLELINE",
+					"CUSTODIAN GUARD",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Custodian Guard",
+				"points": 170.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 3.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "4-5 Custodian Guard",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Custodian Guard",
+					"Custodian Guard (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "24",
+						"special_rules": "assault",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Misericordia",
+						"range": "Melee",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": {
+						"x": 775.0,
+						"y": 900.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m2",
+					"position": {
+						"x": 762.0,
+						"y": 985.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m3",
+					"position": {
+						"x": 712.0,
+						"y": 1055.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m4",
+					"position": {
+						"x": 630.0,
+						"y": 1080.0
+					},
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_CUSTODIAN_GUARD_B",
+			"status": 2.0
+		},
+		"U_GHAZGHKULL_THRAKA_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_GHAZGHKULL_THRAKA_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While a Waaagh! is active for Ghazghkull's army, each time a model in this unit makes a melee attack, add 1 to the Hit roll and the Wound roll. In addition, each time a model in this unit makes a melee attack, a Critical Hit is scored on a 5+ rather than a 6.",
+						"name": "Prophet of Da Great Waaagh!",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While a Waaagh! is active for Ghazghkull's army, friendly ORKS units within 12\" of this unit have the Lethal Hits ability on their melee weapons.",
+						"name": "Ghazghkull's Waaagh! Banner (Aura)",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Ghazghkull Thraka",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"MONSTER",
+					"CHARACTER",
+					"EPIC HERO",
+					"WARBOSS",
+					"GHAZGHKULL THRAKA"
+				],
+				"name": "Ghazghkull Thraka",
+				"points": 300.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 9.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Ghazghkull Thraka",
+						"line": 1.0
+					},
+					{
+						"description": "1 Makari",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"1x Gork's Klaw",
+					"1x Mork's Roar",
+					"1x Makari's Stabba"
+				],
+				"weapons": [
+					{
+						"ap": "-4",
+						"attacks": "5",
+						"damage": "D3+3",
+						"name": "Gork's Klaw",
+						"range": "Melee",
+						"strength": "14",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "D6",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Mork's Roar",
+						"range": "24",
+						"special_rules": "rapid fire 2",
+						"strength": "7",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "4",
+						"damage": "1",
+						"name": "Makari's Stabba",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 100.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 12.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_GHAZGHKULL_THRAKA_A",
+			"status": 7.0
+		},
+		"U_KAPTIN_BADRUKK_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_KAPTIN_BADRUKK_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a ranged attack, re-roll a Hit roll of 1.",
+						"name": "Flashiest Gitz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is on the battlefield, subtract 1 from the Toughness characteristic of enemy INFANTRY units that are within 6\" of this model.",
+						"name": "Ded Glowy Ammo (Aura)",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Kaptin Badrukk can be attached to a Flash Gitz unit.",
+						"name": "Leader",
+						"type": "Core"
+					}
+				],
+				"display_name": "Kaptin Badrukk",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"INFANTRY",
+					"CHARACTER",
+					"FREEBOOTER",
+					"KAPTIN BADRUKK"
+				],
+				"name": "Kaptin Badrukk",
+				"points": 100.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Kaptin Badrukk",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Da Rippa",
+					"1x Kustom mega-blasta",
+					"1x Power klaw"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Da Rippa",
+						"range": "Melee",
+						"special_rules": "lethal hits",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "2",
+						"damage": "D6",
+						"name": "Kustom mega-blasta",
+						"range": "24",
+						"special_rules": "blast",
+						"strength": "8",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_KAPTIN_BADRUKK_A",
+			"status": 2.0
+		},
+		"U_KOMMANDOS_H": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_KOMMANDOS_H",
+			"meta": {
+				"abilities": [
+					{
+						"description": "During deployment, this unit can be set up anywhere on the battlefield that is more than 9\" horizontally away from the enemy deployment zone and more than 9\" away from all enemy models.",
+						"name": "Infiltrators",
+						"type": "Core"
+					},
+					{
+						"description": "If every model in a unit has this ability, then each time a ranged attack is made against this unit, subtract 1 from the Hit roll.",
+						"name": "Stealth",
+						"type": "Core"
+					},
+					{
+						"description": "After deployment, this unit can make a Normal Move of up to 6\", but must end that move more than 9\" horizontally away from all enemy models.",
+						"name": "Scout 6\"",
+						"range": 6.0,
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "At the start of your Shooting phase, if this unit is within 9\" of one or more enemy units, it can use this ability. If it does, until the end of the phase, this unit is not eligible to shoot, but you roll one D6 for each model in this unit that is within 9\" of an enemy unit: for each 5+, that enemy unit suffers 1 mortal wound.",
+						"name": "Throat Slittas",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Enemy units cannot use the Fire Overwatch Stratagem to shoot at this unit.",
+						"name": "Sneaky Surprise",
+						"type": "Datasheet"
+					},
+					{
+						"description": "At the start of the Declare Battle Formations step, this unit can be split into two units, each containing five models.",
+						"name": "Patrol Squad",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your opponent's Shooting phase, when this unit is selected as the target of a ranged attack, until the end of the phase, models in this unit have a 5+ invulnerable save.",
+						"name": "Distraction Grot",
+						"type": "Wargear"
+					},
+					{
+						"description": "Once per battle, after this unit ends a Normal move, you can select one enemy unit within 12\" of and visible to this unit and roll one D6: on a 3+, that enemy unit suffers D3 mortal wounds.",
+						"name": "Bomb Squigs",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Kommandos",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"GRENADES",
+					"INFANTRY",
+					"KOMMANDOS",
+					"ORKS"
+				],
+				"name": "Kommandos",
+				"points": 135.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Boss Nob",
+						"line": 1.0
+					},
+					{
+						"description": "9 Kommandos",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"10x Choppa",
+					"10x Slugga"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Slugga",
+						"range": "12",
+						"special_rules": "pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Choppa",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_KOMMANDOS_H",
+			"status": 7.0
+		},
+		"U_LOOTAS_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_LOOTAS_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "If your Army Faction is ORKS, once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase, the Waaagh! is active for your army and:\n- Units from your army with this ability are eligible to declare a charge in a turn in which they Advanced.\n- Add 1 to the Strength and Attacks characteristics of melee weapons equipped by models from your army with this ability.\n- Models from your army with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time a model in this unit makes a ranged attack, re-roll a Hit roll of 1. If that attack targets a unit that is within range of an objective marker, you can re-roll the Hit roll instead.",
+						"name": "Dat's Our Loot!",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Lootas",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"LOOTAS",
+					"INFANTRY"
+				],
+				"model_profiles": {
+					"loota_deffgun": {
+						"label": "Loota (Deffgun)",
+						"stats_override": {},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Deffgun",
+							"Close combat weapon"
+						]
+					},
+					"loota_kmb": {
+						"label": "Loota (Kustom Mega-blasta)",
+						"stats_override": {},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Kustom mega-blasta",
+							"Close combat weapon"
+						]
+					},
+					"spanner": {
+						"label": "Spanner",
+						"stats_override": {
+							"ballistic_skill": 4.0
+						},
+						"transport_slots": 1.0,
+						"weapons": [
+							"Kustom mega-blasta",
+							"Close combat weapon"
+						]
+					}
+				},
+				"name": "Lootas",
+				"points": 100.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Spanner",
+						"line": 1.0
+					},
+					{
+						"description": "8 Lootas",
+						"line": 2.0
+					},
+					{
+						"description": "2 Lootas (KMB)",
+						"line": 3.0
+					}
+				],
+				"wargear": [
+					"1x Spanner",
+					"1x Close combat weapon",
+					"1x Kustom mega-blasta",
+					"2x Loota (KMB)",
+					"2x Close combat weapon",
+					"2x Kustom mega-blasta",
+					"8x Loota",
+					"8x Close combat weapon",
+					"8x Deffgun"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "6",
+						"damage": "2",
+						"name": "Deffgun",
+						"range": "48",
+						"special_rules": "heavy, rapid fire 1",
+						"strength": "8",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"damage": "D6",
+						"name": "Kustom mega-blasta",
+						"range": "24",
+						"special_rules": "hazardous",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m5",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m6",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m7",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m8",
+					"model_type": "loota_deffgun",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m9",
+					"model_type": "loota_kmb",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m10",
+					"model_type": "loota_kmb",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m11",
+					"model_type": "spanner",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_LOOTAS_A",
+			"status": 7.0
+		},
+		"U_MEGANOBZ_L": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_MEGANOBZ_L",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time a model in this unit makes a melee attack, if this unit made a Charge move this turn, add 1 to the Wound roll.",
+						"name": "Krumpin' Time",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Meganobz",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"INFANTRY",
+					"MEGA ARMOUR",
+					"ORKS",
+					"MEGANOBZ",
+					"GRENADES"
+				],
+				"model_profiles": {
+					"meganob_klaw": {
+						"label": "Meganob (Power Klaw)",
+						"stats_override": {},
+						"transport_slots": 2.0,
+						"weapons": [
+							"Kustom shoota",
+							"Power klaw"
+						]
+					},
+					"meganob_saws": {
+						"label": "Meganob (Killsaws)",
+						"stats_override": {},
+						"transport_slots": 2.0,
+						"weapons": [
+							"Kustom shoota",
+							"Killsaws"
+						]
+					}
+				},
+				"name": "Meganobz",
+				"points": 160.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 5.0,
+					"objective_control": 1.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "2-6 Meganobz",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "4",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kustom shoota",
+						"range": "18",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					},
+					{
+						"ap": "-3",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Killsaws",
+						"range": "Melee",
+						"special_rules": "twin-linked",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m2",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m3",
+					"model_type": "meganob_klaw",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m4",
+					"model_type": "meganob_saws",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m5",
+					"model_type": "meganob_saws",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_MEGANOBZ_L",
+			"status": 7.0
+		},
+		"U_NOB_WAAAGH_BANNER_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_NOB_WAAAGH_BANNER_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, at the start of the battle round, this model can use this ability. If it does, until the start of the next battle round, this model's unit gains the benefits of the Waaagh! ability as if you had called a Waaagh! this battle round.",
+						"name": "Plant the Waaagh! Banner",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is gaining the benefits of the Waaagh! ability, it has a 4+ invulnerable save and an Objective Control characteristic of 5.",
+						"name": "Da Boss Iz Watchin'",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Nob with Waaagh! Banner can be attached to a Boyz, Breaka Boyz, or Nobz unit.",
+						"name": "Leader",
+						"type": "Core"
+					}
+				],
+				"display_name": "Nob with Waaagh! Banner",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ORKS",
+					"NOB WITH WAAAGH! BANNER",
+					"INFANTRY",
+					"CHARACTER"
+				],
+				"name": "Nob with Waaagh! Banner",
+				"points": 70.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Nob with Waaagh! Banner",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kustom shoota",
+					"1x Waaagh! banner"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "4",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kustom shoota",
+						"range": "18",
+						"special_rules": "rapid fire 2",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Waaagh! banner",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_NOB_WAAAGH_BANNER_A",
+			"status": 2.0
+		},
+		"U_PAINBOSS_I": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_PAINBOSS_I",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Each time this model would lose a wound, roll one D6: on a 5+, that wound is not lost.",
+						"name": "Feel No Pain 5+",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, models in that unit have the Feel No Pain 5+ ability.",
+						"name": "Dok's Toolz",
+						"type": "Datasheet"
+					},
+					{
+						"description": "At the end of your Movement phase, you can select one friendly BEAST SNAGGA CHARACTER model within 3\" of this model. That model regains up to 3 lost wounds.",
+						"name": "Sawbonez",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model is leading a unit, that unit is eligible to declare a charge in a turn in which it Fell Back.",
+						"name": "One Scalpel Short of a Medpack",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, if the bearer's unit is below its Starting Strength, you can return up to D3 destroyed Bodyguard models to that unit.",
+						"name": "Grot Orderly",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Painboss",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"BEAST SNAGGA",
+					"ORKS",
+					"PAINBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BEAST SNAGGA BOYZ",
+						"BOYZ"
+					]
+				},
+				"name": "Painboss",
+				"points": 70.0,
+				"stats": {
+					"fnp": 5.0,
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Painboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Beast Snagga klaw",
+					"1x Grot Orderly"
+				],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "3",
+						"damage": "2",
+						"name": "Beast Snagga klaw",
+						"range": "Melee",
+						"special_rules": "anti-monster 4+, anti-vehicle 4+",
+						"strength": "9",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_PAINBOSS_I",
+			"status": 2.0
+		},
+		"U_SHIELD_CAPTAIN_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_SHIELD_CAPTAIN_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, when this model's unit is selected to fight, it can use this ability. If it does, until that fight is resolved, both Ka'tah Stances are active for that unit instead of only one.",
+						"name": "Master of the Stances",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle round, you can select one model from your army with this ability and target that model's unit with a Stratagem. If you do, reduce the CP cost of that use of that Stratagem by 1CP.",
+						"name": "Strategic Mastery",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					}
+				],
+				"display_name": "Shield-Captain",
+				"enhancements": [],
+				"is_warlord": true,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY",
+					"SHIELD-CAPTAIN"
+				],
+				"leader_data": {
+					"can_lead": [
+						"CUSTODIAN GUARD"
+					]
+				},
+				"name": "Shield-Captain",
+				"points": 120.0,
+				"stats": {
+					"invuln": 4.0,
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 7.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Shield-Captain",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Shield-Captain (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "7",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 7.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 7.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_SHIELD_CAPTAIN_A",
+			"status": 2.0
+		},
+		"U_SHIELD_CAPTAIN_JETBIKE_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_SHIELD_CAPTAIN_JETBIKE_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "This model can be attached to a unit of Vertus Praetors.",
+						"name": "Leader",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Once per battle, at the end of the Fight phase, if this model's unit has fought this phase, if it is within Engagement Range of one or more enemy units, it can make a Fall Back move or, if it is not within Engagement Range of one or more enemy units, it can make a Normal move",
+						"name": "Sweeping Advance",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle round, you can select one model from your army with this ability and target that model's unit with a Stratagem. If you do, reduce the CP cost of that use of that Stratagem by 1CP.",
+						"name": "Strategic Mastery",
+						"type": "Datasheet"
+					}
+				],
+				"base_dimensions": {
+					"length": 75.0,
+					"width": 42.0
+				},
+				"base_type": "oval",
+				"display_name": "Shield-captain On Dawneagle Jetbike",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"MOUNTED",
+					"CHARACTER",
+					"FLY",
+					"SHIELD-CAPTAIN",
+					"DAWNEAGLE JETBIKE",
+					"IMPERIUM"
+				],
+				"leader_data": {
+					"can_lead": [
+						"VERTUS PRAETORS"
+					]
+				},
+				"name": "Shield-captain On Dawneagle Jetbike",
+				"points": 150.0,
+				"stats": {
+					"invuln": 4.0,
+					"leadership": 6.0,
+					"move": 12.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 7.0,
+					"wounds": 8.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Shield-Captain on Dawneagle Jetbike",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "2",
+						"damage": "D6+1",
+						"name": "Salvo launcher",
+						"range": "24",
+						"special_rules": "twin-linked",
+						"strength": "10",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Interceptor lance",
+						"range": "Melee",
+						"special_rules": "lance",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_dimensions": {
+						"length": 75.0,
+						"width": 42.0
+					},
+					"base_mm": 75.0,
+					"base_type": "oval",
+					"current_wounds": 8.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 8.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_SHIELD_CAPTAIN_JETBIKE_A",
+			"status": 2.0
+		},
+		"U_STRIKE_FORCE_A": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_STRIKE_FORCE_A",
+			"meta": {
+				"display_name": "Strike Force",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"UNKNOWN"
+				],
+				"name": "Strike Force",
+				"points": 2000.0,
+				"stats": {
+					"move": 6.0,
+					"save": 3.0,
+					"toughness": 4.0
+				},
+				"wargear": []
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_STRIKE_FORCE_A",
+			"status": 2.0
+		},
+		"U_TELEMON_HEAVY_DREADNOUGHT_I": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_TELEMON_HEAVY_DREADNOUGHT_I",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Each time a unit with this ability is selected to fight, select one Ka'tah Stance for it to assume: Dacatarai (Sustained Hits 1) or Rendax (Lethal Hits). That stance is active for melee attacks until the unit finishes attacking.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time an attack is allocated to this model, subtract 1 from the Damage characteristic of that attack.",
+						"name": "Guardian Eternal",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+						"name": "Damaged: 1-4 Wounds Remaining",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Telemon Heavy Dreadnought",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"IMPERIUM",
+					"TELEMON HEAVY DREADNOUGHT",
+					"VEHICLE",
+					"WALKER"
+				],
+				"name": "Telemon Heavy Dreadnought",
+				"points": 265.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 8.0,
+					"objective_control": 5.0,
+					"save": 2.0,
+					"toughness": 12.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Telemon Heavy Dreadnought",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Telemon Caestus",
+						"range": "12",
+						"special_rules": "twin-linked",
+						"strength": "7",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "6",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Spiculus bolt launcher",
+						"range": "36",
+						"special_rules": "",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "8",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Iliastus accelerator culverin",
+						"range": "48",
+						"special_rules": "",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Telemon Caestus",
+						"range": "Melee",
+						"special_rules": "",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "16",
+						"ballistic_skill": "2",
+						"damage": "1",
+						"name": "Telemon Storm Cannon",
+						"range": "72",
+						"special_rules": "",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-4",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "D6+1",
+						"name": "Twin arachnus las-blaze",
+						"range": "48",
+						"special_rules": "twin-linked",
+						"strength": "14",
+						"type": "Ranged"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 100.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": {
+						"x": 1400.0,
+						"y": 780.0
+					},
+					"status_effects": [],
+					"wounds": 12.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_TELEMON_HEAVY_DREADNOUGHT_I",
+			"status": 2.0
+		},
+		"U_WARBOSS_B": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {
+				"charged_this_turn": true,
+				"fights_first": true
+			},
+			"id": "U_WARBOSS_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, add 4 to the Attacks characteristic of this model's melee weapons.",
+						"name": "Da Biggest and da Best",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss Alpha",
+				"enhancements": [],
+				"is_warlord": true,
+				"keywords": [
+					"CHARACTER",
+					"GRENADES",
+					"INFANTRY",
+					"ORKS",
+					"WARBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss",
+				"points": 75.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kombi-weapon",
+					"1x Power klaw",
+					"1x Twin sluggas"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Twin slugga",
+						"range": "12",
+						"special_rules": "pistol, twin-linked",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Attack squig",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 1400.0,
+						"y": 900.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_WARBOSS_B",
+			"status": 2.0
+		},
+		"U_WARBOSS_C": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WARBOSS_C",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, add 4 to the Attacks characteristic of this model's melee weapons.",
+						"name": "Da Biggest and da Best",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"GRENADES",
+					"INFANTRY",
+					"ORKS",
+					"WARBOSS"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss",
+				"points": 75.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 4.0,
+					"toughness": 5.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x Kombi-weapon",
+					"1x Power klaw",
+					"1x Twin sluggas"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "1",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Kombi-weapon",
+						"range": "24",
+						"special_rules": "anti-infantry 4+, devastating wounds, rapid fire 1",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"ballistic_skill": "5",
+						"damage": "1",
+						"name": "Twin slugga",
+						"range": "12",
+						"special_rules": "pistol, twin-linked",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Attack squig",
+						"range": "Melee",
+						"special_rules": "extra attacks",
+						"strength": "4",
+						"type": "Melee",
+						"weapon_skill": "4"
+					},
+					{
+						"ap": "-1",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Big choppa",
+						"range": "Melee",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "Power klaw",
+						"range": "Melee",
+						"strength": "10",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_WARBOSS_C",
+			"status": 2.0
+		},
+		"U_WARBOSS_IN_MEGA_ARMOUR_D": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WARBOSS_IN_MEGA_ARMOUR_D",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, each time a model in that unit makes a melee attack, add 1 to the Hit roll.",
+						"name": "Might is Right",
+						"type": "Datasheet"
+					},
+					{
+						"description": "While the Waaagh! is active for your army, this model's 'uge choppa has a Damage characteristic of 3.",
+						"name": "Dead Brutal",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Warboss in Mega Armour",
+				"enhancements": [
+					"Tellyporta"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"MEGA ARMOUR",
+					"ORKS",
+					"WARBOSS",
+					"WARBOSS IN MEGA ARMOUR"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Warboss in Mega Armour",
+				"points": 115.0,
+				"stats": {
+					"fnp": 5.0,
+					"leadership": 6.0,
+					"move": 5.0,
+					"objective_control": 1.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 7.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Warboss in Mega Armour",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x 'Uge choppa"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "3",
+						"ballistic_skill": "4",
+						"damage": "1",
+						"name": "Big shoota",
+						"range": "36",
+						"special_rules": "rapid fire 2",
+						"strength": "5",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "4",
+						"damage": "2",
+						"name": "'Uge choppa",
+						"range": "Melee",
+						"strength": "12",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 50.0,
+					"current_wounds": 7.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 7.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_WARBOSS_IN_MEGA_ARMOUR_D",
+			"status": 2.0
+		},
+		"U_WAZBOM_BLASTAJET": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WAZBOM_BLASTAJET",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Deadly Demise D3",
+						"name": "Deadly Demise",
+						"parameter": "D3",
+						"type": "Core"
+					},
+					{
+						"description": "Waaagh! faction ability",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "Each time this model makes a ranged attack that targets a unit that cannot FLY, re-roll a Hit roll of 1.",
+						"name": "Blastajet Attack Run",
+						"type": "Datasheet"
+					}
+				],
+				"damaged_profile": {
+					"description": "While this model has 1-4 wounds remaining, each time this model makes an attack, subtract 1 from the Hit roll.",
+					"wounds_remaining": "1-4"
+				},
+				"display_name": "Wazbom Blastajet",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"WAZBOM BLASTAJET",
+					"ORKS",
+					"GRENADES",
+					"AIRCRAFT",
+					"VEHICLE",
+					"SPEED FREEKS",
+					"FLY"
+				],
+				"name": "Wazbom Blastajet",
+				"points": 175.0,
+				"stats": {
+					"invulnerable_save": 6.0,
+					"leadership": 7.0,
+					"move": 20.0,
+					"objective_control": 0.0,
+					"save": 3.0,
+					"toughness": 9.0,
+					"wounds": 12.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Wazbom Blastajet",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "D3",
+						"ballistic_skill": "4",
+						"damage": "4",
+						"name": "Smasha gun",
+						"range": "48",
+						"special_rules": "blast",
+						"strength": "9",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "D3",
+						"ballistic_skill": "4",
+						"damage": "D6",
+						"name": "Twin wazbom mega-kannon",
+						"range": "36",
+						"special_rules": "blast, hazardous, twin-linked",
+						"strength": "12",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "3",
+						"damage": "1",
+						"name": "Armoured hull",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "4"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 120.0,
+					"current_wounds": 12.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 12.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_WAZBOM_BLASTAJET",
+			"status": 7.0
+		},
+		"U_WEIRDBOY_J": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WEIRDBOY_J",
+			"meta": {
+				"abilities": [
+					{
+						"description": "When this model is destroyed, roll one D6. On a 6, each unit within 6\" suffers D3 mortal wounds.",
+						"name": "Deadly Demise D3",
+						"type": "Core"
+					},
+					{
+						"description": "Once per battle, at the start of your Command phase, you can call a Waaagh!. If you do, until the start of your next Command phase: units with this ability are eligible to charge in a turn in which they Advanced; add 1 to the Strength and Attacks characteristics of melee weapons equipped by models with this ability; models with this ability have a 5+ invulnerable save.",
+						"name": "Waaagh!",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, add 1 to the Strength and Damage characteristics of this model's 'Eadbanger weapon for every 5 models in that unit (rounding down), but while that unit contains 10 or more models, that weapon has the [HAZARDOUS] ability.",
+						"name": "Waaagh! Energy",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per turn, at the end of your Movement phase, one WEIRDBOY from your army can use this ability. If it does, roll one D6: on a 1, that WEIRDBOY's unit suffers D6 mortal wounds; on a 2+, remove this WEIRDBOY's unit from the battlefield and set it up again anywhere on the battlefield that is more than 9\" horizontally away from all enemy models.",
+						"name": "Da Jump",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Weirdboy",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"CHARACTER",
+					"INFANTRY",
+					"PSYKER",
+					"ORKS",
+					"WEIRDBOY"
+				],
+				"leader_data": {
+					"can_lead": [
+						"BOYZ"
+					]
+				},
+				"name": "Weirdboy",
+				"points": 65.0,
+				"stats": {
+					"leadership": 7.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 5.0,
+					"toughness": 5.0,
+					"wounds": 4.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Weirdboy",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"1x 'Eadbanger",
+					"1x Weirdboy staff"
+				],
+				"weapons": [
+					{
+						"ap": "-3",
+						"attacks": "1",
+						"ballistic_skill": "4",
+						"damage": "1",
+						"name": "'Eadbanger",
+						"range": "24",
+						"special_rules": "precision, psychic",
+						"strength": "6",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "3",
+						"damage": "D3",
+						"name": "Weirdboy staff",
+						"range": "Melee",
+						"special_rules": "psychic",
+						"strength": "8",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 4.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 4.0
+				}
+			],
+			"owner": 2.0,
+			"squad_id": "U_WEIRDBOY_J",
+			"status": 2.0
+		},
+		"U_WITCHSEEKERS_C": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WITCHSEEKERS_C",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"parameter": "6\"",
+						"type": "Core"
+					},
+					{
+						"description": "Models in this unit have the Feel No Pain 3+ ability against Psychic Attacks and mortal wounds.",
+						"name": "Daughters of the Abyss",
+						"type": "Datasheet"
+					},
+					{
+						"description": "In your Shooting phase, after this unit has shot, select one enemy unit hit by one or more of those attacks. That enemy unit must take a Battle-shock test.",
+						"name": "Sanctified Flames",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Witchseekers Alpha",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"ANATHEMA PSYKANA",
+					"IMPERIUM",
+					"INFANTRY",
+					"WITCHSEEKERS"
+				],
+				"name": "Witchseekers",
+				"points": 50.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 3.0,
+					"toughness": 3.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Witchseeker Sister Superior",
+						"line": 1.0
+					},
+					{
+						"description": "3-9 Witchseekers",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"Witchseeker Sister Superior",
+					"Witchseeker"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Witchseeker flamer",
+						"range": "12",
+						"special_rules": "ignores cover, torrent",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_WITCHSEEKERS_C",
+			"status": 2.0
+		},
+		"U_WITCHSEEKERS_D": {
+			"attached_to": null,
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"disembarked_this_phase": false,
+			"embarked_in": null,
+			"flags": {},
+			"id": "U_WITCHSEEKERS_D",
+			"meta": {
+				"abilities": [
+					{
+						"description": "",
+						"name": "Core",
+						"parameter": "6\"",
+						"type": "Core"
+					},
+					{
+						"description": "Models in this unit have the Feel No Pain 3+ ability against Psychic Attacks and mortal wounds.",
+						"name": "Daughters of the Abyss",
+						"type": "Datasheet"
+					},
+					{
+						"description": "In your Shooting phase, after this unit has shot, select one enemy unit hit by one or more of those attacks. That enemy unit must take a Battle-shock test.",
+						"name": "Sanctified Flames",
+						"type": "Datasheet"
+					}
+				],
+				"display_name": "Witchseekers Beta",
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"ANATHEMA PSYKANA",
+					"IMPERIUM",
+					"INFANTRY",
+					"WITCHSEEKERS"
+				],
+				"name": "Witchseekers",
+				"points": 65.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 1.0,
+					"save": 3.0,
+					"toughness": 3.0,
+					"wounds": 1.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Witchseeker Sister Superior",
+						"line": 1.0
+					},
+					{
+						"description": "3-9 Witchseekers",
+						"line": 2.0
+					}
+				],
+				"wargear": [
+					"Witchseeker Sister Superior",
+					"Witchseeker"
+				],
+				"weapons": [
+					{
+						"ap": "0",
+						"attacks": "D6",
+						"ballistic_skill": null,
+						"damage": "1",
+						"name": "Witchseeker flamer",
+						"range": "12",
+						"special_rules": "ignores cover, torrent",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "0",
+						"attacks": "2",
+						"damage": "1",
+						"name": "Close combat weapon",
+						"range": "Melee",
+						"strength": "3",
+						"type": "Melee",
+						"weapon_skill": "3"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m1",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m2",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m3",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				},
+				{
+					"alive": true,
+					"base_mm": 32.0,
+					"current_wounds": 1.0,
+					"id": "m4",
+					"position": null,
+					"status_effects": [],
+					"wounds": 1.0
+				}
+			],
+			"owner": 1.0,
+			"squad_id": "U_WITCHSEEKERS_D",
+			"status": 2.0
+		},
+		"U_STOMPA_A": {
+			"id": "U_STOMPA_A",
+			"squad_id": "U_STOMPA_A",
+			"owner": 2,
+			"status": 2,
+			"meta": {
+				"name": "Stompa",
+				"keywords": [
+					"ORKS",
+					"STOMPA",
+					"TITANIC",
+					"TOWERING",
+					"TRANSPORT",
+					"VEHICLE",
+					"WALKER"
+				],
+				"stats": {
+					"move": 10,
+					"toughness": 14,
+					"save": 2,
+					"wounds": 30,
+					"leadership": 6,
+					"objective_control": 12,
+					"invuln": 6
+				},
+				"points": 600,
+				"is_warlord": false,
+				"enhancements": [],
+				"wargear": [
+					"1x Deffkannon",
+					"1x Mega-choppa",
+					"1x Skorcha",
+					"1x Supa-gatler",
+					"1x Supa-rokkits",
+					"1x Twin big shoota",
+					"3x Big shoota"
+				],
+				"weapons": [
+					{
+						"name": "Big shoota",
+						"type": "Ranged",
+						"range": "36",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"strength": "5",
+						"ap": "0",
+						"damage": "1",
+						"special_rules": "rapid fire 2",
+						"abilities": [
+							{
+								"id": "rapid_fire",
+								"x": 2
+							}
+						]
+					},
+					{
+						"name": "Deffkannon",
+						"type": "Ranged",
+						"range": "72",
+						"attacks": "3D6",
+						"ballistic_skill": "5",
+						"strength": "14",
+						"ap": "-3",
+						"damage": "D6",
+						"special_rules": "blast",
+						"abilities": [
+							{
+								"id": "blast"
+							}
+						]
+					},
+					{
+						"name": "Skorcha",
+						"type": "Ranged",
+						"range": "12",
+						"attacks": "D6",
+						"ballistic_skill": "N/A",
+						"strength": "5",
+						"ap": "-1",
+						"damage": "1",
+						"special_rules": "ignores cover, torrent",
+						"abilities": [
+							{
+								"id": "ignores_cover"
+							},
+							{
+								"id": "torrent"
+							}
+						]
+					},
+					{
+						"name": "Supa-gatler",
+						"type": "Ranged",
+						"range": "24",
+						"attacks": "20",
+						"ballistic_skill": "5",
+						"strength": "7",
+						"ap": "-1",
+						"damage": "2",
+						"special_rules": "sustained hits 1",
+						"abilities": [
+							{
+								"id": "sustained_hits",
+								"x": 1
+							}
+						]
+					},
+					{
+						"name": "Supa-rokkits",
+						"type": "Ranged",
+						"range": "100",
+						"attacks": "D6",
+						"ballistic_skill": "5",
+						"strength": "12",
+						"ap": "-3",
+						"damage": "D6+2",
+						"special_rules": "blast",
+						"abilities": [
+							{
+								"id": "blast"
+							}
+						]
+					},
+					{
+						"name": "Twin big shoota",
+						"type": "Ranged",
+						"range": "36",
+						"attacks": "3",
+						"ballistic_skill": "5",
+						"strength": "5",
+						"ap": "0",
+						"damage": "1",
+						"special_rules": "rapid fire 2, twin linked",
+						"abilities": [
+							{
+								"id": "rapid_fire",
+								"x": 2
+							},
+							{
+								"id": "twin_linked"
+							}
+						]
+					},
+					{
+						"name": "Mega-choppa \u2013 Strike",
+						"type": "Melee",
+						"range": "Melee",
+						"attacks": "6",
+						"weapon_skill": "3",
+						"strength": "24",
+						"ap": "-5",
+						"damage": "10"
+					},
+					{
+						"name": "Mega-choppa \u2013 Sweep",
+						"type": "Melee",
+						"range": "Melee",
+						"attacks": "18",
+						"weapon_skill": "3",
+						"strength": "10",
+						"ap": "-2",
+						"damage": "3"
+					}
+				],
+				"abilities": [
+					{
+						"name": "Waaagh!",
+						"type": "Faction",
+						"description": "Once per battle, until your next Command phase:\n  -> The unit gains the Advance & Charge ability.\n  -> Add 1 to the unit's Strength characteristic (melee).\n  -> Add 1 to the unit's Attacks characteristic (melee).\n  -> The unit has a 5+ invulnerable save."
+					},
+					{
+						"name": "Deadly Demise 2D6",
+						"type": "Core",
+						"description": "Before this model is removed from play:\n  -> Roll one D6: on a 6+, each enemy unit within 6\" suffers 2D6 mortal wounds."
+					},
+					{
+						"name": "Stompin' Forward",
+						"type": "Datasheet",
+						"description": "This model can move over terrain features as though they were not there."
+					},
+					{
+						"name": "Waaagh! Effigy (Aura)",
+						"type": "Datasheet",
+						"description": "If the unit has the ORKS keyword, for the rest of the battle, add 1 to the Leadership characteristic of friendly units within 12\"."
+					},
+					{
+						"name": "TRANSPORT",
+						"type": "Core",
+						"description": "This model has a transport capacity of 22 ORKS INFANTRY models."
+					}
+				],
+				"unit_composition": [
+					{
+						"description": "1 Stompa",
+						"line": 1
+					}
+				]
+			},
+			"models": [
+				{
+					"id": "m1",
+					"wounds": 30,
+					"current_wounds": 30,
+					"base_mm": 180,
+					"position": {
+						"x": 600.0,
+						"y": 900.0
+					},
+					"alive": true,
+					"status_effects": []
+				}
+			],
+			"flags": {}
+		}
+	}
+}

--- a/40k/tests/scenarios/sp/stompa_gets_to_fight_11e.json
+++ b/40k/tests/scenarios/sp/stompa_gets_to_fight_11e.json
@@ -1,0 +1,80 @@
+{
+  "id": "stompa_gets_to_fight_11e",
+  "covers": [
+    "fight.select_fighter_offer_11e",
+    "scripts.rules.FightSequencer.peek_selection"
+  ],
+  "fixture": "stompa_fight_11e",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Regression for the 2026-07-12 report: an engaged Stompa was never offered its fight. Four units are in base contact and alternate through the 11e Fight step (12.04): P2 Warboss + Stompa (Orks), P1 Custodian Guard + Telemon (Custodes). The bug was in get_available_actions: it drove SELECT_FIGHTER offers off the legacy fight_sequence queue via current_fight_index, which advances one-per-fight regardless of WHICH unit fought. Once a player legally picked out of queue order, the queue desynced and the getter offered a unit the validator then rejected ('Not your selection'); the AI acted on that stale offer, hit its failure fallback, and END_FIGHT forfeited every remaining fight — including the human Stompa. The getter now offers exactly the FightSequencer's candidates, tagged with the picking player, via the new pure peek_selection(). This scenario drives the full alternation with disable_ai and asserts, at the key moment (Warboss + Custodian Guard already fought), that the offer is the Stompa for Player 2 — and that selecting it succeeds and it deals damage. Setup-only privileges: CP zeroed to suppress stratagem prompts; model wounds inflated so no unit dies mid-alternation and the aliveness of the drag/attack targets stays deterministic.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_TELEMON_HEAVY_DREADNOUGHT_I\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 2 },
+    { "act": "screenshot", "label": "01_pile_in_step_opens" },
+
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 2 } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 1 },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 1 } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 2 },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"player\"]", "equals": 2 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"candidates\"]", "equals": ["U_WARBOSS_B"] },
+
+    { "act": "dispatch_action", "action": { "type": "SELECT_FIGHTER", "unit_id": "U_WARBOSS_B", "player": 2 } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_EPIC_CHALLENGE", "unit_id": "U_WARBOSS_B", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "ASSIGN_ATTACKS", "unit_id": "U_WARBOSS_B", "target_id": "U_TELEMON_HEAVY_DREADNOUGHT_I", "weapon_id": "power_klaw_melee", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_AND_RESOLVE_ATTACKS", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "ROLL_DICE", "player": 2, "payload": { "fast_roll": true } } },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"player\"]", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"candidates\"]", "equals": ["U_CUSTODIAN_GUARD_B"] },
+
+    { "act": "dispatch_action", "action": { "type": "SELECT_FIGHTER", "unit_id": "U_CUSTODIAN_GUARD_B", "player": 1 } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "SELECT_KATAH_STANCE", "unit_id": "U_CUSTODIAN_GUARD_B", "stance": "dacatarai", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "ASSIGN_ATTACKS", "unit_id": "U_CUSTODIAN_GUARD_B", "target_id": "U_STOMPA_A", "weapon_id": "guardian_spear_melee", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_AND_RESOLVE_ATTACKS", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "ROLL_DICE", "player": 1, "payload": { "fast_roll": true } } },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "screenshot", "label": "02_warboss_and_custodian_guard_have_fought" },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.fought.has(\"U_WARBOSS_B\")", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.fought.has(\"U_CUSTODIAN_GUARD_B\")", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.fought.has(\"U_STOMPA_A\")", "equals": false },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"player\"]", "equals": 2 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"candidates\"]", "equals": ["U_STOMPA_A"] },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.picker", "equals": 2 },
+
+    { "act": "dispatch_action", "action": { "type": "SELECT_FIGHTER", "unit_id": "U_STOMPA_A", "player": 2 } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_phase_property", "property": "active_fighter_id", "equals": "U_STOMPA_A" },
+    { "act": "screenshot", "label": "03_stompa_selected_to_fight" },
+
+    { "act": "dispatch_action", "action": { "type": "ASSIGN_ATTACKS", "unit_id": "U_STOMPA_A", "target_id": "U_CUSTODIAN_GUARD_B", "weapon_id": "mega_choppa___sweep_melee", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_AND_RESOLVE_ATTACKS", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "ROLL_DICE", "player": 2, "payload": { "fast_roll": true } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.fought.has(\"U_STOMPA_A\")", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().units_that_fought.has(\"U_STOMPA_A\")", "equals": true },
+    { "act": "screenshot", "label": "04_stompa_fought" }
+  ]
+}

--- a/40k/tests/test_iss050_fight_phase_11e.gd
+++ b/40k/tests/test_iss050_fight_phase_11e.gd
@@ -219,6 +219,45 @@ func _run_tests():
 	_check("a Fights First unit became eligible mid-step: return to FF combats (12.04)",
 		pick.step == "fights_first" and pick.candidates == ["BLUE_SQUAD"], str(pick))
 
+	print("\n-- peek_selection is a pure preview of next_selection (2026-07-12) --")
+	# get_available_actions polls the sequencer every UI/AI refresh; the poll
+	# must NOT advance picker/step or the alternation desyncs and the wrong
+	# unit gets offered (the reported Stompa-never-fights bug).
+	b = _pg41_board()
+	seq = FightSequencer.new()
+	seq.begin(b, 1)
+	var peek1 = seq.peek_selection(b)
+	var peek2 = seq.peek_selection(b)
+	_check("peek is idempotent — repeated calls return the same result",
+		peek1 == peek2, "%s vs %s" % [str(peek1), str(peek2)])
+	var picker_before = seq.picker
+	var step_before = seq.step
+	seq.peek_selection(b)
+	_check("peek does not mutate picker", seq.picker == picker_before, "picker=%d" % seq.picker)
+	_check("peek does not mutate step", seq.step == step_before, "step=%s" % seq.step)
+	var real = seq.next_selection(b)
+	_check("peek matches the authoritative next_selection (player)", peek1.player == real.player,
+		"peek=%d real=%d" % [peek1.player, real.player])
+	_check("peek matches the authoritative next_selection (candidates)",
+		peek1.candidates == real.candidates, "%s vs %s" % [str(peek1.candidates), str(real.candidates)])
+	_check("peek matches the authoritative next_selection (step)", peek1.step == real.step,
+		"%s vs %s" % [str(peek1.step), str(real.step)])
+	# Peek across the fights_first -> remaining transition: after both FF units
+	# have fought, peek must still (without mutating) surface the remaining
+	# combatant for the correct player — this is exactly the offer that used to
+	# come from the desynced legacy queue instead.
+	b = _pg41_board()
+	b.units["BLUE_SQUAD"].models[0].position = {"x": 460, "y": 460}  # engage the transport
+	seq = FightSequencer.new()
+	seq.begin(b, 1)
+	seq.select_to_fight("RED_MONSTER", b)   # RED FF
+	seq.select_to_fight("RED_SQUAD", b)     # RED FF (BLUE has no FF)
+	var peek_rem = seq.peek_selection(b)
+	_check("peek crosses FF->remaining without mutating: offers a remaining unit to BLUE",
+		peek_rem.step == "remaining" and peek_rem.player == 2, str(peek_rem))
+	_check("peek across the step boundary still leaves seq.step untouched",
+		seq.step == "fights_first", "step=%s" % seq.step)
+
 	GameConstants.edition = 10
 	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
 	quit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Problem

An engaged unit (reported: a Stompa in base contact) could be denied its fight entirely when playing against the AI. In the report's game log the tell was `P2 Stompa fights – expected 16.7 melee dmg vs Custodian Guard` immediately followed by `P2 Stompa no longer in combat — ending fight` — the **AI trying to select the human's Stompa**, failing, and then ending the whole phase.

## Root cause

In `FightPhase.get_available_actions()`, at 11th edition the "select a unit to fight" offer fell back to the legacy `fight_sequence` queue. That queue's `current_fight_index` advances one-per-fight regardless of *which* unit fought, so once a player legally picked out of the queue's precomputed order the queue desynced and the getter offered a unit the sequencer-backed validator then rejected (`"Not your selection"`). The AI acted on that stale offer, hit its `SELECT_FIGHTER` failure fallback, and sent `END_FIGHT` — which at 11e runs the 12.07 forfeit loop and marks **every** remaining unit as fought, forfeiting the human's fights too.

## Changes

- **`FightSequencer.peek_selection()`** — new pure, non-mutating preview of `next_selection()`. `get_available_actions()` polls it every UI/AI refresh, so it must not advance `picker`/`step`.
- **`FightPhase.get_available_actions()`** — at 11e, offer exactly the sequencer's candidates tagged with the picking player, instead of the desyncing legacy queue. 10e keeps the queue path.
- **`AIDecisionMaker._decide_fight()`** — only consider `SELECT_FIGHTER` offers addressed to the evaluating player, so the AI never submits the opponent's unit mid-alternation.
- **`AIPlayer`** — a failed `SELECT_FIGHTER` now re-evaluates against fresh offers instead of ending the phase; `END_FIGHT` is sent only when the sequencer reports no unit is eligible, or as a last resort after 3 consecutive failures (counter resets on any success).

## Tests

- **`tests/scenarios/sp/stompa_gets_to_fight_11e.json`** — windowed scenario driving the full 11e alternation (Warboss + Custodian Guard + Stompa + Telemon), asserting the Stompa is offered to its owner after the first two fought, is selected, and deals damage. New fixture `stompa_fight_11e`. **52/52 assertions pass.**
- **`test_iss050_fight_phase_11e.gd`** — `peek_selection` purity + parity with `next_selection` across the fights-first → remaining boundary. **45/45 pass.**

## Validation

- Reproduced the bug live on unpatched code (AI ended the phase, Stompa forfeited), then confirmed post-fix the Stompa fights — screenshot showed it assigning Mega-choppa attacks and destroying a Custodian Guard model, with 0 errors in the debug log.
- Regression check: 5 related fight scenarios still green (152 assertions); game boots with 0 script errors.

Changelog entry added (v0.22.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoR5ZiAxXhHXXvT1wpWBLD

---
_Generated by [Claude Code](https://claude.ai/code/session_01DoR5ZiAxXhHXXvT1wpWBLD)_