### PR TITLE
Add missing .uid sidecars for four test scripts

### DIFF
--- a/40k/tests/helpers/tier2_probe.gd.uid
+++ b/40k/tests/helpers/tier2_probe.gd.uid
@@ -1,0 +1,1 @@
+uid://yvwkan8jul5l

--- a/40k/tests/test_ai_battle_plan.gd.uid
+++ b/40k/tests/test_ai_battle_plan.gd.uid
@@ -1,0 +1,1 @@
+uid://c184k4kmx4fmr

--- a/40k/tests/test_ai_reactive_window_guard.gd.uid
+++ b/40k/tests/test_ai_reactive_window_guard.gd.uid
@@ -1,0 +1,1 @@
+uid://d02jp401ecshi

--- a/40k/tests/test_solid_terrain_movement_11e.gd.uid
+++ b/40k/tests/test_solid_terrain_movement_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://ihrfvp1vtee5


### PR DESCRIPTION
## Summary

Follow-up to #574: `godot --headless --import` generated UID sidecar files for four test scripts that were committed without them — three from recently merged branches (`tier2_probe.gd`, `test_ai_battle_plan.gd`, `test_ai_reactive_window_guard.gd`) and one from the solid-terrain suite added in #574 (`test_solid_terrain_movement_11e.gd`).

Committing the sidecars keeps script UIDs stable across machines instead of each clone regenerating random ids (Godot 4.4 expects `.uid` files to be version-controlled alongside their scripts, as the rest of the repo already does).

Metadata-only: 4 files, 4 lines, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VMtqzhhpmZsQA5UBXmVjgz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMtqzhhpmZsQA5UBXmVjgz)_