### PR TITLE
Fix: shooting target assignment via board-click not populating Current Targets

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.43.8",
+			"date": "2026-07-14",
+			"summary": "Fixed shooting-phase target assignment by clicking on an enemy unit not filling the 'Current Targets' list. When you selected a weapon and clicked an enemy that had several of your models able to fire at it, the Split Fire picker opened, you chose how many to send, and the assignment was actually made — but the 'Current Targets' panel stayed empty and the 'Confirm Targets' button stayed greyed out, so it looked like nothing happened and you couldn't proceed. Assigning via the 'Quick Assign' buttons worked because it refreshed the panel directly. Now the panel and buttons refresh after every target you commit, whichever way you assigned it.",
+			"changes": [
+				"Fixed: clicking an enemy unit to assign shooting targets now fills the 'Current Targets' list and enables 'Confirm Targets'. Previously, assignments made through the Split Fire picker (or the Devastating Wounds choice prompt) committed silently — the target was assigned but the on-screen list and buttons never updated.",
+				"The fix refreshes the assignment UI at the moment the assignment is actually committed, so it works the same whether the picker/choice dialog was involved or not — matching how the 'Quick Assign' and 'Apply to All' buttons already behaved."
+			]
+		},
+		{
 			"version": "0.43.7",
 			"date": "2026-07-14",
 			"summary": "Moved the AI Turn Summary into the game log instead of a floating pop-up. After each computer turn a summary of what the AI did (units moved, reinforcements arrived, charges declared, units fought, etc.) used to appear as a separate window pinned to the right-hand side of the screen — but it was drawn on top of the existing menus and combat log, so it overlapped them and was awkward to read. That pop-up is gone. The same summary now appears as a single card in the right-hand game log, labelled 'AI Turn Summary', with the full per-phase breakdown shown by default so you can read it at a glance — plus a 'hide details' toggle if you want to collapse it. It filters with the log's 'AI' category and can be clicked to review the board at that point in the game.",

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -4945,6 +4945,16 @@ func _post_assign_ui_update(weapon_id: String, target_id: String, chosen_model_i
 	_last_preview_target_id = ""
 	_update_damage_preview(weapon_id)
 
+	# Refresh the "Current Targets" basket + confirm/clear/undo buttons.
+	# CRITICAL: this must run here (not only at the synchronous _update_ui_state()
+	# call in _select_target_for_current_weapon) because the split-fire picker and
+	# the [DEVASTATING WOUNDS] ability dialog commit the assignment ASYNCHRONOUSLY
+	# from their confirm callbacks — long after that synchronous call already ran
+	# against an empty weapon_assignments map. Without this, a board-click that
+	# opens the picker would populate the forecast but leave CURRENT TARGETS empty,
+	# while quick-assign (which calls _update_ui_state directly) worked fine.
+	_update_ui_state()
+
 # SPLIT-FIRE: Re-render the column-2 text of a weapon row to show every pending
 # (target → count) entry for that weapon. Called after every assign / undo /
 # clear so the tree stays in sync with the phase's pending_assignments.

--- a/40k/tests/scenarios/sp/split_fire_picker_populates_basket.json
+++ b/40k/tests/scenarios/sp/split_fire_picker_populates_basket.json
@@ -1,0 +1,65 @@
+{
+  "id": "split_fire_picker_populates_basket",
+  "covers": [
+    "shooting.split_fire_picker_ui",
+    "shooting.current_targets_basket",
+    "scripts.ShootingController._post_assign_ui_update"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Regression for the 'CURRENT TARGETS stays empty when I assign by clicking the target' bug. Manually selecting a target opens the Split Fire picker; committing it goes through _commit_split_assignment -> _post_assign_ui_update, which previously did NOT call _update_ui_state(). The only _update_ui_state() call sat in _select_target_for_current_weapon and ran SYNCHRONOUSLY, before the async picker confirm, so the CURRENT TARGETS ItemList (and the Confirm/Clear/Undo buttons) never refreshed after the real assignment landed. Quick-assign always worked because it calls _update_ui_state() directly. Steps drive the real player path: select Custodian Guard B, clear the auto-assigned target, re-select the Guardian spear row, open the picker via _select_target_for_current_weapon (assert it appears while the basket is still empty), confirm it, then assert pending_assignments grew AND the CURRENT TARGETS basket now has exactly one row AND the Confirm button is enabled.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "dispatch_action", "action": {
+      "type": "SELECT_SHOOTER",
+      "actor_unit_id": "U_CUSTODIAN_GUARD_B"
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._on_clear_pressed()" },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").target_basket.get_item_count()",
+      "equals": 0 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.get_root().get_first_child().get_metadata(0)",
+      "equals": "guardian_spear_ranged" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.get_root().get_first_child().select(0)" },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.emit_signal(\"item_selected\")" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._select_target_for_current_weapon(\"U_BATTLEWAGON_G\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").get_node_or_null(\"SplitFirePicker\") != null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").target_basket.get_item_count()",
+      "equals": 0 },
+    { "act": "screenshot", "label": "01_picker_open_basket_empty" },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").get_node(\"SplitFirePicker\").emit_signal(\"confirmed\")" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").current_phase.pending_assignments.size()",
+      "equals": 1 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").target_basket.get_item_count()",
+      "equals": 1 },
+    { "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").confirm_button.disabled",
+      "equals": false },
+    { "act": "screenshot", "label": "02_basket_populated_after_confirm" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes a shooting-phase bug: assigning a target by **clicking on an enemy unit** committed the assignment but left the **"Current Targets"** panel empty and the **"Confirm Targets"** button greyed out, so it looked like nothing happened and the player couldn't proceed. Assigning via **Quick Assign** worked.

## Root cause

The "Current Targets" `ItemList` and the Confirm/Clear/Undo button states are rebuilt inside `_update_ui_state()`.

The manual board-click path (`_select_target_for_current_weapon`) only calls `_update_ui_state()` **synchronously** — which runs *before* the Split Fire picker (or the Devastating Wounds ability dialog) resolves. The assignment is actually committed **later**, from those dialogs' confirm callbacks, via `_commit_split_assignment` / `_dispatch_assign_with_choices` → `_post_assign_ui_update`, which **never called `_update_ui_state()`**. So the panel and buttons never refreshed after the real assignment landed.

Quick Assign and Auto/Apply-to-All call `_update_ui_state()` directly, which is why only the click-to-assign flow was broken.

## Fix

Call `_update_ui_state()` at the end of `_post_assign_ui_update()` — the common commit point for both dialog paths. Idempotent with the existing synchronous call on the single-bearer fast path.

## Validation (windowed, live game via `addons/godot_mcp` bridge, `audit_386` fixture)

- **With fix:** opening the Split Fire picker and confirming populates CURRENT TARGETS (basket `item_count` 0 → 1) and enables Confirm.
- **Without fix (same live flow):** assignment commits (`pending=1`) but the basket stays empty and Confirm stays disabled — reproduces the report exactly.
- New regression scenario `tests/scenarios/sp/split_fire_picker_populates_basket.json` **passes with the fix (22/22)** and **fails without it** (basket + Confirm asserts).
- Related shooting scenarios still green: `iss047c_ability_choice_prompts_11e`, `more_dakka_bursts`, `grenade_then_shoot_desync`.

## Changes

- `40k/scripts/ShootingController.gd` — the one-line fix (+ explanatory comment).
- `40k/tests/scenarios/sp/split_fire_picker_populates_basket.json` — new windowed regression scenario.
- `40k/data/version_history.json` — version bump to 0.43.6 with a player-facing changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXB9HmnZet95mHkd5qLLP3

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXB9HmnZet95mHkd5qLLP3)_