### PR TITLE
Clear movement engagement-range overlay on phase exit

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.5",
+			"date": "2026-07-14",
+			"summary": "Fixed the red enemy 'engagement range' circles from the Movement phase lingering on the board after you advanced to the Shooting phase. Those red rings are only there to show where your models can't move during your Movement phase; they now clear away the moment the phase ends, so the Shooting phase board is no longer cluttered by them.",
+			"changes": [
+				"Fixed: the red engagement-range rings drawn around enemy units during the Movement phase (the 'don't move here' circles) no longer stay on the board once you move on to the Shooting phase — they are cleared when the Movement phase ends.",
+				"The same cleanup also removes the leftover blue move-range and coherency overlays that could linger past the Movement phase, so nothing movement-only survives into the next phase."
+			]
+		},
+		{
 			"version": "0.42.4",
 			"date": "2026-07-13",
 			"summary": "Fixed the confusing 'consolidate failed — skipping movement' messages in the Fight phase. When a unit had no legal Consolidation move — most commonly right after it wiped out the only enemy it was fighting, with no other enemy or objective within 3\" — the AI would still try to shuffle it toward the nearest objective (even one 10\"+ away), the rules would correctly reject the move, and the log filled with alarming 'consolidate failed' / 'validation failed' lines. The unit still couldn't legally move (that part was correct 10th-edition behaviour: Consolidation must end closer to an enemy within 3\" or an objective within 3\"), but the game now recognises that up front and the unit simply holds position — no scary 'failed' spam.",

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -214,7 +214,23 @@ func _exit_tree() -> void:
 		ruler_visual.queue_free()  
 	if ghost_visual and is_instance_valid(ghost_visual):
 		ghost_visual.queue_free()
-	
+
+	# T-094: Free the movement-only overlay containers that live under BoardRoot.
+	# These were previously leaked on phase exit, so any rings still present when
+	# the Movement phase ended survived into the Shooting phase. The enemy
+	# engagement-range overlay (the red "don't move here" circles) was the most
+	# visible offender and cluttered the board once movement was over. Free all
+	# three so no movement-only overlay outlives the phase.
+	if move_range_visual and is_instance_valid(move_range_visual):
+		move_range_visual.queue_free()
+		move_range_visual = null
+	if er_overlay_visual and is_instance_valid(er_overlay_visual):
+		er_overlay_visual.queue_free()
+		er_overlay_visual = null
+	if coherency_dots_visual and is_instance_valid(coherency_dots_visual):
+		coherency_dots_visual.queue_free()
+		coherency_dots_visual = null
+
 	# Clean up individual model path visuals
 	for model_id in model_path_visuals:
 		var line = model_path_visuals[model_id]

--- a/40k/tests/scenarios/sp/er_overlay_cleared_on_shooting_phase_11e.json
+++ b/40k/tests/scenarios/sp/er_overlay_cleared_on_shooting_phase_11e.json
@@ -1,0 +1,54 @@
+{
+  "id": "er_overlay_cleared_on_shooting_phase_11e",
+  "covers": [
+    "movementcontroller.er_overlay_cleared_on_phase_exit",
+    "shooting.no_leftover_movement_engagement_rings"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "edition": 11,
+  "description": "Player report: the red enemy engagement-range circles drawn during the Movement phase (T-094 'don't move here' rings) stayed on the board after switching to the Shooting phase, cluttering it. Root cause: MovementController._exit_tree() freed most of its BoardRoot visuals but not the MovementERVisual (nor MoveRangeVisual / MovementCoherencyVisual) containers, so any rings still present when the phase ended leaked into the next phase. This scenario teleports the enemy Warboss (40mm) next to the Shield-Captain, clicks the Shield-Captain to begin a Normal Move (which populates MovementERVisual with red rings around every enemy model), then transitions to the Shooting phase WITHOUT confirming the move. Asserts: (a) the ER rings are present during movement; (b) after the transition the MovementERVisual container — and the sibling move-range / coherency containers — are gone, so no red circles remain in the Shooting phase.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_SHIELD_CAPTAIN_A\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 800.0}}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_WARBOSS_B\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 1000.0}}, true)" },
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().game_state_snapshot[\"units\"][\"U_SHIELD_CAPTAIN_A\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 800.0}}, true)" },
+    { "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance().game_state_snapshot[\"units\"][\"U_WARBOSS_B\"][\"models\"][0].merge({\"position\": {\"x\": 300.0, \"y\": 1000.0}}, true)" },
+    { "act": "execute_script", "script": "main._recreate_unit_visuals()" },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "click_unit", "unit_id": "U_SHIELD_CAPTAIN_A" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script",
+      "script": "main.movement_controller.active_unit_id",
+      "equals": "U_SHIELD_CAPTAIN_A" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/MovementERVisual\").get_child_count()",
+      "expect_min": 1 },
+    { "act": "screenshot", "label": "01_movement_red_er_rings_present" },
+
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(8)" },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"BoardRoot/MovementERVisual\") == null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"BoardRoot/MoveRangeVisual\") == null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"BoardRoot/MovementCoherencyVisual\") == null",
+      "equals": true },
+    { "act": "screenshot", "label": "02_shooting_no_red_er_rings" }
+  ]
+}


### PR DESCRIPTION
## Problem

The red enemy engagement-range rings drawn during the Movement phase (the T-094 "don't move here" circles) stayed on the board after advancing to the Shooting phase, cluttering it. Reported by a player.

## Root cause

`MovementController._exit_tree()` freed most of its `BoardRoot` visuals but never freed the `MovementERVisual` container (nor its siblings `MoveRangeVisual` / `MovementCoherencyVisual`). These overlay containers are parented to `BoardRoot`, **not** to the controller, so when the controller is `queue_free`'d on a phase transition the containers — and any rings still present when the phase ended — outlived the Movement phase and leaked into Shooting.

## Fix

Free all three movement-only overlay containers in `_exit_tree()`, so no movement affordance survives into the next phase. The cleanup is unconditional on phase exit, so it covers every way of leaving Movement (confirm a move, remain stationary, or just end the phase). The in-movement show/clear behaviour is unchanged.

## Validation (ran the real windowed game)

Added windowed scenario `er_overlay_cleared_on_shooting_phase_11e.json`: begins a Normal Move (red rings appear), transitions to Shooting **without** confirming, and asserts the three containers are gone.

- **Pre-fix**: the three `get_node_or_null(...) == null` assertions fail — the containers (red rings included) are still present in Shooting. Reproduces the reported bug.
- **Post-fix**: 22/22 steps pass; the Shooting board is clean.
- Regression: the existing `movement_er_ring_matches_check_11e` scenario still passes 31/31, confirming in-Movement ring behaviour is untouched.
- No `SCRIPT ERROR` lines in the debug log during the run.

Before (Shooting, pre-fix): red rings persist around the enemy units. After (Shooting, post-fix): board is clean.

## Changelog

Bumped to **0.42.5** (2026-07-14) with a player-facing summary.

## Files

- `40k/scripts/MovementController.gd` — free the three overlay containers in `_exit_tree()`
- `40k/tests/scenarios/sp/er_overlay_cleared_on_shooting_phase_11e.json` — new windowed regression scenario
- `40k/data/version_history.json` — 0.42.5 changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TQXtaV4TEDskFDDWCvy6K

---
_Generated by [Claude Code](https://claude.ai/code/session_015TQXtaV4TEDskFDDWCvy6K)_