### PR TITLE
Unit color as a ring (default) + distinct auto-colors for duplicate squads

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -1553,6 +1553,15 @@ func get_unit_color(unit_id: String) -> Color:
 		return Color.from_string(hex, Color.TRANSPARENT)
 	return Color.TRANSPARENT
 
+func clear_unit_color(unit_id: String) -> void:
+	# Reset a unit's stored token color to "unassigned" so the next
+	# auto_assign_unit_color / draw re-picks one. Mirrors set_unit_color — the
+	# unit_visuals map is UI metadata and is mutated directly here (in GameState,
+	# the state owner) rather than by a caller reaching into GameState.state.
+	_ensure_unit_visuals()
+	if state["unit_visuals"].has(unit_id):
+		state["unit_visuals"][unit_id]["color"] = ""
+
 func set_unit_label(unit_id: String, label: String) -> void:
 	_ensure_unit_visuals()
 	if not state["unit_visuals"].has(unit_id):

--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -1577,15 +1577,61 @@ func get_used_colors_for_player(player: int) -> Array:
 	return colors
 
 func auto_assign_unit_color(unit_id: String) -> Color:
+	# Pick a distinct token color for this unit. Multiple squads of the SAME name
+	# (e.g. two "Boyz" squads, whose meta.name is identical — only display_name
+	# gets the Greek suffix) must each get a different color so the player can
+	# tell them apart on the board. We prefer a palette color no unit is using
+	# army-wide; if the faction palette is exhausted, we at least keep same-named
+	# siblings distinct.
 	var unit = get_unit(unit_id)
 	if unit.is_empty():
 		return Color(0.4, 0.4, 0.4)
 	var player = unit.get("owner", 1)
 	var faction_name = state.get("factions", {}).get(str(player), {}).get("name", "")
-	var used = get_used_colors_for_player(player)
-	var color = FactionPalettes.get_auto_color(faction_name, used)
-	set_unit_color(unit_id, color)
-	return color
+	var base_name = str(unit.get("meta", {}).get("name", ""))
+	var palette = FactionPalettes.get_palette(faction_name)
+	if palette.is_empty():
+		var fallback = Color(0.4, 0.4, 0.4)
+		set_unit_color(unit_id, fallback)
+		return fallback
+
+	# Colors already assigned to this player's units, keyed by hex string.
+	# NOTE: comparison is by hex (color.to_html) rather than Color.is_equal_approx
+	# because set_unit_color stores an 8-bit-quantised hex; comparing that back
+	# against the float palette entry with is_equal_approx never matched, so the
+	# old code always returned palette[0] and every unit came out the same color.
+	var used_all := {}
+	var used_siblings := {}
+	_ensure_unit_visuals()
+	for uid in state["unit_visuals"]:
+		if uid == unit_id:
+			continue
+		var other = get_unit(uid)
+		if other.get("owner", 0) != player:
+			continue
+		var hex = state["unit_visuals"][uid].get("color", "")
+		if hex == "":
+			continue
+		used_all[hex] = true
+		if str(other.get("meta", {}).get("name", "")) == base_name:
+			used_siblings[hex] = true
+
+	# 1) first palette color unused by ANY of the player's units
+	var chosen = palette[0]
+	var found := false
+	for color in palette:
+		if not used_all.has(color.to_html(false)):
+			chosen = color
+			found = true
+			break
+	# 2) palette exhausted army-wide — keep at least same-named squads distinct
+	if not found:
+		for color in palette:
+			if not used_siblings.has(color.to_html(false)):
+				chosen = color
+				break
+	set_unit_color(unit_id, chosen)
+	return chosen
 
 
 ## ISS-025: the action-pipeline diff applier (moved from PhaseManager —

--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -1166,6 +1166,65 @@ func max_tokens_per_model() -> int:
 			mx = max(mx, int(counts[k]))
 	return mx
 
