### PR TITLE
Terrain scatter: remove red barrels + add a Settings toggle to hide scatter props

### DIFF
--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -46,6 +46,12 @@ var show_unit_labels: bool = true
 # default) they show only a compact height glyph chip (T/M/L).
 var terrain_debug_labels: bool = false
 
+# Terrain scatter props — when true (default) terrain pieces render their
+# decorative scatter sprites (ruins: crates + sandbags, woods: trees) and other
+# cosmetic per-type details. When false the board shows only the terrain
+# footprints, borders and walls, for a cleaner/less cluttered look.
+var show_terrain_scatter: bool = true
+
 # Gameplay settings
 # When true, the computer automatically chooses which wounded/destroyed models
 # are removed during wound allocation instead of prompting the local player.
@@ -84,6 +90,7 @@ signal ruins_style_changed(new_style: String)
 signal auto_allocate_wounds_changed(enabled: bool)
 signal unit_style_changed(new_style: String)
 signal terrain_debug_labels_changed(enabled: bool)
+signal terrain_scatter_changed(enabled: bool)
 
 # P3-111: Settings config file path
 const SETTINGS_FILE_PATH: String = "user://settings.cfg"
@@ -345,6 +352,12 @@ func set_terrain_debug_labels(enabled: bool) -> void:
 	_save_settings()
 	print("[SettingsService] terrain_debug_labels set to %s" % str(enabled))
 
+func set_show_terrain_scatter(enabled: bool) -> void:
+	show_terrain_scatter = enabled
+	terrain_scatter_changed.emit(show_terrain_scatter)
+	_save_settings()
+	print("[SettingsService] show_terrain_scatter set to %s" % str(enabled))
+
 # ============================================================================
 # P3-111: Settings Persistence
 # ============================================================================
@@ -366,6 +379,7 @@ func _save_settings() -> void:
 	config.set_value("visual", "colorblind_mode", colorblind_mode)
 	config.set_value("visual", "show_unit_labels", show_unit_labels)
 	config.set_value("visual", "terrain_debug_labels", terrain_debug_labels)
+	config.set_value("visual", "show_terrain_scatter", show_terrain_scatter)
 	config.set_value("visual", "board_style", board_style)
 	config.set_value("visual", "ruins_style", ruins_style)
 
@@ -406,6 +420,7 @@ func _load_settings() -> void:
 	colorblind_mode = config.get_value("visual", "colorblind_mode", "none")
 	show_unit_labels = config.get_value("visual", "show_unit_labels", true)
 	terrain_debug_labels = config.get_value("visual", "terrain_debug_labels", false)
