### PR TITLE
Enforce 11th-edition unit coherency (2" + 9" envelope) across the whole game

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -9537,39 +9537,45 @@ static func _validate_charge_direction_constraint_rules(unit_id: String, per_mod
 
 # Validate unit coherency for charge
 static func _validate_unit_coherency_for_charge_rules(unit_id: String, per_model_paths: Dictionary, board: Dictionary) -> Dictionary:
-	var errors = []
 	var units = board.get("units", {})
 	var unit = units.get(unit_id, {})
 
 	# Build model dicts with final positions for shape-aware distance
 	var final_models = []
+	var moved_ids := {}
 	for model_id in per_model_paths:
 		var path = per_model_paths[model_id]
 		if path is Array and path.size() > 0:
+			moved_ids[model_id] = true
 			var model = _get_model_in_unit_rules(unit, model_id)
 			var model_at_final = model.duplicate()
 			model_at_final["position"] = Vector2(path[-1][0], path[-1][1])
 			final_models.append(model_at_final)
 
+	# Coherency is a whole-unit condition: include the UNMOVED alive models at their
+	# current positions so a single dragged model cannot legally break away from the
+	# rest of its unit (mirrors ChargePhase._validate_unit_coherency_for_charge).
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		if model.get("position") == null:
+			continue
+		var mid = model.get("id", "")
+		if moved_ids.has(mid):
+			continue
+		final_models.append(model)
+
 	if final_models.size() < 2:
 		return {"valid": true, "errors": []}  # Single model or no movement
 
-	# Check that each model is within 2" horizontally AND 5" vertically of at least one other model
-	for i in range(final_models.size()):
-		var has_nearby_model = false
+	# Delegate to the edition-aware single source of truth (11e 03.03: within 2" of a
+	# mate AND within 9" of every other model in the unit).
+	var result = AttackSequence.check_unit_coherency({"models": final_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
 
-		for j in range(final_models.size()):
-			if i == j:
-				continue
-
-			if Measurement.is_within_coherency(final_models[i], final_models[j]):
-				has_nearby_model = true
-				break
-
-		if not has_nearby_model:
-			errors.append("Unit coherency broken: model %d too far from other models" % i)
-
-	return {"valid": errors.is_empty(), "errors": errors}
+	var offenders = result.get("offenders", [])
+	return {"valid": false, "errors": ["Unit coherency broken: %d model(s) out of coherency — every model must be within 2\" of a mate AND within 9\" of every other model in the unit" % offenders.size()]}
 
 # Charge close-distance enforcement (11e Charge Move 11.04, "WHILE MOVING").
 # Per-model rule: every charging model that CAN end its move within 1" of a

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -4,12 +4,13 @@
 		{
 			"version": "0.35.1",
 			"date": "2026-07-13",
-			"summary": "Deployment now enforces and explains 11th-edition unit coherency (core rules 03.03). A unit is in coherency only while every model is within 2\" of at least one other model AND within 9\" of EVERY other model in the unit — so spreading a unit (e.g. Warbikers with an attached Deffkilla Wartrike) too far now blocks the deploy with a message that names the exact 9\" rule instead of a vague 'within 2\" of mates'.",
+			"summary": "Unit coherency is now enforced by the 11th-edition rule (core rules 03.03) everywhere in the game — deployment, movement, advance, scout, charge and fight. A unit is in coherency only while every model is within 2\" of at least one other model AND within 9\" of EVERY other model in the unit, so spreading a unit (e.g. Warbikers with an attached Deffkilla Wartrike) too far is now blocked with a message that names the exact 9\" rule instead of the old vague 'within 2\" of mates'.",
 			"changes": [
-				"Deployment coherency now uses the 11th-edition rule: every model must be within 2\" of at least one mate AND within 9\" of every other model in the unit. The old 10th-edition 'units of 7+ models need two neighbours each' behaviour has been removed from deployment.",
+				"Coherency now uses the 11th-edition rule across ALL phases: every model must be within 2\" of at least one mate AND within 9\" of every other model in the unit. The old 10th-edition 'units of 7+ models need two neighbours each' behaviour has been removed from deployment, movement, advance, scout, charge and fight.",
+				"Fight and charge coherency were previously under-enforced (they only checked the 2\" rule and ignored the 9\" spread) — they now apply the full 11th-edition rule, so a unit can no longer legally string itself out beyond 9\" during a pile-in, consolidation or charge.",
 				"The deploy error now tells you how many models are out of coherency and which rule is broken — e.g. 'Some models are more than 9\" apart — pull the unit closer together' or 'Some models are more than 2\" from their nearest mate'.",
-				"The on-board coherency range circles now match the deploy gate exactly (both use one shared 11th-edition check), so a model that is touching a neighbour but sits more than 9\" from a far-flung mate correctly shows RED instead of misleading green.",
-				"Both deployment checks — the confirm-button gate and the deploy-action validator — now share the same single source of truth used elsewhere in the game, so they can never disagree."
+				"The on-board deployment coherency circles and the live movement coherency indicator now match the deploy/move gates exactly (all use one shared 11th-edition check), so a model that is touching a neighbour but sits more than 9\" from a far-flung mate correctly shows out-of-coherency instead of misleading green.",
+				"All coherency checks in the game — every phase, the deploy-action validator, the movement UI and the AI's formation planner — now share one single source of truth, so they can never disagree."
 			]
 		},
 		{

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -4,11 +4,12 @@
 		{
 			"version": "0.35.1",
 			"date": "2026-07-13",
-			"summary": "Deployment coherency now explains itself. When a deploy is blocked for coherency, the error spells out that units of 7+ models (e.g. Warbikers with an attached Deffkilla Wartrike) need every model within 2\" of at least TWO others, and says how many models are failing — instead of the old vague 'within 2\" of mates'.",
+			"summary": "Deployment now enforces and explains 11th-edition unit coherency (core rules 03.03). A unit is in coherency only while every model is within 2\" of at least one other model AND within 9\" of EVERY other model in the unit — so spreading a unit (e.g. Warbikers with an attached Deffkilla Wartrike) too far now blocks the deploy with a message that names the exact 9\" rule instead of a vague 'within 2\" of mates'.",
 			"changes": [
-				"Coherency deploy error now reads e.g. 'Cannot deploy: 2 model(s) out of coherency. This unit has 7 models, so EVERY model must be within 2\" of at least 2 others in the unit - not just 1.'",
-				"Fixed the on-board coherency range circles: for a 7+ model unit, a model that touches only one mate now correctly shows RED (out of coherency) instead of misleading green. The circles now use the exact same check as the deploy gate, so the visual and the confirm button can never disagree.",
-				"Coherency has nothing to do with 9\" - it is only 2\" horizontal (and 5\" vertical). The size threshold (2-6 models need 1 neighbour, 7+ need 2) is now made explicit to the player."
+				"Deployment coherency now uses the 11th-edition rule: every model must be within 2\" of at least one mate AND within 9\" of every other model in the unit. The old 10th-edition 'units of 7+ models need two neighbours each' behaviour has been removed from deployment.",
+				"The deploy error now tells you how many models are out of coherency and which rule is broken — e.g. 'Some models are more than 9\" apart — pull the unit closer together' or 'Some models are more than 2\" from their nearest mate'.",
+				"The on-board coherency range circles now match the deploy gate exactly (both use one shared 11th-edition check), so a model that is touching a neighbour but sits more than 9\" from a far-flung mate correctly shows RED instead of misleading green.",
+				"Both deployment checks — the confirm-button gate and the deploy-action validator — now share the same single source of truth used elsewhere in the game, so they can never disagree."
 			]
 		},
 		{

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.35.1",
+			"date": "2026-07-13",
+			"summary": "Deployment coherency now explains itself. When a deploy is blocked for coherency, the error spells out that units of 7+ models (e.g. Warbikers with an attached Deffkilla Wartrike) need every model within 2\" of at least TWO others, and says how many models are failing — instead of the old vague 'within 2\" of mates'.",
+			"changes": [
+				"Coherency deploy error now reads e.g. 'Cannot deploy: 2 model(s) out of coherency. This unit has 7 models, so EVERY model must be within 2\" of at least 2 others in the unit - not just 1.'",
+				"Fixed the on-board coherency range circles: for a 7+ model unit, a model that touches only one mate now correctly shows RED (out of coherency) instead of misleading green. The circles now use the exact same check as the deploy gate, so the visual and the confirm button can never disagree.",
+				"Coherency has nothing to do with 9\" - it is only 2\" horizontal (and 5\" vertical). The size threshold (2-6 models need 1 neighbour, 7+ need 2) is now made explicit to the player."
+			]
+		},
+		{
 			"version": "0.35.0",
 			"date": "2026-07-12",
 			"summary": "Every unit in the two default armies now has top-down artwork. All 12 units across Recon Stomps (Orks) and Custodes Lions (Adeptus Custodes) render bird's-eye sprites on their bases — including the Stompa's full effigy hull, rotor-spinning Deffkoptas and Warbikes that fill their oval bases, and gold Allarus Terminators.",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -2106,22 +2106,15 @@ func _validate_unit_coherency_for_charge(unit_id: String, per_model_paths: Dicti
 	if final_models.size() < 2:
 		return {"valid": true, "errors": []}  # Single model or no movement
 
-	# Check that each model is within 2" horizontally AND 5" vertically of at least one other model
-	for i in range(final_models.size()):
-		var has_nearby_model = false
+	# Delegate to the edition-aware single source of truth (11e 03.03: within 2" of a
+	# mate AND within 9" of every other model in the unit).
+	var result = AttackSequence.check_unit_coherency({"models": final_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
 
-		for j in range(final_models.size()):
-			if i == j:
-				continue
-
-			if Measurement.is_within_coherency(final_models[i], final_models[j]):
-				has_nearby_model = true
-				break
-
-		if not has_nearby_model:
-			errors.append("Unit coherency broken: model %d too far from other models" % i)
-
-	return {"valid": errors.is_empty(), "errors": errors}
+	var offenders = result.get("offenders", [])
+	errors.append("Unit coherency broken: %d model(s) out of coherency — every model must be within 2\" of a mate AND within 9\" of every other model in the unit" % offenders.size())
+	return {"valid": false, "errors": errors}
 
 func _validate_base_to_base_possible(unit_id: String, per_model_paths: Dictionary, target_ids: Array, rolled_distance: int) -> Dictionary:
 	# 11.04 WHILE MOVING (11e): each charging model that CAN end within 1" of a

--- a/40k/phases/DeploymentPhase.gd
+++ b/40k/phases/DeploymentPhase.gd
@@ -181,13 +181,16 @@ func _validate_deploy_unit_action(action: Dictionary) -> Dictionary:
 
 func _check_deployment_coherency(model_positions: Array, model_rotations: Array, unit: Dictionary) -> Dictionary:
 	"""Issue #335: Validate that the unit is being deployed in coherency.
-	Mirrors the logic in MovementPhase._check_models_coherency() and
-	DeploymentController._is_unit_coherent(), reusing Measurement.is_within_coherency()
-	(2" horizontal edge-to-edge AND 5" vertical).
-	2-6 models require 1 sibling within range; 7+ models require 2 siblings (chain rule).
-	Single-model units short-circuit as coherent. Models with null positions (not yet placed)
-	are skipped — full coherency is only enforced once all models are placed.
-	Returns {valid: bool, errors: Array}."""
+	Delegates to the edition-aware AttackSequence.check_unit_coherency() — the single
+	source of truth also used by ScoringPhase and DeploymentController._is_unit_coherent()
+	— so the deploy-action validator, the UI deploy gate and the rest of the game all
+	enforce exactly one ruleset.
+	11e (core rules 03.03): a unit is in coherency only while every model is within 2\"
+	horizontally / 5\" vertically of at least one other model AND within 9\" of every
+	other model in the unit. (The legacy 10e '7+ models need 2 neighbours' rule lives
+	inside check_unit_coherency behind its edition gate.)
+	Models with null positions (not yet placed) are skipped — full coherency is only
+	enforced once all models are placed. Returns {valid: bool, errors: Array}."""
 	var unit_models = unit.get("models", [])
 
 	# Build the list of models with their proposed deployment positions/rotations.
@@ -203,6 +206,7 @@ func _check_deployment_coherency(model_positions: Array, model_rotations: Array,
 			continue
 		var final_model: Dictionary = unit_models[i].duplicate()
 		final_model["position"] = pos
+		final_model["alive"] = true
 		if i < model_rotations.size():
 			final_model["rotation"] = model_rotations[i]
 		placed_models.append(final_model)
@@ -211,31 +215,16 @@ func _check_deployment_coherency(model_positions: Array, model_rotations: Array,
 	if placed_models.size() <= 1:
 		return {"valid": true, "errors": []}
 
-	# Match the 10e convention used elsewhere in the codebase
-	# (MovementPhase._check_models_coherency, DeploymentController._is_unit_coherent):
-	# 2-6 models -> 1 connection; 7+ models -> 2 connections.
-	var required_connections = 1 if placed_models.size() <= 6 else 2
-	var errors: Array = []
+	var result = AttackSequence.check_unit_coherency({"models": placed_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
 
-	for i in range(placed_models.size()):
-		var connections = 0
-		for j in range(placed_models.size()):
-			if i == j:
-				continue
-			# Measurement.is_within_coherency enforces 2" horizontal (80px @ 40px/inch)
-			# AND 5" vertical (elevation) using shape-aware edge-to-edge distance.
-			if Measurement.is_within_coherency(placed_models[i], placed_models[j]):
-				connections += 1
-				if connections >= required_connections:
-					break
-
-		if connections < required_connections:
-			var model_id = placed_models[i].get("id", "model %d" % i)
-			var needed_str = "%d model(s)" % required_connections
-			log_phase_message("Deployment coherency check failed: model %s has %d connections, needs %s" % [model_id, connections, needed_str])
-			errors.append("Unit coherency broken: model %s is not within 2\" horizontally and 5\" vertically of %s" % [model_id, needed_str])
-
-	return {"valid": errors.size() == 0, "errors": errors}
+	var offenders = result.get("offenders", [])
+	log_phase_message("Deployment coherency check failed: %d model(s) out of coherency (%s)" % [offenders.size(), ", ".join(offenders)])
+	var reason := "every model must be within 2\" of at least one other model AND within 9\" of every other model in the unit"
+	if GameConstants.edition < 11:
+		reason = "every model must be within 2\" of the required number of other models in the unit"
+	return {"valid": false, "errors": ["Unit coherency broken: %s (%d model(s) out of coherency)." % [reason, offenders.size()]]}
 
 func _validate_composite_deploy_action(action: Dictionary) -> Dictionary:
 	"""P2-43: Validate a composite deploy action that bundles deploy + embark/attach atomically."""

--- a/40k/phases/DeploymentPhase.gd
+++ b/40k/phases/DeploymentPhase.gd
@@ -168,10 +168,10 @@ func _validate_deploy_unit_action(action: Dictionary) -> Dictionary:
 					var id_j = model_j.get("id", "model %d" % j)
 					errors.append("Models %s and %s overlap each other" % [id_i, id_j])
 
-	# Issue #335: Validate unit coherency (2" horizontal / 5" vertical) after per-model zone checks.
-	# Per WH40K 10e core rules, deployed units must be set up in unit coherency:
-	# - 2-6 models: each model within 2" horizontally + 5" vertically of at least 1 sibling
-	# - 7+ models:  each model within 2" horizontally + 5" vertically of at least 2 siblings
+	# Issue #335: Validate unit coherency after per-model zone checks.
+	# Per WH40K 11th-edition core rules (03.03), a deployed unit is in coherency only while
+	# every model is within 2" horizontally / 5" vertically of at least one other model AND
+	# within 9" horizontally / 5" vertically of every other model in the unit.
 	if not unit.is_empty() and model_positions.size() > 1:
 		var coherency_check = _check_deployment_coherency(model_positions, model_rotations, unit)
 		if not coherency_check.valid:
@@ -185,10 +185,9 @@ func _check_deployment_coherency(model_positions: Array, model_rotations: Array,
 	source of truth also used by ScoringPhase and DeploymentController._is_unit_coherent()
 	— so the deploy-action validator, the UI deploy gate and the rest of the game all
 	enforce exactly one ruleset.
-	11e (core rules 03.03): a unit is in coherency only while every model is within 2\"
-	horizontally / 5\" vertically of at least one other model AND within 9\" of every
-	other model in the unit. (The legacy 10e '7+ models need 2 neighbours' rule lives
-	inside check_unit_coherency behind its edition gate.)
+	11th edition (core rules 03.03): a unit is in coherency only while every model is within
+	2\" horizontally / 5\" vertically of at least one other model AND within 9\" of every
+	other model in the unit.
 	Models with null positions (not yet placed) are skipped — full coherency is only
 	enforced once all models are placed. Returns {valid: bool, errors: Array}."""
 	var unit_models = unit.get("models", [])
@@ -222,8 +221,6 @@ func _check_deployment_coherency(model_positions: Array, model_rotations: Array,
 	var offenders = result.get("offenders", [])
 	log_phase_message("Deployment coherency check failed: %d model(s) out of coherency (%s)" % [offenders.size(), ", ".join(offenders)])
 	var reason := "every model must be within 2\" of at least one other model AND within 9\" of every other model in the unit"
-	if GameConstants.edition < 11:
-		reason = "every model must be within 2\" of the required number of other models in the unit"
 	return {"valid": false, "errors": ["Unit coherency broken: %s (%d model(s) out of coherency)." % [reason, offenders.size()]]}
 
 func _validate_composite_deploy_action(action: Dictionary) -> Dictionary:

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -3516,10 +3516,10 @@ func _validate_base_to_base_if_possible(unit_id: String, movements: Dictionary, 
 	return {"valid": errors.is_empty(), "errors": errors}
 
 func _validate_unit_coherency(unit_id: String, new_positions: Dictionary) -> Dictionary:
-	# Use similar logic to MovementPhase coherency checking
+	# Delegates to the edition-aware AttackSequence.check_unit_coherency() single source
+	# of truth (11e 03.03: within 2" of a mate AND within 9" of every other model).
 	var unit = get_unit(unit_id)
 	var models = unit.get("models", [])
-	var errors = []
 
 	# Build model dicts with updated positions
 	var all_models = []
@@ -3537,20 +3537,15 @@ func _validate_unit_coherency(unit_id: String, new_positions: Dictionary) -> Dic
 				continue
 			all_models.append(model)
 
-	# Check coherency rule: within 2" horizontally AND 5" vertically (shape-aware edge-to-edge)
-	for i in range(all_models.size()):
-		var has_nearby_model = false
-		for j in range(all_models.size()):
-			if i == j:
-				continue
-			if Measurement.is_within_coherency(all_models[i], all_models[j]):
-				has_nearby_model = true
-				break
+	if all_models.size() <= 1:
+		return {"valid": true, "errors": []}
 
-		if not has_nearby_model and all_models.size() > 1:
-			errors.append("Model %d breaks unit coherency (not within 2\" horizontally and 5\" vertically of any other model)" % i)
-	
-	return {"valid": errors.is_empty(), "errors": errors}
+	var result = AttackSequence.check_unit_coherency({"models": all_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
+
+	var offenders = result.get("offenders", [])
+	return {"valid": false, "errors": ["Unit coherency broken: %d model(s) out of coherency — every model must be within 2\" of a mate AND within 9\" of every other model in the unit" % offenders.size()]}
 
 func _clear_unit_fight_state(unit_id: String) -> void:
 	# Clear any temporary fight flags

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -1278,32 +1278,20 @@ func _validate_confirm_unit_move(action: Dictionary) -> Dictionary:
 	return {"valid": true, "errors": []}
 
 func _check_models_coherency(final_models: Array) -> Dictionary:
-	"""Check unit coherency for an array of model dicts with positions.
-	Each model must be within 2" horizontally AND 5" vertically of at least one other model
-	(2 others for 7+ model units). Returns {valid: bool, errors: Array}."""
+	"""Check unit coherency for an array of model dicts with positions (11e core rules 03.03):
+	every model must be within 2" horizontally / 5" vertically of at least one other model AND
+	within 9" of every other model in the unit. Delegates to the edition-aware
+	AttackSequence.check_unit_coherency() single source of truth. Returns {valid, errors}."""
 	if final_models.size() <= 1:
 		return {"valid": true, "errors": []}
 
-	var model_count = final_models.size()
-	var required_connections = 1 if model_count <= 6 else 2
+	var result = AttackSequence.check_unit_coherency({"models": final_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
 
-	for i in range(final_models.size()):
-		var connections = 0
-		for j in range(final_models.size()):
-			if i == j:
-				continue
-			if Measurement.is_within_coherency(final_models[i], final_models[j]):
-				connections += 1
-				if connections >= required_connections:
-					break  # No need to check further
-
-		if connections < required_connections:
-			var model_id = final_models[i].get("id", "model %d" % i)
-			var needed_str = "%d model(s)" % required_connections
-			log_phase_message("Coherency check failed: model %s has %d connections, needs %s" % [model_id, connections, needed_str])
-			return {"valid": false, "errors": ["Unit coherency broken: model %s is not within 2\" horizontally and 5\" vertically of %s" % [model_id, needed_str]]}
-
-	return {"valid": true, "errors": []}
+	var offenders = result.get("offenders", [])
+	log_phase_message("Coherency check failed: %d model(s) out of coherency (%s)" % [offenders.size(), ", ".join(offenders)])
+	return {"valid": false, "errors": ["Unit coherency broken: %d model(s) out of coherency — every model must be within 2\" of a mate AND within 9\" of every other model in the unit" % offenders.size()]}
 
 func _validate_unit_coherency_after_move(unit_id: String, move_data: Dictionary) -> Dictionary:
 	"""Validate that the unit maintains coherency after all staged moves are applied.
@@ -7716,28 +7704,9 @@ func _check_group_unit_coherency(group_moves: Array, unit_id: String) -> bool:
 			moved_model["position"] = Vector2(dest[0], dest[1])
 			final_models[model_id] = moved_model
 
-	# Check coherency rules using shape-aware edge-to-edge distance
-	var model_count = final_models.size()
-
-	for model_id1 in final_models:
-		var connections = 0
-
-		for model_id2 in final_models:
-			if model_id1 == model_id2:
-				continue
-
-			var distance = Measurement.model_to_model_distance_inches(final_models[model_id1], final_models[model_id2])
-
-			if distance <= 2.0 + Measurement.DISTANCE_TOLERANCE_INCHES:
-				connections += 1
-
-		# Coherency rules based on unit size
-		var required_connections = 1 if model_count <= 6 else 2
-
-		if connections < required_connections:
-			return false
-
-	return true
+	# Check coherency via the edition-aware single source of truth (11e 03.03:
+	# within 2" of a mate AND within 9" of every other model in the unit).
+	return AttackSequence.check_unit_coherency({"models": final_models.values()}).get("coherent", true)
 
 func _check_terrain_collision(position: Vector2, model: Dictionary) -> bool:
 	"""Check if a position collides with impassable terrain using shape-aware bounds"""

--- a/40k/phases/ScoutPhase.gd
+++ b/40k/phases/ScoutPhase.gd
@@ -618,26 +618,15 @@ func _check_scout_coherency(unit: Dictionary, staged_positions: Dictionary, orig
 			final_model["position"] = original_positions[model_id]
 		final_models.append(final_model)
 
-	var model_count = final_models.size()
-	var required_connections = 1 if model_count <= 6 else 2
+	# Delegate to the edition-aware single source of truth (11e 03.03: within 2" of a
+	# mate AND within 9" of every other model in the unit).
+	var result = AttackSequence.check_unit_coherency({"models": final_models})
+	if result.get("coherent", true):
+		return {"valid": true, "errors": []}
 
-	for i in range(final_models.size()):
-		var connections = 0
-		for j in range(final_models.size()):
-			if i == j:
-				continue
-			if Measurement.is_within_coherency(final_models[i], final_models[j]):
-				connections += 1
-				if connections >= required_connections:
-					break
-
-		if connections < required_connections:
-			var model_id = final_models[i].get("id", "model %d" % i)
-			var needed_str = "%d model(s)" % required_connections
-			log_phase_message("Scout coherency check failed: model %s has %d connections, needs %s" % [model_id, connections, needed_str])
-			return {"valid": false, "errors": ["Unit coherency broken: model %s is not within 2\" of %s" % [model_id, needed_str]]}
-
-	return {"valid": true, "errors": []}
+	var offenders = result.get("offenders", [])
+	log_phase_message("Scout coherency check failed: %d model(s) out of coherency (%s)" % [offenders.size(), ", ".join(offenders)])
+	return {"valid": false, "errors": ["Unit coherency broken: %d model(s) out of coherency — every model must be within 2\" of a mate AND within 9\" of every other model in the unit" % offenders.size()]}
 
 func _scout_position_overlaps_other_units(pos: Vector2, model_data: Dictionary, scout_unit_id: String) -> bool:
 	# Shape-aware overlap check against every model that is NOT part of the

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -9883,12 +9883,13 @@ static func _try_move_with_collision_check(
 						if _path_crosses_monster_vehicle(orig_pos, candidate, model_radius * radius_factor, mv_models):
 							continue
 
-					# Check coherency with placed models
+					# Check coherency with placed models. Neighbour requirement mirrors
+					# AttackSequence.check_unit_coherency: 11e needs 1, legacy 10e needs 2 at 7+.
 					var coherent_count = 0
 					for pm in placed_models:
 						if candidate.distance_to(pm.position) <= coherency_max_px:
 							coherent_count += 1
-					var required = 1 if (destinations.size() + failed_models.size()) <= 6 else 2
+					var required = 2 if (GameConstants.edition < 11 and (destinations.size() + failed_models.size()) >= 7) else 1
 					if coherent_count >= mini(required, destinations.size()):
 						destinations[model_id] = [candidate.x, candidate.y]
 						placed_models.append({
@@ -9939,7 +9940,8 @@ static func _try_formation_move(
 	var model_count = alive_models.size()
 	var base_radius_inches = (base_mm / 2.0) / 25.4
 	var coherency_max_px = (2.0 + base_radius_inches * 2.0) * PIXELS_PER_INCH
-	var required_connections = 1 if model_count <= 6 else 2
+	# Neighbour requirement mirrors AttackSequence.check_unit_coherency (11e: 1; legacy 10e: 2 at 7+).
+	var required_connections = 2 if (GameConstants.edition < 11 and model_count >= 7) else 1
 	var step = model_radius * 2.0 + 8.0
 	var fm_unit_kw: Array = unit.get("meta", {}).get("keywords", [])
 
@@ -17028,7 +17030,8 @@ static func _resolve_formation_collisions(positions: Array, base_mm: int, deploy
 	var base_radius_inches = (base_mm / 2.0) / 25.4
 	var coherency_max_px = (2.0 + base_radius_inches * 2.0) * PIXELS_PER_INCH
 
-	var required_connections = 1 if positions.size() <= 6 else 2
+	# Neighbour requirement mirrors AttackSequence.check_unit_coherency (11e: 1; legacy 10e: 2 at 7+).
+	var required_connections = 2 if (GameConstants.edition < 11 and positions.size() >= 7) else 1
 
 	for pos in positions:
 		# Combine deployed models + already-placed formation models for collision
@@ -17107,23 +17110,28 @@ static func _resolve_formation_collisions(positions: Array, base_mm: int, deploy
 	return resolved
 
 static func _check_formation_coherency(positions: Array, base_mm: int) -> bool:
-	"""Check that all positions maintain 2\" unit coherency (each model within 2\" of at least one other).
-	For 7+ model units, each model must be within 2\" of at least 2 others.
-	Uses edge-to-edge distance (center distance minus both base radii)."""
+	"""Check 11e unit coherency (core rules 03.03) for a set of same-base positions:
+	each model within 2\" edge-to-edge of at least one other AND within 9\" edge-to-edge of
+	every other. Neighbour count and envelope mirror AttackSequence.check_unit_coherency
+	(legacy 10e needs 2 neighbours at 7+ and has no envelope). Uses center distance minus
+	both base radii."""
 	if positions.size() <= 1:
 		return true
-	var required_connections = 1 if positions.size() <= 6 else 2
+	var required_connections = 2 if (GameConstants.edition < 11 and positions.size() >= 7) else 1
 	var base_radius_inches = (base_mm / 2.0) / 25.4
-	var coherency_threshold_px = (GameConstants.coherency_distance_inches() + base_radius_inches * 2.0) * PIXELS_PER_INCH  # 2" edge-to-edge = 2" + both radii center-to-center
+	var near_px = (GameConstants.coherency_distance_inches() + base_radius_inches * 2.0) * PIXELS_PER_INCH  # 2" edge-to-edge
+	var envelope_px = (GameConstants.coherency_envelope_inches() + base_radius_inches * 2.0) * PIXELS_PER_INCH  # 9" edge-to-edge
+	var apply_envelope = GameConstants.edition >= 11
 	for i in range(positions.size()):
 		var connections = 0
 		for j in range(positions.size()):
 			if i == j:
 				continue
-			if positions[i].distance_to(positions[j]) <= coherency_threshold_px:
+			var d = positions[i].distance_to(positions[j])
+			if d <= near_px:
 				connections += 1
-				if connections >= required_connections:
-					break
+			if apply_envelope and d > envelope_px:
+				return false  # 9" envelope broken
 		if connections < required_connections:
 			return false
 	return true

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -1628,14 +1628,12 @@ func _coherency_model_at(index: int, unit_data: Dictionary) -> Dictionary:
 
 func _compute_coherency_status() -> Dictionary:
 	"""Single source of truth for deployment coherency over the currently-placed
-	temp models. Delegates to the edition-aware AttackSequence.check_unit_coherency()
-	so deployment matches every other phase and the active ruleset.
+	temp models. Delegates to AttackSequence.check_unit_coherency() so deployment
+	matches every other phase.
 
-	11e (core rules 03.03): a unit of 2+ models is in coherency only while EVERY model is
+	11th edition (core rules 03.03): a unit of 2+ models is in coherency only while EVERY model is
 	  • within 2\" horizontally / 5\" vertically of at least ONE other model in the unit, AND
 	  • within 9\" horizontally / 5\" vertically of EVERY other model in the unit (the envelope).
-	(The legacy 10e '7+ models need 2 neighbours' rule, and the absence of the envelope,
-	live inside check_unit_coherency behind its edition gate — not duplicated here.)
 
 	Returns {unit_empty, placed_count, total_models, incoherent_indices,
 	spread_violation, isolation_violation}."""
@@ -1675,9 +1673,7 @@ func _compute_coherency_status() -> Dictionary:
 	# thresholds check_unit_coherency uses.
 	if not result.get("coherent", true):
 		var coh_px = Measurement.inches_to_px(GameConstants.coherency_distance_inches())
-		var envelope_px = 0.0
-		if GameConstants.edition >= 11:
-			envelope_px = Measurement.inches_to_px(GameConstants.coherency_envelope_inches())
+		var envelope_px = Measurement.inches_to_px(GameConstants.coherency_envelope_inches())
 		for a in range(synthetic_models.size()):
 			var neighbors = 0
 			for b in range(synthetic_models.size()):
@@ -1686,7 +1682,7 @@ func _compute_coherency_status() -> Dictionary:
 				var d = Measurement.model_to_model_distance_px(synthetic_models[a], synthetic_models[b])
 				if d <= coh_px:
 					neighbors += 1
-				if envelope_px > 0.0 and d > envelope_px:
+				if d > envelope_px:
 					status["spread_violation"] = true
 			if neighbors < 1:
 				status["isolation_violation"] = true

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -1534,11 +1534,11 @@ func _update_coherency_circles() -> void:
 
 func _update_coherency_circles_static() -> void:
 	"""DEPLOY-VIS-5: When no ghost is active, show coherency status between placed models.
-	A model's circle is green when it satisfies the unit's coherency requirement —
-	within 2\" of at least 1 other model for 2-6 model units, at least 2 others for
-	7+ model units — and red when it does not. Uses the same _compute_coherency_status()
-	as the confirm-time enforcement so the visual and the deploy gate never disagree
-	(previously a 7+ unit could show all-green while confirm rejected it)."""
+	A model's circle is green when it satisfies the unit's 11e coherency requirement
+	(within 2\" of at least one other model AND within 9\" of every other model) and red
+	when it does not. Uses the same _compute_coherency_status() as the confirm-time
+	enforcement so the visual and the deploy gate never disagree — e.g. a model that is
+	touching a neighbour but is more than 9\" from a far-flung mate now correctly shows red."""
 	if coherency_circles.is_empty():
 		return
 	var status = _compute_coherency_status()
@@ -1612,7 +1612,9 @@ func _point_to_line_distance(point: Vector2, line_start: Vector2, line_end: Vect
 
 func _coherency_model_at(index: int, unit_data: Dictionary) -> Dictionary:
 	"""Build a positioned model dict for coherency math from the temp placement
-	buffers, honouring combined (multi-profile) deployments."""
+	buffers, honouring combined (multi-profile) deployments. Sets a unique index-based
+	id and alive=true so AttackSequence.check_unit_coherency's offender list maps
+	cleanly back to model indices for the visuals."""
 	var model: Dictionary
 	if is_combined_deployment and index < combined_models.size():
 		model = combined_models[index]["model_data"].duplicate()
@@ -1620,15 +1622,23 @@ func _coherency_model_at(index: int, unit_data: Dictionary) -> Dictionary:
 		model = unit_data["models"][index].duplicate()
 	model["position"] = temp_positions[index]
 	model["rotation"] = temp_rotations[index] if index < temp_rotations.size() else 0.0
+	model["alive"] = true
+	model["id"] = "coh_%d" % index
 	return model
 
 func _compute_coherency_status() -> Dictionary:
 	"""Single source of truth for deployment coherency over the currently-placed
-	temp models. Per 10e: a unit of 2-6 models needs every model within 2\"
-	horizontally / 5\" vertically of at least ONE other model; a unit of 7+ models
-	needs every model within range of at least TWO others (attached leaders count
-	toward the model total). Distance is edge-to-edge.
-	Returns {unit_empty, placed_count, total_models, required_neighbors, incoherent_indices}."""
+	temp models. Delegates to the edition-aware AttackSequence.check_unit_coherency()
+	so deployment matches every other phase and the active ruleset.
+
+	11e (core rules 03.03): a unit of 2+ models is in coherency only while EVERY model is
+	  • within 2\" horizontally / 5\" vertically of at least ONE other model in the unit, AND
+	  • within 9\" horizontally / 5\" vertically of EVERY other model in the unit (the envelope).
+	(The legacy 10e '7+ models need 2 neighbours' rule, and the absence of the envelope,
+	live inside check_unit_coherency behind its edition gate — not duplicated here.)
+
+	Returns {unit_empty, placed_count, total_models, incoherent_indices,
+	spread_violation, isolation_violation}."""
 	var unit_data = GameState.get_unit(unit_id)
 
 	var placed_indices = []
@@ -1636,45 +1646,63 @@ func _compute_coherency_status() -> Dictionary:
 		if temp_positions[i] != null:
 			placed_indices.append(i)
 
-	# Use the combined total (includes unplaced slots) so the 7+ threshold is based
-	# on the whole unit, not just how many are currently on the board.
-	var total_models = temp_positions.size()
-	var required_neighbors = 1 if total_models <= 6 else 2
 	var status = {
 		"unit_empty": unit_data.is_empty(),
 		"placed_count": placed_indices.size(),
-		"total_models": total_models,
-		"required_neighbors": required_neighbors,
+		"total_models": temp_positions.size(),
 		"incoherent_indices": [],
+		"spread_violation": false,    # 11e 9" envelope broken (models too far apart)
+		"isolation_violation": false, # a model has no mate within 2"
 	}
 	if unit_data.is_empty() or placed_indices.size() < 2:
 		return status
 
+	# Build a synthetic unit from the temp positions and ask the canonical checker.
+	var synthetic_models: Array = []
+	var id_to_index := {}
 	for i in placed_indices:
-		var model_i = _coherency_model_at(i, unit_data)
-		var neighbor_count = 0
-		for j in placed_indices:
-			if i == j:
-				continue
-			# Use shape-aware coherency check: 2" horizontal AND 5" vertical
-			if Measurement.is_within_coherency(model_i, _coherency_model_at(j, unit_data)):
-				neighbor_count += 1
-				if neighbor_count >= required_neighbors:
-					break
-		if neighbor_count < required_neighbors:
-			status["incoherent_indices"].append(i)
+		var m = _coherency_model_at(i, unit_data)
+		id_to_index[m["id"]] = i
+		synthetic_models.append(m)
+
+	var result = AttackSequence.check_unit_coherency({"models": synthetic_models})
+	for offender in result.get("offenders", []):
+		if id_to_index.has(offender):
+			status["incoherent_indices"].append(id_to_index[offender])
+
+	# Classify WHY (informational only — the verdict above is authoritative) so the
+	# player-facing message can name the specific broken condition. Mirrors the
+	# thresholds check_unit_coherency uses.
+	if not result.get("coherent", true):
+		var coh_px = Measurement.inches_to_px(GameConstants.coherency_distance_inches())
+		var envelope_px = 0.0
+		if GameConstants.edition >= 11:
+			envelope_px = Measurement.inches_to_px(GameConstants.coherency_envelope_inches())
+		for a in range(synthetic_models.size()):
+			var neighbors = 0
+			for b in range(synthetic_models.size()):
+				if a == b:
+					continue
+				var d = Measurement.model_to_model_distance_px(synthetic_models[a], synthetic_models[b])
+				if d <= coh_px:
+					neighbors += 1
+				if envelope_px > 0.0 and d > envelope_px:
+					status["spread_violation"] = true
+			if neighbors < 1:
+				status["isolation_violation"] = true
 	return status
 
 func _coherency_failure_message() -> String:
-	"""Player-facing explanation of why deployment coherency failed. Spells out the
-	2-neighbour requirement for 7+ model units, which the old generic message hid."""
+	"""Player-facing explanation of why deployment coherency failed. States the full 11e
+	rule (2\" to a mate AND 9\" to every model) and names whichever condition is broken."""
 	var status = _compute_coherency_status()
 	var bad = status["incoherent_indices"].size()
-	var req = int(status["required_neighbors"])
-	var total = int(status["total_models"])
-	if req >= 2:
-		return "Cannot deploy: %d model(s) out of coherency. This unit has %d models, so EVERY model must be within 2\" of at least 2 others in the unit — not just 1." % [bad, total]
-	return "Cannot deploy: %d model(s) out of coherency. Every model must be within 2\" of at least 1 other model in the unit." % bad
+	var msg = "Cannot deploy: %d model(s) out of coherency. Every model must be within 2\" of at least one other model in the unit AND within 9\" of every other model in the unit." % bad
+	if status["spread_violation"]:
+		msg += " Some models are more than 9\" apart — pull the unit closer together."
+	elif status["isolation_violation"]:
+		msg += " Some models are more than 2\" from their nearest mate."
+	return msg
 
 func _check_coherency_warning() -> void:
 	var status = _compute_coherency_status()
@@ -1684,9 +1712,11 @@ func _check_coherency_warning() -> void:
 
 	var incoherent_indices = status["incoherent_indices"]
 	if incoherent_indices.size() > 0:
-		var required_neighbors = int(status["required_neighbors"])
-		var rule_text = "within 2\" horizontally and 5\" vertically of %d+ model(s)" % required_neighbors
-		var msg = "Coherency warning: %d model(s) not %s" % [incoherent_indices.size(), rule_text]
+		var msg = "Coherency warning: %d model(s) out of coherency" % incoherent_indices.size()
+		if status["spread_violation"]:
+			msg += " — some are >9\" from another model in the unit"
+		elif status["isolation_violation"]:
+			msg += " — some are >2\" from any mate"
 		print("[WARNING] %s" % msg)
 		_show_toast(msg, Color.YELLOW)
 		emit_signal("coherency_warning_changed", true, msg)
@@ -1694,10 +1724,10 @@ func _check_coherency_warning() -> void:
 		emit_signal("coherency_warning_changed", false, "")
 
 func _is_unit_coherent() -> bool:
-	"""Check if the currently placed models satisfy unit coherency rules.
-	Per 10e rules: 2-6 models = each within 2\" horizontally and 5\" vertically of at least 1 other;
-	7+ models = each within 2\" horizontally and 5\" vertically of at least 2 others.
-	Single-model units are always coherent.
+	"""Check if the currently placed models satisfy unit coherency rules (11e 03.03):
+	every model within 2\" horizontally / 5\" vertically of at least one other model AND
+	within 9\" of every other model in the unit. Single-model units are always coherent.
+	Coherency is only enforced once every model in the unit is placed.
 	Distance is measured edge-to-edge (nearest base edge to nearest base edge)."""
 	var status = _compute_coherency_status()
 	if status["unit_empty"]:

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -788,7 +788,7 @@ func undo() -> void:
 func confirm() -> void:
 	# Enforce unit coherency before allowing deployment
 	if not _is_unit_coherent():
-		_show_toast("Cannot deploy: unit is not in coherency (all models must be within 2\" of mates)", Color.RED)
+		_show_toast(_coherency_failure_message(), Color.RED)
 		return
 
 	# In reinforcement OR scout-reserves mode, emit signal BEFORE clearing state
@@ -1534,16 +1534,17 @@ func _update_coherency_circles() -> void:
 
 func _update_coherency_circles_static() -> void:
 	"""DEPLOY-VIS-5: When no ghost is active, show coherency status between placed models.
-	Each placed model's circle is green if it has at least one neighbor within 2\",
-	red if it has no neighbors within 2\"."""
-	var unit_data = GameState.get_unit(unit_id)
-	if unit_data.is_empty():
+	A model's circle is green when it satisfies the unit's coherency requirement —
+	within 2\" of at least 1 other model for 2-6 model units, at least 2 others for
+	7+ model units — and red when it does not. Uses the same _compute_coherency_status()
+	as the confirm-time enforcement so the visual and the deploy gate never disagree
+	(previously a 7+ unit could show all-green while confirm rejected it)."""
+	if coherency_circles.is_empty():
 		return
-
-	var placed_indices = []
-	for i in range(temp_positions.size()):
-		if temp_positions[i] != null:
-			placed_indices.append(i)
+	var status = _compute_coherency_status()
+	if status["unit_empty"]:
+		return
+	var incoherent_indices = status["incoherent_indices"]
 
 	for i in range(coherency_circles.size()):
 		if i >= temp_positions.size() or temp_positions[i] == null:
@@ -1552,38 +1553,12 @@ func _update_coherency_circles_static() -> void:
 			continue
 		coherency_circles[i].visible = true
 
-		# Single model is always coherent
-		if placed_indices.size() <= 1:
+		# A lone placed model is always coherent
+		if status["placed_count"] <= 1:
 			coherency_circles[i].set_in_range(true)
 			continue
 
-		# Check if this model has at least one neighbor within 2"
-		var has_neighbor = false
-		var model_i: Dictionary
-		if is_combined_deployment and i < combined_models.size():
-			model_i = combined_models[i]["model_data"].duplicate()
-		else:
-			model_i = unit_data["models"][i].duplicate()
-		model_i["position"] = temp_positions[i]
-		model_i["rotation"] = temp_rotations[i] if i < temp_rotations.size() else 0.0
-
-		for j in placed_indices:
-			if j == i:
-				continue
-			var model_j: Dictionary
-			if is_combined_deployment and j < combined_models.size():
-				model_j = combined_models[j]["model_data"].duplicate()
-			else:
-				model_j = unit_data["models"][j].duplicate()
-			model_j["position"] = temp_positions[j]
-			model_j["rotation"] = temp_rotations[j] if j < temp_rotations.size() else 0.0
-
-			var dist = Measurement.model_to_model_distance_inches(model_i, model_j)
-			if dist <= GameConstants.coherency_distance_inches() + Measurement.DISTANCE_TOLERANCE_INCHES:
-				has_neighbor = true
-				break
-
-		coherency_circles[i].set_in_range(has_neighbor)
+		coherency_circles[i].set_in_range(not (i in incoherent_indices))
 
 func _create_token_visual(unit_id: String, model_index: int, pos: Vector2, is_preview: bool = false, rotation: float = 0.0) -> Node2D:
 	var token = Node2D.new()
@@ -1635,60 +1610,81 @@ func _circle_wholly_in_polygon(center: Vector2, radius: float, polygon: PackedVe
 func _point_to_line_distance(point: Vector2, line_start: Vector2, line_end: Vector2) -> float:
 	return Measurement.point_to_line_distance(point, line_start, line_end)
 
-func _check_coherency_warning() -> void:
-	var unit_data = GameState.get_unit(unit_id)
-	if unit_data.is_empty():
-		emit_signal("coherency_warning_changed", false, "")
-		return
+func _coherency_model_at(index: int, unit_data: Dictionary) -> Dictionary:
+	"""Build a positioned model dict for coherency math from the temp placement
+	buffers, honouring combined (multi-profile) deployments."""
+	var model: Dictionary
+	if is_combined_deployment and index < combined_models.size():
+		model = combined_models[index]["model_data"].duplicate()
+	else:
+		model = unit_data["models"][index].duplicate()
+	model["position"] = temp_positions[index]
+	model["rotation"] = temp_rotations[index] if index < temp_rotations.size() else 0.0
+	return model
 
-	# Build list of placed model indices and their data
+func _compute_coherency_status() -> Dictionary:
+	"""Single source of truth for deployment coherency over the currently-placed
+	temp models. Per 10e: a unit of 2-6 models needs every model within 2\"
+	horizontally / 5\" vertically of at least ONE other model; a unit of 7+ models
+	needs every model within range of at least TWO others (attached leaders count
+	toward the model total). Distance is edge-to-edge.
+	Returns {unit_empty, placed_count, total_models, required_neighbors, incoherent_indices}."""
+	var unit_data = GameState.get_unit(unit_id)
+
 	var placed_indices = []
 	for i in range(temp_positions.size()):
 		if temp_positions[i] != null:
 			placed_indices.append(i)
 
-	if placed_indices.size() < 2:
-		emit_signal("coherency_warning_changed", false, "")
-		return
-
-	# Per 10th edition: units with 2-6 models need each model within 2" of at least 1 other.
-	# Units with 7+ models need each model within 2" of at least 2 others.
-	var total_models = temp_positions.size()  # Use combined total for combined deployments
+	# Use the combined total (includes unplaced slots) so the 7+ threshold is based
+	# on the whole unit, not just how many are currently on the board.
+	var total_models = temp_positions.size()
 	var required_neighbors = 1 if total_models <= 6 else 2
-	var incoherent_indices = []
+	var status = {
+		"unit_empty": unit_data.is_empty(),
+		"placed_count": placed_indices.size(),
+		"total_models": total_models,
+		"required_neighbors": required_neighbors,
+		"incoherent_indices": [],
+	}
+	if unit_data.is_empty() or placed_indices.size() < 2:
+		return status
 
 	for i in placed_indices:
-		# Get model data from combined_models or unit_data
-		var model_i: Dictionary
-		if is_combined_deployment and i < combined_models.size():
-			model_i = combined_models[i]["model_data"].duplicate()
-		else:
-			model_i = unit_data["models"][i].duplicate()
-		model_i["position"] = temp_positions[i]
-		model_i["rotation"] = temp_rotations[i] if i < temp_rotations.size() else 0.0
-
+		var model_i = _coherency_model_at(i, unit_data)
 		var neighbor_count = 0
 		for j in placed_indices:
 			if i == j:
 				continue
-			var model_j: Dictionary
-			if is_combined_deployment and j < combined_models.size():
-				model_j = combined_models[j]["model_data"].duplicate()
-			else:
-				model_j = unit_data["models"][j].duplicate()
-			model_j["position"] = temp_positions[j]
-			model_j["rotation"] = temp_rotations[j] if j < temp_rotations.size() else 0.0
-
 			# Use shape-aware coherency check: 2" horizontal AND 5" vertical
-			if Measurement.is_within_coherency(model_i, model_j):
+			if Measurement.is_within_coherency(model_i, _coherency_model_at(j, unit_data)):
 				neighbor_count += 1
 				if neighbor_count >= required_neighbors:
 					break
-
 		if neighbor_count < required_neighbors:
-			incoherent_indices.append(i)
+			status["incoherent_indices"].append(i)
+	return status
 
+func _coherency_failure_message() -> String:
+	"""Player-facing explanation of why deployment coherency failed. Spells out the
+	2-neighbour requirement for 7+ model units, which the old generic message hid."""
+	var status = _compute_coherency_status()
+	var bad = status["incoherent_indices"].size()
+	var req = int(status["required_neighbors"])
+	var total = int(status["total_models"])
+	if req >= 2:
+		return "Cannot deploy: %d model(s) out of coherency. This unit has %d models, so EVERY model must be within 2\" of at least 2 others in the unit — not just 1." % [bad, total]
+	return "Cannot deploy: %d model(s) out of coherency. Every model must be within 2\" of at least 1 other model in the unit." % bad
+
+func _check_coherency_warning() -> void:
+	var status = _compute_coherency_status()
+	if status["unit_empty"] or status["placed_count"] < 2:
+		emit_signal("coherency_warning_changed", false, "")
+		return
+
+	var incoherent_indices = status["incoherent_indices"]
 	if incoherent_indices.size() > 0:
+		var required_neighbors = int(status["required_neighbors"])
 		var rule_text = "within 2\" horizontally and 5\" vertically of %d+ model(s)" % required_neighbors
 		var msg = "Coherency warning: %d model(s) not %s" % [incoherent_indices.size(), rule_text]
 		print("[WARNING] %s" % msg)
@@ -1703,57 +1699,19 @@ func _is_unit_coherent() -> bool:
 	7+ models = each within 2\" horizontally and 5\" vertically of at least 2 others.
 	Single-model units are always coherent.
 	Distance is measured edge-to-edge (nearest base edge to nearest base edge)."""
-	var unit_data = GameState.get_unit(unit_id)
-	if unit_data.is_empty():
+	var status = _compute_coherency_status()
+	if status["unit_empty"]:
 		return true
 
-	var placed_indices = []
-	for i in range(temp_positions.size()):
-		if temp_positions[i] != null:
-			placed_indices.append(i)
-
-	# Single model or empty — always coherent
-	if placed_indices.size() <= 1:
+	# Single model (or none) placed — always coherent
+	if status["placed_count"] <= 1:
 		return true
 
-	# Check all models are placed before enforcing
-	var total_models = temp_positions.size()
-	if placed_indices.size() < total_models:
-		# Not all models placed yet — can't enforce coherency
+	# Not all models placed yet — can't enforce coherency
+	if status["placed_count"] < status["total_models"]:
 		return true
 
-	var required_neighbors = 1 if placed_indices.size() <= 6 else 2
-
-	for i in placed_indices:
-		var model_i: Dictionary
-		if is_combined_deployment and i < combined_models.size():
-			model_i = combined_models[i]["model_data"].duplicate()
-		else:
-			model_i = unit_data["models"][i].duplicate()
-		model_i["position"] = temp_positions[i]
-		model_i["rotation"] = temp_rotations[i] if i < temp_rotations.size() else 0.0
-
-		var neighbor_count = 0
-		for j in placed_indices:
-			if i == j:
-				continue
-			var model_j: Dictionary
-			if is_combined_deployment and j < combined_models.size():
-				model_j = combined_models[j]["model_data"].duplicate()
-			else:
-				model_j = unit_data["models"][j].duplicate()
-			model_j["position"] = temp_positions[j]
-			model_j["rotation"] = temp_rotations[j] if j < temp_rotations.size() else 0.0
-
-			# Use shape-aware coherency check: 2" horizontal AND 5" vertical
-			if Measurement.is_within_coherency(model_i, model_j):
-				neighbor_count += 1
-				if neighbor_count >= required_neighbors:
-					break
-		if neighbor_count < required_neighbors:
-			return false
-
-	return true
+	return status["incoherent_indices"].is_empty()
 
 func _shape_wholly_in_polygon(center: Vector2, model_data: Dictionary, rotation: float, polygon: PackedVector2Array) -> bool:
 	return Measurement.shape_wholly_in_polygon(center, model_data, rotation, polygon)

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -3127,17 +3127,17 @@ func _update_coherency_preview(ghost_world_pos: Vector2) -> void:
 			"in_coherency": in_coherency
 		})
 
-	# Determine required connections for coherency (10th Ed rules)
-	var total_alive = alive_models.size()
-	var required_connections = 1 if total_alive <= 6 else 2
-	var ghost_is_coherent = coherent_count >= required_connections
+	# Determine coherency via the edition-aware single source of truth (11e 03.03:
+	# within 2" of a mate AND within 9" of every other model in the unit). The ghost is
+	# coherent when dropping the dragged model here leaves it satisfying coherency.
+	var coherency_models = other_models_data.duplicate()
+	coherency_models.append(ghost_model)
+	var ghost_id = str(ghost_model.get("id", "__ghost__"))
+	var coh_result = AttackSequence.check_unit_coherency({"models": coherency_models})
+	var ghost_is_coherent = not (ghost_id in coh_result.get("offenders", []))
 
 	# Build status text
-	var status_text = ""
-	if ghost_is_coherent:
-		status_text = "Coherent"
-	else:
-		status_text = "%d/%d needed" % [coherent_count, required_connections]
+	var status_text = "Coherent" if ghost_is_coherent else "Out of coherency"
 
 	# Update the ghost visual with coherency data
 	ghost_token.set_coherency_preview(lines_data, status_text, ghost_is_coherent)


### PR DESCRIPTION
## Why

A player deploying Warbikers with an attached Deffkilla Wartrike (7 models) hit a coherency error they couldn't make sense of. Investigation showed the game was enforcing the **10th-edition** coherency rule ("units of 7+ models need each model within 2" of *two* neighbours"), while this game runs **11th edition** (`GameConstants.edition = 11`). The 11th-edition rule (core rules **03.03**) is different:

> A unit is in coherency only while **every** model is:
> - within **2"** horizontally / 5" vertically of **at least one** other model, **AND**
> - within **9"** horizontally / 5" vertically of **every** other model in the unit.

There is no "7+ needs two neighbours" rule in 11e — and the real reason the player's unit was blocked was the **9" envelope**, which the old error message never mentioned.

## What changed

Every coherency check in the game now routes through the single, edition-aware source of truth `AttackSequence.check_unit_coherency()` (already used by `ScoringPhase` and pinned by `test_iss042_coherency_11e.gd`), so the whole game enforces one ruleset:

**Deployment**
- `DeploymentController` (confirm-button gate, live warning, on-board range circles) and `DeploymentPhase` (deploy-action validator) now use the 11e rule. The deploy error names the broken condition ("Some models are more than 9" apart — pull the unit closer together" / "…more than 2" from their nearest mate") and how many models are out.
- The range circles use the same check as the gate, so a model touching a neighbour but sitting >9" from a far-flung mate now shows out-of-coherency instead of misleading green.

**Movement / Scout** — were applying the stale 10e neighbour rule:
- `MovementPhase._check_models_coherency` (used by after-move validation + several placement paths) and `_check_group_unit_coherency`.
- `ScoutPhase._check_scout_coherency`.

**Fight / Charge** — were *under*-enforcing (only the 2" single-neighbour rule, no 9" envelope, so a unit could legally string itself out past 9"):
- `FightPhase._validate_unit_coherency` (pile-in / consolidate).
- `ChargePhase._validate_unit_coherency_for_charge`.
- `RulesEngine._validate_unit_coherency_for_charge_rules` — now also counts the **unmoved** alive models (it previously checked only the moved subset, so a single dragged model could break away undetected).

**UI / AI** — kept consistent so they never mislead or stall:
- `MovementController`'s live ghost coherency indicator now uses the canonical check.
- `AIDecisionMaker`'s formation planner + `_check_formation_coherency` mirror the canonical edition-aware neighbour rule and apply the 9" envelope.

## Validation

- **Live (MCP bridge, edition 11):** spread 7-model formations are rejected via the 9" envelope and compact ones pass — verified for deployment (both gates), `MovementPhase` (both checks), `ScoutPhase`, `FightPhase`, `RulesEngine` charge coherency, and `AIDecisionMaker._check_formation_coherency`. A 7-model "square-spiral" (each end touches one mate, all within 9") is coherent under 11e but incoherent under 10e, confirming the edition switch. No errors fired.
- **Headless:** `test_iss042_coherency_11e` 11/11, `test_charge_phase_fixes` 32/0, `test_t105_da_jump_pin` 33/0, `test_iss040_move_types` 18/0, `test_iss002_game_constants` 13/0, `test_mp_scoring_11e` 7/0. (The 3 failures in `test_audit_already_done_pin` are pre-existing ungated-print / path-sum lint pins — identical print counts to `main` — and unrelated to coherency.)

Changelog entry added as **0.38.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019BciyuHY3UMc1AgBkfjLuk)_