### PR TITLE
Show primary mission scoring rules + text in the Scoring panel

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.36.0",
+			"date": "2026-07-13",
+			"summary": "The Scoring phase now spells out each player's primary mission in full: alongside the card name you get the official scoring blurb and a plain-English, per-rule VP breakdown, so you can see exactly how your primary scores without a rulebook.",
+			"changes": [
+				"Primary mission panel (Scoring phase): each player's disposition-paired card now shows a 'PRIMARY MISSIONS' section with the card title, the official mission text, and a bullet list of every scoring rule — e.g. 'End of game: +10VP — control the enemy's home objective'.",
+				"Each rule line reads its timing (Command phase / End of turn / End of game), the battle-round window (R2+, R1–2, ...), the VP, and the condition, generated from the same rules the game actually scores so the text can't drift from the maths.",
+				"Card names are colour-coded per player and cards built from approximate rules are still marked with a '~'.",
+				"No change to how primaries score — this is display only."
+			]
+		},
+		{
 			"version": "0.35.0",
 			"date": "2026-07-12",
 			"summary": "Every unit in the two default armies now has top-down artwork. All 12 units across Recon Stomps (Orks) and Custodes Lions (Adeptus Custodes) render bird's-eye sprites on their bases — including the Stompa's full effigy hull, rotor-spinning Deffkoptas and Warbikes that fill their oval bases, and gold Allarus Terminators.",

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -339,20 +339,63 @@ func _build_objective_control_section(panel: VBoxContainer, _current_player: int
 
 	# Mission info — at e11 (GDM 2026) each player scores their OWN
 	# disposition-paired primary card, so show both instead of the shared
-	# 10e mission name. "~" marks cards built from approximate source rows.
+	# 10e mission name. Each card shows its title, the official scoring blurb
+	# and a per-rule VP breakdown so a player can read exactly what it awards
+	# (not just the name). "~" marks cards built from approximate source rows.
 	if GameConstants.edition >= 11 and not MissionManager.player_primary_missions.is_empty():
+		var primary_title = Label.new()
+		primary_title.text = "PRIMARY MISSIONS"
+		primary_title.add_theme_font_size_override("font_size", 13)
+		primary_title.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+		if FactionPalettes:
+			primary_title.add_theme_font_override("font", FactionPalettes.FONT_RAJDHANI_BOLD)
+		panel.add_child(primary_title)
+
 		for p in [1, 2]:
+			if p == 2:
+				panel.add_child(_create_spacer(4))
 			var card = MissionManager.get_primary_mission_for_player(p)
 			var disp = MissionManager.player_dispositions.get(str(p), "")
+			var p_color = FactionPalettes.get_player_border_color(p) if FactionPalettes else Color(0.8, 0.8, 0.6)
+
+			# Card title (kept as P{p}PrimaryMissionLabel for the panel scenario)
 			var card_label = Label.new()
 			card_label.name = "P%dPrimaryMissionLabel" % p
 			card_label.text = "P%d Primary: %s%s (%s)" % [
 				p, card.get("name", "?"),
 				" ~" if card.get("approximate", false) else "",
 				PrimaryMissionData11e.get_disposition_name(disp)]
-			card_label.add_theme_font_size_override("font_size", 11)
-			card_label.add_theme_color_override("font_color", Color(0.55, 0.52, 0.45))
+			card_label.add_theme_font_size_override("font_size", 12)
+			card_label.add_theme_color_override("font_color", p_color)
+			if FactionPalettes:
+				card_label.add_theme_font_override("font", FactionPalettes.FONT_RAJDHANI_BOLD)
+			card_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			panel.add_child(card_label)
+
+			# Official scoring blurb (prose)
+			var blurb: String = PrimaryMissionData11e.get_card_text(card)
+			if blurb != "":
+				var text_label = Label.new()
+				text_label.name = "P%dPrimaryTextLabel" % p
+				text_label.text = blurb
+				text_label.add_theme_font_size_override("font_size", 10)
+				text_label.add_theme_color_override("font_color", Color(0.62, 0.6, 0.52))
+				text_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+				panel.add_child(text_label)
+
+			# Per-rule VP breakdown (what the engine actually scores)
+			var lines: Array = PrimaryMissionData11e.get_scoring_lines(card)
+			if not lines.is_empty():
+				var rules_label = Label.new()
+				rules_label.name = "P%dPrimaryRulesLabel" % p
+				var strs := PackedStringArray()
+				for l in lines:
+					strs.append("• " + str(l))
+				rules_label.text = "\n".join(strs)
+				rules_label.add_theme_font_size_override("font_size", 10)
+				rules_label.add_theme_color_override("font_color", Color(0.5, 0.8, 0.5))
+				rules_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+				panel.add_child(rules_label)
 	else:
 		var mission_name = MissionManager.get_current_mission_name()
 		var mission_info = Label.new()

--- a/40k/scripts/data/PrimaryMissionData11e.gd
+++ b/40k/scripts/data/PrimaryMissionData11e.gd
@@ -433,6 +433,35 @@ static func _load_cards() -> void:
 		],
 	})
 
