### PR TITLE
Fix spurious "consolidate failed" spam when a unit has no legal 12.08 move

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.4",
+			"date": "2026-07-13",
+			"summary": "Fixed the confusing 'consolidate failed — skipping movement' messages in the Fight phase. When a unit had no legal Consolidation move — most commonly right after it wiped out the only enemy it was fighting, with no other enemy or objective within 3\" — the AI would still try to shuffle it toward the nearest objective (even one 10\"+ away), the rules would correctly reject the move, and the log filled with alarming 'consolidate failed' / 'validation failed' lines. The unit still couldn't legally move (that part was correct 10th-edition behaviour: Consolidation must end closer to an enemy within 3\" or an objective within 3\"), but the game now recognises that up front and the unit simply holds position — no scary 'failed' spam.",
+			"changes": [
+				"Consolidation (12.08): a unit that has no enemy within 3\" and no objective within 3\" now cleanly holds position instead of logging 'consolidate failed — skipping movement'. This is the expected outcome after you kill the last enemy you were fighting and nothing else is nearby — Consolidation is not a free 3\" move, it must head toward an enemy or objective in range.",
+				"The AI's consolidation targeting now uses the same 3\" range gates as the rules validator (enemy within 3\", or objective within 3\"), so it no longer attempts moves toward out-of-range objectives that were always going to be rejected.",
+				"When it IS your unit's turn to consolidate, the picker still lists it and labels units that can't move with '[No move possible from here]', so you can see at a glance why a unit holds position. If the computer is moving/consolidating your units on its own turn, make sure you're on the latest build — a recent fix (0.42.2) hands your half of every Fight-phase step back to you."
+			]
+		},
+		{
 			"version": "0.42.3",
 			"date": "2026-07-13",
 			"summary": "Fixed a bug that broke the Movement phase completely: when you entered Movement, the right-hand unit list was empty and clicking your models did nothing, so you couldn't move anyone. This was caused by a coding error introduced with the 11th-edition coherency update (0.41.1) that stopped the Movement controller from loading. Movement now works again — the unit list populates, and selecting a unit (from the list or by clicking its models on the board) starts its move as before.",

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -14789,29 +14789,39 @@ static func _compute_consolidate_action(snapshot: Dictionary, unit_id: String, p
 	}
 
 static func _determine_ai_consolidate_mode(snapshot: Dictionary, unit: Dictionary, player: int) -> String:
-	"""Determine whether the AI should consolidate toward enemies (ENGAGEMENT) or
-	toward the nearest objective (OBJECTIVE).
-	- ENGAGEMENT: at least one alive enemy model is within 4" (3" move + 1" ER)
-	  of at least one alive friendly model in this unit.
-	- OBJECTIVE: no enemy is reachable but an objective exists.
-	- NONE: neither target is available.
-	T7-43: In rounds 4-5, prefer OBJECTIVE over ENGAGEMENT when enemies are only
-	marginally reachable (3-4") and an uncontrolled/contested objective is nearby."""
+	"""Determine which consolidation mode the AI should use. The 12.08 modes are
+	MANDATORY and assessed in a fixed order with hard range gates — the mode
+	returned here MUST match what FightPhase._validate_consolidate_11e will accept,
+	or the move is rejected and the player sees "consolidate failed — skipping
+	movement" for a unit that legitimately has no legal move:
+	- ENGAGEMENT: an alive enemy model is within 3" (edge-to-edge) of one of our
+	  models — the rules gate for Ongoing/Engaging consolidation. (Engaging is
+	  mandatory when in range, so we never divert to an objective instead.)
+	- OBJECTIVE: no enemy within 3", but an objective is within range (3" + the
+	  objective marker radius, matching ConsolidationMove.OBJECTIVE_RANGE_INCHES).
+	- NONE: neither is in range — the unit holds position (empty movements, a
+	  clean no-op). This is the common case after wiping out the enemy you fought.
+	Previously this over-reached — ENGAGEMENT for enemies up to 4" away and
+	OBJECTIVE whenever ANY objective existed anywhere on the board — so the AI
+	computed illegal moves the validator rejected on almost every board."""
 	var unit_owner = int(unit.get("owner", player))
 	var unit_keywords = unit.get("meta", {}).get("keywords", [])
 	var has_fly = "FLY" in unit_keywords
 
-	var engagement_check_range_px = (3.0 + GameConstants.engagement_range_inches()) * PIXELS_PER_INCH  # 3" pile-in move + ER
-	# T7-43: Tighter range for "firmly engaged" — enemy within 2" means we should stay
-	var firm_engagement_range_px = 2.0 * PIXELS_PER_INCH
+	# 12.08 Engaging gate: "within 3\" of one or more enemy units" (edge-to-edge).
+	# Ongoing (already engaged, within 1" ER) is a subset, so 3" covers both.
+	var engaging_range_px = 3.0 * PIXELS_PER_INCH
+	# 12.08 Objective gate: within 3" of the objective, measured model-edge to
+	# marker centre — the extra ~0.79" is the 20mm marker radius (keep in sync
+	# with ConsolidationMove.OBJECTIVE_RANGE_INCHES / MissionManager).
+	var objective_range_px = 3.78740157 * PIXELS_PER_INCH
 
 	var alive_models = _get_alive_models_with_positions(unit)
 	if alive_models.is_empty():
 		return "NONE"
 
-	# Check if any enemy model is within 4" of any of our models (edge-to-edge)
-	var enemy_reachable = false
-	var enemy_firmly_engaged = false
+	# Is any alive enemy model within 3" (edge-to-edge) of any of our models?
+	var enemy_in_range = false
 	for model in alive_models:
 		var mpos = _get_model_position(model)
 		if mpos == Vector2.INF:
@@ -14836,33 +14846,34 @@ static func _determine_ai_consolidate_mode(snapshot: Dictionary, unit: Dictionar
 					continue
 				var ebr = _model_bounding_radius_px(em.get("base_mm", 32), em.get("base_type", "circular"), em.get("base_dimensions", {}))
 				var edge_dist_px = mpos.distance_to(ep) - mbr - ebr
-				if edge_dist_px <= engagement_check_range_px:
-					enemy_reachable = true
-				if edge_dist_px <= firm_engagement_range_px:
-					enemy_firmly_engaged = true
+				if edge_dist_px <= engaging_range_px:
+					enemy_in_range = true
+					break
+			if enemy_in_range:
+				break
+		if enemy_in_range:
+			break
 
-	if enemy_reachable:
-		# T7-43: In rounds 4-5, if enemies are only marginally reachable (not firmly engaged),
-		# prefer consolidating toward objectives instead. Objective control > kills in late game.
-		var consol_battle_round = snapshot.get("meta", {}).get("battle_round", snapshot.get("battle_round", 1))
-		if consol_battle_round >= 4 and not enemy_firmly_engaged:
-			var objectives = _get_objectives(snapshot)
-			if not objectives.is_empty():
-				# Check if any objective is nearby and uncontrolled/contested
-				var unit_centroid = _get_unit_centroid(unit)
-				if unit_centroid != Vector2.INF:
-					for obj_pos in objectives:
-						var obj_dist = unit_centroid.distance_to(obj_pos)
-						if obj_dist <= 6.0 * PIXELS_PER_INCH:  # Objective within 6" — worth consolidating toward
-							print("AIDecisionMaker: [STRATEGY] Round %d — consolidating toward objective instead of marginally reachable enemy" % consol_battle_round)
-							return "OBJECTIVE"
+	# Engaging/Ongoing is MANDATORY when an enemy is within 3" (12.08) — take it.
+	if enemy_in_range:
 		return "ENGAGEMENT"
 
-	# No enemy reachable — check for objectives
-	var objectives = _get_objectives(snapshot)
-	if not objectives.is_empty():
-		return "OBJECTIVE"
+	# Otherwise Objective consolidation, but ONLY if an objective is actually in
+	# range (model edge within 3" + marker radius). An objective merely existing
+	# somewhere on the board does not permit a consolidation move toward it.
+	for obj_pos in _get_objectives(snapshot):
+		for model in alive_models:
+			var mpos = _get_model_position(model)
+			if mpos == Vector2.INF:
+				continue
+			var mbr = _model_bounding_radius_px(model.get("base_mm", 32), model.get("base_type", "circular"), model.get("base_dimensions", {}))
+			if mpos.distance_to(obj_pos) - mbr <= objective_range_px:
+				return "OBJECTIVE"
 
+	# No enemy within 3" and no objective within 3" — there is no legal 12.08
+	# consolidation move, so the unit holds position (this is the expected result
+	# after wiping out the enemy you were fighting with nothing else nearby).
+	print("AIDecisionMaker: %s has no legal consolidation move (no enemy or objective within 3\") — holding position" % _dn(unit, unit.get("id", "")))
 	return "NONE"
 
 static func _compute_consolidate_movements_engagement(snapshot: Dictionary, unit_id: String, unit: Dictionary, player: int) -> Dictionary:

--- a/40k/tests/unit/test_ai_consolidate_no_illegal_move.gd
+++ b/40k/tests/unit/test_ai_consolidate_no_illegal_move.gd
@@ -1,0 +1,150 @@
+extends SceneTree
+
+# Regression: the AI must not attempt an ILLEGAL consolidation move that the
+# 12.08 validator rejects, spamming the player's log with
+# "consolidate failed — skipping movement" / "no movement (validation failed)".
+#
+# Reported bug: a unit killed the enemy it was fighting; there was no other enemy
+# within 3" and no objective within 3", so per 12.08 it had NO legal
+# consolidation move. But AIDecisionMaker._determine_ai_consolidate_mode returned
+# OBJECTIVE whenever ANY objective existed anywhere on the board (and ENGAGEMENT
+# for enemies up to 4" away), so the AI computed a 3" move toward an out-of-range
+# objective. FightPhase._validate_consolidate_11e correctly rejected it (mode ""),
+# the AI retried empty, and the player saw a scary "failed" for every such unit.
+#
+# The fix makes the AI defer to the authoritative ConsolidationMove.select_mode
+# gate, so it holds position (empty movements) when no legal move exists — which
+# validates as a clean no-op.
+#
+# Usage: godot --headless --path 40k -s tests/unit/test_ai_consolidate_no_illegal_move.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run)
+
+func _px(inches: float) -> float:
+	return root.get_node("/root/Measurement").inches_to_px(inches)
+
+func _unit(id: String, owner: int, x: float, y: float, alive := true) -> Dictionary:
+	return {
+		"id": id, "owner": owner, "status": 2,
+		"flags": {"was_eligible_to_fight": true},
+		"meta": {"name": id, "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 2}},
+		"models": [
+			{"id": "m1", "alive": alive, "wounds": 2, "current_wounds": (2 if alive else 0),
+			 "base_mm": 32, "base_type": "circular", "position": {"x": x, "y": y}},
+		]
+	}
+
+# Drive the real FightPhase to P2's half of the 12.07 Consolidate step so the
+# validator (not a stub) judges the AI's action. In the live flow
+# _begin_consolidation_step_11e stamps was_eligible_to_fight on every unit that
+# fought; the phase transition clears that stamp, so re-apply it here for the
+# P2 unit that (in the reported scenario) killed its enemy and so was eligible.
+func _enter_p2_consolidate(fp, gs) -> void:
+	fp.consolidation_step_11e = fp.ConsolidationStep11e.ACTIVE
+	fp.consolidating_player_11e = 2
+	fp.consolidation_done_players_11e = {}
+	fp.units_that_consolidated_11e = {}
+	for uid in gs.state["units"]:
+		if int(gs.state["units"][uid].get("owner", 0)) == 2:
+			gs.state["units"][uid]["flags"]["was_eligible_to_fight"] = true
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_ai_consolidate_no_illegal_move ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var pm = root.get_node_or_null("PhaseManager")
+	var ADM = load("res://scripts/AIDecisionMaker.gd")
+	var MoveTypes = load("res://scripts/rules/movetypes/MoveTypes.gd")
+	var tmpl = MoveTypes.get_type("consolidation")
+	if gs == null or pm == null:
+		_check("autoloads present", false); _finish(); return
+
+	var prev_state = gs.state.duplicate(true)
+	var prev_edition = GameConstants.edition
+	GameConstants.edition = 11
+
+	var bx := 1000.0
+	var by := 1000.0
+
+	# ---------------------------------------------------------------------
+	# Scenario 1 (the bug): killed the only enemy, nearest objective 12" away.
+	# ---------------------------------------------------------------------
+	gs.state["units"] = {
+		"AI_BOYZ": _unit("AI_BOYZ", 2, bx, by),
+		"DEAD_FOE": _unit("DEAD_FOE", 1, bx + 40, by, false),  # wiped out
+	}
+	gs.state["board"] = {"objectives": [
+		{"id": "FAR", "position": {"x": bx + _px(12.0), "y": by}}
+	]}
+	gs.state["meta"]["active_player"] = 2
+	gs.state["meta"]["phase"] = 10
+	gs.state["meta"]["battle_round"] = 2
+
+	pm.transition_to_phase(10)
+	var fp = pm.get_current_phase_instance()
+	_enter_p2_consolidate(fp, gs)
+
+	_check("precondition: no legal consolidation mode (nothing within 3\")",
+		str(tmpl.select_mode("AI_BOYZ", gs.state).mode) == "",
+		"mode=%s" % str(tmpl.select_mode("AI_BOYZ", gs.state).mode))
+
+	var action = ADM._compute_consolidate_action(gs.state, "AI_BOYZ", 2)
+	_check("FIX: AI holds position (empty movements) instead of moving toward the 12\" objective",
+		action.get("movements", {}).is_empty(),
+		"movements=%s desc=%s" % [str(action.get("movements")), str(action.get("_ai_description"))])
+
+	# The action the AI actually submits must pass the real validator (no
+	# "consolidate failed" churn). action.player is required by the phase.
+	action["player"] = 2
+	var res = fp.execute_action(action)
+	_check("AI's consolidation action is ACCEPTED by FightPhase (no validation failure)",
+		res.get("success", false), str(res))
+
+	# ---------------------------------------------------------------------
+	# Scenario 2 (control): objective genuinely within range -> AI still moves.
+	# ---------------------------------------------------------------------
+	gs.state["units"] = {
+		"AI_BOYZ": _unit("AI_BOYZ", 2, bx, by),
+		"DEAD_FOE": _unit("DEAD_FOE", 1, bx + 40, by, false),
+	}
+	gs.state["board"] = {"objectives": [
+		{"id": "NEAR", "position": {"x": bx + _px(2.0), "y": by}}
+	]}
+	_enter_p2_consolidate(fp, gs)
+	var mode2 = ADM._determine_ai_consolidate_mode(gs.state, gs.state["units"]["AI_BOYZ"], 2)
+	_check("control: objective within 3\" -> AI still selects OBJECTIVE (valid consolidations unaffected)",
+		mode2 == "OBJECTIVE", "mode=%s" % mode2)
+
+	# ---------------------------------------------------------------------
+	# Scenario 3 (control): live enemy within 3" -> AI engages (mandatory).
+	# ---------------------------------------------------------------------
+	gs.state["units"] = {
+		"AI_BOYZ": _unit("AI_BOYZ", 2, bx, by),
+		"LIVE_FOE": _unit("LIVE_FOE", 1, bx + _px(2.0), by, true),  # ~0.7" edge -> engaged
+	}
+	gs.state["board"] = {"objectives": []}
+	_enter_p2_consolidate(fp, gs)
+	var mode3 = ADM._determine_ai_consolidate_mode(gs.state, gs.state["units"]["AI_BOYZ"], 2)
+	_check("control: enemy within 3\" -> AI selects ENGAGEMENT",
+		mode3 == "ENGAGEMENT", "mode=%s" % mode3)
+
+	GameConstants.edition = prev_edition
+	gs.state = prev_state
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/unit/test_ai_consolidate_no_illegal_move.gd.uid
+++ b/40k/tests/unit/test_ai_consolidate_no_illegal_move.gd.uid
@@ -1,0 +1,1 @@
+uid://cm0cp3fl4abm8

--- a/40k/tests/unit/test_ai_consolidation.gd
+++ b/40k/tests/unit/test_ai_consolidation.gd
@@ -140,17 +140,27 @@ func test_consolidate_mode_detection_engagement():
 
 func test_consolidate_mode_detection_objective():
 	print("\n--- test_consolidate_mode_detection_objective ---")
+	# 12.08 Objective consolidation applies only when the unit is within range of
+	# an objective (3" + marker radius) AND no enemy is within 3". Objective at
+	# (500, 640): 140px = 3.5" from the friendly's model centre -> ~2.9" edge,
+	# in range. Enemy 10" away.
 	var snapshot = _create_test_snapshot()
-	# Place friendly unit 10" from enemy — beyond 4" engagement-check range
-	# 10" = 400px
-	_add_unit(snapshot, "friendly_1", 2, Vector2(200, 500), "Assault Marines", 2, 6, 1,
+	snapshot.board.objectives = [{"id": "obj_near", "position": Vector2(500, 640), "zone": "no_mans_land"}]
+	_add_unit(snapshot, "friendly_1", 2, Vector2(500, 500), "Assault Marines", 2, 6, 1,
 		["INFANTRY"], [_make_melee_weapon()])
-	_add_unit(snapshot, "enemy_1", 1, Vector2(600, 500), "Enemy Unit", 2, 6, 1)
+	_add_unit(snapshot, "enemy_1", 1, Vector2(900, 500), "Enemy Unit", 2, 6, 1)
 
 	var unit = snapshot.units["friendly_1"]
 	var mode = AIDecisionMaker._determine_ai_consolidate_mode(snapshot, unit, 2)
 	_assert(mode == "OBJECTIVE",
-		"Mode should be OBJECTIVE when enemy is beyond 4\" but objectives exist")
+		"Mode should be OBJECTIVE when an objective is within 3\" and no enemy is in range")
+
+	# But an objective merely EXISTING far away does NOT permit a move toward it
+	# (the reported bug): pushed to 20"+ away, the unit has no legal move -> NONE.
+	snapshot.board.objectives = [{"id": "obj_far", "position": Vector2(880, 1200), "zone": "no_mans_land"}]
+	var mode_far = AIDecisionMaker._determine_ai_consolidate_mode(snapshot, unit, 2)
+	_assert(mode_far == "NONE",
+		"Mode should be NONE when the only objective is out of consolidation range (12.08)")
 
 
 func test_consolidate_mode_detection_none():
@@ -230,12 +240,15 @@ func test_consolidate_base_contact_holds_position():
 
 func test_consolidate_objective_mode_moves_toward_objective():
 	print("\n--- test_consolidate_objective_mode_moves_toward_objective ---")
+	# Objective in range (3.7" from the model centre -> ~3.1" edge, still within
+	# the 3.79" gate) and no enemy nearby, so Objective consolidation applies and
+	# the model advances toward the marker.
 	var snapshot = _create_test_snapshot()
-	# Place friendly unit far from enemies (beyond 4") but objective at (880, 1200)
-	# 10" = 400px from enemy
-	_add_unit(snapshot, "friendly_1", 2, Vector2(200, 500), "Assault Marines", 2, 6, 1,
+	var obj_pos = Vector2(500, 648)  # 148px = 3.7" from friendly centre
+	snapshot.board.objectives = [{"id": "obj_near", "position": obj_pos, "zone": "no_mans_land"}]
+	_add_unit(snapshot, "friendly_1", 2, Vector2(500, 500), "Assault Marines", 2, 6, 1,
 		["INFANTRY"], [_make_melee_weapon()])
-	_add_unit(snapshot, "enemy_1", 1, Vector2(600, 500), "Enemy Unit", 2, 6, 1)
+	_add_unit(snapshot, "enemy_1", 1, Vector2(1000, 500), "Enemy Unit", 2, 6, 1)
 
 	var result = AIDecisionMaker._compute_consolidate_action(snapshot, "friendly_1", 2)
 
@@ -244,12 +257,11 @@ func test_consolidate_objective_mode_moves_toward_objective():
 
 	var movements = result.get("movements", {})
 	_assert(movements.size() > 0,
-		"Should produce movements toward objective when enemy is out of reach")
+		"Should produce movements toward objective when it is in range and no enemy is near")
 
 	if movements.has("0"):
 		var new_pos = movements["0"]
-		var old_pos = Vector2(200, 500)
-		var obj_pos = Vector2(880, 1200)  # objective position from snapshot
+		var old_pos = Vector2(500, 500)
 		_assert(new_pos.distance_to(obj_pos) < old_pos.distance_to(obj_pos),
 			"Model should end closer to objective after consolidation (objective mode)")
 
@@ -261,11 +273,15 @@ func test_consolidate_objective_mode_moves_toward_objective():
 
 func test_consolidate_multiple_models_toward_objective():
 	print("\n--- test_consolidate_multiple_models_toward_objective ---")
+	# 3 models clustered within objective range (no enemy near) -> all advance
+	# toward the marker. Models sit at x=200,240,280 y=500; objective at
+	# (240, 610) is ~2.75" from the row -> in range for the whole unit.
 	var snapshot = _create_test_snapshot()
-	# Place 3 models far from enemies, should all move toward objective
+	var obj_pos = Vector2(240, 610)
+	snapshot.board.objectives = [{"id": "obj_near", "position": obj_pos, "zone": "no_mans_land"}]
 	_add_unit(snapshot, "friendly_1", 2, Vector2(200, 500), "Assault Marines", 2, 6, 3,
 		["INFANTRY"], [_make_melee_weapon()], 4, 3, 1, 32, 40.0)
-	_add_unit(snapshot, "enemy_1", 1, Vector2(800, 500), "Enemy Unit", 2, 6, 1)
+	_add_unit(snapshot, "enemy_1", 1, Vector2(1000, 500), "Enemy Unit", 2, 6, 1)
 
 	var result = AIDecisionMaker._compute_consolidate_action(snapshot, "friendly_1", 2)
 	var movements = result.get("movements", {})
@@ -274,7 +290,6 @@ func test_consolidate_multiple_models_toward_objective():
 		"Multiple models should produce at least some consolidation movements toward objective")
 
 	# All movements should bring models closer to the objective
-	var obj_pos = Vector2(880, 1200)
 	for model_idx_str in movements:
 		var new_pos = movements[model_idx_str]
 		var model_idx = int(model_idx_str)
@@ -289,12 +304,14 @@ func test_consolidate_multiple_models_toward_objective():
 
 func test_consolidate_respects_3_inch_limit():
 	print("\n--- test_consolidate_respects_3_inch_limit ---")
+	# Objective 4" from the model centre (edge ~3.37", within the 3.79" gate) so
+	# Objective consolidation applies, but the marker is >3" away so the move is
+	# clamped to the 3" maximum. Enemy far so it does not force engagement.
 	var snapshot = _create_test_snapshot()
-	# Place unit 5" from enemy — within 4" check but movement is clamped to 3"
-	# 5" = 200px
+	snapshot.board.objectives = [{"id": "obj_near", "position": Vector2(300, 660), "zone": "no_mans_land"}]
 	_add_unit(snapshot, "friendly_1", 2, Vector2(300, 500), "Assault Marines", 2, 6, 1,
 		["INFANTRY"], [_make_melee_weapon()])
-	_add_unit(snapshot, "enemy_1", 1, Vector2(500, 500), "Enemy Unit", 2, 6, 1)
+	_add_unit(snapshot, "enemy_1", 1, Vector2(1100, 500), "Enemy Unit", 2, 6, 1)
 
 	var result = AIDecisionMaker._compute_consolidate_action(snapshot, "friendly_1", 2)
 	var movements = result.get("movements", {})
@@ -306,7 +323,7 @@ func test_consolidate_respects_3_inch_limit():
 		_assert(move_dist_inches <= 3.05,
 			"Consolidation should not exceed 3\" (moved %.2f\")" % move_dist_inches)
 		_assert_approx(move_dist_inches, 3.0, 0.1,
-			"Should move close to the maximum 3\" when enemy is beyond 3\"")
+			"Should move close to the maximum 3\" when the objective is beyond 3\"")
 	else:
 		_assert(movements.size() > 0, "Should produce a movement for the model")
 


### PR DESCRIPTION
## Problem

The Fight-phase log filled with alarming `consolidate failed — skipping movement` / `Consolidate X — no movement (validation failed)` lines for units that had just wiped out the enemy they were fighting (reported for Stormboyz and Warbikers). The player reasonably read this as "my unit should be able to consolidate but the game denied it."

## Root cause

A mismatch between the AI's consolidation targeting and the rules validator:

- `AIDecisionMaker._determine_ai_consolidate_mode` returned **OBJECTIVE whenever *any* objective existed anywhere on the board** (even 10"+ away) and **ENGAGEMENT for enemies up to 4"** away.
- The 12.08 validator (`ConsolidationMove.select_mode` → `FightPhase._validate_consolidate_11e`) only permits a move toward an enemy within **3"** or an objective within **3"** (+ marker radius).

So the AI computed a 3" move the validator always rejected, retried with empty movements, and logged the scary "failed" lines — on essentially every board where a unit fought but had nothing in consolidation range.

The move was genuinely impossible (Consolidation is not a free 3" move; per 12.08 it must end closer to an enemy within 3" or an objective within 3"), so the **outcome** was correct — only the churn and messaging were wrong.

## Fix

- The AI now uses the same 3" / 3"+marker range gates as the validator and respects the mandatory mode order (Engaging is taken when in range, never diverted to an objective).
- When nothing is in range the unit cleanly **holds position** (empty movements = a valid no-op) with a clear diagnostic log line instead of a "failed" retry.
- Player control is unchanged: the human consolidation picker already labels such units `[No move possible from here]`.

## Validation

- New regression test `test_ai_consolidate_no_illegal_move.gd` drives the **real `FightPhase` validator** — killed-enemy → clean hold (accepted, no failure); in-range enemy/objective → still consolidates. 5/5 pass.
- `test_ai_consolidation.gd` updated to rules-valid geometry (the old cases asserted moves toward 20"+ objectives / 3.7" enemies, both illegal at 12.08). 38/38 pass.
- `test_global_consolidation_11e` (34/34), `_ai_11e` (11/11), and `test_ai_no_control_human_fight_turn` (23/23) remain green; game boots windowed with no script errors.
- Changelog bumped to 0.42.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X8aikJrkjX5Ti9t8gVUyd

---
_Generated by [Claude Code](https://claude.ai/code/session_019X8aikJrkjX5Ti9t8gVUyd)_