### PR TITLE
Controller support M3: model carry — stick-driven model movement (v0.33.0)

### DIFF
--- a/40k/autoloads/InputDeviceManager.gd
+++ b/40k/autoloads/InputDeviceManager.gd
@@ -188,7 +188,10 @@ func _input(event: InputEvent) -> void:
 	elif event is InputEventJoypadMotion and absf(event.axis_value) >= PAD_AXIS_CLAIM:
 		_claim(InputMode.PAD)
 	elif event is InputEventKey and event.pressed:
-		_claim(InputMode.KBM)
+		# The synthetic window also covers keys: PadRouter synthesizes the
+		# rebindable rotate_left/right key events for pad rotation (M3).
+		if Time.get_ticks_msec() >= _ignore_mouse_until_ms:
+			_claim(InputMode.KBM)
 	elif event is InputEventMouseButton and event.pressed:
 		if Time.get_ticks_msec() >= _ignore_mouse_until_ms:
 			_claim(InputMode.KBM)
@@ -285,7 +288,7 @@ func _find_confirm_button(root: Node) -> Button:
 		var n: Node = queue.pop_front()
 		if n is Button and n.visible and n.focus_mode != Control.FOCUS_NONE and not n.disabled:
 			candidates.append(n)
-		for child in n.get_children():
+		for child in n.get_children(true):
 			queue.append(child)
 	if candidates.is_empty():
 		return null

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -44,10 +44,31 @@ const HINTS_FOCUS := [
 	["a", "Press"],
 	["b", "Back To Board"],
 ]
+const HINTS_CARRY := [
+	["ls", "Move Model"],
+	["a", "Drop"],
+	["lb", "Rotate ⟲"],
+	["rb", "Rotate ⟳"],
+	["b", "Cancel"],
+	["menu", "Confirm / End"],
+]
 
 # The target currently highlighted by LB/RB in shooting TARGET_SELECT mode
 # (empty when none). Windowed scenarios assert this.
 var target_highlight_id: String = ""
+
+# M3 model-carry state: the model currently "picked up" rides the virtual
+# cursor (warp + held synthetic LMB — the real drag code runs underneath).
+# carry_model_index is which of the selected unit's alive models D-pad ◀ ▶
+# hops to. Windowed scenarios assert both.
+var carry_active: bool = false
+var carry_model_index: int = 0
+var _carry_pickup_screen := Vector2.ZERO
+var _carry_unit_id: String = ""  # resets carry_model_index when the unit changes
+
+
+func is_carrying() -> bool:
+	return carry_active
 
 
 func _ready() -> void:
@@ -62,10 +83,16 @@ func _input(event: InputEvent) -> void:
 	InputDeviceManager.claim_pad()
 	match event.button_index:
 		JOY_BUTTON_LEFT_SHOULDER:
-			_cycle(-1)
+			if carry_active:
+				_synth_rotate(true)
+			else:
+				_cycle(-1)
 			get_viewport().set_input_as_handled()
 		JOY_BUTTON_RIGHT_SHOULDER:
-			_cycle(1)
+			if carry_active:
+				_synth_rotate(false)
+			else:
+				_cycle(1)
 			get_viewport().set_input_as_handled()
 		JOY_BUTTON_Y:
 			if _toggle_datasheet():
@@ -74,15 +101,30 @@ func _input(event: InputEvent) -> void:
 			if _context_action():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_A:
-			if _assign_highlighted_target():
+			if _handle_a():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_B:
 			if _handle_back():
 				get_viewport().set_input_as_handled()
-		JOY_BUTTON_DPAD_UP, JOY_BUTTON_DPAD_DOWN, JOY_BUTTON_DPAD_LEFT, JOY_BUTTON_DPAD_RIGHT:
+		JOY_BUTTON_DPAD_UP, JOY_BUTTON_DPAD_DOWN:
 			if _enter_panel_focus():
 				get_viewport().set_input_as_handled()