+# Regression guard for the auto token-color bug: every SET of same-named units
+# (same meta.name) belonging to `player` must end up with DISTINCT colors so two
+# "Boyz" squads never render identically. Clears then re-runs
+# auto_assign_unit_color for all of the player's units so it tests the
+# assignment logic itself, not whatever colors the fixture was saved with (the
+# old hex-roundtrip bug returned palette[0] for every unit). Callable from
+# execute_script as same_name_colors_distinct(1) with equals true.
+func same_name_colors_distinct(player: int) -> bool:
+	GameState._ensure_unit_visuals()
+	var by_name := {}
+	for uid in GameState.state.get("units", {}):
+		var u = GameState.state["units"][uid]
+		if int(u.get("owner", 0)) != player:
+			continue
+		if GameState.state["unit_visuals"].has(uid):
+			GameState.state["unit_visuals"][uid]["color"] = ""
+		var nm := str(u.get("meta", {}).get("name", ""))
+		if not by_name.has(nm):
+			by_name[nm] = []
+		by_name[nm].append(uid)
+	# Re-assign every one of the player's units (order = dict/id order).
+	for uid in GameState.state.get("units", {}):
+		if int(GameState.state["units"][uid].get("owner", 0)) == player:
+			GameState.auto_assign_unit_color(uid)
+	# Within each same-name group, colors must be unique.
+	for nm in by_name:
+		var ids: Array = by_name[nm]
+		if ids.size() < 2:
+			continue
+		var seen := {}
+		for uid in ids:
+			var hex := GameState.get_unit_color(uid).to_html(false)
+			if seen.has(hex):
+				return false
+			seen[hex] = true
+	return true
+
+# True when the first board token reports "ring" color-display mode — proves the
+# SettingsService.unit_color_display_mode setting reaches TokenVisual. Callable
+# from execute_script as first_token_ring_mode() with equals true/false.
+func first_token_ring_mode() -> bool:
+	var scene := get_tree().current_scene
+	if scene == null:
+		return false
+	var tl := scene.get_node_or_null("BoardRoot/TokenLayer")
+	if tl == null:
+		return false
+	for c in tl.get_children():
+		if c.has_method("_is_ring_color_mode"):
+			return c._is_ring_color_mode()
+	return false
+
+# Set the unit color-display mode and return the resulting stored value so an
+# execute_script step can both drive the toggle and assert it in one call:
+# set_color_display_mode("ring") with equals "ring".
+func set_color_display_mode(mode: String) -> String:
+	SettingsService.set_unit_color_display_mode(mode)
+	return SettingsService.unit_color_display_mode
+
 func _send_click(screen_pos: Vector2) -> void:
 	# Warp the live cursor to the target BEFORE injecting the event. GUI Controls
 	# route by event position, but board/world handlers (e.g. DeploymentController

--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -1180,8 +1180,7 @@ func same_name_colors_distinct(player: int) -> bool:
 		var u = GameState.state["units"][uid]
 		if int(u.get("owner", 0)) != player:
 			continue
-		if GameState.state["unit_visuals"].has(uid):
-			GameState.state["unit_visuals"][uid]["color"] = ""
+		GameState.clear_unit_color(uid)
 		var nm := str(u.get("meta", {}).get("name", ""))
 		if not by_name.has(nm):
 			by_name[nm] = []

--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -8,6 +8,12 @@ var deployment_zone_depth_inches: float = 12.0
 # Unit visual style: "letter" (colored base+letter), "enhanced" (gradient+sprites), "style_a" (silhouettes), "style_b" (faction glyphs), "classic" (plain)
 var unit_visual_style: String = "letter"
 
+# How a unit's custom/auto-assigned color is applied to its token in letter
+# mode: "full" fills the whole base with the color (original behavior); "ring"
+# keeps a neutral base and draws the color only as a ring just inside the base
+# perimeter, so the model art stays readable and squads are told apart by ring.
+var unit_color_display_mode: String = "full"
+
 # Sprite directory for user-provided token art (Phase 2)
 var sprite_directory: String = "user://sprites/"
 
@@ -89,6 +95,7 @@ signal board_style_changed(new_style: String)
 signal ruins_style_changed(new_style: String)
 signal auto_allocate_wounds_changed(enabled: bool)
 signal unit_style_changed(new_style: String)
+signal unit_color_display_changed(new_mode: String)
 signal terrain_debug_labels_changed(enabled: bool)
 signal terrain_scatter_changed(enabled: bool)
 
