### PR TITLE
Fight: render melee dice as d6 face icons, not numbers

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.5",
+			"date": "2026-07-14",
+			"summary": "The melee (Fight) resolution window now shows dice as proper d6 face icons everywhere, instead of a mix of plain numbers in the Combat Log and numbers-in-boxes on the Command Re-roll row. The pip faces match the dice used in the Shooting resolution log and the animated dice roller, so dice look consistent across the whole game — gold for 6s, red for 1s, green/red for pass/fail against the target number.",
+			"changes": [
+				"Fight phase Combat Log: hit, wound, save and Feel No Pain rolls now render as inline d6 face icons (rounded square + pips) rather than bracketed number lists like [ 1 5 5 3 6 6 4 4 2 ].",
+				"Command Re-roll row: each clickable die now shows its face icon instead of a number in a square; hover it to see the value and re-roll it.",
+				"Dice colours follow the same rules as the rest of the game: 6 = gold (critical), 1 = red (fumble), and otherwise green when the roll passes its target and red when it fails.",
+				"Command Re-roll results in the log now show the original face → the new face as icons too."
+			]
+		},
+		{
 			"version": "0.42.4",
 			"date": "2026-07-13",
 			"summary": "Fixed the confusing 'consolidate failed — skipping movement' messages in the Fight phase. When a unit had no legal Consolidation move — most commonly right after it wiped out the only enemy it was fighting, with no other enemy or objective within 3\" — the AI would still try to shuffle it toward the nearest objective (even one 10\"+ away), the rules would correctly reject the move, and the log filled with alarming 'consolidate failed' / 'validation failed' lines. The unit still couldn't legally move (that part was correct 10th-edition behaviour: Consolidation must end closer to an enemy within 3\" or an objective within 3\"), but the game now recognises that up front and the unit simply holds position — no scary 'failed' spam.",

--- a/40k/dialogs/FightSequenceDialog.gd
+++ b/40k/dialogs/FightSequenceDialog.gd
@@ -21,6 +21,11 @@ signal staged_reroll_requested(stage: String, die_index: int)  # Command Re-roll
 var current_phase = null
 var current_stage: String = ""       # "hits" | "wounds" while paused
 
+# Verification hook: how many d6 face icons have been added to the combat log.
+# Windowed scenarios assert this is > 0 to prove the log renders dice as icons
+# (DiceFaceIcons) rather than as bare numbers.
+var _log_dice_icon_count: int = 0
+
 # UI nodes
 var vbox: VBoxContainer
 var header_label: Label
@@ -78,7 +83,7 @@ func _ready() -> void:
 	reroll_row.visible = false
 	var reroll_scroll = ScrollContainer.new()
 	reroll_scroll.name = "RerollScroll"
-	reroll_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 44)
+	reroll_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 52)
 	reroll_scroll.add_child(reroll_row)
 	vbox.add_child(reroll_scroll)
 
@@ -118,6 +123,8 @@ func _ready() -> void:
 	dice_log_rich_text.set_custom_minimum_size(Vector2(DialogConstants.LARGE.x - 40, 200))
 	dice_log_rich_text.bbcode_enabled = true
 	dice_log_rich_text.scroll_following = true
+	# Untagged text (labels emitted between inline dice icons) renders white.
+	dice_log_rich_text.add_theme_color_override("default_color", Color.WHITE)
 	vbox.add_child(dice_log_rich_text)
 
 	print("FightSequenceDialog initialized")
@@ -154,31 +161,44 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 			var total = dice_data.get("total_attacks", dice_data.get("successes", 0))
 			_add_to_dice_log("[b]Rolling to Hit:[/b] [color=cyan]%d automatic hits[/color]" % total, Color.WHITE)
 		"hit_roll_melee", "to_hit":
-			_add_to_dice_log(_format_roll_line("hit", dice_data), Color.WHITE)
+			_append_roll_line("hit", dice_data)
 		"wound_roll_melee", "to_wound":
