### PR TITLE
Add changelog entry documenting the Movement-phase load fix

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.3",
+			"date": "2026-07-13",
+			"summary": "Fixed a bug that broke the Movement phase completely: when you entered Movement, the right-hand unit list was empty and clicking your models did nothing, so you couldn't move anyone. This was caused by a coding error introduced with the 11th-edition coherency update (0.41.1) that stopped the Movement controller from loading. Movement now works again — the unit list populates, and selecting a unit (from the list or by clicking its models on the board) starts its move as before.",
+			"changes": [
+				"Fixed: entering the Movement phase showed an empty right-hand panel and ignored clicks on your models, making it impossible to move units. This affected every game, and was most visible after loading a save.",
+				"Root cause was a leftover reference to a variable removed during the 0.41.1 coherency migration, which made the whole Movement controller script fail to load."
+			]
+		},
+		{
 			"version": "0.42.2",
 			"date": "2026-07-13",
 			"summary": "Fixed: when the AI charged one of your units, the computer would then pile in (move) your own charged unit for you during the Fight phase, so you never got control of it. Now, on the AI's turn, the AI only ever piles in, fights and consolidates its OWN units — every time it is your half of the Pile In, Fight or Consolidate step, the game waits for you and shows your dialog instead of the AI acting for you.",


### PR DESCRIPTION
## Summary

Documents the Movement-phase bug for players: entering Movement showed an empty right-hand panel and clicking models did nothing, so no unit could be moved (the reporter hit it after loading a Command-phase save, but it affected every game).

## Note on the code fix

While investigating, I found the **code fix already landed on `main`** independently via a recently-merged PR — `MovementController.gd` now removes the orphaned `required_connections` reference (`%d/%d in coherency`), identical in effect to what this branch originally carried. So after rebasing this branch onto the updated `main`, its code change is redundant and has been dropped. **This PR now contributes only the player-facing `0.42.3` "What's New" entry** that documents the fix, which `main` shipped without a changelog note.

## Root cause (for the record)

The 11e coherency migration (`088b72a`, released as 0.41.1) removed the `required_connections` variable from `_update_coherency_preview()` but left one reference in a debug `print` at `MovementController.gd:3155`. A single undeclared identifier makes the whole script fail to parse, so `setup_movement_controller()`'s `load("res://scripts/MovementController.gd").new()` returned `null` and `movement_controller` stayed null on every Movement-phase entry — no right-hand panel got built, and Main's board-click handler (`elif current_phase == MOVEMENT and movement_controller:`) fell through.

## Verification

- Reproduced the reporter's flow against the running game: before the fix `movement_controller` was `null` with 0 unit-list items; with the fix present it instantiates, the list shows 8 units, and selecting a unit (list row or board model click) begins a Normal Move; 0 errors in the debug log.
- Windowed scenario `click_select_unit_movement.json`: **37/37 pass** with the fix; **fails at step 3** (`Invalid named index 'active_unit_id' for base type Nil`) without it — a genuine regression net.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PLJGzeEqmZCzcbLpmm72vp