+	# Attach the official prose scoring blurbs (source of truth for the
+	# human-readable card text shown in the Scoring panel).
+	_attach_texts()
+
+## Load the official prose scoring text from the 40kdc dataset and attach it to
+## each card as card["text"]. Matched by id (underscore<->hyphen). Best-effort:
+## if the file is missing/unreadable the cards simply carry no blurb and the UI
+## falls back to the generated per-rule breakdown.
+static func _attach_texts() -> void:
+	var path := "res://data/40kdc/missionCards.json"
+	if not FileAccess.file_exists(path):
+		return
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return
+	var raw := f.get_as_text()
+	f.close()
+	var data = JSON.parse_string(raw)
+	if typeof(data) != TYPE_ARRAY:
+		return
+	var text_by_id := {}
+	for entry in data:
+		if typeof(entry) == TYPE_DICTIONARY and entry.get("card_type", "") == "primary":
+			text_by_id[str(entry.get("id", ""))] = str(entry.get("text", ""))
+	for key in _cards:
+		var json_id: String = str(_cards[key].get("id", "")).replace("_", "-")
+		if text_by_id.has(json_id):
+			_cards[key]["text"] = text_by_id[json_id]
+
 # ============================================================================
 # PUBLIC API
 # ============================================================================
@@ -465,3 +494,148 @@ static func is_valid_disposition(disposition: String) -> bool:
 
 static func get_disposition_name(disposition: String) -> String:
 	return DISPOSITION_NAMES.get(disposition, disposition)