-			_add_to_dice_log(_format_roll_line("wound", dice_data), Color.WHITE)
+			_append_roll_line("wound", dice_data)
 		"save_roll_melee", "save_roll", "save":
-			_add_to_dice_log(_format_save_line(dice_data), Color.WHITE)
+			_append_save_line(dice_data)
 		"feel_no_pain":
-			var prevented = dice_data.get("wounds_prevented", 0)
-			_add_to_dice_log("[b]Feel No Pain[/b] (need %s): %s → [color=cyan]%d prevented[/color]" % [
-				dice_data.get("threshold", "?"), _dice_str(dice_data.get("rolls_raw", [])), prevented], Color.WHITE)
+			_append_fnp_line(dice_data)
 		"hazardous_check", "hazardous":
-			_add_to_dice_log("[b][color=red]Hazardous:[/color][/b] %s" % dice_data.get("message", str(dice_data.get("rolls_raw", []))), Color.WHITE)
+			var hz_rolls = dice_data.get("rolls_raw", [])
+			if not (hz_rolls as Array).is_empty():
+				dice_log_rich_text.append_text("[b][color=red]Hazardous:[/color][/b] ")
+				_append_dice_icons(hz_rolls, 0, 7)
+				dice_log_rich_text.append_text("\n")
+			else:
+				_add_to_dice_log("[b][color=red]Hazardous:[/color][/b] %s" % dice_data.get("message", ""), Color.WHITE)
 		_:
 			# Fallback for any other dice block with rolls.
 			var rolls = dice_data.get("rolls_raw", dice_data.get("rolls", []))
 			if not (rolls as Array).is_empty():
-				var line = "[b]%s[/b]" % context.capitalize().replace("_", " ")
+				var thr_str = str(dice_data.get("threshold", ""))
+				var thr_num = _threshold_to_int(thr_str)
+				dice_log_rich_text.append_text("[b]%s[/b]" % context.capitalize().replace("_", " "))
 				if dice_data.has("threshold"):
-					line += " (need %s)" % dice_data.get("threshold", "")
-				line += ": %s" % _dice_str(rolls)
+					dice_log_rich_text.append_text(" (need %s)" % thr_str)
+				dice_log_rich_text.append_text(": ")
+				_append_dice_icons(rolls, thr_num, 6 if thr_num > 0 else 7)
 				if dice_data.has("successes"):
-					line += " → [b][color=green]%d[/color][/b]" % int(dice_data.get("successes", 0))
-				_add_to_dice_log(line, Color.WHITE)
+					dice_log_rich_text.append_text(" → [b][color=green]%d[/color][/b]" % int(dice_data.get("successes", 0)))
+				dice_log_rich_text.append_text("\n")
 
-func _format_roll_line(kind: String, dice_data: Dictionary) -> String:
-	var threshold = str(dice_data.get("threshold", ""))
+func _append_roll_line(kind: String, dice_data: Dictionary) -> void:
+	# Hit/wound roll: bold label + threshold, the rolled dice as inline d6 face
+	# icons, any Command Re-roll transitions (old face → new face), then the
+	# success / miss / crit summary.
+	if not dice_log_rich_text:
+		return
+	var threshold_str = str(dice_data.get("threshold", ""))
+	var threshold_num = _threshold_to_int(threshold_str)
 	var rolls_raw = dice_data.get("rolls_raw", [])
 	var rolls_modified = dice_data.get("rolls_modified", [])
 	var display_rolls = rolls_modified if not (rolls_modified as Array).is_empty() else rolls_raw
@@ -186,56 +206,89 @@ func _format_roll_line(kind: String, dice_data: Dictionary) -> String:
 	var successes = int(dice_data.get("successes", 0))
 
 	var label = "Rolling to Hit" if kind == "hit" else "Rolling to Wound"
