### PR TITLE
Put Wazdakka Gutsmek on his correct 120×92mm oval base

### DIFF
--- a/40k/armies/recon_stomps.json
+++ b/40k/armies/recon_stomps.json
@@ -544,10 +544,15 @@
      "id": "m1",
      "wounds": 10,
      "current_wounds": 10,
-     "base_mm": 32,
+     "base_mm": 120,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "base_type": "oval",
+     "base_dimensions": {
+      "length": 92,
+      "width": 120
+     }
     }
    ]
   },

--- a/40k/data/40kdc/units.json
+++ b/40k/data/40kdc/units.json
@@ -56989,6 +56989,11 @@
   "faction_keywords": [
    "Orks"
   ],
+  "base_size_mm": {
+   "shape": "oval",
+   "width": 120,
+   "length": 92
+  },
   "model_count": {
    "min": 1,
    "max": 1

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
     {
+      "version": "0.33.1",
+      "date": "2026-07-13",
+      "summary": "Wazdakka Gutsmek now sits on his correct 120mm x 92mm oval base instead of a 32mm round one, so his footprint, movement, engagement range and charges match the tabletop model.",
+      "changes": [
+        "Wazdakka Gutsmek's base is now a 120mm x 92mm oval (previously a 32mm round base), matching his physical Warhammer 40,000 model.",
+        "This affects his board footprint, base-to-base contact, engagement range and how the token renders and rotates."
+      ]
+    },
+    {
       "version": "0.33.0",
       "date": "2026-07-13",
       "summary": "Model carry \u2014 the heart of controller play: with a unit selected, press A to pick its model up onto the cursor, steer it with the left stick (slower, precise speed while carrying), A drops it, LB/RB rotates it, D-pad left/right hops between the unit's models, B cancels back to where it was picked up, and X undoes the last placed model. Works in the Movement phase and Deployment (including transport embark prompts).",


### PR DESCRIPTION
## Summary

Wazdakka Gutsmek is a `MOUNTED VEHICLE` Epic Hero, but his model in the Recon Stomps army was defined with `base_mm: 32` and no `base_type`, so the game treated him as a **32mm round base**. That gave him the wrong board footprint, base-to-base contact, engagement range, charge geometry and token rendering — and tripped the existing MA-34 "VEHICLE/MONSTER with small base and no base_type" warning in `ArmyListManager`.

This puts him on a **120mm × 92mm oval**, matching the physical Warhammer 40,000 model.

## Changes

- **`40k/armies/recon_stomps.json`** (runtime army) — model `m1`: `base_mm` 32 → 120, added `base_type: "oval"` and `base_dimensions: {length: 92, width: 120}`, following the codebase convention (`width` = long axis, `length` = short axis, `base_mm` = long axis).
- **`40k/data/40kdc/units.json`** (datacard source of truth) — added the missing `base_size_mm: {shape: "oval", width: 120, length: 92}` to the `wazdakka-gutsmek` entry, so regenerated armies pick up the correct base. Matches the existing 120×92 oval datacards (e.g. `corvus-blackstar`, `stormtalon-gunship`).
- **`40k/data/version_history.json`** — new `0.33.1` changelog entry (player-facing change).

## Validation (live, windowed)

Ran the game in a windowed container session and drove the real player path via the `addons/godot_mcp` bridge:

- Started a Recon Stomps match → formations → roll-off → deployment, and deployed Wazdakka through the real `DEPLOY_UNIT` pipeline.
- His token **renders as a 120×92 oval**: the live `TokenVisual.base_shape` is an `OvalBase` with bounds `mm_to_px(92) × mm_to_px(120)` = 144.88 × 188.98 px.
- `Measurement.create_base_shape()` returns an `OvalBase` with the correct dimensions and `needs_pivot_cost: true`.
- **`verify_delivery` → `verdict: PASS`** — scene integrity, autoloads, phase = DEPLOYMENT, zero log errors, and all five base assertions (base_type oval, base_mm 120, width 120, length 92, OvalBase created) pass.

No behavioral code changed — this is a data fix plus a changelog entry. Existing scenarios that reference Wazdakka only assert `is_warlord`, which is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AYbgy9R4yQTV9cGHkFhth

---
_Generated by [Claude Code](https://claude.ai/code/session_016AYbgy9R4yQTV9cGHkFhth)_