+
+# ============================================================================
+# HUMAN-READABLE SCORING TEXT (for the in-game primary-mission panel)
+# ============================================================================
+
+## Official prose description of a card's scoring, sourced verbatim from the
+## 40kdc dataset (missionCards.json). Empty string if the card has no blurb.
+static func get_card_text(card: Dictionary) -> String:
+	return str(card.get("text", ""))
+
+## One readable line per scoring rule, in card order — e.g.
+## "Command phase (R2+): +3VP — per objective you control". Rendered under the
+## card name in the Scoring panel so a player can read exactly what the card
+## awards instead of only its title. Derived from the SAME structured rules the
+## engine scores, so the text can never drift from the actual behaviour.
+static func get_scoring_lines(card: Dictionary) -> Array:
+	var lines: Array = []
+	for rule in card.get("rules", []):
+		lines.append(describe_rule(rule))
+	return lines
+
+static func describe_rule(rule: Dictionary) -> String:
+	return "%s: %s — %s" % [_describe_timing(rule), _describe_vp(rule), _describe_condition(rule)]
+
+static func _describe_timing(rule: Dictionary) -> String:
+	var base := ""
+	match str(rule.get("when", "")):
+		"command": base = "Command phase"
+		"eot": base = "End of turn"
+		"eot_any": base = "End of any turn"
+		"eog": base = "End of game"
+		_: base = str(rule.get("when", "?"))
+	var rtxt := _describe_rounds(rule.get("rounds", []))
+	return base if rtxt == "" else "%s %s" % [base, rtxt]
+
+static func _describe_rounds(rounds) -> String:
+	if typeof(rounds) != TYPE_ARRAY or rounds.size() < 2:
+		return ""
+	var lo := int(rounds[0])
+	var hi := int(rounds[1])
+	if lo <= 1 and hi >= 5:
+		return ""  # every round — no qualifier needed
+	if lo == hi:
+		return "(R%d)" % lo
+	if hi >= 5:
+		return "(R%d+)" % lo
+	return "(R%d–%d)" % [lo, hi]
+
+static func _describe_vp(rule: Dictionary) -> String:
+	if rule.has("vp_per"):
+		return "+%dVP" % int(rule["vp_per"])
+	if rule.has("vp"):
+		return "+%dVP" % int(rule["vp"])
+	return "VP"
+
+static func _describe_condition(rule: Dictionary) -> String:
+	var t := str(rule.get("type", ""))
+	var excl := " (excl. home)" if rule.get("exclude_home", false) else ""
+	match t:
+		"hold_min":
+			var n := int(rule.get("min", 1))
+			return "control %d+ objective%s%s" % [n, "s" if n != 1 else "", excl]
+		"per_objective":
+			var s := "per objective you control"
+			if rule.get("zone", "") == "enemy_territory":
+				s += " in enemy territory"
+			elif rule.get("exclude_home", false):
+				s += " (excl. home)"
+			if rule.get("require_hold_home", false):
+				s += ", while you hold your own home"
+			return s
+		"per_new_objective":
+			return "per objective newly taken this turn"
+		"hold_more":
+			return "control more objectives than your opponent"
+		"hold_enemy_home":
+			return "control the enemy's home objective"
+		"hold_central":
+			return "control the central objective"
+		"hold_central_plus_nml":
+			return "control the central objective + another No Man's Land objective"
+		"hold_new":
+			return "control an objective you didn't hold at the start of your turn%s" % excl
+		"destroyed_min":
+			var dn := int(rule.get("min", 1))
+			return "destroy %d+ enemy unit%s" % [dn, "s" if dn != 1 else ""]
+		"destroyed_per_unit":
+			return "per enemy unit you destroy this turn"
+		"killed_more_than_opponent_last_turn":
+			return "destroy more units than your opponent did on their last turn"
+		"quarters":
+			return "have units in %d+ table quarters" % int(rule.get("min", 3))
+		"triangulated_count":
+			return "Triangulate %s objective(s)" % _tier_text(rule)
+		"consecrated_count":
+			return "Consecrate %s objective(s)" % _tier_text(rule)
+		"consecrated_enemy_home":
+			return "Consecrate the enemy's home objective"
+		"condemned_left":
+			return "a Condemned enemy unit leaves the battlefield"
+		"sabotage_per_objective":
+			return "per objective you Sabotage (bonus in enemy territory)"
+		"central_operation_markers":
+			return "control the central objective, +1VP per operation marker on it"
+		"destroyed_near_central":
+			return "destroy an enemy unit on a central objective"
+		"vanguard_terrain_area":
+			return "complete a Vanguard Operation in enemy territory"
+		"sensor_sweep_vp":
+			return "complete a Sensor Sweep action"
+		"relic_final_marker":
+			return "be the last player holding a relic marker"
+		"decoyed_score":
+			return "per objective you Decoy (bonus in enemy territory)"
+		"decoyed_total_eog":
+			return "Decoy %d+ objectives in total" % int(rule.get("min", 4))
+		"no_enemy_markers":
+			return "no enemy operation markers remain"
+		"intel_tokens_placed":
+			return "per Extract Intelligence action you complete"
+		"operation_markers_min":
+			return "have %d+ operation markers on the battlefield" % int(rule.get("min", 3))
+		"intel_token_on_enemy_home":
+			return "place a marker near the enemy's home objective"
+		"trapped_score":
+			return "per terrain area you Booby Trap this turn (bonus if it holds an objective)"
+		"destroyed_started_on_objective":
+			return "destroy an enemy unit that started the turn on an objective"
+		"destroyed_in_terrain_area":
+			return "destroy an enemy unit in %s terrain area" % ("a trapped" if rule.get("trapped_only", false) else "a")
+		"no_enemy_wholly_in_my_dz":
+			return "no enemy units are wholly within your territory"
+		"action":
+			return "complete the '%s' action" % str(rule.get("action_name", "mission"))
+		_:
+			return t.replace("_", " ")
+
+## Tier label for the exclusive_group count rules (Triangulate / Consecrate):
+## "exactly 2", "1–2" or "3+" depending on the rule's count bounds.
+static func _tier_text(rule: Dictionary) -> String:
+	var lo := int(rule.get("count_min", 1))
+	if rule.has("count_max"):
+		var hi := int(rule["count_max"])
+		return str(lo) if lo == hi else "%d–%d" % [lo, hi]
+	return "%d+" % lo

