### PR TITLE
Fix: AI's fighters no longer show the attack-allocation dialog to the human

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.43.1",
+			"date": "2026-07-14",
+			"summary": "Fixed a Fight-phase bug where the game asked YOU to choose targets for the computer's attacks. When the AI's units fought (e.g. you playing Orks vs the AI's Custodes), the 'who do you want to allocate these attacks to?' target-selection dialog popped up for you instead of the AI just picking its own targets and fighting. Cause: the Fight controller only refreshed the 'whose fighter is this?' owner when a human picked a fighter from a dialog, so once one of your units had fought, that owner stayed pointed at you; when the AI's unit fought next, the controller thought the human owned it and showed you the AI's attack-allocation dialog. The controller now updates the owner every time any unit is selected to fight, so the AI silently resolves its own attacks and the dialog only ever appears for your own units.",
+			"changes": [
+				"Fixed: the Fight phase no longer shows you the attack-target dialog for the computer's units. The AI now picks targets and fights with its own units automatically, and you are only asked to allocate attacks for units you control.",
+				"Same fix also stops the AI's Pile In and Consolidate prompts from being shown to you \u2014 the controller now tracks the active fighter's real owner and hands each dialog to the correct player as control alternates back and forth during the Fight phase."
+			]
+		},
+		{
 			"version": "0.43.0",
 			"date": "2026-07-14",
 			"summary": "Added a new pickable army: the Orks 'Battlewagons' list (2000 pts, Rollin' Deff / Speedwaaagh! themed). It shows up in the Player 1/Player 2 army dropdowns like any other list and is ready to deploy and play. The list is a grot-and-gitz horde built around three Battlewagons (each with Targetin' Gizmos) and a trio of Big Meks, backed by Meks, Burna Boyz, Deffkoptas, Gretchin, Lootas, Stormboyz, Tankbustas and Warbikers. New top-down unit art was drawn for every model type that didn't already have a sprite, so the whole army reads at a glance on the board.",

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -1010,10 +1010,23 @@ func _on_attack_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_
 
 func _on_fighter_selected(unit_id: String) -> void:
 	current_fighter_id = unit_id
-	
+
+	# Keep current_fighter_owner in sync with whichever unit is now fighting.
+	# This signal fires for EVERY fighter selection — including AI-selected
+	# fighters, which never pass through _on_fighter_selected_from_dialog (the
+	# only other place that refreshed current_fighter_owner). Without this, the
+	# owner stays stale from the previous (often human) activation, so the AI's
+	# own attack-assignment / pile-in / consolidate prompts fail the
+	# is_ai_player(current_fighter_owner) gate and get shown to the human player.
+	# (Symptom: human Orks fight, then the AI's Custodes fight and the "who do you
+	# want to allocate the Custodes' attacks to" dialog pops up for the human.)
+	var unit = GameState.get_unit(unit_id)
+	if not unit.is_empty():
+		current_fighter_owner = int(unit.get("owner", current_fighter_owner))
+
 	# Debug logging
-	print("Selected fighter: ", unit_id)
-	
+	print("Selected fighter: ", unit_id, " (owner player %d)" % current_fighter_owner)
+
 	_refresh_attack_tree()
 	_show_engagement_indicators()
 	_update_ui_state()

--- a/40k/tests/integration/test_fight_ai_attack_dialog_suppressed.gd
+++ b/40k/tests/integration/test_fight_ai_attack_dialog_suppressed.gd
@@ -1,0 +1,107 @@
+extends SceneTree
+
+# Integration regression for the reported Fight-phase bug:
+#   "Playing Orks vs the AI's Custodes, the game popped up the 'who do you want
+#    to allocate the Custodes' models' attacks to' dialog for ME (the human)."
+#
+# This drives the REAL FightController inside the live scene tree (so
+# get_node_or_null("/root/AIPlayer") resolves and the real dialog-gate branch
+# runs) with the real autoloads, and asserts that when the AI's unit is the
+# active fighter, _on_attack_assignment_required takes the "Skipping dialog for
+# AI player" branch and creates NO AttackAssignmentDialog node.
+#
+# Root cause / fix: current_fighter_owner was only refreshed in the human dialog
+# paths, so after a human unit fought it stayed on the human's player number;
+# _on_fighter_selected (which fires for every selection, including AI ones) now
+# refreshes it from the selected unit's owner, so the is_ai_player() gate is
+# correct for the AI's fighters.
+#
+# Headless is sufficient here: the bug's effect is whether a dialog NODE is
+# created in the tree, which needs no GPU. (The full windowed UI cannot be
+# exercised in the sandbox — sustained GL/X11 rendering is terminated — so the
+# node-level assertion is the reproducible proof of the player-facing effect.)
+#
+# Usage: godot --headless --path 40k -s tests/integration/test_fight_ai_attack_dialog_suppressed.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run)
+
+func _count_attack_dialogs() -> int:
+	var n := 0
+	for c in root.get_children():
+		if c is AcceptDialog and str(c.name).begins_with("AttackAssignmentDialog"):
+			n += 1
+	return n
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_fight_ai_attack_dialog_suppressed ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var ai = root.get_node_or_null("AIPlayer")
+	if gs == null or ai == null:
+		_check("autoloads present", false, "gs=%s ai=%s" % [gs, ai]); _finish(); return
+
+	var prev_enabled = ai.enabled
+	var prev_players = ai.ai_players.duplicate(true)
+	ai.enabled = true
+	ai.ai_players = {1: false, 2: true}  # P1 human (Orks), P2 AI (Custodes)
+
+	gs.state["units"] = {
+		"U_ORK": {"id": "U_ORK", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Ork Boyz", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 1}},
+			"models": [{"id": "m0", "alive": true, "wounds": 1, "current_wounds": 1, "base_mm": 32, "base_type": "circular", "position": {"x": 500, "y": 500}}]},
+		"U_CUST": {"id": "U_CUST", "owner": 2, "status": 2, "flags": {"charged_this_turn": true},
+			"meta": {"name": "Custodian Guard", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 3}},
+			"models": [{"id": "e0", "alive": true, "wounds": 3, "current_wounds": 3, "base_mm": 40, "base_type": "circular", "position": {"x": 548, "y": 500}}]},
+	}
+	gs.state["meta"]["active_player"] = 2
+
+	var FC = load("res://scripts/FightController.gd")
+	var fc = FC.new()
+	fc.name = "TestFightController"
+	root.add_child(fc)
+
+	# The human's Ork unit fights first — the human dialog gate is correct here.
+	# (We do NOT trigger the human attack-assignment dialog: its own 0.3s timer
+	# would create a dialog later and pollute the AI dialog count below.)
+	fc._on_fighter_selected("U_ORK")
+	_check("owner is P1 while the human's Ork unit is the fighter",
+		fc.current_fighter_owner == 1, "got %d" % fc.current_fighter_owner)
+
+	# The AI's Custodes unit fights next. This is the reported bug: pre-fix the
+	# owner stayed on P1, so this handler built the dialog for the human.
+	fc._on_fighter_selected("U_CUST")
+	_check("FIX: owner switches to the AI (P2) for the Custodes fighter",
+		fc.current_fighter_owner == 2, "got %d" % fc.current_fighter_owner)
+
+	var ai_before := _count_attack_dialogs()
+	fc._on_attack_assignment_required("U_CUST", {})
+	# Wait past the human path's 0.3s pre-dialog timer: with the fix the AI
+	# branch returns synchronously and never schedules a dialog, so nothing is
+	# created even after the wait. Without the fix the stale human owner would
+	# fall through and (attempt to) build the dialog here.
+	await create_timer(0.5).timeout
+	_check("FIX: NO AttackAssignmentDialog is created for the AI's Custodes attacks",
+		_count_attack_dialogs() == ai_before,
+		"dialogs now=%d (was %d)" % [_count_attack_dialogs(), ai_before])
+
+	fc.queue_free()
+	ai.enabled = prev_enabled
+	ai.ai_players = prev_players
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/integration/test_fight_ai_attack_dialog_suppressed.gd.uid
+++ b/40k/tests/integration/test_fight_ai_attack_dialog_suppressed.gd.uid
@@ -1,0 +1,1 @@
+uid://4ow5upempeap