-	var line = "[b]%s[/b] (need %s): %s" % [label, threshold, _dice_str(display_rolls)]
+	dice_log_rich_text.append_text("[b]%s[/b] (need %s): " % [label, threshold_str])
+	_append_dice_icons(display_rolls, threshold_num, 6)
+
 	var rerolls = dice_data.get("rerolls", dice_data.get("wound_rerolls", []))
 	if not (rerolls as Array).is_empty():
-		line += "  [color=orange]("
-		for rr in rerolls:
-			line += "%d→%d " % [rr.get("original", 0), rr.get("rerolled_to", 0)]
-		line = line.strip_edges() + ")[/color]"
+		dice_log_rich_text.append_text("  [color=orange]([/color]")
+		for ridx in range((rerolls as Array).size()):
+			var rr = rerolls[ridx]
+			_append_dice_icons([int(rr.get("original", 0))], threshold_num, 6)
+			dice_log_rich_text.append_text(" [color=orange]→[/color] ")
+			_append_dice_icons([int(rr.get("rerolled_to", 0))], threshold_num, 6)
+			if ridx < (rerolls as Array).size() - 1:
+				dice_log_rich_text.append_text("  ")
+		dice_log_rich_text.append_text("[color=orange])[/color]")
+
 	var fails = max(0, total - successes)
 	var noun = kind if successes == 1 else kind + "s"
-	line += " → [b][color=green]%d %s[/color][/b]" % [successes, noun]
+	dice_log_rich_text.append_text(" → [b][color=green]%d %s[/color][/b]" % [successes, noun])
 	if kind == "hit" and total > 0:
 		var miss_word = "miss" if fails == 1 else "misses"
-		line += "[color=gray], %d %s[/color]" % [fails, miss_word]
+		dice_log_rich_text.append_text("[color=gray], %d %s[/color]" % [fails, miss_word])
 	var crits = int(dice_data.get("critical_hits", dice_data.get("critical_wounds", 0)))
 	if crits > 0:
 		var crit_kind = "critical hit" if kind == "hit" else "critical wound"
-		line += "  [color=#c8a24a](%d %s%s)[/color]" % [crits, crit_kind, "" if crits == 1 else "s"]
+		dice_log_rich_text.append_text("  [color=#c8a24a](%d %s%s)[/color]" % [crits, crit_kind, "" if crits == 1 else "s"])
 	var sustained = int(dice_data.get("sustained_bonus_hits", 0))
 	if kind == "hit" and sustained > 0:
-		line += "  [color=#c8a24a](+%d Sustained)[/color]" % sustained
+		dice_log_rich_text.append_text("  [color=#c8a24a](+%d Sustained)[/color]" % sustained)
 	var lethal_autos = int(dice_data.get("lethal_hits_auto_wounds", 0))
 	if kind == "wound" and lethal_autos > 0:
-		line += "  [color=#c8a24a](%d Lethal auto-wound%s)[/color]" % [lethal_autos, "" if lethal_autos == 1 else "s"]
-	return line
+		dice_log_rich_text.append_text("  [color=#c8a24a](%d Lethal auto-wound%s)[/color]" % [lethal_autos, "" if lethal_autos == 1 else "s"])
+	dice_log_rich_text.append_text("\n")
 
-func _format_save_line(dice_data: Dictionary) -> String:
-	var threshold = str(dice_data.get("threshold", "?"))
+func _append_save_line(dice_data: Dictionary) -> void:
+	if not dice_log_rich_text:
+		return
+	var threshold_str = str(dice_data.get("threshold", "?"))
+	var threshold_num = _threshold_to_int(threshold_str)
 	var rolls = dice_data.get("rolls_raw", [])
 	var saved = int(dice_data.get("successes", 0))
 	var failed = int(dice_data.get("failed", max(0, (rolls as Array).size() - saved)))