+		JOY_BUTTON_DPAD_LEFT:
+			if _hop_model(-1) or _enter_panel_focus():
+				get_viewport().set_input_as_handled()
+		JOY_BUTTON_DPAD_RIGHT:
+			if _hop_model(1) or _enter_panel_focus():
+				get_viewport().set_input_as_handled()
 	_update_hints()
+
+
+func _handle_a() -> bool:
+	if carry_active:
+		_drop_carry()
+		return true
+	if _assign_highlighted_target():
+		return true
+	return _try_begin_carry()
 
 
 # ============================================================================
@@ -162,7 +204,7 @@ func _find_visible_item_list(root: Node) -> ItemList:
 		var n: Node = queue.pop_front()
 		if n is ItemList and n.is_visible_in_tree() and n.item_count > 0:
 			return n
-		for child in n.get_children():
+		for child in n.get_children(true):
 			queue.append(child)
 	return null
 
@@ -203,20 +245,40 @@ func _assign_highlighted_target() -> bool:
 
 
 func _context_action() -> bool:
-	if VirtualCursor.is_cursor_active():
+	if VirtualCursor.is_cursor_active() and not carry_active:
 		return false  # cursor mode owns X (right-click); VC consumed it anyway
 	var sc = _shooting_controller_in_shooting_phase()
 	if sc != null and str(sc.active_shooter_id) != "":
 		sc._keyboard_skip_unit()
 		target_highlight_id = ""
 		return true
+	# Movement: X = undo last staged model (plan §4.2 context action).
+	var m := get_tree().current_scene
+	if m != null and ("current_phase" in m) and m.current_phase == GameStateData.Phase.MOVEMENT \
+			and not carry_active and m.movement_controller != null and is_instance_valid(m.movement_controller) \
+			and str(m.movement_controller.active_unit_id) != "" \
+			and m.movement_controller.has_method("_on_undo_model_pressed"):
+		m.movement_controller._on_undo_model_pressed()
+		return true
 	return false
 
 
 func _handle_back() -> bool:
+	if carry_active:
+		_cancel_carry()
+		return true
+	# One B returns fully to the board: release panel focus AND park the
+	# cursor together — leaving either behind makes the next A ambiguous
+	# (click vs press-focused vs pickup).
+	var did_reset := false
 	var focused := get_viewport().gui_get_focus_owner()
 	if focused != null:
 		focused.release_focus()
+		did_reset = true
+	if VirtualCursor.is_cursor_active():
+		VirtualCursor.park()
+		did_reset = true
+	if did_reset:
 		return true
 	var sc = _shooting_controller_in_shooting_phase()
 	if sc != null and str(sc.active_shooter_id) != "":
@@ -224,6 +286,150 @@ func _handle_back() -> bool:
 		target_highlight_id = ""
 		return true
 	return false
