### PR TITLE
Move AI Turn Summary from floating pop-up into the game log

### DIFF
--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -397,6 +397,20 @@ func add_ai_thinking_block(player: int, header: String, lines: Array, context: D
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, "ai_thinking_block")
 
+func add_ai_turn_summary(player: int, header: String, lines: Array) -> void:
+	"""Post-AI-turn digest rendered as a single collapsible card in the game log.
+	Replaces the old AITurnSummaryPanel pop-up (which overlapped existing menus);
+	the summary now lives ONLY here. `header` is the first line (shown as the card
+	headline); `lines` are the per-phase breakdown, hidden behind the card's
+	'details' toggle so the once-per-turn card stays scannable."""
+	var text = header
+	for line in lines:
+		text += "\n" + str(line)
+	entries.append({"text": text, "type": "ai_turn_summary", "history_index": _current_history_marker()})
+	print("[GameEventLog] %s" % text)
+	DebugLogger.info("GameEventLog: %s" % text, {})
+	emit_signal("entry_added", text, "ai_turn_summary")
+
 func get_last_entry_history_index() -> int:
 	"""History-browser marker of the most recent entry (-1 if none). GameLogPanel
 	reads this synchronously from its entry_added handler to make the new card

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.43.7",
+			"date": "2026-07-14",
+			"summary": "Moved the AI Turn Summary into the game log instead of a floating pop-up. After each computer turn a summary of what the AI did (units moved, reinforcements arrived, charges declared, units fought, etc.) used to appear as a separate window pinned to the right-hand side of the screen — but it was drawn on top of the existing menus and combat log, so it overlapped them and was awkward to read. That pop-up is gone. The same summary now appears as a single card in the right-hand game log, labelled 'AI Turn Summary', with the full per-phase breakdown shown by default so you can read it at a glance — plus a 'hide details' toggle if you want to collapse it. It filters with the log's 'AI' category and can be clicked to review the board at that point in the game.",
+			"changes": [
+				"The post-turn 'AI Turn Summary' no longer appears as a separate pop-up window that covered the existing menus.",
+				"The same information (units moved, reinforcements, charges, fights, stratagems, notable moments) is now logged as an 'AI Turn Summary' card in the right-hand game log, expanded by default so the full per-phase breakdown is visible.",
+				"Use the card's 'hide details' toggle to collapse it; it hides/shows with the log's 'AI' filter like other AI entries."
+			]
+		},
+		{
 			"version": "0.43.6",
 			"date": "2026-07-14",
 			"summary": "The charge phase's 'UNITS THAT CAN CHARGE' list now only shows units that actually have an enemy within 12\" — i.e. a target that a charge could reach. Previously the list showed every unit that was allowed to charge, even ones with no enemy anywhere near them, so you'd select a unit expecting to charge and find an empty 'ELIGIBLE TARGETS' box. The list is now filtered so every unit shown has at least one reachable target, which is far less confusing.",

--- a/40k/scripts/AITurnSummaryPanel.gd
+++ b/40k/scripts/AITurnSummaryPanel.gd
@@ -1,35 +1,20 @@
-extends PanelContainer
+extends Node
 class_name AITurnSummaryPanel
 
-# AITurnSummaryPanel - Post-turn summary popup showing what the AI did (T7-19)
-# Appears after each AI turn ends, consuming the ai_turn_ended signal and the
-# _action_log from AIPlayer. Displays a categorized summary: units moved,
-# shooting results, charge results, fight results, stratagems used, etc.
-# The panel auto-shows when the AI finishes a thinking sequence and can be
-# dismissed with a button click or the Escape key.
+# AITurnSummaryPanel - Post-turn AI digest emitter (T7-19)
+# Originally a right-hand-side pop-up panel, this now writes the AI turn summary
+# straight into the GAME LOG as a single collapsible card instead of covering the
+# existing menus with a separate window. It still consumes the `ai_turn_ended`
+# signal and the `_action_log` from AIPlayer, categorizes the actions per phase
+# (units moved, shooting/charge/fight results, stratagems used, reinforcements…),
+# and shows the notable moments — but the digest now lives ONLY in the game log
+# (via GameEventLog.add_ai_turn_summary) and is shown nowhere else.
+#
+# NOTE: the class is still named AITurnSummaryPanel (and still referenced from
+# Main.gd) for continuity; it is no longer a Control/pop-up, just a lightweight
+# node that formats the summary and hands it to the log.
 
-const WhiteDwarfThemeData = preload("res://scripts/WhiteDwarfTheme.gd")
 const GameStateData = preload("res://autoloads/GameState.gd")
-
-# Layout constants
-const PANEL_WIDTH: float = 380.0
-const PANEL_MAX_HEIGHT: float = 420.0
-const FONT_SIZE: int = 12
-const HEADER_FONT_SIZE: int = 14
-const TITLE_FONT_SIZE: int = 16
-const CATEGORY_FONT_SIZE: int = 13
-
-# Auto-dismiss timer (seconds) — panel hides itself after this duration
-const AUTO_DISMISS_DELAY: float = 12.0
-
-# Color constants (matching existing panel themes)
-const COLOR_P1: Color = Color(0.4, 0.6, 0.85)
-const COLOR_P2: Color = Color(0.85, 0.4, 0.4)
-const COLOR_GOLD: Color = Color(0.833, 0.588, 0.376)
-const COLOR_PARCHMENT: Color = Color(0.922, 0.882, 0.780)
-const COLOR_CATEGORY: Color = Color(0.9, 0.78, 0.5)
-const COLOR_STAT: Color = Color(0.75, 0.85, 0.75)
-const COLOR_EMPTY: Color = Color(0.5, 0.5, 0.5)
 
 # Phase name lookup
 const PHASE_NAMES = {
@@ -44,221 +29,82 @@ const PHASE_NAMES = {
 	GameStateData.Phase.MORALE: "Morale",
 }
 
-# UI nodes (built procedurally in _build_ui)
-var _title_label: Label
-var _close_button: Button
-var _scroll_container: ScrollContainer
-var _summary_label: RichTextLabel
-var _dismiss_button: Button
-
-# State
-var _auto_dismiss_timer: float = 0.0
-var _is_counting_down: bool = false
-
 func _ready() -> void:
-	_build_ui()
-	visible = false
-	mouse_filter = Control.MOUSE_FILTER_STOP  # Block clicks through to game
-	print("[AITurnSummaryPanel] T7-19: Ready")
-
-func _build_ui() -> void:
 	name = "AITurnSummaryPanel"
-
-	# Anchor to right side of screen, vertically centered
-	anchor_left = 1.0
-	anchor_right = 1.0
-	anchor_top = 0.5
-	anchor_bottom = 0.5
-	offset_left = -(PANEL_WIDTH + 15.0)
-	offset_right = -15.0
-	offset_top = -PANEL_MAX_HEIGHT / 2.0
-	offset_bottom = PANEL_MAX_HEIGHT / 2.0
-
-	# Dark background with gold border — WhiteDwarf style
-	var style = StyleBoxFlat.new()
-	style.bg_color = Color(0.08, 0.07, 0.06, 0.95)
-	style.border_color = Color(WhiteDwarfThemeData.WH_GOLD, 0.8)
-	style.set_border_width_all(2)
-	style.border_width_top = 3
-	style.set_corner_radius_all(4)
-	style.set_content_margin_all(10)
-	add_theme_stylebox_override("panel", style)
-
-	# Main VBox
-	var vbox = VBoxContainer.new()
-	vbox.name = "MainVBox"
-	add_child(vbox)
-
-	# Title bar with close button
-	var title_bar = HBoxContainer.new()
-	title_bar.name = "TitleBar"
-	vbox.add_child(title_bar)
-
-	_title_label = Label.new()
-	_title_label.text = "AI Turn Summary"
-	_title_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_title_label.add_theme_font_size_override("font_size", TITLE_FONT_SIZE)
-	_title_label.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_GOLD)
-	title_bar.add_child(_title_label)
-
-	_close_button = Button.new()
-	_close_button.text = "X"
-	_close_button.custom_minimum_size = Vector2(28, 28)
-	_close_button.pressed.connect(_dismiss)
-	WhiteDwarfThemeData.apply_to_button(_close_button)
-	title_bar.add_child(_close_button)
-
-	# Separator
-	var _gsep1 = ColorRect.new()
-	_gsep1.custom_minimum_size = Vector2(0, 2)
-	_gsep1.color = Color(WhiteDwarfThemeData.WH_GOLD.r, WhiteDwarfThemeData.WH_GOLD.g, WhiteDwarfThemeData.WH_GOLD.b, 0.4)
-	_gsep1.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	vbox.add_child(_gsep1)
-
-	# Scroll container for summary content
-	_scroll_container = ScrollContainer.new()
-	_scroll_container.name = "SummaryScroll"
-	_scroll_container.size_flags_vertical = Control.SIZE_EXPAND_FILL
-	_scroll_container.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	vbox.add_child(_scroll_container)
-
-	# RichTextLabel for color-coded BBCode summary
-	_summary_label = RichTextLabel.new()
-	_summary_label.name = "SummaryLabel"
-	_summary_label.bbcode_enabled = true
-	_summary_label.fit_content = true
-	_summary_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	_summary_label.scroll_active = false  # ScrollContainer handles scrolling
-	_summary_label.add_theme_font_size_override("normal_font_size", FONT_SIZE)
-	_summary_label.add_theme_font_size_override("bold_font_size", FONT_SIZE + 1)
-	_scroll_container.add_child(_summary_label)
-
-	# Bottom separator
-	var _gsep2 = ColorRect.new()
-	_gsep2.custom_minimum_size = Vector2(0, 2)
-	_gsep2.color = Color(WhiteDwarfThemeData.WH_GOLD.r, WhiteDwarfThemeData.WH_GOLD.g, WhiteDwarfThemeData.WH_GOLD.b, 0.4)
-	_gsep2.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	vbox.add_child(_gsep2)
-
-	# Dismiss button at bottom
-	_dismiss_button = Button.new()
-	_dismiss_button.text = "Dismiss"
-	_dismiss_button.custom_minimum_size = Vector2(0, 32)
-	_dismiss_button.pressed.connect(_dismiss)
-	WhiteDwarfThemeData.apply_to_button(_dismiss_button)
-	vbox.add_child(_dismiss_button)
-
-func _process(delta: float) -> void:
-	if not visible or not _is_counting_down:
-		return
-	_auto_dismiss_timer += delta
-	if _auto_dismiss_timer >= AUTO_DISMISS_DELAY:
-		_dismiss()
-
-func _unhandled_input(event: InputEvent) -> void:
-	if not visible:
-		return
-	if event is InputEventKey and event.pressed and event.keycode == KEY_ESCAPE:
-		_dismiss()
-		get_viewport().set_input_as_handled()
+	print("[AITurnSummaryPanel] T7-19: Ready (logs to game log, no pop-up)")
 
 # ── Public API ──────────────────────────────────────────────────────────
 
 func show_summary(player: int, action_summary: Array) -> void:
-	"""Called when ai_turn_ended fires. Builds and displays the turn summary."""
+	"""Called when ai_turn_ended fires. Builds the turn summary and appends it to
+	the game log as a collapsible card (no pop-up window)."""
 	if action_summary.is_empty():
 		print("[AITurnSummaryPanel] T7-19: No actions to summarize for player %d" % player)
 		return
 
-	_build_summary_content(player, action_summary)
+	var built = _build_summary(player, action_summary)
+	var header: String = built.get("header", "AI Turn Summary")
+	var lines: Array = built.get("lines", [])
 
-	# Show the panel with a fade-in
-	visible = true
-	modulate.a = 0.0
-	var tween = create_tween()
-	tween.tween_property(self, "modulate:a", 1.0, 0.3)
-
-	# Start auto-dismiss countdown
-	_auto_dismiss_timer = 0.0
-	_is_counting_down = true
-
-	print("[AITurnSummaryPanel] T7-19: Showing summary for player %d (%d actions)" % [player, action_summary.size()])
+	var gel = get_node_or_null("/root/GameEventLog")
+	if gel and gel.has_method("add_ai_turn_summary"):
+		gel.add_ai_turn_summary(player, header, lines)
+		print("[AITurnSummaryPanel] T7-19: Logged summary for player %d (%d actions)" % [player, action_summary.size()])
+	else:
+		push_warning("[AITurnSummaryPanel] GameEventLog.add_ai_turn_summary unavailable — summary not logged")
 
 func hide_summary() -> void:
-	"""Hide the panel immediately."""
-	_dismiss()
+	"""No-op — retained for API compatibility now that there is no pop-up to hide."""
+	pass
 
 # ── Private ─────────────────────────────────────────────────────────────
 
-func _dismiss() -> void:
-	_is_counting_down = false
-	if visible:
-		var tween = create_tween()
-		tween.tween_property(self, "modulate:a", 0.0, 0.2)
-		tween.tween_callback(func(): visible = false; modulate.a = 1.0)
-		print("[AITurnSummaryPanel] T7-19: Dismissed")
+func _build_summary(player: int, action_summary: Array) -> Dictionary:
+	"""Parse the action log into a plain-text header + per-phase breakdown lines
+	suitable for a game-log card. First element of `lines` follows the header."""
+	var lines: Array = []
 
-func _build_summary_content(player: int, action_summary: Array) -> void:
-	"""Parse the action log and build a categorized summary."""
-	_summary_label.clear()
-
-	var player_color = COLOR_P1 if player == 1 else COLOR_P2
-	var player_hex = player_color.to_html(false)
-	var gold_hex = COLOR_GOLD.to_html(false)
-	var cat_hex = COLOR_CATEGORY.to_html(false)
-	var stat_hex = COLOR_STAT.to_html(false)
-	var parchment_hex = COLOR_PARCHMENT.to_html(false)
-
-	# Header
+	# Header — player, faction, battle round
 	var faction_name = ""
+	var battle_round = 0
 	var game_state = _get_game_state()
 	if game_state:
 		faction_name = game_state.get_faction_name(player)
-	var header_text = "Player %d" % player
-	if faction_name != "":
-		header_text += " (%s)" % faction_name
-	_summary_label.append_text("[b][color=#%s]%s[/color][/b]\n" % [player_hex, header_text])
-
-	# Round info
-	var battle_round = 0
-	if game_state:
 		battle_round = game_state.get_battle_round()
+	var header = "AI Turn Summary — Player %d" % player
+	if faction_name != "":
+		header += " (%s)" % faction_name
 	if battle_round > 0:
-		_summary_label.append_text("[color=#%s]Battle Round %d[/color]\n\n" % [gold_hex, battle_round])
+		header += ", Battle Round %d" % battle_round
 
 	# Categorize actions by phase, then by type within each phase
 	var phase_actions = _categorize_by_phase(action_summary)
 
-	if phase_actions.is_empty():
-		_summary_label.append_text("[color=#%s]No significant actions taken.[/color]\n" % COLOR_EMPTY.to_html(false))
-		return
+	var any_content = false
+	if not phase_actions.is_empty():
+		for phase_id in phase_actions:
+			var phase_name = PHASE_NAMES.get(phase_id, "Phase %d" % phase_id)
+			var actions = phase_actions[phase_id]
+			var counts = _count_action_categories(actions)
+			if counts.is_empty():
+				continue
+			any_content = true
 
-	# Render each phase's summary
-	for phase_id in phase_actions:
-		var phase_name = PHASE_NAMES.get(phase_id, "Phase %d" % phase_id)
-		var actions = phase_actions[phase_id]
-		var counts = _count_action_categories(actions)
+			# Phase sub-header
+			lines.append(phase_name)
 
-		if counts.is_empty():
-			continue
+			# Category stats (icon + label + count)
+			for entry in _format_category_counts(counts):
+				lines.append("  " + entry.text)
 
-		# Phase header
-		_summary_label.append_text("[b][color=#%s]%s[/color][/b]\n" % [cat_hex, phase_name])
+			# Notable action descriptions (charges, stratagems, reinforcements)
+			for desc in _get_notable_actions(actions):
+				lines.append("  > " + desc)
 
-		# Category stats
-		for entry in _format_category_counts(counts):
-			_summary_label.append_text("  [color=#%s]%s[/color]\n" % [stat_hex, entry.text])
+	if not any_content:
+		lines.append("No significant actions taken.")
 
-		# Show notable action descriptions (up to 3 per phase)
-		var notable = _get_notable_actions(actions)
-		if not notable.is_empty():
-			for desc in notable:
-				_summary_label.append_text("  [color=#%s]> %s[/color]\n" % [parchment_hex, desc])
-
-		_summary_label.append_text("\n")
-
-	# Scroll to top
-	call_deferred("_scroll_to_top")
+	return {"header": header, "lines": lines}
 
 func _categorize_by_phase(actions: Array) -> Dictionary:
 	"""Group actions by their phase ID, preserving phase order."""
@@ -370,10 +216,6 @@ func _get_notable_actions(actions: Array) -> Array:
 				notable.append(desc)
 
 	return notable
-
-func _scroll_to_top() -> void:
-	if _scroll_container and is_instance_valid(_scroll_container):
-		_scroll_container.scroll_vertical = 0
 
 func _get_game_state() -> Node:
 	"""Get GameState autoload via node tree."""

--- a/40k/scripts/GameLogPanel.gd
+++ b/40k/scripts/GameLogPanel.gd
@@ -977,6 +977,14 @@ func _create_simple_card(text: String, entry_type: String, animate: bool) -> voi
 				block_context = gel.get_last_entry_context()
 			card = _make_ai_thinking_block_card(text, block_context)
 			final_category = EntryCategory.AI_THINKING
+		"ai_turn_summary":
+			# Post-AI-turn digest (replaces the old AITurnSummaryPanel popup).
+			# Same collapsible layout as thinking blocks, but with a prominent
+			# gold header and "details" wording. The per-phase breakdown is shown
+			# expanded by default (this is a once-per-turn digest the player wants
+			# to see); the toggle still lets them collapse it.
+			card = _make_ai_thinking_block_card(text, {}, "details", "[b][color=#D4964A]%s[/color][/b]", true)
+			final_category = EntryCategory.AI_THINKING
 		_:
 			card = _make_simple_entry_card(text, entry_type, category)
 			final_category = category
@@ -987,7 +995,7 @@ func _create_simple_card(text: String, entry_type: String, animate: bool) -> voi
 	_register_card(card, final_category)
 
 	# Track AI cards for filtering
-	if entry_type == "ai_thinking" or entry_type == "ai_thinking_block":
+	if entry_type == "ai_thinking" or entry_type == "ai_thinking_block" or entry_type == "ai_turn_summary":
 		_ai_cards.append(card)
 
 	if animate and card.visible:
@@ -1165,13 +1173,16 @@ func _make_simple_entry_card(text: String, entry_type: String, category: int) ->
 
 	return card
 
-func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -> PanelContainer:
+func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}, toggle_noun: String = "considerations", header_format: String = "[i][color=#8899AA]%s[/color][/i]", start_expanded: bool = false) -> PanelContainer:
 	"""Collapsible card for one AI decision's verbose reasoning.
 	First line of `text` is the headline; remaining lines are the considered