-	var line = "[b]Saving Throws[/b] (need %s): %s → [color=green]%d saved[/color], [color=red]%d failed[/color]" % [
-		threshold, _dice_str(rolls), saved, failed]
+	dice_log_rich_text.append_text("[b]Saving Throws[/b] (need %s): " % threshold_str)
+	_append_dice_icons(rolls, threshold_num, 7)  # a 6 on a save isn't a crit — no gold
+	dice_log_rich_text.append_text(" → [color=green]%d saved[/color], [color=red]%d failed[/color]" % [saved, failed])
 	var dev = int(dice_data.get("devastating_wounds_bypassed", 0))
 	if dev > 0:
-		line += "  [color=#c8a24a](%d DEVASTATING — no save)[/color]" % dev
-	return line
+		dice_log_rich_text.append_text("  [color=#c8a24a](%d DEVASTATING — no save)[/color]" % dev)
+	dice_log_rich_text.append_text("\n")
 
-func _dice_str(rolls: Array) -> String:
+func _append_fnp_line(dice_data: Dictionary) -> void:
+	if not dice_log_rich_text:
+		return
+	var threshold_str = str(dice_data.get("threshold", "?"))
+	var threshold_num = _threshold_to_int(threshold_str)
+	var prevented = int(dice_data.get("wounds_prevented", 0))
+	dice_log_rich_text.append_text("[b]Feel No Pain[/b] (need %s): " % threshold_str)
+	_append_dice_icons(dice_data.get("rolls_raw", []), threshold_num, 7)
+	dice_log_rich_text.append_text(" → [color=cyan]%d prevented[/color]\n" % prevented)
+
+func _append_dice_icons(rolls: Array, threshold_num: int, crit_threshold: int = 6) -> void:
+	# Render `rolls` as inline d6 face icons (rounded square + pips), in roll
+	# order, using the shared DiceFaceIcons textures — the same faces the shooting
+	# resolution log and the Command Re-roll row use, so dice look consistent
+	# across the whole game. Colour follows standard d6 semantics: crit (gold),
+	# fumble (red), pass/fail vs threshold, else neutral.
+	if not dice_log_rich_text:
+		return
 	if rolls.is_empty():
-		return "[color=gray]—[/color]"
-	var parts = []
-	for r in rolls:
-		var v = int(r)
-		if v == 6:
-			parts.append("[color=#d4af37]6[/color]")
-		elif v == 1:
-			parts.append("[color=#a04040]1[/color]")
-		else:
-			parts.append(str(v))
-	return "[ " + " ".join(parts) + " ]"
+		dice_log_rich_text.append_text("[color=gray]—[/color]")
+		return
+	for i in range(rolls.size()):
+		var v = int(rolls[i])
+		var bg = DiceFaceIcons.color_for(v, threshold_num, threshold_num > 0, crit_threshold)
+		dice_log_rich_text.add_image(DiceFaceIcons.get_face(v, bg), 18, 18, Color.WHITE, INLINE_ALIGNMENT_CENTER)
+		if i < rolls.size() - 1:
+			dice_log_rich_text.append_text(" ")
+	_log_dice_icon_count += rolls.size()
+
+func _threshold_to_int(threshold_str: String) -> int:
+	var s = threshold_str.strip_edges()
+	if s.is_empty() or s == "?":
+		return 0
+	return int(s.replace("+", ""))
 
 func _add_to_dice_log(text: String, color: Color) -> void:
 	if not dice_log_rich_text:
@@ -276,13 +329,13 @@ func _on_stage_paused(stage: String, info: Dictionary) -> void:
 		var rolls = info.get("modified_rolls", [])
 		if (rolls as Array).is_empty():
 			rolls = info.get("hit_rolls", info.get("wound_rolls", []))
-		_populate_reroll_row(stage, rolls)
+		_populate_reroll_row(stage, rolls, _threshold_to_int(str(info.get("threshold", ""))))
 	else:
 		reroll_label.visible = false
 		reroll_row.visible = false
 		_clear_reroll_row()
 