@@ -346,6 +353,15 @@ func set_unit_visual_style_setting(style: String) -> void:
 	_save_settings()
 	print("[SettingsService] Unit visual style set to %s" % style)
 
+func set_unit_color_display_mode(mode: String) -> void:
+	if mode not in ["full", "ring"]:
+		print("[SettingsService] Invalid unit color display mode: %s" % mode)
+		return
+	unit_color_display_mode = mode
+	unit_color_display_changed.emit(unit_color_display_mode)
+	_save_settings()
+	print("[SettingsService] Unit color display mode set to %s" % mode)
+
 func set_terrain_debug_labels(enabled: bool) -> void:
 	terrain_debug_labels = enabled
 	terrain_debug_labels_changed.emit(terrain_debug_labels)
@@ -373,6 +389,7 @@ func _save_settings() -> void:
 
 	# Visual
 	config.set_value("visual", "unit_visual_style", unit_visual_style)
+	config.set_value("visual", "unit_color_display_mode", unit_color_display_mode)
 	config.set_value("visual", "retro_mode", retro_mode)
 	config.set_value("visual", "ui_scale", ui_scale)
 	config.set_value("visual", "animation_speed", animation_speed)
@@ -414,6 +431,7 @@ func _load_settings() -> void:
 
 	# Visual
 	unit_visual_style = config.get_value("visual", "unit_visual_style", "letter")
+	unit_color_display_mode = config.get_value("visual", "unit_color_display_mode", "full")
 	retro_mode = config.get_value("visual", "retro_mode", false)
 	ui_scale = config.get_value("visual", "ui_scale", 1.0)
 	animation_speed = config.get_value("visual", "animation_speed", 1.0)

--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -9,10 +9,10 @@ var deployment_zone_depth_inches: float = 12.0
 var unit_visual_style: String = "letter"
 
 # How a unit's custom/auto-assigned color is applied to its token in letter
-# mode: "full" fills the whole base with the color (original behavior); "ring"
-# keeps a neutral base and draws the color only as a ring just inside the base
-# perimeter, so the model art stays readable and squads are told apart by ring.
-var unit_color_display_mode: String = "full"
+# mode: "ring" (default) keeps a neutral base and draws the color only as a ring
+# just inside the base perimeter, so the model art stays readable and squads are
+# told apart by ring; "full" fills the whole base with the color (original look).
+var unit_color_display_mode: String = "ring"
 
 # Sprite directory for user-provided token art (Phase 2)
 var sprite_directory: String = "user://sprites/"
@@ -431,7 +431,7 @@ func _load_settings() -> void:
 
 	# Visual
 	unit_visual_style = config.get_value("visual", "unit_visual_style", "letter")