--- a/40k/tests/scenarios/sp/iss064c_primary_mission_panel_11e.json
+++ b/40k/tests/scenarios/sp/iss064c_primary_mission_panel_11e.json
@@ -1,14 +1,15 @@
 {
   "id": "iss064c_primary_mission_panel_11e",
   "covers": [
-    "ui.ScoringPanel.primary_missions_11e"
+    "ui.ScoringPanel.primary_missions_11e",
+    "ui.ScoringPanel.primary_scoring_text_11e"
   ],
   "fixture": "audit_374_kunnin",
   "edition": 11,
   "rng_seed": 42,
   "transition_to_phase": 11,
   "disable_ai": true,
-  "description": "Audit Tier-1 #1 UI surface (GDM 2026): at e11 the Scoring-phase right panel shows each player's OWN disposition-paired primary card instead of the shared 10e mission name. P1 Priority Assets vs P2 Purge the Foe pairs to Vital Link (flagged ~ approximate) and Destroyer's Wrath; the panel rebuild renders both named labels with the exact card + disposition text.",
+  "description": "Audit Tier-1 #1 UI surface (GDM 2026): at e11 the Scoring-phase right panel shows each player's OWN disposition-paired primary card — the card name, the official scoring blurb, AND a per-rule VP breakdown (not just the title). P1 Priority Assets vs P2 Purge the Foe pairs to Vital Link (flagged ~ approximate) and Destroyer's Wrath; the panel renders both named header labels, the prose text labels, and the rules labels with the exact VP lines.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 11 },
@@ -27,6 +28,25 @@
       "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryMissionLabel",
       "property": "text",
       "equals": "P2 Primary: Destroyer's Wrath (Purge the Foe)" },
-    { "act": "screenshot", "label": "01_per_player_primary_cards_in_panel" }
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryTextLabel" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryTextLabel\").text.find(\"Maintain Control action\") >= 0",
+      "equals": true },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryRulesLabel" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryRulesLabel\").text.find(\"+10VP\") >= 0 and main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P1PrimaryRulesLabel\").text.find(\"enemy's home objective\") >= 0",
+      "equals": true },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryTextLabel" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryTextLabel\").text.find(\"out-killing the opponent\") >= 0",
+      "equals": true },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryRulesLabel" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryRulesLabel\").text.find(\"destroy 1+ enemy unit\") >= 0 and main.get_node(\"HUD_Right/VBoxContainer/ScoringScrollContainer/ScoringPanel/P2PrimaryRulesLabel\").text.find(\"+6VP\") >= 0",
+      "equals": true },
+
+    { "act": "screenshot", "label": "01_primary_cards_scoring_text_in_panel" }
   ]
 }


### PR DESCRIPTION
## Summary

At 11th edition the Scoring-phase right panel only showed each player's primary card **name** (e.g. `P1 Primary: Vital Link (Priority Assets)`) — unlike secondary missions, which show their full scoring text. Players had to open the docs to know what their primary actually awards.

The panel now renders a **PRIMARY MISSIONS** section per player with:

- the **card title** (faction-coloured; `~` still marks approximate cards),
- the **official prose blurb**, sourced verbatim from the 40kdc dataset (`missionCards.json`) and attached to each card by id, and
- a **plain-English, per-rule VP breakdown** generated from the *same structured rules the engine scores* — so the displayed text can never drift from the actual maths (e.g. `End of game: +10VP — control the enemy's home objective`).

This is **display-only** — no scoring behaviour changed.

## Changes

- **`40k/scripts/data/PrimaryMissionData11e.gd`** — new `get_card_text()` / `get_scoring_lines()` plus timing/rounds/VP/condition formatters; best-effort loading of the prose blurbs (a missing JSON just falls back to the generated breakdown).
- **`40k/scripts/ScoringController.gd`** — replaced the one-line label with the title + blurb + rules rendering.
- **`40k/tests/scenarios/sp/iss064c_primary_mission_panel_11e.json`** — extended the windowed scenario to assert the new text/rules labels and their exact VP content.
- **`40k/data/version_history.json`** — new entry `0.36.0`.

## Validation

- **Windowed scenario** `iss064c_primary_mission_panel_11e` — 18/18 assertions pass, driving the real Scoring panel and asserting the exact VP lines; screenshot captured of the rendered blurb + rule bullets.
- **No ERROR / SCRIPT ERROR** lines in the debug log during the run.
- **Headless suite** `test_primary_missions_11e.gd` — 56/56 pass, confirming the data model is intact and scoring is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016izaHKowyHYxCFx8ta22YG

---
_Generated by [Claude Code](https://claude.ai/code/session_016izaHKowyHYxCFx8ta22YG)_