-func _populate_reroll_row(stage: String, rolls: Array) -> void:
+func _populate_reroll_row(stage: String, rolls: Array, threshold_num: int = 0) -> void:
 	_clear_reroll_row()
 	if rolls.is_empty():
 		reroll_label.visible = false
@@ -292,11 +345,16 @@ func _populate_reroll_row(stage: String, rolls: Array) -> void:
 	reroll_label.visible = true
 	reroll_row.visible = true
 	for i in range(rolls.size()):
+		var v = int(rolls[i])
 		var die_btn = Button.new()
 		die_btn.name = "Die%d" % i
-		die_btn.text = str(int(rolls[i]))
-		die_btn.custom_minimum_size = Vector2(38, 38)
-		die_btn.tooltip_text = "Re-roll this die with Command Re-roll (1 CP)"
+		# Show each die as its face icon (pips) rather than a number, matching the
+		# combat log and the rest of the game's dice visuals.
+		var bg = DiceFaceIcons.color_for(v, threshold_num, threshold_num > 0, 6)
+		die_btn.icon = DiceFaceIcons.get_face(v, bg)
+		die_btn.expand_icon = true
+		die_btn.custom_minimum_size = Vector2(44, 44)
+		die_btn.tooltip_text = "Re-roll this %d with Command Re-roll (1 CP)" % v
 		_WhiteDwarfTheme.apply_to_button(die_btn)
 		die_btn.pressed.connect(_on_reroll_die_pressed.bind(i))
 		reroll_row.add_child(die_btn)

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -1250,34 +1250,47 @@ func _on_dice_rolled(dice_data: Dictionary) -> void:
 
 	log_text += ":\n"
 
-	# Color-code individual dice results
+	# Flush the header, then render the dice as inline d6 face icons (rounded
+	# square + pips) via the shared DiceFaceIcons textures — the same faces used
+	# by the shooting resolution log, the FightSequenceDialog and the animated
+	# dice roller — instead of a [n, n, n] number list, so dice look consistent
+	# across the whole game.
+	dice_log_display.append_text(log_text)
+	dice_log_display.append_text("  Rolls: ")
 	if not rolls_raw.is_empty():
-		var target_num = int(threshold.replace("+", "")) if threshold != "" else 4
-		var colored_rolls = []
-		for roll in rolls_raw:
-			if roll >= target_num:
-				colored_rolls.append("[color=green]%d[/color]" % roll)
-			else:
-				colored_rolls.append("[color=gray]%d[/color]" % roll)
-
-		log_text += "  Rolls: [%s]" % ", ".join(colored_rolls)
+		var target_num = int(threshold.replace("+", "")) if threshold != "" else 0
+		_append_dice_icons(dice_log_display, rolls_raw, target_num, context)
 	else:
-		log_text += "  Rolls: %s" % str(rolls_raw)
+		dice_log_display.append_text("[color=gray]—[/color]")
 
 	# Add success count
-	log_text += " → [b][color=green]%d successes[/color][/b]" % successes
+	var suffix = " → [b][color=green]%d successes[/color][/b]" % successes
 
 	# Save roll: show failed saves (which cause wounds)
 	if context == "save_roll":
 		var failed = dice_data.get("failed", 0)
 		if failed > 0:
-			log_text += ", [color=red]%d failed (wounds)[/color]" % failed
+			suffix += ", [color=red]%d failed (wounds)[/color]" % failed
 		else:
-			log_text += " [color=green](all saved!)[/color]"
+			suffix += " [color=green](all saved!)[/color]"
 
-	log_text += "\n"
+	suffix += "\n"
 
