### PR TITLE
Fix Charge-phase 'Snap to Contact' button doing nothing after a charge

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.42.5",
+			"date": "2026-07-14",
+			"summary": "Fixed the Charge phase 'Snap to Contact' button appearing to do nothing. The button (along with 'Undo Last Model') only ever appeared when you were actively moving a charging unit, but once you confirmed that charge — or between charges, or while a Command Re-roll prompt was still open — it was left on screen looking clickable even though there was nothing to move. Clicking it in those states silently did nothing. The Confirm / Snap to Contact / Undo Last Model buttons now hide together the moment a charge is finished, so 'Snap to Contact' is only shown when it will actually move models.",
+			"changes": [
+				"Fixed: the 'Snap to Contact' button no longer lingers on screen after a charge is confirmed (and between charges, and while a Command Re-roll dialog is open). Previously it stayed visible and enabled with nothing to move, so clicking it did nothing.",
+				"The 'Snap to Contact' and 'Undo Last Model' buttons now show only while you are actively positioning a charging unit, and 'Snap to Contact' is greyed out once every model is already in engagement range (use 'Confirm Charge Moves' at that point).",
+				"If 'Snap to Contact' is ever triggered with nothing to place, it now tells you why instead of doing nothing silently."
+			]
+		},
+		{
 			"version": "0.42.4",
 			"date": "2026-07-13",
 			"summary": "Fixed the confusing 'consolidate failed — skipping movement' messages in the Fight phase. When a unit had no legal Consolidation move — most commonly right after it wiped out the only enemy it was fighting, with no other enemy or objective within 3\" — the AI would still try to shuffle it toward the nearest objective (even one 10\"+ away), the rules would correctly reject the move, and the log filled with alarming 'consolidate failed' / 'validation failed' lines. The unit still couldn't legally move (that part was correct 10th-edition behaviour: Consolidation must end closer to an enemy within 3\" or an objective within 3\"), but the game now recognises that up front and the unit simply holds position — no scary 'failed' spam.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -697,7 +697,27 @@ func _update_button_states() -> void:
 		roll_button.disabled = not can_roll
 	if is_instance_valid(skip_button):
 		skip_button.disabled = not can_skip
-	
+
+	# T-092 fix: the confirm-row buttons (Snap to Contact + Undo Last Model)
+	# must only be interactable while an active charge move is in progress.
+	# Previously only confirm_button's visibility was toggled (in
+	# _enable_charge_movement / _on_confirm_charge_moves); the Snap and Undo
+	# buttons were never hidden or disabled after creation, so they lingered
+	# visible + ENABLED after a charge was confirmed, between charges, and
+	# while a Command Re-roll decision was still pending. Clicking Snap in any
+	# of those states does nothing — _on_auto_path_charge early-returns on the
+	# empty models_to_move — which reads to the player as "the Snap to Contact
+	# button doesn't do anything". Gate both on awaiting_movement here so they
+	# track the charge-move state everywhere _update_button_states runs (unit
+	# select, reset, next-charge refresh, roll made, decline reroll, ...).
+	if is_instance_valid(auto_path_charge_button):
+		auto_path_charge_button.visible = awaiting_movement
+		# Only snap-able while there are still models left to place.
+		auto_path_charge_button.disabled = models_to_move.is_empty()
+	if is_instance_valid(undo_charge_model_button):
+		undo_charge_model_button.visible = awaiting_movement
+		undo_charge_model_button.disabled = _moved_model_order.is_empty()
+
 	# Update charge status
 	_update_charge_status()
 
@@ -1136,6 +1156,17 @@ func _enable_charge_movement(unit_id: String, max_distance: int) -> void:
 		print("DEBUG: Confirm button size: ", confirm_button.size)
 	else:
 		print("WARNING: Confirm button not created!")
+
+	# T-092 fix: reveal the Snap to Contact + Undo Last Model buttons alongside
+	# confirm now that a charge move is active. _update_button_states() (called
+	# right after the roll resolves) keeps them in sync from here on, but show
+	# them explicitly so they appear even on any path that skips that refresh.
+	if is_instance_valid(auto_path_charge_button):
+		auto_path_charge_button.visible = true
+		auto_path_charge_button.disabled = models_to_move.is_empty()
+	if is_instance_valid(undo_charge_model_button):
+		undo_charge_model_button.visible = true
+		undo_charge_model_button.disabled = _moved_model_order.is_empty()
 
 func _clear_movement_visuals() -> void:
 	# Clear ghost visual
@@ -1993,6 +2024,14 @@ func _on_confirm_charge_moves() -> void:
 	_clear_movement_visuals()
 	if is_instance_valid(confirm_button):
 		confirm_button.visible = false
+	# T-092 fix: hide the Snap to Contact + Undo buttons together with confirm
+	# so they don't linger visible + clickable (and silently no-op) once this
+	# charge is done. _update_ui_for_next_charge() → _update_button_states()
+	# also enforces this, but hide here so there's no one-frame flash.
+	if is_instance_valid(auto_path_charge_button):
+		auto_path_charge_button.visible = false
+	if is_instance_valid(undo_charge_model_button):
+		undo_charge_model_button.visible = false
 
 	# Update UI for next charge selection
 	_update_ui_for_next_charge()
@@ -3566,7 +3605,14 @@ func _clear_charge_trajectory_preview() -> void:
 # + own_base_radius + 0.5") from the nearest target model along the
 # straight-line approach.
 func _on_auto_path_charge() -> void:
-	if active_unit_id == "" or models_to_move.is_empty():
+	# T-092 fix: the button is now hidden/disabled unless a charge move is
+	# active (see _update_button_states), but guard defensively — if it is ever
+	# triggered with nothing to place, tell the player instead of silently
+	# doing nothing (the original "Snap to Contact does nothing" symptom).
+	if active_unit_id == "" or not awaiting_movement or models_to_move.is_empty():
+		print("[T-092 auto-path] Snap to Contact ignored — no active charge move (active_unit=%s, awaiting_movement=%s, models_to_move=%d)" % [active_unit_id, str(awaiting_movement), models_to_move.size()])
+		if is_instance_valid(charge_info_label) and awaiting_movement and models_to_move.is_empty():
+			charge_info_label.text = "All models already in engagement range — click 'Confirm Charge Moves'"
 		return
 	var unit = GameState.get_unit(active_unit_id)
 	if unit.is_empty():

--- a/40k/tests/scenarios/sp/snap_to_contact_button.json
+++ b/40k/tests/scenarios/sp/snap_to_contact_button.json
@@ -1,12 +1,12 @@
 {
   "id": "snap_to_contact_button",
-  "covers": ["charge.ux.snap_to_contact_button", "charge.base_contact.bulk_snap"],
+  "covers": ["charge.ux.snap_to_contact_button", "charge.base_contact.bulk_snap", "charge.ux.snap_button_lifecycle"],
   "fixture": "test_charge_congestion",
   "edition": 11,
   "rng_seed": 42,
   "transition_to_phase": 9,
   "disable_ai": true,
-  "description": "The charge-phase 'Snap to Contact' button, driven as a player: select a 3-model Boyz unit (~2.9\" edge from a lone Shield-Captain), declare, roll (seeded 12), then CLICK the real SnapToContactButton. Before the fix the handler died on its first line with 'Invalid call to function get in base Node (ChargePhase). Expected 1 arguments.' — a two-argument Object.get() — so the click did nothing and models never closed to base contact. After the fix every model must end in true base-to-base contact (edge distance 0\") with the target, including the models whose straight-line lane is blocked by an already-snapped squadmate (the angular-sweep fallback slides them around the target's base). The Confirm click then applies the charge through the real APPLY_CHARGE_MOVE pipeline, proving the snapped positions pass the phase's base-contact enforcement.",
+  "description": "The charge-phase 'Snap to Contact' button, driven as a player: select a 3-model Boyz unit (~2.9\" edge from a lone Shield-Captain), declare, roll (seeded 12), then CLICK the real SnapToContactButton. Before the fix the handler died on its first line with 'Invalid call to function get in base Node (ChargePhase). Expected 1 arguments.' — a two-argument Object.get() — so the click did nothing and models never closed to base contact. After the fix every model must end in true base-to-base contact (edge distance 0\") with the target, including the models whose straight-line lane is blocked by an already-snapped squadmate (the angular-sweep fallback slides them around the target's base). The Confirm click then applies the charge through the real APPLY_CHARGE_MOVE pipeline, proving the snapped positions pass the phase's base-contact enforcement. Finally, once the charge is confirmed the whole confirm row (Confirm / Snap to Contact / Undo Last Model) must hide again: previously only Confirm was hidden, so the Snap button lingered visible + enabled with nothing to move and silently did nothing when clicked — the reported 'Snap to Contact button doesn't do anything' bug.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.8 },
     { "act": "expect_state", "path": "meta.phase", "equals": 9 },
@@ -79,6 +79,12 @@
     { "act": "execute_script",
       "script": "\"U_CHARGER_0\" in PhaseManager.get_current_phase_instance().get_completed_charges()",
       "equals": true },
-    { "act": "screenshot", "label": "04_charge_confirmed" }
+    { "act": "screenshot", "label": "04_charge_confirmed" },
+
+    { "act": "execute_script", "script": "main.charge_controller.models_to_move.is_empty()", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.awaiting_movement", "equals": false },
+    { "act": "execute_script", "script": "main.charge_controller.confirm_button.visible", "equals": false },
+    { "act": "execute_script", "script": "main.charge_controller.auto_path_charge_button.visible", "equals": false },
+    { "act": "execute_script", "script": "main.charge_controller.undo_charge_model_button.visible", "equals": false }
   ]
 }

--- a/40k/tests/unit/test_ai_no_control_human_fight_turn.gd.uid
+++ b/40k/tests/unit/test_ai_no_control_human_fight_turn.gd.uid
@@ -1,0 +1,1 @@
+uid://bbaef56bggymf


### PR DESCRIPTION
## Problem

The Charge-phase **Snap to Contact** button appeared to do nothing. Reproduced live in the running game via the MCP bridge: after a charge was confirmed the button read `visible=true` / `disabled=false` while `models_to_move` was empty and `awaiting_movement` was false.

Root cause: in `ChargeController.gd`, the Snap-to-Contact button and its sibling **Undo Last Model** button had their visible/enabled state set once at creation and never managed again. Only the *Confirm* button was hidden when a charge finished, so Snap and Undo lingered on screen — visible and clickable — after a charge was confirmed, between charges, and while a Command Re-roll prompt was still open. In all of those states `models_to_move` is empty, so clicking Snap hit the early-return in `_on_auto_path_charge()` and silently did nothing.

Evidence captured after confirming a charge:

| Check | Value |
|---|---|
| `models_to_move` empty | true |
| `awaiting_movement` | false |
| Confirm button visible | false ✓ |
| **Snap button visible** | **true** ← lingering |
| **Snap button disabled** | **false** ← still clickable |

## Fix

- Gate the confirm-row buttons (Snap / Undo) on `awaiting_movement` in `_update_button_states()`, which runs on every charge-phase state transition.
- Explicitly show them when a charge move begins in `_enable_charge_movement`, and hide them together with Confirm when the charge is confirmed.
- Snap is greyed out once every model is already placed (`models_to_move` empty); its handler now reports why instead of no-oping if ever triggered with nothing to move.

## Verification

- Extended the `snap_to_contact_button` **windowed scenario** (drives the real `SnapToContactButton` / `ConfirmChargeButton` clicks) to also assert the confirm-row buttons hide after the charge is confirmed — passes 40/40.
- Visual confirmation: after confirming a charge, the CHARGE ACTIONS panel returns to the clean "Step 1: Select a unit" state with Snap/Undo/Confirm all gone (they were present during the active charge).
- Ran the broader charge scenario set — no new regressions (the one `custodian_charge_congested_ovals` failure also fails on unmodified `main`; it's a seed producing a failed charge roll, unrelated to this change — verified via `git stash`).
- Also tested and rejected a plausible alternate hypothesis (Escape stranding the Command Re-roll dialog): the dialog ignores Escape, so that path was not the cause.

## Changelog

Adds a `0.42.5` entry to `40k/data/version_history.json`.

Second commit tracks a missing Godot `.uid` sidecar for an already-tracked test script (all other test `.uid` files in `tests/unit/` are tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TrAnAJ7gJnEGBXF3zLXq2X

---
_Generated by [Claude Code](https://claude.ai/code/session_01TrAnAJ7gJnEGBXF3zLXq2X)_