-	unit_color_display_mode = config.get_value("visual", "unit_color_display_mode", "full")
+	unit_color_display_mode = config.get_value("visual", "unit_color_display_mode", "ring")
 	retro_mode = config.get_value("visual", "retro_mode", false)
 	ui_scale = config.get_value("visual", "ui_scale", 1.0)
 	animation_speed = config.get_value("visual", "animation_speed", 1.0)

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.37.0",
+			"date": "2026-07-13",
+			"summary": "Unit colors can now show as a ring instead of filling the whole base, and duplicate squads of the same unit are automatically given different colors. Settings > Visual has a new 'Unit Color' option (Full Base / Ring Only) — 'Ring Only' keeps a neutral base and paints your chosen color as a ring inside the base edge, so the model art stays clear. Deploying a second squad of the same name (e.g. a second Boyz) now auto-picks a different color from the first.",
+			"changes": [
+				"New Settings > Visual dropdown 'Unit Color' with 'Full Base' (original) and 'Ring Only' — Ring Only draws the unit color as a ring just inside the base perimeter over a neutral base.",
+				"Right-click > Change Color still sets the color; the new setting only changes whether it fills the base or shows as a ring. Applies live to every token, no reload needed, and persists between sessions.",
+				"Duplicate squads of the same unit type/name now get distinct auto-assigned colors as you deploy them (fixes a bug where every squad came out the same color).",
+				"Takes effect in the default 'Letter' unit style where the token color is used."
+			]
+		},
+		{
 			"version": "0.36.0",
 			"date": "2026-07-13",
 			"summary": "Added a Settings toggle to hide terrain scatter props. Settings > Visual now has a 'Terrain Scatter Props (crates, sandbags, trees)' checkbox — turn it off for a cleaner, less cluttered board that shows just the terrain footprints, borders and walls. On by default; the choice is saved between sessions.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -4,10 +4,11 @@
 		{
 			"version": "0.37.0",
 			"date": "2026-07-13",
-			"summary": "Unit colors can now show as a ring instead of filling the whole base, and duplicate squads of the same unit are automatically given different colors. Settings > Visual has a new 'Unit Color' option (Full Base / Ring Only) — 'Ring Only' keeps a neutral base and paints your chosen color as a ring inside the base edge, so the model art stays clear. Deploying a second squad of the same name (e.g. a second Boyz) now auto-picks a different color from the first.",
+			"summary": "Unit colors now display as a ring by default instead of filling the whole base, and duplicate squads of the same unit are automatically given different colors. The new Settings > Visual 'Unit Color' option defaults to 'Ring Only', which keeps a neutral base and paints your chosen color as a ring inside the base edge so the model art stays clear — switch it to 'Full Base' for the original solid-base look. Deploying a second squad of the same name (e.g. a second Boyz) now auto-picks a different color from the first.",
 			"changes": [
-				"New Settings > Visual dropdown 'Unit Color' with 'Full Base' (original) and 'Ring Only' — Ring Only draws the unit color as a ring just inside the base perimeter over a neutral base.",
-				"Right-click > Change Color still sets the color; the new setting only changes whether it fills the base or shows as a ring. Applies live to every token, no reload needed, and persists between sessions.",
+				"Unit colors now show as a ring around the model by default (neutral base, color band just inside the base perimeter) so the model art stays readable.",
+				"New Settings > Visual dropdown 'Unit Color' — 'Ring Only' (default) or 'Full Base' (the original solid colored base).",
+				"Right-click > Change Color still sets the color; the setting only changes whether it fills the base or shows as a ring. Applies live to every token, no reload needed, and persists between sessions.",
 				"Duplicate squads of the same unit type/name now get distinct auto-assigned colors as you deploy them (fixes a bug where every squad came out the same color).",
 				"Takes effect in the default 'Letter' unit style where the token color is used."
 			]

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -21,6 +21,7 @@ var _music_volume_label: Label
 var _sfx_volume_label: Label
 
 var _visual_style_dropdown: OptionButton
+var _unit_color_display_dropdown: OptionButton
 var _ui_scale_slider: HSlider
 var _ui_scale_label: Label
 var _animation_speed_slider: HSlider
@@ -161,6 +162,7 @@ func _build_ui() -> void:
 	_board_style_dropdown = _add_dropdown_row(visual_content, "Board Texture:", ["Grass", "Mud", "Desert", "Stone", "Felt", "Tilepack", "None (Solid)"], "_on_board_style_changed")
 	_ruins_style_dropdown = _add_dropdown_row(visual_content, "Ruins Texture:", ["Concrete", "Marble", "Brick", "Weathered Stone", "None (Solid)"], "_on_ruins_style_changed")
 	_visual_style_dropdown = _add_dropdown_row(visual_content, "Unit Style:", ["Letter (Default)", "Enhanced", "Silhouettes", "Faction Glyphs", "Classic"], "_on_visual_style_changed")
+	_unit_color_display_dropdown = _add_dropdown_row(visual_content, "Unit Color:", ["Full Base", "Ring Only"], "_on_unit_color_display_changed")
 	_ui_scale_slider = _add_slider_row(visual_content, "UI Scale:", 0.5, 2.0, 0.1, "_on_ui_scale_changed")
 	_ui_scale_label = _get_last_value_label()
 	_animation_speed_slider = _add_slider_row(visual_content, "Animation Speed:", 0.25, 3.0, 0.25, "_on_animation_speed_changed")
@@ -482,6 +484,10 @@ func _load_current_settings() -> void:
 	var style_index = ["letter", "enhanced", "style_a", "style_b", "classic"].find(SettingsService.unit_visual_style)
 	if style_index >= 0:
 		_visual_style_dropdown.selected = style_index
+	if _unit_color_display_dropdown:
+		var color_mode_index = ["full", "ring"].find(SettingsService.unit_color_display_mode)
+		if color_mode_index >= 0:
+			_unit_color_display_dropdown.selected = color_mode_index
 	_ui_scale_slider.value = SettingsService.ui_scale
 	_update_scale_label(_ui_scale_label, SettingsService.ui_scale)
 	_animation_speed_slider.value = SettingsService.animation_speed
@@ -558,6 +564,11 @@ func _on_visual_style_changed(index: int) -> void:
 	var styles = ["letter", "enhanced", "style_a", "style_b", "classic"]
 	if index >= 0 and index < styles.size():
 		SettingsService.set_unit_visual_style_setting(styles[index])
+
+func _on_unit_color_display_changed(index: int) -> void:
+	var modes = ["full", "ring"]
+	if index >= 0 and index < modes.size():
+		SettingsService.set_unit_color_display_mode(modes[index])
 
 func _on_ui_scale_changed(value: float) -> void:
 	SettingsService.set_ui_scale(value)

--- a/40k/scripts/TokenVisual.gd
+++ b/40k/scripts/TokenVisual.gd
@@ -31,6 +31,11 @@ var is_exhausted_this_phase: bool = false
 const T09_EXHAUSTION_MODULATE := Color(0.6, 0.6, 0.6, 1.0)
 const T09_NORMAL_MODULATE := Color(1.0, 1.0, 1.0, 1.0)
 
+# Neutral base fill used in "ring" color-display mode (letter style). The unit's
+# color is drawn only as a ring on top of this, so the base itself is a plain
+# dark slate that keeps the model art and colored ring readable.
+const LETTER_RING_BASE_FILL := Color(0.24, 0.24, 0.27, 1.0)
+
 # Animated sprite system
 var _anim_resolved: bool = false
 var _animations: Dictionary = {}               # animation_name -> SpriteAnimationData
@@ -70,6 +75,10 @@ func _ready() -> void:
 	if SettingsService and SettingsService.has_signal("unit_style_changed"):
 		if not SettingsService.is_connected("unit_style_changed", _on_unit_style_changed):
 			SettingsService.connect("unit_style_changed", _on_unit_style_changed)
+	# Toggling full-base vs ring color display must repaint idle tokens too.
+	if SettingsService and SettingsService.has_signal("unit_color_display_changed"):
+		if not SettingsService.is_connected("unit_color_display_changed", _on_unit_style_changed):
+			SettingsService.connect("unit_color_display_changed", _on_unit_style_changed)
 	# T08: two concentric rings expose faction vs player-slot color so
 	# scenarios can assert per-ring modulate. FactionRing draws inner ring;
 	# SlotRing draws a slightly larger thin outer ring. Both render on top
@@ -747,14 +756,19 @@ func _draw_letter_mode() -> void:
 
 	# Get unit color (auto-assign if not yet set)
 	var token_color = _get_token_color()
-	var border_shade = Color(token_color.r * 0.6, token_color.g * 0.6, token_color.b * 0.6)
+	# In "ring" color mode the base stays a neutral color and token_color is drawn
+	# only as a ring inside the perimeter (see Layer 3c); in "full" mode the whole
+	# base is filled with token_color as before.
+	var ring_mode = _is_ring_color_mode()
+	var base_fill = LETTER_RING_BASE_FILL if ring_mode else token_color
+	var border_shade = Color(base_fill.r * 0.6, base_fill.g * 0.6, base_fill.b * 0.6)
 
 	# --- Layer 1: Solid fill ---
 	if shape_type == "circular":
-		draw_circle(Vector2.ZERO, radius, token_color)
+		draw_circle(Vector2.ZERO, radius, base_fill)
 	else:
 		var poly_points = _get_shape_polygon(rot)
-		draw_colored_polygon(poly_points, token_color)
+		draw_colored_polygon(poly_points, base_fill)
 
 	# --- Layer 2: Thin darker border ---
 	if shape_type == "circular":
@@ -778,7 +792,7 @@ func _draw_letter_mode() -> void:
 	else:
 		var label = _get_letter_label()
 		if label != "":
-			var text_color = FactionPalettes.get_contrast_text_color(token_color)
+			var text_color = FactionPalettes.get_contrast_text_color(base_fill)
 			var font = _get_faction_font()
 			# Font size ~60% of base diameter, smaller for multi-char labels
 			var base_font_size = int(radius * 1.2)
@@ -789,6 +803,12 @@ func _draw_letter_mode() -> void:
 			# Faux-bold: draw 3x with sub-pixel offsets
 			for offset in [Vector2(-0.5, 0), Vector2(0.5, 0), Vector2(0, 0)]:
 				draw_string(font, text_pos + offset, label, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, text_color)
+
+	# --- Layer 3c: Unit color ring (ring color mode) ---
+	# Drawn on top of the model art so the squad-identifying color is always
+	# visible as a band just inside the base perimeter.
+	if ring_mode:
+		_draw_unit_color_ring(radius, token_color, shape_type, rot)
 
 	# --- Layer 3b: MA-20 model type colored ring ---
 	_draw_model_type_ring(radius)
@@ -839,6 +859,38 @@ func _get_token_color() -> Color:
 	if color == Color.TRANSPARENT:
 		color = GameState.auto_assign_unit_color(unit_id)
 	return color
+
+
+func _is_ring_color_mode() -> bool:
+	# The color is shown as a ring (neutral base) rather than filling the base.
+	return SettingsService != null and SettingsService.unit_color_display_mode == "ring"
+
+
+func _draw_unit_color_ring(radius: float, ring_color: Color, shape_type: String, rot: float) -> void:
+	# Draw the unit's color as a band just inside the base perimeter, following
+	# the base shape. Width scales with base size but stays legible on tiny bases.
+	var ring_width: float = max(3.5, radius * 0.18)
+	var c := ring_color
+	c.a = 1.0
+	if shape_type == "circular":
+		# Centre the band so its outer edge sits ~1px inside the base border.
+		var r: float = radius - ring_width * 0.5 - 1.0
+		if r <= 0.0:
+			r = radius * 0.5
+		draw_arc(Vector2.ZERO, r, 0, TAU, 48, c, ring_width)
+	else:
+		var pts := _get_shape_polygon(rot)
+		var inset: float = ring_width * 0.5 + 1.0
+		var ring_pts := PackedVector2Array()
+		for p in pts:
+			var l: float = p.length()
+			if l > inset:
+				ring_pts.append(p * ((l - inset) / l))
+			else:
+				ring_pts.append(p)
+		if ring_pts.size() > 0:
+			ring_pts.append(ring_pts[0])
+			draw_polyline(ring_pts, c, ring_width)
 
 
 func _get_letter_label() -> String:

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -9,6 +9,24 @@
   ],
   "tiles": [
     {
+      "id": "tokens.auto_color_same_name",
+      "description": "Duplicate squads sharing a meta.name (e.g. two Boyz squads) get DISTINCT auto-assigned token colors. GameState.auto_assign_unit_color picks the first faction-palette color unused army-wide, falling back to same-name-unused when the palette is exhausted. Regression guard for the hex-roundtrip compare bug where Color.is_equal_approx never matched the stored 8-bit hex, so every unit came out palette[0].",
+      "scenarios": [
+        "unit_color_ring_display"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "tokens.color_ring_display",
+      "description": "Settings > Visual 'Unit Color' = 'Ring Only' (default) makes TokenVisual draw the unit color as a ring inside a neutral base instead of filling the whole base. Toggling SettingsService.unit_color_display_mode emits unit_color_display_changed and reaches the live board token, asserted via TokenVisual._is_ring_color_mode().",
+      "scenarios": [
+        "unit_color_ring_display"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "ai.speed.top_menu_dropdown",
       "description": "In-game 'AI Speed' OptionButton in the top menu bar (HUD_Bottom/HBoxContainer, rendered as the top row) next to the AI Suggestion button. Reveals itself through the natural Main._ready() flow for single-viewer human-vs-AI games; a real click opens the popup and keyboard navigation selects a preset that drives AIPlayer.set_ai_speed_preset.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/unit_color_ring_display.json
+++ b/40k/tests/scenarios/sp/unit_color_ring_display.json
@@ -1,0 +1,23 @@
+{
+  "id": "unit_color_ring_display",
+  "covers": ["tokens.auto_color_same_name", "tokens.color_ring_display"],
+  "fixture": "custodian_guard_dupes",
+  "transition_to_phase": 6,
+  "description": "Two player-facing token-color behaviours: (1) duplicate same-name squads get DISTINCT auto-assigned colors (regression guard for the hex-roundtrip bug that painted every squad palette[0]); (2) the 'Unit Color: Ring Only' display setting makes TokenVisual draw the color as a ring inside a neutral base instead of filling the whole base. The setting is checked end-to-end: toggling SettingsService reaches the live board token via _is_ring_color_mode().",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "script": "set_color_display_mode(\"full\")", "equals": "full" },
+    { "act": "execute_script", "script": "first_token_ring_mode()", "equals": false },
+    { "act": "screenshot", "label": "before_full_base" },
+
+    { "act": "execute_script", "script": "same_name_colors_distinct(1)", "equals": true },
+
+    { "act": "execute_script", "script": "set_color_display_mode(\"ring\")", "equals": "ring" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "first_token_ring_mode()", "equals": true },
+    { "act": "screenshot", "label": "after_ring_only" },
+
+    { "act": "execute_script", "script": "set_color_display_mode(\"full\")", "equals": "full" }
+  ]
+}


### PR DESCRIPTION
## Summary

Two token-color improvements for the default **Letter** unit style, addressing a request to (1) show a unit's color as a ring around the model instead of filling the whole base, and (2) automatically differentiate duplicate squads of the same unit.

### 1. Ring color-display mode (now the default)
- New **Settings → Visual → "Unit Color"** dropdown: **Ring Only** (default) / **Full Base**.
- **Ring Only** keeps a neutral dark base and draws the unit's color as a band just inside the base perimeter, so the model art stays readable while squads are still told apart by color.
- Right-click → **Change Color** still sets the color; this setting only changes *how* it's shown. It applies live to every token (no reload) and persists between sessions.

### 2. Distinct auto-colors per same-name squad
- Deploying a second squad of the same unit (e.g. a second Boyz) now auto-picks a different color from the first.
- Fixes a real bug: colors were compared with `Color.is_equal_approx` against an 8-bit-quantized *stored hex* that never matched, so `auto_assign_unit_color` always returned `palette[0]` and **every** squad came out the same color. It now picks the first palette color unused army-wide, falling back to same-name-unused when the palette is exhausted.

## Changes
- `SettingsService.gd` — new `unit_color_display_mode` ("ring" default), `unit_color_display_changed` signal, setter, persistence.
- `TokenVisual.gd` — `_is_ring_color_mode()` / `_draw_unit_color_ring()`; letter-mode base fill and text-contrast honor ring mode; repaints on the new signal.
- `SettingsMenu.gd` — "Unit Color" dropdown wired to the setting.
- `GameState.gd` — rewrote `auto_assign_unit_color` (hex-based comparison; same-name distinctness).
- `ScenarioRunner.gd` — test helpers (`same_name_colors_distinct`, `first_token_ring_mode`, `set_color_display_mode`).
- `tests/scenarios/sp/unit_color_ring_display.json` — new windowed scenario.
- `data/version_history.json` — 0.37.0 entry.

## Validation
- Windowed scenario `unit_color_ring_display.json` passes **10/10** — asserts same-name squads get distinct colors and that toggling the setting reaches the live board token (`_is_ring_color_mode()`).
- Drove a live Orks-vs-Custodes deployment through the in-game MCP bridge: before the fix, four Stormboyz squads all got `338026`; after, four distinct colors. Captured full-base vs ring-only screenshots; debug log had **0 errors**.
- Confirmed the new default on a fresh launch (no `settings.cfg`): `unit_color_display_mode == "ring"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFDAG2ysEvySXegWgfJ3As

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFDAG2ysEvySXegWgfJ3As)_