--- a/40k/tests/unit/test_fight_owner_tracking.gd
+++ b/40k/tests/unit/test_fight_owner_tracking.gd
@@ -1,0 +1,131 @@
+extends SceneTree
+
+# Regression: the Fight-phase attack-allocation dialog must NOT be shown to the
+# human for the AI's fighters.
+#
+# Reported bug: playing Orks (human, P1) vs Custodes (AI, P2), when the AI's
+# Custodes were selected to fight, the game popped up the "who do you want to
+# allocate the Custodes' models' attacks to" dialog (AttackAssignmentDialog) for
+# the human. Same class of bug would also mis-show the pile-in / consolidate
+# dialogs for the AI's fighters.
+#
+# Root cause: FightController tracked current_fighter_owner only in the human
+# dialog paths (_on_fighter_selected_from_dialog, the 11e step pickers). The AI
+# selects fighters by submitting SELECT_FIGHTER directly, which reaches the
+# controller as the phase's `fighter_selected` signal -> _on_fighter_selected,
+# and that handler set current_fighter_id but never refreshed
+# current_fighter_owner. So after a human unit fought, current_fighter_owner
+# stayed on the human's player number; when the AI's unit then fought, the
+# dialog handlers' is_ai_player(current_fighter_owner) gate saw the human and
+# showed the dialog.
+#
+# The fix makes _on_fighter_selected (which fires for EVERY fighter selection,
+# AI or human) refresh current_fighter_owner from the selected unit's owner.
+#
+# This test drives the real FightController._on_fighter_selected and asserts the
+# owner tracks whichever unit is fighting, and that the resulting is_ai_player
+# gate (used by _on_attack_assignment_required / _on_pile_in_required /
+# _on_consolidate_required to skip the dialog) resolves correctly.
+#
+# Usage: godot --headless --path 40k -s tests/unit/test_fight_owner_tracking.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run)
+
+func _board(gs) -> void:
+	# U_ORK (P1, human) and U_CUST (P2, AI), engaged and eligible to fight.
+	gs.state["units"] = {
+		"U_ORK": {"id": "U_ORK", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Ork Boyz", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 1}},
+			"models": [
+				{"id": "m0", "alive": true, "wounds": 1, "current_wounds": 1, "base_mm": 32, "base_type": "circular", "position": {"x": 500, "y": 500}},
+			]},
+		"U_CUST": {"id": "U_CUST", "owner": 2, "status": 2, "flags": {"charged_this_turn": true},
+			"meta": {"name": "Custodian Guard", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 3}},
+			"models": [
+				{"id": "e0", "alive": true, "wounds": 3, "current_wounds": 3, "base_mm": 40, "base_type": "circular", "position": {"x": 540, "y": 500}},
+			]},
+	}
+	gs.state["meta"]["active_player"] = 2   # the AI's turn (Custodes charged)
+	gs.state["meta"]["phase"] = 10
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_fight_owner_tracking ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var ai = root.get_node_or_null("AIPlayer")
+	if gs == null or ai == null:
+		_check("autoloads present", false, "gs=%s ai=%s" % [gs, ai]); _finish(); return
+
+	var prev_enabled = ai.enabled
+	var prev_players = ai.ai_players.duplicate(true)
+	ai.enabled = true
+	ai.ai_players = {1: false, 2: true}  # P1 human (Orks), P2 AI (Custodes)
+
+	_board(gs)
+
+	# Build a bare FightController. We do NOT add it to the tree: _ready() would
+	# try to resolve SceneRefs UI nodes that don't exist headless. The handler
+	# under test only reads GameState + its own member vars; every UI helper it
+	# calls is null-guarded, so a bare instance exercises the real code path.
+	var FightControllerScript = load("res://scripts/FightController.gd")
+	var fc = FightControllerScript.new()
+
+	_check("controller starts with no owner", fc.current_fighter_owner == -1,
+		"got %d" % fc.current_fighter_owner)
+
+	# --- The human's Ork unit is selected to fight first ---
+	fc._on_fighter_selected("U_ORK")
+	_check("after human fighter selected: current_fighter_id == U_ORK",
+		fc.current_fighter_id == "U_ORK", "got %s" % fc.current_fighter_id)
+	_check("after human fighter selected: owner tracks P1 (human)",
+		fc.current_fighter_owner == 1, "got %d" % fc.current_fighter_owner)
+	_check("human fighter: is_ai_player(owner) is FALSE -> human dialog would show (correct)",
+		not ai.is_ai_player(fc.current_fighter_owner))
+
+	# --- The AI's Custodes unit is now selected to fight ---
+	# THE BUG: pre-fix, current_fighter_owner stayed 1 here (never refreshed),
+	# so the dialog handlers' is_ai_player() gate saw the human and popped the
+	# AttackAssignmentDialog for the AI's attacks. The fix refreshes it to 2.
+	fc._on_fighter_selected("U_CUST")
+	_check("after AI fighter selected: current_fighter_id == U_CUST",
+		fc.current_fighter_id == "U_CUST", "got %s" % fc.current_fighter_id)
+	_check("FIX: after AI fighter selected: owner switches to P2 (AI)",
+		fc.current_fighter_owner == 2, "got %d (pre-fix this stayed 1)" % fc.current_fighter_owner)
+	_check("FIX: AI fighter: is_ai_player(owner) is TRUE -> dialog is skipped for AI",
+		ai.is_ai_player(fc.current_fighter_owner))
+
+	# --- Back to the human's unit: the owner must switch back ---
+	fc._on_fighter_selected("U_ORK")
+	_check("owner switches back to P1 when the human fighter is re-selected",
+		fc.current_fighter_owner == 1, "got %d" % fc.current_fighter_owner)
+	_check("human fighter again: is_ai_player(owner) is FALSE",
+		not ai.is_ai_player(fc.current_fighter_owner))
+
+	# --- Robustness: a missing/unknown unit must not corrupt a valid owner ---
+	fc._on_fighter_selected("U_CUST")
+	_check("owner is P2 before the bad-id call", fc.current_fighter_owner == 2)
+	fc._on_fighter_selected("DOES_NOT_EXIST")
+	_check("unknown unit id does not clobber the last valid owner",
+		fc.current_fighter_owner == 2, "got %d" % fc.current_fighter_owner)
+
+	fc.free()
+	ai.enabled = prev_enabled
+	ai.ai_players = prev_players
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/unit/test_fight_owner_tracking.gd.uid
+++ b/40k/tests/unit/test_fight_owner_tracking.gd.uid
@@ -1,0 +1,1 @@
+uid://c3xesvj3cnjtv


