### PR TITLE
Charge phase: only list units with an enemy within 12"

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.43.6",
+			"date": "2026-07-14",
+			"summary": "The charge phase's 'UNITS THAT CAN CHARGE' list now only shows units that actually have an enemy within 12\" — i.e. a target that a charge could reach. Previously the list showed every unit that was allowed to charge, even ones with no enemy anywhere near them, so you'd select a unit expecting to charge and find an empty 'ELIGIBLE TARGETS' box. The list is now filtered so every unit shown has at least one reachable target, which is far less confusing.",
+			"changes": [
+				"Charge phase: 'UNITS THAT CAN CHARGE' now lists only units with at least one enemy within 12\" (a target a charge could reach). Units eligible to charge but with no enemy in range are hidden.",
+				"The 'ELIGIBLE TARGETS' list a selected unit shows is now guaranteed non-empty — selecting any listed unit always presents at least one target.",
+				"The 'X eligible' charge counter in the right panel now counts only these in-range units, so it matches the list you see."
+			]
+		},
+		{
 			"version": "0.43.5",
 			"date": "2026-07-14",
 			"summary": "Charge moves can now be made in multiple steps, exactly like Movement-phase moves. Previously, once you dragged a charging model and let go, that model was 'done' — you couldn't pick it up again, so there was no way to route it around a wall, terrain, or your own models and still use the rest of your charge distance. Now each charging model can be dragged as many times as you like; every drag adds to the total distance used and the model can keep moving until it reaches engagement range or spends its charge roll. Only 'Confirm Charge Moves' finalises the charge.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -636,11 +636,18 @@ func _refresh_ui() -> void:
 	
 	# Use ChargePhase's eligible units method which respects completed_charges
 	var eligible_unit_ids = current_phase.get_eligible_charge_units()
+	# Only surface units that actually have an enemy within 12" (a chargeable
+	# target). A unit can be "eligible to charge" per the rules yet have no target
+	# in range, which was reported as confusing — it appears chargeable but
+	# selecting it shows an empty ELIGIBLE TARGETS list. Filtering here keeps the
+	# UNITS THAT CAN CHARGE list consistent with the targets each unit can reach.
+	var chargeable_unit_ids = _filter_units_with_charge_targets(eligible_unit_ids)
 	var current_player = current_phase.get_current_player()
 	var units = current_phase.get_units_for_player(current_player)
-	
+
 	print("ChargeController: Refreshing UI for player ", current_player)
 	print("ChargeController: Eligible units from phase: ", eligible_unit_ids)
+	print("ChargeController: Chargeable (target within 12\") units: ", chargeable_unit_ids)
 	print("ChargeController: Completed charges: ", current_phase.get_completed_charges() if current_phase.has_method("get_completed_charges") else "N/A")
 	
 	# Debug help: Show why units might not be eligible
@@ -669,9 +676,12 @@ func _refresh_ui() -> void:
 				print("    BLOCKED: Unit has already charged this phase")
 			else:
 				print("    SHOULD BE ELIGIBLE - this might be a bug")
-	
+	elif chargeable_unit_ids.is_empty():
+		# Units can charge per the rules but none has an enemy within 12".
+		print("ChargeController: ", eligible_unit_ids.size(), " unit(s) can charge but none has a target within 12\" — none shown.")
+
 	var can_charge_count = 0
-	for unit_id in eligible_unit_ids:
+	for unit_id in chargeable_unit_ids:
 		if unit_id in units:
 			var unit = units[unit_id]
 			can_charge_count += 1
@@ -681,7 +691,7 @@ func _refresh_ui() -> void:
 			unit_selector.add_item(unit_name)
 			unit_selector.set_item_metadata(unit_selector.get_item_count() - 1, unit_id)
 			print("    Added eligible unit ", unit_id, " (", unit_name, ") to selector")
-	
+
 	print("ChargeController: Found ", can_charge_count, " units that can still charge")
 	
 	# CRITICAL: Ensure charge buttons exist and remain visible after refresh
@@ -695,6 +705,31 @@ func _can_unit_charge(unit: Dictionary) -> bool:
 	var unit_id = unit.get("id", "")
 	var board = GameState.create_snapshot()
 	return RulesEngine.eligible_to_charge(unit_id, board)
+
+func get_displayed_charge_unit_ids() -> Array:
+	# The unit ids currently listed in the UNITS THAT CAN CHARGE selector, i.e.
+	# after the target-within-12" filter. Read-only accessor exposed for windowed
+	# scenario tests / tooling so they can assert exactly which units are shown.
+	var ids: Array = []
+	if not is_instance_valid(unit_selector):
+		return ids
+	for i in range(unit_selector.get_item_count()):
+		ids.append(unit_selector.get_item_metadata(i))
+	return ids
+
+func _filter_units_with_charge_targets(unit_ids: Array) -> Array:
+	# Keep only units that have at least one enemy within 12" (a chargeable
+	# target). Uses the SAME RulesEngine query that populates the ELIGIBLE TARGETS
+	# list (charge_targets_within_12), so a unit is shown in UNITS THAT CAN CHARGE
+	# only when selecting it would actually offer a target to charge. This is a
+	# display-only refinement; the phase's own eligibility (used by AI / phase
+	# logic) is unchanged.
+	var result: Array = []
+	var board = GameState.create_snapshot()
+	for unit_id in unit_ids:
+		if not RulesEngine.charge_targets_within_12(unit_id, board).is_empty():
+			result.append(unit_id)
+	return result
 
 func _update_button_states() -> void:
 	if not current_phase:
@@ -2310,9 +2345,10 @@ func _update_ui_for_next_charge() -> void:
 	_ensure_charge_panel_visible()
 	_ensure_charge_buttons_exist()
 	
-	# Check if more units can charge
+	# Check if more units can charge (only those with a target within 12", to
+	# match what UNITS THAT CAN CHARGE now shows).
 	if current_phase and is_instance_valid(current_phase):
-		var eligible_units = current_phase.get_eligible_charge_units()
+		var eligible_units = _filter_units_with_charge_targets(current_phase.get_eligible_charge_units())
 		if eligible_units.size() > 0:
 			# Immediately show available units and update status
 			if is_instance_valid(charge_info_label):
@@ -2439,7 +2475,8 @@ func _update_charge_status() -> void:
 		return
 
 	var completed = current_phase.get_completed_charges().size()
-	var eligible = current_phase.get_eligible_charge_units().size()
+	# Count only units with a target within 12", matching the filtered list.
+	var eligible = _filter_units_with_charge_targets(current_phase.get_eligible_charge_units()).size()
 
 	if is_instance_valid(charge_status_label):
 		charge_status_label.text = "Charges: %d completed, %d eligible" % [completed, eligible]

--- a/40k/tests/scenarios/sp/charge_units_filtered_by_target_in_range.json
+++ b/40k/tests/scenarios/sp/charge_units_filtered_by_target_in_range.json
@@ -1,0 +1,41 @@
+{
+  "id": "charge_units_filtered_by_target_in_range",
+  "covers": ["charge.ux.units_that_can_charge_filtered_by_target_in_range", "scripts.ChargeController.filter_units_with_charge_targets"],
+  "fixture": "audit_372_charge_modifier",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "The charge phase 'UNITS THAT CAN CHARGE' list now only shows units that have at least one enemy within 12\" (a target a charge could actually reach). On this fixture the phase reports 5 charge-eligible Ork units: Battlewagon (~8.9\"), Boyz E (~7.8\") and Boyz F (~6.9\") are within 12\" of an enemy, while Boyz K (~15\") and Strike Force (~19\") are eligible to charge per the rules but have NO enemy within 12\". This scenario proves the two out-of-range units are excluded from the selector (get_displayed_charge_unit_ids returns the 3 in-range units, not all 5) even though they remain in the phase's raw get_eligible_charge_units() list.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script", "script": "is_instance_valid(main.charge_controller)", "equals": true },
+
+    { "act": "execute_script", "script": "RulesEngine.eligible_to_charge(\"U_BOYZ_K\", GameState.create_snapshot())", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.eligible_to_charge(\"U_STRIKE_FORCE_A\", GameState.create_snapshot())", "equals": true },
+
+    { "act": "execute_script", "script": "RulesEngine.charge_targets_within_12(\"U_BOYZ_K\", GameState.create_snapshot()).is_empty()", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.charge_targets_within_12(\"U_STRIKE_FORCE_A\", GameState.create_snapshot()).is_empty()", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.charge_targets_within_12(\"U_BATTLEWAGON_G\", GameState.create_snapshot()).is_empty()", "equals": false },
+    { "act": "execute_script", "script": "RulesEngine.charge_targets_within_12(\"U_BOYZ_F\", GameState.create_snapshot()).is_empty()", "equals": false },
+
+    { "act": "execute_script", "script": "main.charge_controller.current_phase.get_eligible_charge_units().has(\"U_BOYZ_K\")", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.current_phase.get_eligible_charge_units().has(\"U_STRIKE_FORCE_A\")", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.current_phase.get_eligible_charge_units().size()", "equals": 5 },
+
+    { "act": "execute_script", "script": "main.charge_controller._refresh_ui()" },
+
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().has(\"U_BATTLEWAGON_G\")", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().has(\"U_BOYZ_E\")", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().has(\"U_BOYZ_F\")", "equals": true },
+
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().has(\"U_BOYZ_K\")", "equals": false },
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().has(\"U_STRIKE_FORCE_A\")", "equals": false },
+    { "act": "execute_script", "script": "main.charge_controller.get_displayed_charge_unit_ids().size()", "equals": 3 },
+
+    { "act": "screenshot", "label": "01_units_that_can_charge_filtered" }
+  ]
+}


### PR DESCRIPTION
## Summary

In the charge phase, the **"UNITS THAT CAN CHARGE"** list showed every charge-eligible unit — even ones with no enemy anywhere within 12". Selecting such a unit presented an empty **"ELIGIBLE TARGETS"** box, which was reported as confusing.

`ChargeController` now filters the selector to units that have at least one enemy within 12" — a target a charge could actually reach — so every unit shown has something to charge.

## Changes

- **`40k/scripts/ChargeController.gd`**
  - New `_filter_units_with_charge_targets()` keeps a unit only if `RulesEngine.charge_targets_within_12()` returns a target — the **same** query that populates the ELIGIBLE TARGETS list, so the two lists stay consistent.
  - `_refresh_ui()` populates the selector from the filtered set.
  - The **"X eligible"** counter and the "are there more units to charge?" check use the same filtered set, so nothing contradicts the visible list.
  - Added a read-only `get_displayed_charge_unit_ids()` accessor for windowed test assertions.
  - Display-only refinement: the phase's own `get_eligible_charge_units()` (used by AI / phase logic) is **unchanged**, so game rules are unaffected.
- **`40k/tests/scenarios/sp/charge_units_filtered_by_target_in_range.json`** — new windowed scenario.
- **`40k/data/version_history.json`** — bumped to 0.43.6 with a player-facing changelog entry.

## Validation

- New windowed scenario passes **21/21 steps**: on the fixture, 5 Ork units are charge-eligible; it proves **Boyz K (~15") and Strike Force (~19")** — eligible but with no enemy within 12" — are **excluded** from the selector, while the 3 in-range units (Battlewagon, Boyz E, Boyz F) remain shown, even though all 5 stay in the raw `get_eligible_charge_units()`.
- Screenshot confirms the UI renders exactly 3 units and the status line reads **"Charges: 0 completed, 3 eligible."**
- **0 errors** in the debug log during the run.
- The 5 existing charge scenarios (`charge_requirement_hint`, `372_ere_we_go_charge_modifier`, `charge_overdeclare_fails`, `waaagh_advance_then_charge`, `charge_undo_last_model_button`) all still pass — no regressions.

## Note

The filter uses straight-line edge-to-edge distance ≤ 12", matching how the game already computes eligible charge targets. It does not account for terrain/pathing (a unit could still fail to reach a technically-within-12" target), but that mirrors the existing ELIGIBLE TARGETS behavior, so the two lists are now consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014n6GcagZsJpbaioeUyweWT

---
_Generated by [Claude Code](https://claude.ai/code/session_014n6GcagZsJpbaioeUyweWT)_