+	show_terrain_scatter = config.get_value("visual", "show_terrain_scatter", true)
 	board_style = config.get_value("visual", "board_style", "grass")
 	ruins_style = config.get_value("visual", "ruins_style", "concrete")
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.35.1",
+			"date": "2026-07-13",
+			"summary": "Removed the red barrel props from ruins terrain. Viewed top-down they read as flat red circles that looked like objective or blast markers rather than scenery, so ruins now scatter only crates and sandbags.",
+			"changes": [
+				"Ruins terrain no longer scatters the top-down barrel sprite (the red circles); crates and sandbags remain."
+			]
+		},
+		{
 			"version": "0.35.0",
 			"date": "2026-07-12",
 			"summary": "Every unit in the two default armies now has top-down artwork. All 12 units across Recon Stomps (Orks) and Custodes Lions (Adeptus Custodes) render bird's-eye sprites on their bases — including the Stompa's full effigy hull, rotor-spinning Deffkoptas and Warbikes that fill their oval bases, and gold Allarus Terminators.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.36.0",
+			"date": "2026-07-13",
+			"summary": "Added a Settings toggle to hide terrain scatter props. Settings > Visual now has a 'Terrain Scatter Props (crates, sandbags, trees)' checkbox — turn it off for a cleaner, less cluttered board that shows just the terrain footprints, borders and walls. On by default; the choice is saved between sessions.",
+			"changes": [
+				"New Settings > Visual checkbox 'Terrain Scatter Props (crates, sandbags, trees)' — toggles the decorative props scattered on terrain pieces.",
+				"Takes effect immediately on the board (no reload needed) and persists across sessions.",
+				"When off, terrain still shows its footprints, borders, objective markers and walls — only the cosmetic scatter is hidden."
+			]
+		},
+		{
 			"version": "0.35.1",
 			"date": "2026-07-13",
 			"summary": "Removed the red barrel props from ruins terrain. Viewed top-down they read as flat red circles that looked like objective or blast markers rather than scenery, so ruins now scatter only crates and sandbags.",

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -29,6 +29,7 @@ var _colorblind_dropdown: OptionButton
 var _board_style_dropdown: OptionButton
 var _ruins_style_dropdown: OptionButton
 var _terrain_debug_checkbox: CheckBox
+var _terrain_scatter_checkbox: CheckBox
 
 var _auto_allocate_checkbox: CheckBox
 
@@ -166,6 +167,7 @@ func _build_ui() -> void:
 	_animation_speed_label = _get_last_value_label()
 	_colorblind_dropdown = _add_dropdown_row(visual_content, "Colorblind Mode:", ["None", "Protanopia (Red-Green)", "Deuteranopia (Green-Red)", "Tritanopia (Blue-Yellow)"], "_on_colorblind_changed")
 	_terrain_debug_checkbox = _add_checkbox_row(visual_content, "Terrain Debug Labels (internal ids + LoS badges)", "_on_terrain_debug_labels_toggled")
+	_terrain_scatter_checkbox = _add_checkbox_row(visual_content, "Terrain Scatter Props (crates, sandbags, trees)", "_on_terrain_scatter_toggled")
 
 	# ── Gameplay Tab ──
 	var gameplay_scroll = _create_tab_scroll()
@@ -489,6 +491,8 @@ func _load_current_settings() -> void:
 		_colorblind_dropdown.selected = cb_index
 	if _terrain_debug_checkbox:
 		_terrain_debug_checkbox.button_pressed = SettingsService.terrain_debug_labels
+	if _terrain_scatter_checkbox:
+		_terrain_scatter_checkbox.button_pressed = SettingsService.show_terrain_scatter
 
 	# Gameplay
 	if _auto_allocate_checkbox:
@@ -570,6 +574,9 @@ func _on_colorblind_changed(index: int) -> void:
 
 func _on_terrain_debug_labels_toggled(pressed: bool) -> void:
 	SettingsService.set_terrain_debug_labels(pressed)
+
+func _on_terrain_scatter_toggled(pressed: bool) -> void:
+	SettingsService.set_show_terrain_scatter(pressed)
 
 # ============================================================================
 # Gameplay Callbacks

--- a/40k/scripts/TerrainVisual.gd
+++ b/40k/scripts/TerrainVisual.gd
@@ -101,12 +101,20 @@ func _ready() -> void:
 		SettingsService.ruins_style_changed.connect(_on_ruins_style_changed)
 		if SettingsService.has_signal("terrain_debug_labels_changed"):
 			SettingsService.terrain_debug_labels_changed.connect(_on_terrain_debug_labels_changed)
+		if SettingsService.has_signal("terrain_scatter_changed"):
+			SettingsService.terrain_scatter_changed.connect(_on_terrain_scatter_changed)
 
 	print("[TerrainVisual] Initialized")
 
 ## Re-render all terrain when the debug-labels setting flips, so the label
 ## style switches live without reloading the board.
 func _on_terrain_debug_labels_changed(_enabled: bool) -> void:
+	if TerrainManager and TerrainManager.terrain_features.size() > 0:
+		_on_terrain_loaded(TerrainManager.terrain_features)
+
+## Re-render all terrain when the scatter-props setting flips, so the decorative
+## crates/sandbags/trees appear or disappear live without reloading the board.
+func _on_terrain_scatter_changed(_enabled: bool) -> void:
 	if TerrainManager and TerrainManager.terrain_features.size() > 0:
 		_on_terrain_loaded(TerrainManager.terrain_features)
 
@@ -157,6 +165,12 @@ func _get_label_text(terrain_data: Dictionary) -> String:
 ## Whether the verbose internal id labels + LoS badges should render.
 func _debug_labels_enabled() -> bool:
 	return SettingsService != null and SettingsService.terrain_debug_labels
+
+## Whether decorative scatter props (crates, sandbags, trees, per-type details)
+## should render. Defaults to true when SettingsService is unavailable so the
+## automated harness/tests still see the props unless a test opts out.
+func _scatter_enabled() -> bool:
+	return SettingsService == null or SettingsService.show_terrain_scatter
 
 func _add_terrain_piece(terrain_data: Dictionary) -> void:
 	var container = Node2D.new()
@@ -219,8 +233,10 @@ func _add_terrain_piece(terrain_data: Dictionary) -> void:
 	if label_panel != null:
 		container.add_child(label_panel)
 
-	# Add type-specific decorative details
-	_add_terrain_decorations(container, terrain_data)
+	# Add type-specific decorative details (crates, sandbags, trees, scorch
+	# marks, …) unless the player has hidden scatter props for a cleaner board.
+	if _scatter_enabled():
+		_add_terrain_decorations(container, terrain_data)
 
 	# Add LoS-blocker badge only with debug labels on — the compact height chip
 	# already encodes blocks_los via its gold tint.

--- a/40k/scripts/TerrainVisual.gd
+++ b/40k/scripts/TerrainVisual.gd
@@ -334,7 +334,6 @@ func _add_terrain_decorations(container: Node2D, terrain_data: Dictionary) -> vo
 const _RUINS_PROPS := [
 	"res://assets/tilepack/crateWood.png",
 	"res://assets/tilepack/crateMetal.png",
-	"res://assets/tilepack/barrelBlack_top.png",
 	"res://assets/tilepack/sandbagBrown.png",
 	"res://assets/tilepack/sandbagBeige.png",
 ]
@@ -369,7 +368,7 @@ func _scatter_props(container: Node2D, terrain_id: String, position: Vector2, si
 		container.add_child(sprite)
 		placed += 1
 
-## Ruins: crates, barrels and sandbags strewn inside the footprint
+## Ruins: crates and sandbags strewn inside the footprint
 func _add_ruins_decorations(container: Node2D, terrain_id: String, position: Vector2, size: Vector2, polygon_points: PackedVector2Array) -> void:
 	# Scale prop count with footprint area (a 4x6" ruin gets ~4, big ones ~8)
 	var area_sq_inches = (size.x / 40.0) * (size.y / 40.0)

--- a/40k/tests/scenarios/sp/terrain_scatter_toggle.json
+++ b/40k/tests/scenarios/sp/terrain_scatter_toggle.json
@@ -1,0 +1,59 @@
+{
+  "id": "terrain_scatter_toggle",
+  "covers": [
+    "settings.show_terrain_scatter",
+    "board.terrain.scatter_props",
+    "ui.settings_menu.visual"
+  ],
+  "fixture": "co_pretrigger",
+  "transition_to_phase": 6,
+  "description": "Player-facing toggle for terrain scatter props (crates/sandbags/trees). Drives the SettingsService.show_terrain_scatter setting that the Settings > Visual 'Terrain Scatter Props' checkbox is wired to, and proves TerrainVisual re-renders live: with the setting ON the ruins pieces scatter decorative Sprite2D props (count >= 1); toggling it OFF removes every scatter sprite (count == 0) while the terrain footprints/features remain (44 features untouched); toggling back ON restores the props (deterministic, seeded by terrain id). A full-frame pixel_diff confirms the board visibly changes between the off and on captures.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_show_terrain_scatter(true)" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.size()",
+      "expect_min": 1 },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainVisual\").find_children(\"*\", \"Sprite2D\", true, false).size()",
+      "expect_min": 1 },
+
+    { "act": "screenshot", "label": "scatter_on" },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_show_terrain_scatter(false)" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "SettingsService.show_terrain_scatter",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainVisual\").find_children(\"*\", \"Sprite2D\", true, false).size()",
+      "equals": 0 },
+
+    { "act": "execute_script",
+      "script": "TerrainManager.terrain_features.size()",
+      "expect_min": 1 },
+
+    { "act": "screenshot", "label": "scatter_off" },
+
+    { "act": "execute_script",
+      "script": "SettingsService.set_show_terrain_scatter(true)" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainVisual\").find_children(\"*\", \"Sprite2D\", true, false).size()",
+      "expect_min": 1 },
+
+    { "act": "pixel_diff",
+      "before": "scatter_off",
+      "after": "scatter_on",
+      "expect_min_pct": 0.02 }
+  ]
+}