### PR DESCRIPTION
## Problem

In the Fight phase, when an AI-controlled unit was selected to fight (e.g. the human plays Orks vs the AI's Custodes), the "who do you want to allocate these attacks to?" `AttackAssignmentDialog` popped up **for the human** instead of the AI resolving its own attacks.

## Root cause

`FightController` decides whether to show a Fight-phase dialog by checking `is_ai_player(current_fighter_owner)`. That `current_fighter_owner` was only refreshed in the human-driven paths (`_on_fighter_selected_from_dialog` and the 11e Pile In / Consolidate step pickers).

The AI selects fighters by submitting `SELECT_FIGHTER` directly, which reaches the controller as the phase's `fighter_selected` signal → `_on_fighter_selected`. That handler set `current_fighter_id` but **never updated `current_fighter_owner`**. So after one of the human's units had fought, the owner stayed on the human's player number; when the AI's unit fought next, the gate in `_on_attack_assignment_required` (and `_on_pile_in_required` / `_on_consolidate_required`) saw "human" and showed the dialog. The owner never switched back and forth between the fighting units.

## Fix

`_on_fighter_selected` — which fires for **every** fighter selection, AI or human — now refreshes `current_fighter_owner` from the selected unit's `owner`. The AI gate is then correct for the AI's fighters, so its attack-assignment, pile-in, and consolidate prompts are auto-handled and dialogs only ever appear for the player's own units.

```gdscript
func _on_fighter_selected(unit_id: String) -> void:
    current_fighter_id = unit_id
    var unit = GameState.get_unit(unit_id)
    if not unit.is_empty():
        current_fighter_owner = int(unit.get("owner", current_fighter_owner))
    ...
```

## Validation

- **`tests/unit/test_fight_owner_tracking.gd`** — drives the real `FightController._on_fighter_selected` and asserts the owner tracks human → AI → human. Passes with the fix; fails 6 assertions without it.
- **`tests/integration/test_fight_ai_attack_dialog_suppressed.gd`** — adds the real controller to the live scene tree with the real `GameState`/`AIPlayer` autoloads and asserts **no `AttackAssignmentDialog` node is created** for the AI's fighter. Without the fix the dialog IS created (`dialogs now=1` — the reported bug reproduced); with the fix the controller logs `Skipping dialog for AI player 2` and creates nothing.
- Existing related test `test_ai_no_control_human_fight_turn.gd` still passes 23/0 — no regression.
- Added changelog entry v0.42.5 to `version_history.json`.

Note: the full interactive game window could not be screenshotted in the sandbox (it terminates sustained software-rendered GL/X11 processes), so the player-facing effect was validated at the node level — whether the dialog node is created — end-to-end in the real scene tree, which requires no GPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zsQVg8w3JkTSFzA55Nqz7

---
_Generated by [Claude Code](https://claude.ai/code/session_014zsQVg8w3JkTSFzA55Nqz7)_