-	dice_log_display.append_text(log_text)
+	dice_log_display.append_text(suffix)
+
+func _append_dice_icons(target_label: RichTextLabel, rolls: Array, threshold_num: int, context: String) -> void:
+	# Render `rolls` as inline d6 face icons using the shared DiceFaceIcons
+	# textures. Colour follows the standard d6 semantics: crit (gold) on a 6 for
+	# hit/wound rolls, fumble (red) on a 1, pass/fail vs threshold, else neutral.
+	if not target_label or rolls.is_empty():
+		return
+	var crit_threshold = 6 if context in ["to_hit", "hit_roll_melee", "to_wound", "wound_roll_melee"] else 7
+	for i in range(rolls.size()):
+		var v = int(rolls[i])
+		var bg = DiceFaceIcons.color_for(v, threshold_num, threshold_num > 0, crit_threshold)
+		target_label.add_image(DiceFaceIcons.get_face(v, bg), 18, 18, Color.WHITE, INLINE_ALIGNMENT_CENTER)
+		if i < rolls.size() - 1:
+			target_label.append_text(" ")
 
 func _on_fight_sequence_updated(sequence: Array, index: int) -> void:
 	fight_sequence = sequence

--- a/40k/tests/scenarios/sp/staged_fight_reroll_ui.json
+++ b/40k/tests/scenarios/sp/staged_fight_reroll_ui.json
@@ -4,6 +4,8 @@
     "ui.fight.staged_hit_wound_pause",
     "ui.fight.command_reroll",
     "ui.fight.continue_buttons",
+    "ui.fight.log_dice_icons",
+    "ui.fight.reroll_dice_icons",
     "dialogs.FightSequenceDialog"
   ],
   "fixture": "co_pretrigger",
@@ -56,6 +58,21 @@
     {
       "act": "execute_script",
       "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").dice_log_rich_text.get_parsed_text().contains(\"Rolling to Hit\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\")._log_dice_icon_count > 0",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").reroll_row.get_child(0).icon != null",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"FightSequenceDialog\").reroll_row.get_child(0).text == \"\"",
       "equals": true
     },
     { "act": "screenshot", "label": "02_hits_pause_with_reroll_row" },


### PR DESCRIPTION
## Summary

The melee (Fight) resolution UI showed dice inconsistently — plain colour-coded **numbers** in the Combat Log (`[ 1 5 5 3 6 6 4 4 2 ]`) but **numbers-in-boxes** on the Command Re-roll row — and neither matched the pip-faced dice used elsewhere in the game.

This renders melee dice as proper **d6 face icons** (rounded square + pips) everywhere, reusing the shared `DiceFaceIcons` textures already used by the shooting resolution log and the animated dice roller, so dice look consistent across the whole game.

## Changes

- **`FightSequenceDialog.gd`** — Combat Log hit / wound / save / Feel No Pain rolls and Command Re-roll transitions now render as inline d6 face icons (via `add_image()`) instead of a `[ n n n ]` number list; the Command Re-roll row shows each clickable die as its pip-face icon instead of a number in a square.
- **`FightController.gd`** — the right-hand Fight **COMBAT LOG** panel (`Rolls: [1, 4, 2]`) now renders the same inline face icons (this second surface is visible during attacks, so leaving it would have preserved the same number/icon mix).
- Colours follow the game's standard d6 semantics: **6 = gold** (crit), **1 = red** (fumble), otherwise green/red for pass/fail vs the target number.
- Prepended a `version_history.json` entry (0.42.5).

## Validation

Ran the real player path via the `staged_fight_reroll_ui` windowed scenario against the live game (xvfb) — **53/53 passed, zero errors** in the debug log. Added assertions proving the log renders icons (`_log_dice_icon_count > 0`) and the re-roll buttons are icon buttons (icon set, no text). Screenshots captured across the hit stage, a Command Re-roll (`1 → gold 6`, correctly flagged as a critical hit), the wound stage, and completion.

## Note

The re-roll *note* sentence in the log (e.g. `Command Re-roll (1 CP): hit die 1 → 6`) is still prose text — it's a descriptive sentence generated in the phase logic, not a dice widget. The actual dice *displays* (arrays and re-roll boxes) are all icons now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HgufDojszPuUUpRr1YR5Vm

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgufDojszPuUUpRr1YR5Vm)_