### PR DESCRIPTION
## Summary

Two related changes to terrain scatter (the decorative crates/sandbags/props strewn on ruins pieces):

1. **Removed the red barrel props from ruins terrain.** Viewed top-down, the `barrelBlack_top` sprite renders as a flat red circle that read like an objective or blast marker rather than scenery, which was confusing. Ruins now scatter only crates and sandbags.
2. **Added a Settings toggle to hide terrain scatter props.** New **Settings → Visual** checkbox *"Terrain Scatter Props (crates, sandbags, trees)"*. Off = a clean board showing just the terrain footprints, borders, objective markers and walls. On by default; the choice persists between sessions.

## Changes

- `40k/scripts/TerrainVisual.gd` — drop `barrelBlack_top.png` from the ruins prop pool; gate `_add_terrain_decorations()` on the new setting and re-render live when it flips.
- `40k/autoloads/SettingsService.gd` — new `show_terrain_scatter` bool (default true), `terrain_scatter_changed` signal, setter, and save/load persistence to `settings.cfg`.
- `40k/scripts/SettingsMenu.gd` — the checkbox row, refresh-on-open, and toggle handler (mirrors the existing `terrain_debug_labels` setting).
- `40k/tests/scenarios/sp/terrain_scatter_toggle.json` — new windowed scenario.
- `40k/data/version_history.json` — entries `0.35.1` (barrel removal) and `0.36.0` (toggle).

## Validation

Driven live in the running game via the `addons/godot_mcp` bridge on the default `take_and_hold_mirror_1` layout (44 ruins pieces):

- Barrel removal: 167 scatter props render as crates + sandbags only — **0 barrels**.
- Toggle, driven by clicking the real Settings checkbox: setting flips → board re-renders live **167 → 0** scatter sprites with the **44 terrain features untouched**; round-trip back **0 → 167** (deterministic, seeded by terrain id). Persists to `settings.cfg`. Debug log clean (0 errors/warnings).
- Windowed scenario `tests/scenarios/sp/terrain_scatter_toggle.json` **passes 16/16 steps** (167→0→167, features intact, pixel_diff 0.043%).

## Note

The toggle hides all cosmetic terrain decorations (crater scorch marks, hill contours, barricade and impassable markings too), not just ruins crates/sandbags. Easy to scope down to ruins-only scatter if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014vqvYaq8oP3BhweqxG7ZhS

---
_Generated by [Claude Code](https://claude.ai/code/session_014vqvYaq8oP3BhweqxG7ZhS)_