+
+
+# ============================================================================
+# M3 model carry — pickup/drop/cancel/hop/rotate
+# ============================================================================
+
+func _try_begin_carry() -> bool:
+	if VirtualCursor.is_cursor_active():
+		return false  # cursor mode: A is a click (VirtualCursor consumed it)
+	if get_viewport().gui_get_focus_owner() != null:
+		return false
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m):
+		return false
+	match m.current_phase:
+		GameStateData.Phase.MOVEMENT, GameStateData.Phase.CHARGE:
+			var ctrl = m.movement_controller if m.current_phase == GameStateData.Phase.MOVEMENT else m.charge_controller
+			if ctrl == null or not is_instance_valid(ctrl) or str(ctrl.active_unit_id) == "":
+				return false
+			var unit_id := str(ctrl.active_unit_id)
+			if unit_id != _carry_unit_id:
+				_carry_unit_id = unit_id
+				carry_model_index = 0
+			var pos = _model_world_pos(unit_id, carry_model_index)
+			if pos == null:
+				carry_model_index = 0
+				pos = _model_world_pos(unit_id, 0)
+			if pos == null:
+				return false
+			# Center first, THEN project — the warp target must use the final
+			# camera transform.
+			_center_camera_on_world(pos)
+			var screen: Vector2 = m.world_to_screen_position(pos)
+			VirtualCursor.warp_to(screen)
+			VirtualCursor.set_left_button(true)
+			_carry_pickup_screen = screen
+			carry_active = true
+			return true
+		GameStateData.Phase.DEPLOYMENT:
+			# Placement is click-driven with a cursor-following ghost, so
+			# "pickup" is just parking the cursor over the deployment zone;
+			# every A after that is a normal cursor click that places a model.
+			var dc = m.deployment_controller
+			if dc == null or not is_instance_valid(dc) or not dc.is_placing():
+				return false
+			var center := _deployment_zone_center()
+			if center == Vector2.INF:
+				return false
+			_center_camera_on_world(center)
+			VirtualCursor.warp_to(m.world_to_screen_position(center))
+			return true
+	return false
+
+
+func _drop_carry() -> void:
+	VirtualCursor.set_left_button(false)
+	carry_active = false
+
+
+func _cancel_carry() -> void:
+	# The mouse-parity cancel: put the model back where it was picked up and
+	# release (there is no dedicated drag-cancel in the mouse flow either).
+	VirtualCursor.warp_to(_carry_pickup_screen)
+	VirtualCursor.set_left_button(false)
+	carry_active = false
+
+
+func _hop_model(dir: int) -> bool:
+	if carry_active:
+		return false
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m):
+		return false
+	if m.current_phase != GameStateData.Phase.MOVEMENT and m.current_phase != GameStateData.Phase.CHARGE:
+		return false
+	var ctrl = m.movement_controller if m.current_phase == GameStateData.Phase.MOVEMENT else m.charge_controller
+	if ctrl == null or not is_instance_valid(ctrl) or str(ctrl.active_unit_id) == "":
+		return false
+	if str(ctrl.active_unit_id) != _carry_unit_id:
+		_carry_unit_id = str(ctrl.active_unit_id)
+		carry_model_index = 0
+	var unit = GameState.get_unit(str(ctrl.active_unit_id))
+	var alive := 0
+	for model in unit.get("models", []):
+		if model.get("alive", true):
+			alive += 1
+	if alive == 0:
+		return false
+	carry_model_index = wrapi(carry_model_index + dir, 0, alive)
+	var pos = _model_world_pos(str(ctrl.active_unit_id), carry_model_index)
+	if pos != null:
+		_center_camera_on_world(pos)
+	return true
+
+
+# Returns the world-space position (Vector2) of the unit's Nth alive model,
+# or null when out of range.
+func _model_world_pos(unit_id: String, alive_index: int):
+	var unit = GameState.get_unit(unit_id)
+	var idx := 0
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		if idx == alive_index:
+			var pos = model.get("position", null)
+			if pos is Dictionary and pos.has("x"):
+				return Vector2(float(pos.x), float(pos.y))
+			elif pos is Vector2:
+				return pos
+			return null
+		idx += 1
+	return null
+
+
+func _deployment_zone_center() -> Vector2:
+	var player := GameState.get_active_player() if GameState.has_method("get_active_player") else int(GameState.state.get("meta", {}).get("active_player", 1))
+	# PackedVector2Array — don't type-gate on Array, just iterate.
+	var zone = BoardState.get_deployment_zone_for_player(player)
+	if zone == null or zone.size() == 0:
+		return Vector2.INF
+	var center := Vector2.ZERO
+	for point in zone:
+		center += point
+	return center / zone.size()
+
+
+# Pad rotation reuses the rebindable rotate_left/rotate_right keyboard
+# semantics: synthesize the currently-bound key event so MovementController /
+# DeploymentController / ChargeController react exactly as they do to Q/E,
+# including rebinds. The synthetic window stops the device tracker reading
+# our own key events as "keyboard used".
+func _synth_rotate(left: bool) -> void:
+	var binding = KeybindingManager.get_binding("rotate_left" if left else "rotate_right")
+	if binding.is_empty() or int(binding.get("key", 0)) == 0:
+		return
+	InputDeviceManager.note_synthetic_mouse()
+	var press := InputEventKey.new()
+	press.keycode = binding.key as Key
+	press.pressed = true
+	Input.parse_input_event(press)
+	var release := InputEventKey.new()
+	release.keycode = binding.key as Key
+	release.pressed = false
+	Input.parse_input_event(release)
 
 
 # ============================================================================