-	options / rejections, hidden behind a 'considerations' toggle so heavy
-	verbosity stays scannable. When `link_context` carries board positions,
-	the card becomes interactive: hover previews the considered options as
-	arrows on the board (chosen green, rejected red); click pins them."""
+	options / rejections, behind a 'considerations' toggle so heavy verbosity
+	stays scannable. When `link_context` carries board positions, the card
+	becomes interactive: hover previews the considered options as arrows on the
+	board (chosen green, rejected red); click pins them.
+	`toggle_noun` / `header_format` let callers (e.g. the AI turn-summary card)
+	reuse this layout with digest-appropriate wording and a prominent header.
+	`start_expanded` shows the details immediately (the toggle still collapses them)."""
 	var lines = text.split("\n")
 	var header_text = lines[0] if lines.size() > 0 else text
 	var detail_lines: Array = []
@@ -1220,7 +1231,7 @@ func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -
 	header_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	header_label.add_theme_font_size_override("normal_font_size", 11)
 	header_label.add_theme_font_size_override("bold_font_size", 12)
-	header_label.append_text("[i][color=#8899AA]%s[/color][/i]" % header_text)
+	header_label.append_text(header_format % header_text)
 	# Let the card itself receive hover/click for the board-link interaction
 	header_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	header_hbox.add_child(header_label)
