### PR TITLE
Fix: "End Fight Phase" no longer forfeits the opponent's fights (12.04)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.7",
+			"date": "2026-07-14",
+			"summary": "Fixed 'End Fight Phase' ending the fight for your opponent too. When you clicked End Fight Phase, the game forfeited every remaining combat — including your opponent's units that were still owed a fight — and jumped straight to consolidation. Now, ending the Fight phase only stops YOUR own units from fighting; your opponent still gets to fight all of their remaining eligible units (core rule 12.04: when one player stops selecting, the other fights all their remaining units). The confirmation warning also lists only your own unfought units now, not your opponent's.",
+			"changes": [
+				"Fixed: clicking 'End Fight Phase' no longer forfeits your opponent's fights. Only your own remaining units stop fighting — the opponent's eligible units are handed the Fight step and their selection dialog re-opens so they can fight.",
+				"The 'End Fight Phase?' warning now lists only the units YOU would forfeit (your own), instead of also listing the opponent's units as 'won't fight' — which was misleading, since they still get to fight.",
+				"Once your opponent has also finished fighting (or has nothing eligible), ending the Fight phase proceeds to the Consolidate step as before."
+			]
+		},
+		{
 			"version": "0.42.6",
 			"date": "2026-07-14",
 			"summary": "Fixed the red enemy 'engagement range' circles from the Movement phase lingering on the board after you advanced to the Shooting phase. Those red rings are only there to show where your models can't move during your Movement phase; they now clear away the moment the phase ends, so the Shooting phase board is no longer cluttered by them.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -4924,6 +4924,21 @@ func _process_end_fight(action: Dictionary) -> Dictionary:
 			log_phase_message("[11e 12.02] Player %d ends their pile-in half via END_FIGHT" % piling_in_player_11e)
 			return _advance_pile_in_step_11e(create_result(true, []))
 		if consolidation_step_11e == ConsolidationStep11e.NOT_STARTED:
+			# Fight-phase scope fix: "End Fight Phase" ends only the ENDING
+			# player's own fights. Per 12.04, when one player stops selecting,
+			# the OTHER player still fights all of their remaining eligible
+			# units — so if the opponent is owed a fight, hand the Fight step
+			# over to them instead of forfeiting everyone and jumping to the
+			# Consolidate step (the previous behaviour, which wrongly cut the
+			# opponent's units out of the phase).
+			var ending_player := int(action.get("player", GameState.get_active_player()))
+			var opponent := 2 if ending_player == 1 else 1
+			if sequencer_11e != null \
+					and _player_has_eligible_fights_11e(ending_player) \
+					and _player_has_eligible_fights_11e(opponent):
+				_forfeit_player_fights_11e(ending_player)
+				log_phase_message("[11e 12.04] Player %d ended their fights — Player %d still fights their remaining units" % [ending_player, opponent])
+				return _resume_fight_step_after_end_11e(create_result(true, []))
 			return _begin_consolidation_step_11e()
 		if consolidation_step_11e == ConsolidationStep11e.ACTIVE:
 			if sequencer_11e != null:
@@ -4936,6 +4951,50 @@ func _process_end_fight(action: Dictionary) -> Dictionary:
 			return _advance_consolidation_step_11e(create_result(true, []))
 
 	return _run_end_of_fight_triggers(create_result(true, []))
+
+# True while `player` still owns at least one unit the sequencer would offer
+# a fight to. Used by END_FIGHT to decide whether the opponent still gets to
+# fight (12.04) before the phase moves on to the Consolidate step.
+func _player_has_eligible_fights_11e(player: int) -> bool:
+	if sequencer_11e == null:
+		return false
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if sequencer_11e.eligible_to_fight(unit_id, GameState.state):
+			return true
+	return false
+
+# Mark every remaining eligible fight owned by `player` as fought — they
+# forfeit those fights because the player chose to end their fighting. Only
+# this player's units are touched; the opponent's stay eligible so they still
+# get to fight (12.04).
+func _forfeit_player_fights_11e(player: int) -> void:
+	if sequencer_11e == null:
+		return
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if sequencer_11e.eligible_to_fight(unit_id, GameState.state):
+			log_phase_message("[11e 12.04] %s forfeits its fight (Player %d ended their fights)" % [unit_id, player])
+			sequencer_11e.mark_fought(unit_id)
+
+# After the ending player forfeits their own fights, hand the Fight step over
+# to the opponent (12.04) and emit the next fight-selection request. Mirrors
+# _finish_fight_activation_11e's hand-off so the AI / controller / network
+# sync all pick it up the same way. If the sequencer unexpectedly reports no
+# one left, fall through to the Consolidate step instead of stalling.
+func _resume_fight_step_after_end_11e(result: Dictionary) -> Dictionary:
+	_switch_selecting_player()
+	var dialog_data = _build_fight_selection_dialog_data()
+	if dialog_data.is_empty():
+		return _begin_consolidation_step_11e()
+	emit_signal("fight_selection_required", dialog_data)
+	result["trigger_fight_selection"] = true
+	result["fight_selection_data"] = dialog_data
+	return result
 
 # End-of-fight-phase triggers (12.09): Sweeping Advance, then Acrobatic
 # Escape, then phase completion. At edition >= 11 this runs only after the
@@ -5443,9 +5502,15 @@ func _is_unit_within_distance_of_enemies(unit: Dictionary, distance_inches: floa
 
 	return false
 
-func get_unfought_eligible_units() -> Array:
+func get_unfought_eligible_units(only_player: int = -1) -> Array:
 	"""Return array of {unit_id, unit_name, player, subphase} for units that haven't fought yet.
-	Used by the end-fight-phase confirmation dialog (T5-UX7)."""
+	Used by the end-fight-phase confirmation dialog (T5-UX7).
+
+	When only_player >= 1, restrict the result to that player's units. The
+	end-fight confirmation passes the ending (active) player so the warning
+	lists only the units THAT player would forfeit — the opponent's units are
+	not forfeited by ending your own fights (12.04), so listing them as
+	"won't fight" would be misleading."""
 	var unfought = []
 
 	# 11e: the sequencer is authoritative — the 10e tier lists can disagree
@@ -5454,6 +5519,8 @@ func get_unfought_eligible_units() -> Array:
 		for unit_id in GameState.state.get("units", {}):
 			if sequencer_11e.eligible_to_fight(unit_id, GameState.state):
 				var unit = GameState.state.units[unit_id]
+				if only_player >= 1 and int(unit.get("owner", 0)) != only_player:
+					continue
 				unfought.append({
 					"unit_id": unit_id,
 					"unit_name": unit.get("meta", {}).get("name", unit_id),
@@ -5465,6 +5532,8 @@ func get_unfought_eligible_units() -> Array:
 	var all_units = game_state_snapshot.get("units", {})
 
 	for player_key in ["1", "2"]:
+		if only_player >= 1 and int(player_key) != only_player:
+			continue
 		for unit_id in fights_first_sequence.get(player_key, []):
 			if unit_id not in units_that_fought:
 				var unit_name = all_units.get(unit_id, {}).get("meta", {}).get("name", unit_id)

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -9406,7 +9406,10 @@ func _on_phase_action_pressed() -> void:
 			# T5-UX7: Check for unfought units and show confirmation dialog
 			var fight_phase_instance = PhaseManager.get_current_phase_instance()
 			if fight_phase_instance and fight_phase_instance.has_method("get_unfought_eligible_units"):
-				var unfought = fight_phase_instance.get_unfought_eligible_units()
+				# Only warn about the active player's OWN unfought units — ending
+				# your fights no longer forfeits the opponent's (12.04), so the
+				# opponent's units must not be listed as "won't fight".
+				var unfought = fight_phase_instance.get_unfought_eligible_units(active_player)
 				if unfought.size() > 0:
 					print("Main: T5-UX7: %d unfought units remain, showing confirmation dialog" % unfought.size())
 					_show_end_fight_confirmation_dialog(unfought, active_player)

--- a/40k/tests/scenarios/sp/end_fight_scope_opponent_still_fights_11e.json
+++ b/40k/tests/scenarios/sp/end_fight_scope_opponent_still_fights_11e.json
@@ -1,0 +1,63 @@
+{
+  "id": "end_fight_scope_opponent_still_fights_11e",
+  "covers": [
+    "phases.FightPhase._process_end_fight",
+    "phases.FightPhase.get_unfought_eligible_units",
+    "phases.FightPhase._resume_fight_step_after_end_11e",
+    "phases.FightPhase._forfeit_player_fights_11e",
+    "scripts.Main._show_end_fight_confirmation_dialog",
+    "dialogs.EndFightConfirmationDialog"
+  ],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Regression for the reported bug: the active (P2, Orks) player clicks 'End Fight Phase' at the start of the Fight step and the enemy (P1, Custodes) units — still owed a Remaining-Combats fight — were wrongly forfeited too, cutting them out of the phase. Per 12.04, when one player stops selecting, the OTHER player still fights all their remaining eligible units. This scenario drives the REAL player path with clicks: pass the Pile In step, then click the End Fight Phase button. It asserts (1) the confirmation dialog lists ONLY the active player's own unit (the Warboss) — not the opponent's (get_unfought_eligible_units now filters to the ending player); (2) after confirming, the phase does NOT jump to the Consolidate step; (3) the active player's Warboss forfeits while both Custodes units stay eligible; and (4) the Fight step is handed over to Player 1, whose fight-selection dialog re-opens offering their units. Setup-only privileges: CP zeroed to suppress stratagem prompts; model wounds inflated so no unit dies (deterministic aliveness).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_TELEMON_HEAVY_DREADNOUGHT_I\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 2 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 1 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 2 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().current_selecting_player", "equals": 2 },
+    { "act": "screenshot", "label": "01_fight_step_p2_ork_active" },
+
+    { "act": "click_node", "node": "/root/Main/PhaseActionButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "expect_node_visible", "node": "/root/EndFightConfirmationDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"EndFightConfirmationDialog\").unfought_units.size()", "equals": 1 },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"EndFightConfirmationDialog\").unfought_units[0][\"unit_id\"]", "equals": "U_WARBOSS_B" },
+    { "act": "execute_script", "script": "main.get_tree().root.get_node(\"EndFightConfirmationDialog\").unfought_units[0][\"player\"]", "equals": 2 },
+    { "act": "screenshot", "label": "02_confirm_dialog_lists_only_ork_unit" },
+
+    { "act": "click_node", "node": "/root/EndFightConfirmationDialog/Content/Actions/ConfirmEndFight", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "expect_phase_property", "property": "consolidation_step_11e", "equals": 0 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.fought.has(\"U_WARBOSS_B\")", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.eligible_to_fight(\"U_CUSTODIAN_GUARD_B\", GameState.state)", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.eligible_to_fight(\"U_TELEMON_HEAVY_DREADNOUGHT_I\", GameState.state)", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().current_selecting_player", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().sequencer_11e.peek_selection(GameState.state)[\"player\"]", "equals": 1 },
+
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 8.0 },
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog/Content/UnitScroll/UnitList/Fight_U_CUSTODIAN_GUARD_B", "timeout_s": 3.0 },
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog/Content/UnitScroll/UnitList/Fight_U_TELEMON_HEAVY_DREADNOUGHT_I", "timeout_s": 3.0 },
+    { "act": "screenshot", "label": "03_opponent_p1_custodes_still_get_to_fight" }
+  ]
+}

--- a/40k/tests/test_fight_phase_scope_end_fight_11e.gd
+++ b/40k/tests/test_fight_phase_scope_end_fight_11e.gd
@@ -1,0 +1,123 @@
+extends SceneTree
+
+# Fight-phase scope of END_FIGHT (12.04). Ending your OWN fights must not
+# forfeit the opponent's — when one player stops selecting, the other player
+# still gets to fight all of their remaining eligible units before the phase
+# moves on to the Consolidate step.
+#
+# Regression for the reported bug: the Ork (active) player clicked "End Fight
+# Phase" and the enemy Prosecutors (owed a Remaining-Combats fight) were cut
+# out of the phase instead of getting to fight.
+#
+# Drives the REAL FightPhase pipeline (execute_action) and asserts:
+#   1. get_unfought_eligible_units(player) lists only that player's units.
+#   2. Active player's END_FIGHT forfeits only their own units; the opponent
+#      stays eligible and the Fight step is handed over to them (no jump to
+#      the Consolidate step, fight_selection_required re-emitted for them).
+#   3. Once the opponent has also finished, END_FIGHT enters the Consolidate
+#      step as before.
+#
+# Usage: godot --headless --path . -s tests/test_fight_phase_scope_end_fight_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _board(gs) -> void:
+	# 40px = 1"; 25mm base radius ~19.7px. U_ORK (P1) engaged with U_PROS (P2)
+	# at 60px edge-to-edge (~0.52"). Both are eligible to fight (Remaining
+	# Combats — neither has Fights First). P1 is the active player.
+	gs.state["units"] = {
+		"U_ORK": {"id": "U_ORK", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Warbikers", "keywords": ["INFANTRY", "MOUNTED"], "stats": {"move": 12, "wounds": 3}},
+			"models": [
+				{"id": "w0", "alive": true, "wounds": 3, "current_wounds": 3, "base_mm": 25, "base_type": "circular", "position": {"x": 500, "y": 500}},
+			]},
+		"U_PROS": {"id": "U_PROS", "owner": 2, "status": 2, "flags": {},
+			"meta": {"name": "Prosecutors", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 2}},
+			"models": [
+				{"id": "p0", "alive": true, "wounds": 2, "current_wounds": 2, "base_mm": 25, "base_type": "circular", "position": {"x": 560, "y": 500}},
+			]},
+	}
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["phase"] = 10
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_fight_phase_scope_end_fight_11e ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var pm = root.get_node_or_null("PhaseManager")
+	if gs == null or pm == null:
+		_check("autoloads", false); _finish(); return
+	var prev_state = gs.state.duplicate(true)
+	var prev_edition = GameConstants.edition
+
+	GameConstants.edition = 11
+	_board(gs)
+	pm.transition_to_phase(10)  # FIGHT
+	var fp = pm.get_current_phase_instance()
+
+	# Open the phase past the global Pile In step so the Fight step is running.
+	fp.execute_action({"type": "END_PILE_IN", "player": 1})
+	fp.execute_action({"type": "END_PILE_IN", "player": 2})
+	_check("Fight step running", fp.pile_in_step_11e == fp.PileInStep11e.DONE)
+
+	print("\n-- both units are owed a fight --")
+	_check("Ork (P1) eligible", fp.sequencer_11e.eligible_to_fight("U_ORK", gs.state))
+	_check("Prosecutors (P2) eligible", fp.sequencer_11e.eligible_to_fight("U_PROS", gs.state))
+
+	print("\n-- get_unfought_eligible_units filters by player --")
+	var all_unfought = fp.get_unfought_eligible_units()
+	_check("no filter lists both units", all_unfought.size() == 2, str(all_unfought))
+	var p1_unfought = fp.get_unfought_eligible_units(1)
+	_check("player 1 filter lists only the Ork unit",
+		p1_unfought.size() == 1 and p1_unfought[0].unit_id == "U_ORK", str(p1_unfought))
+	var p2_unfought = fp.get_unfought_eligible_units(2)
+	_check("player 2 filter lists only the Prosecutors",
+		p2_unfought.size() == 1 and p2_unfought[0].unit_id == "U_PROS", str(p2_unfought))
+
+	print("\n-- active player (P1) ends their fights: opponent still fights --")
+	var r_end = fp.execute_action({"type": "END_FIGHT", "player": 1})
+	_check("END_FIGHT succeeds", r_end.get("success", false), str(r_end))
+	_check("Ork (P1) forfeited its own fight", not fp.sequencer_11e.eligible_to_fight("U_ORK", gs.state))
+	_check("Prosecutors (P2) are STILL eligible (not forfeited)",
+		fp.sequencer_11e.eligible_to_fight("U_PROS", gs.state))
+	_check("phase did NOT jump to the Consolidate step",
+		fp.consolidation_step_11e == fp.ConsolidationStep11e.NOT_STARTED,
+		str(fp.consolidation_step_11e))
+	_check("Fight step handed over to Player 2", fp.current_selecting_player == 2)
+	_check("END_FIGHT re-opened fight selection for the opponent",
+		r_end.get("trigger_fight_selection", false), str(r_end))
+	var sel_data = r_end.get("fight_selection_data", {})
+	_check("the opponent's selection offers the Prosecutors",
+		sel_data.get("selecting_player", 0) == 2 and sel_data.get("eligible_units", {}).has("U_PROS"),
+		str(sel_data))
+
+	print("\n-- once the opponent has fought, END_FIGHT enters the Consolidate step --")
+	# Simulate the opponent fighting their Prosecutors (flow-level attack
+	# coverage lives in the windowed scenario; the bookkeeping is what matters).
+	fp.sequencer_11e.mark_fought("U_PROS")
+	var r_end2 = fp.execute_action({"type": "END_FIGHT", "player": 1})
+	_check("second END_FIGHT succeeds", r_end2.get("success", false), str(r_end2))
+	_check("Consolidate step now ACTIVE",
+		fp.consolidation_step_11e == fp.ConsolidationStep11e.ACTIVE, str(fp.consolidation_step_11e))
+
+	# Restore
+	GameConstants.edition = prev_edition
+	gs.state = prev_state
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Problem

Clicking **"End Fight Phase"** during the Fight step forfeited *every* remaining combat — including the opponent's units that were still owed a fight — and jumped straight to the Consolidate step. As reported: the Ork (active) player ending the phase wrongly cut the enemy Prosecutors out of the phase entirely.

This violates core rule **12.04**: when one player stops selecting eligible units, the *other* player still fights all of their remaining eligible units before the phase moves on.

## Root cause

`FightPhase._process_end_fight()` (edition ≥ 11) called `_begin_consolidation_step_11e()`, which marks *all* eligible units for *both* players as fought and enters consolidation.

## Fix

- **`_process_end_fight`** now forfeits only the *ending* player's own fights. If the opponent still has eligible units, it hands the Fight step over to them (re-emitting `fight_selection_required`) instead of ending the phase. Once the opponent has also finished — or has none — `END_FIGHT` enters the Consolidate step as before, preserving the walk-to-completion / no-loop semantics.
- **`get_unfought_eligible_units(only_player)`** filters to the ending player, so the confirmation dialog lists only the units *you'd* actually forfeit — not the opponent's (which now still get to fight). `Main.gd` passes `active_player`.

New helpers `_player_has_eligible_fights_11e`, `_forfeit_player_fights_11e`, and `_resume_fight_step_after_end_11e` keep the change self-contained and mirror the existing `_finish_fight_activation_11e` hand-off (so the AI, controller, and network sync all pick it up the same way).

## Validation

- **New headless test** `test_fight_phase_scope_end_fight_11e.gd` — 15/15.
- **New windowed scenario** `end_fight_scope_opponent_still_fights_11e.json` — 37/37 — drives the real "End Fight Phase" button + confirmation dialog with the Ork as active player. Screenshots show the confirm dialog listing only the Ork's own unit, and the opponent's fight-selection dialog re-opening ("PLAYER 1'S TURN TO SELECT") with their units selectable after the active player ends.
- **No regressions**: `global_consolidation_step_11e` (99/0), `stompa_gets_to_fight_11e` (52/0), plus the consolidation / AI / wiring headless tests.

Changelog entry **v0.42.5** prepended to `version_history.json`.

## Behavioral note

After you end your fights and the opponent finishes theirs, the phase waits for one more "End Fight Phase" press (now with no warning, since nothing is eligible) to proceed to consolidation — matching the existing "fight step complete → waiting for END_FIGHT" flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkqcCaJ2xHopyAFJ4yrLTJ)_