@@ -254,7 +460,7 @@ func _find_first_focusable(root: Node) -> Control:
 		if n is Control and n.focus_mode == Control.FOCUS_ALL and n.is_visible_in_tree() \
 				and not (n is BaseButton and n.disabled):
 			return n
-		for child in n.get_children():
+		for child in n.get_children(true):
 			queue.append(child)
 	return null
 
@@ -325,7 +531,9 @@ func _shooting_controller_in_shooting_phase() -> Node:
 
 func _update_hints() -> void:
 	var hints := HINTS_BOARD
-	if get_viewport().gui_get_focus_owner() != null:
+	if carry_active:
+		hints = HINTS_CARRY
+	elif get_viewport().gui_get_focus_owner() != null:
 		hints = HINTS_FOCUS
 	else:
 		var sc = _shooting_controller_in_shooting_phase()

--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -793,7 +793,7 @@ func _find_visible_button_by_text(wanted: String) -> Button:
 		var n: Node = queue.pop_front()
 		if n is Button and n.visible and n.is_visible_in_tree() and not n.disabled and str(n.text).strip_edges() == wanted:
 			return n
-		for child in n.get_children():
+		for child in n.get_children(true):
 			queue.append(child)
 	return null
 
@@ -1266,6 +1266,15 @@ func _coerce_vector2(value):
 
 
 func _node2d_to_screen(node: Node2D) -> Vector2:
+	# Board tokens live under Main's CanvasLayer, which IGNORES the Camera2D —
+	# but viewport.get_canvas_transform() follows it, so the two can drift
+	# apart mid-run. Project through the scene's own BoardRoot transform (the
+	# exact lens every board input handler inverts) whenever possible.
+	var scene := get_tree().current_scene
+	if scene != null and scene.has_method("world_to_screen_position"):
+		var parent := node.get_parent()
+		if parent != null and str(parent.name) == "TokenLayer":
+			return scene.world_to_screen_position(node.position)
 	var viewport := node.get_viewport()
 	if viewport == null:
 		return Vector2.INF

--- a/40k/autoloads/VirtualCursor.gd
+++ b/40k/autoloads/VirtualCursor.gd
@@ -25,6 +25,7 @@ extends CanvasLayer
 signal cursor_mode_changed(active: bool)
 
 const BASE_SPEED := 1500.0  # px/s at full stick deflection (before response curve)
+const CARRY_SPEED := 800.0  # px/s while carrying a model — precision over travel
 const GLIDE_SPEED := 2200.0  # px/s for test-seam glides (deterministic)
 const ARRIVE_EPSILON := 2.0
 
@@ -85,8 +86,13 @@ func _process(delta: float) -> void:
 	var vec := Input.get_vector("pad_cursor_left", "pad_cursor_right", "pad_cursor_up", "pad_cursor_down")
 	if vec != Vector2.ZERO:
 		_set_cursor_active(true)
-		# Quadratic response: gentle deflection = precision, full = speed.
-		_move_cursor(vec.normalized() * BASE_SPEED * vec.length() * vec.length() * delta)
+		if PadRouter.is_carrying():
+			# Carrying a model: linear response with a lower ceiling — inch
+			# budgets are small and precision beats travel speed.
+			_move_cursor(vec * CARRY_SPEED * delta)
+		else:
+			# Quadratic response: gentle deflection = precision, full = speed.
+			_move_cursor(vec.normalized() * BASE_SPEED * vec.length() * vec.length() * delta)
 
 
 func _move_cursor(rel: Vector2) -> void:
@@ -114,6 +120,22 @@ func _move_cursor(rel: Vector2) -> void:
 
 func get_cursor_pos() -> Vector2:
 	return _pos