@@ -1229,7 +1240,7 @@ func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -
 		return card
 
 	var toggle_btn = Button.new()
-	toggle_btn.text = "  %d considerations…" % detail_lines.size()
+	toggle_btn.text = ("  hide %s" % toggle_noun) if start_expanded else ("  %d %s…" % [detail_lines.size(), toggle_noun])
 	toggle_btn.add_theme_font_size_override("font_size", 9)
 	toggle_btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
 	toggle_btn.flat = true
@@ -1243,7 +1254,7 @@ func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -
 	details.scroll_active = false
 	details.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	details.add_theme_font_size_override("normal_font_size", 10)
-	details.visible = false
+	details.visible = start_expanded
 	details.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	for line in detail_lines:
 		var l = str(line)
@@ -1258,7 +1269,7 @@ func _make_ai_thinking_block_card(text: String, link_context: Dictionary = {}) -
 	var detail_count = detail_lines.size()
 	toggle_btn.pressed.connect(func():
 		details.visible = !details.visible
-		toggle_btn.text = ("  hide considerations" if details.visible else "  %d considerations…" % detail_count)
+		toggle_btn.text = ("  hide %s" % toggle_noun if details.visible else "  %d %s…" % [detail_count, toggle_noun])
 	)
 
 	return card
@@ -1421,7 +1432,7 @@ func _categorize_entry_type(entry_type: String) -> int:
 			return EntryCategory.PHASE
 		"p1_action", "p2_action":
 			return EntryCategory.MOVEMENT