+
+
+# M3 carry seams (PadRouter): jump the pointer somewhere (activating cursor
+# mode) and press/release the synthetic left button — both routed through the
+# same warp+event pipeline as stick movement, so drag handlers can't tell the
+# difference from a mouse.
+func warp_to(screen_pos: Vector2) -> void:
+	if not _initialized_pos:
+		_pos = get_viewport().get_visible_rect().size / 2.0
+		_initialized_pos = true
+	_set_cursor_active(true)
+	_move_cursor(screen_pos - _pos)
+
+
+func set_left_button(pressed: bool) -> void:
+	_emit_button(MOUSE_BUTTON_LEFT, pressed)
 
 
 func _edge_pan(push: Vector2) -> void:
@@ -145,6 +167,11 @@ func _input(event: InputEvent) -> void:
 			return
 		match event.button_index:
 			JOY_BUTTON_A:
+				# During an M3 carry the router owns A (drop/cancel semantics);
+				# a second synthetic LMB press mid-drag would confuse the drag
+				# handlers.
+				if PadRouter.is_carrying():
+					return
 				_emit_button(MOUSE_BUTTON_LEFT, event.pressed)
 				get_viewport().set_input_as_handled()
 			JOY_BUTTON_X:
@@ -197,6 +224,9 @@ func _on_device_changed(mode: int) -> void:
 # ============================================================================
 
 func glide_to_screen(target: Vector2, timeout_s: float = 6.0) -> bool:
+	# The glide is pad-layer input by definition; claim the mode so a scenario
+	# whose very first act is a glide isn't gated out of _process.
+	InputDeviceManager.claim_pad()
 	_glide_target = target
 	var elapsed := 0.0
 	while _glide_target != null and elapsed < timeout_s:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,20 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
     {
+      "version": "0.33.0",
+      "date": "2026-07-13",
+      "summary": "Model carry \u2014 the heart of controller play: with a unit selected, press A to pick its model up onto the cursor, steer it with the left stick (slower, precise speed while carrying), A drops it, LB/RB rotates it, D-pad left/right hops between the unit's models, B cancels back to where it was picked up, and X undoes the last placed model. Works in the Movement phase and Deployment (including transport embark prompts).",
+      "changes": [
+        "Movement phase: A (with the cursor parked) picks up the active model \u2014 the real drag rules run underneath, so move caps, terrain, overlaps and unit coherency are enforced exactly as with the mouse; A drops and stages the move, Confirm Move commits it.",
+        "D-pad left/right hops between the selected unit's models so multi-model squads can be moved model by model without hunting; X undoes the last staged model.",
+        "LB/RB rotates the carried model (oval and large bases) \u2014 the same rebindable rotate keys as Q/E, so custom bindings apply on pad too.",
+        "Deployment: A jumps the cursor (and the placement ghost) into your deployment zone, A places each model, LB/RB rotates the ghost, and transport prompts like 'Embark Units in Battlewagon' get pad focus.",
+        "While carrying, the stick uses a slower precision speed \u2014 inch budgets are small and overshooting past the move cap was too easy at cursor speed.",
+        "B now returns you fully to the board in one press (releases panel focus AND parks the cursor) \u2014 previously it could take two presses and the next A could misfire as a click.",
+        "Fixed: controller focus could not reach buttons created inside a dialog's built-in button row (e.g. 'Confirm Embarkation') \u2014 dialog focus and button lookups now see them."
+      ]
+    },
+    {
       "version": "0.32.0",
       "date": "2026-07-12",
       "summary": "Native controller controls arrive: LB/RB cycles your units (the camera jumps to each one), the shooting phase is fully playable without the cursor \u2014 cycle eligible shooters, cycle eligible targets, A assigns, Start confirms \u2014 Y opens the datasheet, X skips the active shooter, a D-pad press hops into the side panels and B hops back out. The button hints at the bottom now change with what you're doing.",

--- a/40k/tests/scenarios/sp/pad_m3_carry_deploy.json
+++ b/40k/tests/scenarios/sp/pad_m3_carry_deploy.json
@@ -1,0 +1,150 @@
+{
+  "id": "pad_m3_carry_deploy",
+  "covers": [
+    "controller.m3.carry_deployment"
+  ],
+  "fixture": "audit_377_defender_first",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "M3 deployment by pad: RB cycles the undeployed-unit list (starting placement of the Battlewagon), A warps the cursor+ghost to the deployment zone, LB rotates the ghost (synthesized rebindable rotate key), a stick nudge finds room for the huge oval base, A places it, cursor-clicking Confirm pops the transport embark dialog, 'Deploy Without Embarking' completes the unit and the deployment turn alternates to player 1; B parks the cursor.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 1
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.active_player",
+      "equals": 2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 10
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "main.deployment_controller.is_placing()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"dep\", str(main.deployment_controller.unit_id))"
+    },
+    {
+      "act": "screenshot",
+      "label": "01_unit_selected_for_deploy"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "VirtualCursor.is_cursor_active()",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "02_ghost_at_zone"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "screenshot",
+      "label": "03_ghost_rotated"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 0,
+      "value": 0.5,
+      "hold_s": 0.25
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "main.deployment_controller.placed_tokens.size()",
+      "expect_min": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "04_model_placed"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Confirm"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "screenshot",
+      "label": "05_embark_dialog"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Deploy Without Embarking"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.active_player",
+      "equals": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "06_unit_confirmed_turn_alternated"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "VirtualCursor.is_cursor_active()",
+      "equals": false
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_m3_carry_move.json
+++ b/40k/tests/scenarios/sp/pad_m3_carry_move.json
@@ -1,0 +1,286 @@
+{
+  "id": "pad_m3_carry_move",
+  "covers": [
+    "controller.m3.carry_movement",
+    "controller.m3.model_hop",
+    "controller.m3.rotate"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "M3 model carry in the Movement phase: A (cursor parked) picks up the active model onto the cursor with a held synthetic LMB (the real drag pipeline runs), the stick drives it within the move cap and unit coherency, A drops (staged_moves grows), D-pad right hops to the next model for a second carry, X undoes the last staged model, Confirm Move lands only the kept move in GameState; then the oval-based jetbike is carried, rotated with LB (rebindable rotate_left synthesized), and the carry cancelled with B.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 7
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"w0y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y)"
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"w1y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y)"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_WITCHSEEKERS_C"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_WITCHSEEKERS_C"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "execute_script",
+      "script": "VirtualCursor.is_cursor_active()",
+      "equals": false
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.movement_controller.dragging_model",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "01_model_picked_up"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 850.0,
+      "y": 100.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "02_first_model_dropped"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 14
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 1
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 910.0,
+      "y": 100.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 2
+    },
+    {
+      "act": "screenshot",
+      "label": "03_second_model_dropped"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 2
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "04_second_model_undone"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Confirm Move"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y - InputDeviceManager.get_meta(\"w0y\")",
+      "expect_min": 35
+    },
+    {
+      "act": "execute_script",
+      "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y - InputDeviceManager.get_meta(\"w1y\"))",
+      "expect_max": 5
+    },
+    {
+      "act": "screenshot",
+      "label": "05_move_confirmed_undo_respected"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_SHIELD_CAPTAIN_JETBIKE_A"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_SHIELD_CAPTAIN_JETBIKE_A"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"rot0\", main.movement_controller.selected_model.get(\"rotation\", 0.0))"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "abs(main.movement_controller.selected_model.get(\"rotation\", 0.0) - InputDeviceManager.get_meta(\"rot0\"))",
+      "expect_min": 0.2
+    },
+    {
+      "act": "screenshot",
+      "label": "06_carried_jetbike_rotated"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    }
+  ]
+}

--- a/PRPs/steam_deck_controller_support.md
+++ b/PRPs/steam_deck_controller_support.md
@@ -1,6 +1,6 @@
 # Steam Deck / Controller Support — Research & Phased Implementation Plan
 
-**Status:** IN PROGRESS — M0 shipped 2026-07-12 (v0.25.0, PR #571 merged); M1 shipped 2026-07-12 (v0.31.0 after merge re-versioning — a complete solo turn played pad-only); M2 shipped 2026-07-12 (v0.32.0; gates `pad_m2_unit_cycle` + `pad_m2_shooting_native` PASS — shooting phase completed with zero virtual-cursor use). Next: M3 (model carry — native stick movement).
+**Status:** IN PROGRESS — M0 shipped 2026-07-12 (v0.25.0, PR #571); M1+M2 shipped 2026-07-12 (v0.31.0/v0.32.0, PR #576); M3 shipped 2026-07-13 (v0.33.0; gates `pad_m3_carry_move` + `pad_m3_carry_deploy` PASS — stick-carried models through the real drag/stage/coherency pipeline in Movement and Deployment). Next: M4 (full native sweep, stratagems, text entry) — including the deferred charge/pile-in carry scenarios.
 **Branch:** `claude/steam-deck-controller-support-1tzorb`
 **Date:** 2026-07-12 (game version at time of writing: 0.21.0)
 **Goal:** Make the full game playable — and eventually *pleasant* — on a Steam Deck with no mouse or keyboard, without regressing the existing mouse/keyboard experience.
@@ -600,13 +600,41 @@ dice + wound allocation walked with A → X skips remaining weapons →
 phase bumper cycling, Y datasheet toggle, D-pad panel-focus entry, B
 release). All M0/M1 pad scenarios + the KBM baseline re-run green (7/7).
 
-### M3 — Model carry: native movement (large — the heart of the feature)
-`ModelCarryController` for Deployment and Movement first (budget readout,
-rotation on bumpers, formation presets, per-model d-pad hop, undo/reset), then
-the same mode reused for Charge moves, pile-in, consolidate. **Gate:**
-Deployment + full Movement phase + a charge executed pad-native
-(`pad_m3_carry_*.json` suite); positions/legality byte-identical to the same
-actions performed by `dispatch_action` (diff against the action log).
+### M3 — Model carry: native movement (large — the heart of the feature) — ✅ SHIPPED 2026-07-13 (v0.33.0, partial: charge/fight carry wired but not yet scenario-gated)
+Shipped: the carry rides the virtual cursor rather than a separate
+`ModelCarryController` — A (cursor parked, unit selected) warps the pointer
+to the active model and holds a synthetic LMB, so **the real drag pipeline
+runs underneath** (move caps, terrain penalties, overlap, coherency, staging
+and CONFIRM_UNIT_MOVE are enforced by the same code the mouse uses — the
+plan's "byte-identical legality" goal by construction). Stick speed drops to
+a linear precision curve while carrying. A drops (stages), B cancels back to
+the pickup point, LB/RB rotates via the *synthesized rebindable*
+`rotate_left`/`rotate_right` key events (respects rebinds; covers Movement,
+Deployment and Charge controllers at once), D-pad ◀ ▶ hops the unit's alive
+models (index resets when the unit changes), X undoes the last staged model.
+Deployment: A warps cursor+ghost to the deployment-zone centroid and every
+A after that is a placement click; the transport embark dialog gets pad
+focus. `_handle_back` (B) now clears panel focus AND parks the cursor in one
+press. Fixed along the way: buttons created via `AcceptDialog.add_button()`
+live in the dialog's INTERNAL button row, which `get_children()` skips by
+default — every pad/scenario button-finder now passes
+`get_children(true)`, and the scenario runner projects tokens through the
+scene's own `world_to_screen_position` (the viewport canvas transform
+follows the unused Camera2D and can drift from the CanvasLayer the board
+actually renders in).
+**Gate (met):** `pad_m3_carry_move` (63/0 — pick up, glide-drag, drop
+staged, hop to model 2, second stage, X undo back to 1, Confirm lands
+exactly the kept move in GameState with the undone model unmoved, then the
+oval-based jetbike is carried, rotated ≥0.2 rad with LB and cancelled) and
+`pad_m3_carry_deploy` (32/0 — Battlewagon placed in-zone after ghost
+rotation, Confirm → embark dialog → Deploy Without Embarking → deployment
+alternates to player 1). Full pad suite + KBM baseline: 9/9.
+**Deferred to the M4 turn:** windowed scenarios for charge-move / pile-in /
+consolidate carry (the CHARGE branch is wired through the same pickup path
+but is NOT yet validated — treat charge-by-pad as unverified until its
+scenario lands), and a budget-clamp so the carried model can't be dragged
+past its remaining inches (currently the drop is rejected exactly like an
+over-cap mouse drop; clamping at the cap edge is better UX).
 
 ### M4 — Full native sweep + stratagems + text entry (medium)
 Command/Scoring flows, stratagem & reactive prompts (overwatch etc.), save/load


### PR DESCRIPTION
## Summary

Milestone **M3** of the controller roadmap (`PRPs/steam_deck_controller_support.md`) — the plan's "heart of the feature": native stick-driven model movement, on top of the merged M0–M2 work (#571, #576).

The carry rides the M1 virtual cursor rather than a parallel system: pressing **A** (cursor parked, unit selected) warps the pointer to the active model and holds a synthetic left-button, so **the real drag pipeline runs underneath** — move caps, terrain penalties, overlaps, unit coherency, staging and CONFIRM_UNIT_MOVE are enforced by exactly the code the mouse uses (the plan's "identical legality" goal by construction).

### Controls
- **A** — pick up the active model / drop it (stages the move)
- **Left stick** — steer the carried model (linear precision speed while carrying)
- **D-pad ◀ ▶** — hop between the unit's alive models
- **LB/RB** — rotate the carried model (via the synthesized *rebindable* `rotate_left`/`rotate_right` keys — covers Movement/Deployment/Charge and respects rebinds)
- **X** — undo the last staged model
- **B** — cancel the carry back to the pickup point
- **Deployment**: A warps cursor+ghost into your zone, each A places a model, transport embark prompts get pad focus

### Fixes with reach beyond M3
- Buttons created via `AcceptDialog.add_button()` live in the dialog's **internal** button row, which `get_children()` skips — every pad/scenario button-finder now passes `get_children(true)` (this is why "Confirm Embarkation" / "Deploy Without Embarking" were unreachable).
- The scenario runner projected board tokens through the viewport canvas transform, which follows the scene's unused Camera2D and drifts from the CanvasLayer the board renders in — tokens now project through the scene's own `world_to_screen_position`, matching every input handler.
- `B` now returns fully to the board in one press (releases panel focus **and** parks the cursor).

## Validation (windowed, injected joypad events, zero mouse)

| Scenario | Result |
|---|---|
| `pad_m3_carry_move` | 63/0 — pick up, glide-drag, drop (staged_moves 1→2), X-undo (→1), Confirm lands **only** the kept move in GameState with the undone model verifiably unmoved; oval jetbike carried, rotated ≥0.2 rad with LB, cancelled with B |
| `pad_m3_carry_deploy` | 32/0 — Battlewagon rotated + placed in-zone, embark dialog driven by pad, deployment alternates P2→P1 |
| `pad_m2_shooting_native` | 35/0 — native shooting regression |
| `51_confirm_movement_mode` | 11/0 — mouse/keyboard regression baseline |

Full pad suite + KBM baseline: **9/9** green (re-verified after merging latest main #575). Zero script errors; screenshots inspected per the validation gate.

### Deferred to M4 (recorded in the plan)
Charge-move / pile-in / consolidate carry is wired through the same pickup path but **not yet scenario-gated** — treat charge-by-pad as unverified until its scenario lands. Also queued: a budget clamp so the carried model stops *at* the move-cap edge instead of the drop being rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvGTkYAcrshzReJWHeZKnB

---
_Generated by [Claude Code](https://claude.ai/code/session_01BvGTkYAcrshzReJWHeZKnB)_