-		"ai_thinking", "ai_thinking_block":
+		"ai_thinking", "ai_thinking_block", "ai_turn_summary":
 			return EntryCategory.AI_THINKING
 		"overwatch":
 			return EntryCategory.OVERWATCH

--- a/40k/tests/scenarios/sp/ai_turn_summary_in_log.json
+++ b/40k/tests/scenarios/sp/ai_turn_summary_in_log.json
@@ -1,0 +1,73 @@
+{
+  "id": "ai_turn_summary_in_log",
+  "covers": [
+    "ui.GameLogPanel.ai_turn_summary_card",
+    "ai.turn_summary.logged_not_popup",
+    "ui.AITurnSummaryPanel.no_popup"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "description": "The post-AI-turn digest now lands in the game log instead of a floating right-hand pop-up that overlapped the existing menus. Drives the exact ai_turn_ended code path (AITurnSummaryPanel.show_summary) with a representative P2 action summary and asserts: (a) a single 'ai_turn_summary' entry reaches GameEventLog, (b) its text carries the header 'AI Turn Summary' plus the per-phase breakdown (units moved, reinforcements, charges, fights) and the notable action descriptions, (c) the AITurnSummaryPanel node no longer builds any pop-up UI (zero child controls), so the summary is shown nowhere but the log. The screenshot captures the collapsible 'AI Turn Summary' card in the right-hand log panel.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.clear()"
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"AITurnSummaryPanel\").get_child_count()",
+      "equals": 0
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"AITurnSummaryPanel\").show_summary(2, [{\"phase\":7,\"action_type\":\"CONFIRM_UNIT_MOVE\",\"description\":\"\"},{\"phase\":7,\"action_type\":\"CONFIRM_UNIT_MOVE\",\"description\":\"\"},{\"phase\":7,\"action_type\":\"PLACE_REINFORCEMENT\",\"description\":\"Allarus Custodians arrives from Strategic Reserves\"},{\"phase\":7,\"action_type\":\"PLACE_REINFORCEMENT\",\"description\":\"Custodian Guard Delta arrives from Strategic Reserves\"},{\"phase\":9,\"action_type\":\"DECLARE_CHARGE\",\"description\":\"Prosecutors declares charge against Stormboyz Alpha\"},{\"phase\":9,\"action_type\":\"SKIP_CHARGE\",\"description\":\"\"},{\"phase\":9,\"action_type\":\"SKIP_CHARGE\",\"description\":\"\"},{\"phase\":9,\"action_type\":\"SKIP_CHARGE\",\"description\":\"\"},{\"phase\":10,\"action_type\":\"SELECT_FIGHTER\",\"description\":\"\"},{\"phase\":10,\"action_type\":\"SELECT_FIGHTER\",\"description\":\"\"}])"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.count_entries_of_type(\"ai_turn_summary\")",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"AI Turn Summary\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"Units moved: 2\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"Reinforcements arrived: 2\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"Charges declared: 1\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"Units fought: 2\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameEventLog.entries[-1][\"text\"].contains(\"Allarus Custodians arrives from Strategic Reserves\")",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "01_ai_turn_summary_card_in_log",
+      "region": [0, 105, 440, 800]
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

The post-AI-turn digest ("AI Turn Summary") used to appear as a separate window pinned to the right-hand side of the screen. It was drawn on top of the existing menus and combat log, so it overlapped them and was awkward to read.

Per the request, that pop-up is gone. The same information now lives **only in the game log**, as a single card — shown nowhere else.

## Changes

- **`scripts/AITurnSummaryPanel.gd`** — repurposed from a `PanelContainer` pop-up into a lightweight node that formats the turn digest (same per-phase categorization: units moved, reinforcements, charges, fights, stratagems, notable moments) and hands it to the log via `GameEventLog.add_ai_turn_summary`. All pop-up UI (panel, tweens, 12s auto-dismiss, Escape handling) is removed. The `class_name` is kept for continuity with `Main.gd` and existing pin tests.
- **`autoloads/GameEventLog.gd`** — new `add_ai_turn_summary()` that emits an `ai_turn_summary` log entry (header + per-phase breakdown lines).
- **`scripts/GameLogPanel.gd`** — renders `ai_turn_summary` as a card reusing the AI-thinking block layout, with a prominent gold header and a `details` toggle. It categorizes under the log's **AI** filter and is clickable in the history browser like other AI cards. The breakdown is **expanded by default** (a once-per-turn digest the player wants to read at a glance); a **"hide details"** toggle still lets them collapse it. `_make_ai_thinking_block_card` gained optional `toggle_noun` / `header_format` / `start_expanded` params so existing AI-thinking cards are unaffected.
- **`data/version_history.json`** — new 0.43.4 changelog entry.

## Validation

New windowed scenario `tests/scenarios/sp/ai_turn_summary_in_log.json` drives the real `ai_turn_ended` → `show_summary` path and asserts:
- a single `ai_turn_summary` entry reaches `GameEventLog` with the correct header + per-phase breakdown (units moved, reinforcements, charges, fights) and notable action descriptions;
- the panel node builds **zero** pop-up UI (no Control children);
- the card renders in the log (screenshot shows the Movement/Charge/Fight breakdown under the header with a "hide details" toggle).

Result: **13/13 steps pass, no errors.** Related AI-thinking / game-log scenarios still pass (`ai_11e_verbose_thinking` 18/0, `ai_thinking_dupe_display_names` 14/0, `game_log_long_entry_expandable` 13/0) — no regression to the shared card renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZsAWY8dCKJ3sXeixh3r5X

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZsAWY8dCKJ3sXeixh3r5X)_