### PR TITLE
Allow pivoting non-circular bases during pile-in / consolidate

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.44.0",
+			"date": "2026-07-14",
+			"summary": "Models on non-circular bases (bikes, and vehicles like the Caladius Grav-tank or a rectangular Battlewagon) can now be pivoted about their centre while piling in — exactly the way you already rotate them in the Movement phase. Right-click-drag a model during pile-in to turn it, or use the Q/E rotate keys, so an oval or rectangular base can be oriented to reach the enemy. As in the Movement phase, the 2\" pivot cost is counted against the model's 3\" pile-in move, so a model that turns can only shuffle 1\" of ground; round infantry bases don't need to pivot and are unaffected.",
+			"changes": [
+				"Pile in: right-click-drag (or press Q / E) to rotate a model on a non-circular base about its centre, matching the Movement-phase rotation controls — useful for pointing a bike or tank so its long base reaches into combat.",
+				"The pivot costs 2\" out of the 3\" pile-in move (Pariah Nexus rule), so a model that turns can still move up to 1\"; the move is rejected if a turn-plus-shuffle would exceed that reduced allowance.",
+				"Only bases that actually need to pivot can be turned — any non-round base, or a round base over 32mm on a flying stem for a Vehicle; standard round infantry bases are left as-is.",
+				"The new facing is saved with the model and applied when the pile-in is confirmed, so a bike/tank keeps the way you turned it. Rotation also works the same way in the end-of-phase Consolidate step."
+			]
+		},
+		{
 			"version": "0.43.10",
 			"date": "2026-07-14",
 			"summary": "AI actions no longer pop up in a separate floating window — they're now shown only in the Game Log. Previously, when the computer took its turn (or reacted during yours), a small 'AI Actions' ticker appeared in the bottom-right corner duplicating what the AI was thinking and doing, then faded away. That information was useful but easy to miss and cluttered the board. All of it — the AI's reasoning, the actions it takes, and (in AI-vs-AI spectator games) the per-phase summaries — now flows into the left-hand Game Log panel like every other event, so there's a single place to follow the whole battle and nothing pops up over the battlefield.",

--- a/40k/dialogs/ConsolidateDialog.gd
+++ b/40k/dialogs/ConsolidateDialog.gd
@@ -14,6 +14,7 @@ var max_distance: float = 3.0
 var phase_reference = null
 var controller_reference = null  # FightController reference
 var model_movements: Dictionary = {}
+var model_rotations: Dictionary = {}  # model_id -> rotation (radians) for pivoting bikes/vehicles
 
 # UI elements
 var status_label: Label = null
@@ -128,6 +129,11 @@ func update_movements(movements: Dictionary) -> void:
 	model_movements = movements
 	_update_status()
 
+func update_rotations(rotations: Dictionary) -> void:
+	"""Called by FightController when the user pivots a model (non-circular base)"""
+	model_rotations = rotations
+	_update_status()
+
 func _update_status() -> void:
 	"""Update status label based on current movements"""
 	if not status_label:
@@ -157,7 +163,8 @@ func _validate_movements() -> Dictionary:
 	# Create action to validate
 	var action = {
 		"unit_id": unit_id,
-		"movements": model_movements
+		"movements": model_movements,
+		"rotations": model_rotations
 	}
 
 	# Use FightPhase validation (consolidate uses same rules as pile-in)

--- a/40k/dialogs/PileInDialog.gd
+++ b/40k/dialogs/PileInDialog.gd
@@ -14,6 +14,7 @@ var max_distance: float = 3.0
 var phase_reference = null
 var controller_reference = null  # FightController reference
 var model_movements: Dictionary = {}
+var model_rotations: Dictionary = {}  # model_id -> rotation (radians) for pivoting bikes/vehicles
 
 # UI elements
 var status_label: Label = null
@@ -124,6 +125,11 @@ func update_movements(movements: Dictionary) -> void:
 	model_movements = movements
 	_update_status()
 
+func update_rotations(rotations: Dictionary) -> void:
+	"""Called by FightController when the user pivots a model (non-circular base)"""
+	model_rotations = rotations
+	_update_status()
+
 func _update_status() -> void:
 	"""Update status label based on current movements"""
 	if not status_label:
@@ -153,7 +159,8 @@ func _validate_movements() -> Dictionary:
 	# Create action to validate
 	var action = {
 		"unit_id": unit_id,
-		"movements": model_movements
+		"movements": model_movements,
+		"rotations": model_rotations
 	}
 
 	# Use FightPhase validation

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -801,10 +801,16 @@ func _validate_pile_in(action: Dictionary) -> Dictionary:
 				log_phase_message("[T4-5] Model %s rejected: already in base contact, moved %.2f\"" % [model_id, move_distance])
 				continue
 
-		# Check 3" movement limit (with floating-point tolerance)
+		# Check 3" movement limit (with floating-point tolerance). A pivoted model
+		# spends part of its budget on the pivot cost (Pariah Nexus).
 		var distance = Measurement.distance_inches(old_pos, new_pos)
-		if distance > 3.0 + MOVEMENT_CAP_EPSILON:
-			errors.append("Model %s pile in exceeds 3\" limit (%.1f\")" % [model_id, distance])
+		var pile_model = _resolve_fight_model(unit_id, model_id)
+		var eff_cap = _fight_effective_move_cap(unit, pile_model, _fight_rotations_from_action(action), model_id)
+		if distance > eff_cap + MOVEMENT_CAP_EPSILON:
+			if eff_cap < 3.0:
+				errors.append("Model %s pile in exceeds %.0f\" limit after pivot cost (%.1f\")" % [model_id, eff_cap, distance])
+			else:
+				errors.append("Model %s pile in exceeds 3\" limit (%.1f\")" % [model_id, distance])
 
 		# Check movement is toward closest enemy
 		if not _is_moving_toward_closest_enemy(unit_id, model_id, old_pos, new_pos):
@@ -1429,6 +1435,15 @@ func _process_pile_in(action: Dictionary) -> Dictionary:
 			"op": "set",
 			"path": "units.%s.models.%s.position" % [unit_id, model_id],
 			"value": {"x": new_pos.x, "y": new_pos.y}
+		})
+
+	# Apply pivots (new facings) for any non-circular bases that rotated
+	var rotations = _fight_rotations_from_action(action)
+	for model_id in rotations:
+		changes.append({
+			"op": "set",
+			"path": "units.%s.models.%s.rotation" % [unit_id, model_id],
+			"value": float(rotations[model_id])
 		})
 
 	emit_signal("pile_in_preview", unit_id, movements)
@@ -2812,6 +2827,15 @@ func _process_consolidate(action: Dictionary) -> Dictionary:
 			"value": {"x": new_pos.x, "y": new_pos.y}
 		})
 
+	# Apply pivots (new facings) for any non-circular bases that rotated
+	var consolidate_rotations = _fight_rotations_from_action(action)
+	for model_id in consolidate_rotations:
+		changes.append({
+			"op": "set",
+			"path": "units.%s.models.%s.rotation" % [unit_id, model_id],
+			"value": float(consolidate_rotations[model_id])
+		})
+
 	# Mark unit as having fought
 	changes.append({
 		"op": "set",
@@ -2917,6 +2941,14 @@ func _process_consolidate_step_11e(action: Dictionary) -> Dictionary:
 			"op": "set",
 			"path": "units.%s.models.%s.position" % [unit_id, model_id],
 			"value": {"x": new_pos.x, "y": new_pos.y}
+		})
+	# Apply pivots (new facings) for any non-circular bases that rotated
+	var consolidate_rotations = _fight_rotations_from_action(action)
+	for model_id in consolidate_rotations:
+		changes.append({
+			"op": "set",
+			"path": "units.%s.models.%s.rotation" % [unit_id, model_id],
+			"value": float(consolidate_rotations[model_id])
 		})
 	units_that_consolidated_11e[unit_id] = true
 
@@ -5964,6 +5996,47 @@ func _fight_movements_from_action(action: Dictionary) -> Dictionary:
 		movements["0"] = Vector2(position.get("x", 0), position.get("y", 0))
 	return movements
 
+func _fight_rotations_from_action(action: Dictionary) -> Dictionary:
+	# Normalise the rotation payload: a {model_key: float} dict of new facings
+	# (radians) for models that were pivoted during a pile-in / consolidate.
+	return action.get("rotations", {}).duplicate()
+
+func _fight_pivot_cost_for_model(unit: Dictionary, model: Dictionary) -> float:
+	# Cost in inches a pivot deducts from a model's 3" pile-in / consolidate move.
+	# Mirrors MovementPhase.get_pivot_value_for_unit but resolved per model so a
+	# mixed-base unit is handled correctly. All non-round bases cost 2" (Pariah
+	# Nexus); a round base >32mm with a flying stem costs 2" on a VEHICLE.
+	var keywords = unit.get("meta", {}).get("keywords", [])
+	if "AIRCRAFT" in keywords:
+		return 0.0
+	var base_type = model.get("base_type", "circular")
+	if base_type != "circular":
+		return 2.0
+	var base_mm = int(model.get("base_mm", 32))
+	if base_mm > 32 and model.get("flying_stem", false) and "VEHICLE" in keywords:
+		return 2.0
+	return 0.0
+
+func _fight_effective_move_cap(unit: Dictionary, model: Dictionary, rotations: Dictionary, key) -> float:
+	# The positional distance a model may move: 3" minus the pivot cost if the
+	# action pivots it (new facing differs from its current stored facing).
+	var cap := 3.0
+	var new_rot = _fight_rotation_for_key(rotations, key)
+	if new_rot != null:
+		var old_rot = float(model.get("rotation", 0.0))
+		if abs(float(new_rot) - old_rot) > 0.001:
+			cap -= _fight_pivot_cost_for_model(unit, model)
+	return max(0.0, cap)
+
+func _fight_rotation_for_key(rotations: Dictionary, key):
+	# Rotations may be keyed by array index ("0") or model id ("m1"), matching
+	# the movement payload. Return the new facing or null if this model unrotated.
+	if rotations.has(key):
+		return rotations[key]
+	if rotations.has(str(key)):
+		return rotations[str(key)]
+	return null
+
 func _resolve_fight_model(unit_id: String, key) -> Dictionary:
 	# A movement key may be an array index ("0") or a model id ("m1").
 	var models = get_unit(unit_id).get("models", [])
@@ -5983,9 +6056,11 @@ func _fight_model_index_for_key(models: Array, key) -> int:
 			return i
 	return -1
 
-func _simulate_fight_board_with_movements(unit_id: String, movements: Dictionary) -> Dictionary:
-	# Deep copy of live state with the proposed model positions applied —
-	# used to evaluate a template's AFTER conditions before committing.
+func _simulate_fight_board_with_movements(unit_id: String, movements: Dictionary, rotations: Dictionary = {}) -> Dictionary:
+	# Deep copy of live state with the proposed model positions (and pivot
+	# facings) applied — used to evaluate a template's AFTER conditions before
+	# committing. Rotation matters for non-circular bases whose engagement reach
+	# depends on their orientation.
 	var sim = GameState.state.duplicate(true)
 	var models = sim.get("units", {}).get(unit_id, {}).get("models", [])
 	for key in movements:
@@ -5993,6 +6068,11 @@ func _simulate_fight_board_with_movements(unit_id: String, movements: Dictionary
 		for i in models.size():
 			if str(i) == str(key) or str(models[i].get("id", "")) == str(key):
 				models[i]["position"] = {"x": np.x, "y": np.y}
+				break
+	for key in rotations:
+		for i in models.size():
+			if str(i) == str(key) or str(models[i].get("id", "")) == str(key):
+				models[i]["rotation"] = float(rotations[key])
 				break
 	return sim
 
@@ -6030,6 +6110,7 @@ func _validate_pile_in_11e(action: Dictionary) -> Dictionary:
 	var ctx = tmpl.before_moving(unit_id, GameState.state, null, {})
 	if ctx.has("error"):
 		return {"valid": false, "errors": [ctx.error]}
+	var rotations = _fight_rotations_from_action(action)
 	var errors: Array = []
 	for key in movements:
 		var old_pos = _get_model_position(unit_id, key)
@@ -6038,11 +6119,16 @@ func _validate_pile_in_11e(action: Dictionary) -> Dictionary:
 			errors.append("Model %s position not found" % str(key))
 			continue
 		var dist = Measurement.distance_inches(old_pos, new_pos)
-		if dist > 3.0 + MOVEMENT_CAP_EPSILON:
-			errors.append("Model %s pile in exceeds 3\" limit (%.1f\")" % [str(key), dist])
+		# A pivoted model spends part of its 3" on the pivot cost (Pariah Nexus).
+		var move_model = _resolve_fight_model(unit_id, key)
+		var cap = _fight_effective_move_cap(unit, move_model, rotations, key)
+		if dist > cap + MOVEMENT_CAP_EPSILON:
+			if cap < 3.0:
+				errors.append("Model %s pile in exceeds %.0f\" limit after pivot cost (%.1f\")" % [str(key), cap, dist])
+			else:
+				errors.append("Model %s pile in exceeds 3\" limit (%.1f\")" % [str(key), dist])
 		if dist > 0.01:
-			var model = _resolve_fight_model(unit_id, key)
-			var ok = tmpl.model_move_allowed(unit_id, model, {"x": new_pos.x, "y": new_pos.y}, GameState.state, ctx)
+			var ok = tmpl.model_move_allowed(unit_id, move_model, {"x": new_pos.x, "y": new_pos.y}, GameState.state, ctx)
 			if not ok.allowed:
 				errors.append("Model %s: %s" % [str(key), ok.reason])
 	var overlap_check = _validate_no_overlaps_for_movement(unit_id, movements)
@@ -6052,7 +6138,7 @@ func _validate_pile_in_11e(action: Dictionary) -> Dictionary:
 	if not coherency_check.get("valid", false):
 		errors.append_array(coherency_check.get("errors", []))
 	# 12.03 AFTER — engaged + started-engaged pairs maintained.
-	var sim = _simulate_fight_board_with_movements(unit_id, movements)
+	var sim = _simulate_fight_board_with_movements(unit_id, movements, rotations)
 	var after = tmpl.after_moving_conditions(unit_id, sim, ctx)
 	if not after.ok:
 		errors.append_array(after.violations)
@@ -6095,6 +6181,7 @@ func _validate_consolidate_11e(action: Dictionary) -> Dictionary:
 	var ctx = tmpl.before_moving(unit_id, GameState.state, null, {"mode": mode})
 	if ctx.has("error"):
 		return {"valid": false, "errors": [ctx.error]}
+	var rotations = _fight_rotations_from_action(action)
 	var errors: Array = []
 	for key in movements:
 		var old_pos = _get_model_position(unit_id, key)
@@ -6103,17 +6190,22 @@ func _validate_consolidate_11e(action: Dictionary) -> Dictionary:
 			errors.append("Model %s position not found" % str(key))
 			continue
 		var dist = Measurement.distance_inches(old_pos, new_pos)
-		if dist > 3.0 + MOVEMENT_CAP_EPSILON:
-			errors.append("Model %s consolidation exceeds 3\" limit (%.1f\")" % [str(key), dist])
+		# A pivoted model spends part of its 3" on the pivot cost (Pariah Nexus).
+		var move_model = _resolve_fight_model(unit_id, key)
+		var cap = _fight_effective_move_cap(unit, move_model, rotations, key)
+		if dist > cap + MOVEMENT_CAP_EPSILON:
+			if cap < 3.0:
+				errors.append("Model %s consolidation exceeds %.0f\" limit after pivot cost (%.1f\")" % [str(key), cap, dist])
+			else:
+				errors.append("Model %s consolidation exceeds 3\" limit (%.1f\")" % [str(key), dist])
 		if dist > 0.01:
-			var model = _resolve_fight_model(unit_id, key)
-			var ok = tmpl.model_move_allowed(unit_id, model, {"x": new_pos.x, "y": new_pos.y}, GameState.state, ctx)
+			var ok = tmpl.model_move_allowed(unit_id, move_model, {"x": new_pos.x, "y": new_pos.y}, GameState.state, ctx)
 			if not ok.allowed:
 				errors.append("Model %s: %s" % [str(key), ok.reason])
 	var overlap_check = _validate_no_overlaps_for_movement(unit_id, movements)
 	if not overlap_check.valid:
 		errors.append_array(overlap_check.errors)
-	var sim = _simulate_fight_board_with_movements(unit_id, movements)
+	var sim = _simulate_fight_board_with_movements(unit_id, movements, rotations)
 	var after = tmpl.after_moving_conditions(unit_id, sim, ctx)
 	if not after.ok:
 		errors.append_array(after.violations)

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -37,6 +37,21 @@ var drag_offset: Vector2 = Vector2.ZERO
 var drag_start_pos: Vector2 = Vector2.ZERO
 var locked_base_contact_models: Dictionary = {}  # T4-5: model_id -> true for models already in base contact
 
+# Model rotation during pile-in / consolidate. Mirrors the MovementController
+# pivot rules: only models on a non-circular base (or a round base >32mm with a
+# flying stem on a VEHICLE) may be pivoted about their centre, and the pivot
+# cost (2") counts against the model's 3" pile-in/consolidate move. Right-click
+# drag rotates (as in the movement phase); the rotate_left/rotate_right
+# keybinds nudge the last-touched model in 15° steps.
+var original_model_rotations: Dictionary = {}  # model_id -> float (radians)
+var current_model_rotations: Dictionary = {}   # model_id -> float (radians)
+var pile_in_rotating_model: bool = false
+var rotation_model_id: String = ""
+var rotation_start_angle: float = 0.0
+var rotation_model_start: float = 0.0
+var pile_in_last_touched_model: String = ""  # last model clicked/rotated (for keyboard pivots)
+const PILE_IN_MAX_INCHES: float = 3.0
+
 # UI References (board_view / hud_bottom / hud_right live in PhaseControllerBase)
 var movement_visual: Line2D
 var range_visual: Node2D
@@ -1806,7 +1821,9 @@ func _on_pile_in_confirmed(movements: Dictionary, unit_id: String) -> void:
 
 	# Convert model IDs from "m1" format to array indices "0" format for FightPhase
 	var converted_movements = {}
-	if not movements.is_empty() and current_phase:
+	var converted_rotations = {}
+	var rotations = get_pile_in_rotations()
+	if current_phase and (not movements.is_empty() or not rotations.is_empty()):
 		var unit = current_phase.get_unit(unit_id)
 		if unit:
 			var models = unit.get("models", [])
@@ -1817,8 +1834,13 @@ func _on_pile_in_confirmed(movements: Dictionary, unit_id: String) -> void:
 						converted_movements[str(i)] = movements[model_id]
 						print("[FightController] Converted ", model_id, " to index ", i)
 						break
+			for model_id in rotations:
+				for i in range(models.size()):
+					if models[i].get("id", "") == model_id:
+						converted_rotations[str(i)] = rotations[model_id]
+						break
 
-	print("[FightController] Converted movements: ", converted_movements)
+	print("[FightController] Converted movements: ", converted_movements, " rotations: ", converted_rotations)
 
 	# current_fighter_owner can be stale (-1) on re-request paths — the
 	# unit's owner is always the right submitting player for PILE_IN
@@ -1830,6 +1852,7 @@ func _on_pile_in_confirmed(movements: Dictionary, unit_id: String) -> void:
 		"type": "PILE_IN",
 		"unit_id": unit_id,
 		"movements": converted_movements,
+		"rotations": converted_rotations,
 		"player": pile_in_player
 	}
 	emit_signal("fight_action_requested", action)
@@ -2012,7 +2035,9 @@ func _on_consolidate_confirmed(movements: Dictionary, unit_id: String) -> void:
 
 	# Convert model IDs from "m1" format to array indices "0" format for FightPhase
 	var converted_movements = {}
-	if not movements.is_empty() and current_phase:
+	var converted_rotations = {}
+	var rotations = get_pile_in_rotations()
+	if current_phase and (not movements.is_empty() or not rotations.is_empty()):
 		var unit = current_phase.get_unit(unit_id)
 		if unit:
 			var models = unit.get("models", [])
@@ -2023,8 +2048,13 @@ func _on_consolidate_confirmed(movements: Dictionary, unit_id: String) -> void:
 						converted_movements[str(i)] = movements[model_id]
 						print("[FightController] Converted ", model_id, " to index ", i)
 						break
+			for model_id in rotations:
+				for i in range(models.size()):
+					if models[i].get("id", "") == model_id:
+						converted_rotations[str(i)] = rotations[model_id]
+						break
 
-	print("[FightController] Converted movements: ", converted_movements)
+	print("[FightController] Converted movements: ", converted_movements, " rotations: ", converted_rotations)
 
 	# current_fighter_owner can be stale (-1) on re-request paths — the
 	# unit's owner is always the right submitting player for CONSOLIDATE
@@ -2036,6 +2066,7 @@ func _on_consolidate_confirmed(movements: Dictionary, unit_id: String) -> void:
 		"type": "CONSOLIDATE",
 		"unit_id": unit_id,
 		"movements": converted_movements,
+		"rotations": converted_rotations,
 		"player": action_player
 	}
 	emit_signal("fight_action_requested", action)
@@ -2253,7 +2284,10 @@ func _enable_pile_in_mode(unit_id: String, dialog: Node) -> void:
 
 	original_model_positions.clear()
 	current_model_positions.clear()
+	original_model_rotations.clear()
+	current_model_rotations.clear()
 	locked_base_contact_models.clear()
+	pile_in_last_touched_model = ""
 
 	var models = unit.get("models", [])
 	for i in range(models.size()):
@@ -2266,6 +2300,10 @@ func _enable_pile_in_mode(unit_id: String, dialog: Node) -> void:
 		var model_id = model.get("id", "m%d" % (i+1))
 		original_model_positions[model_id] = pos
 		current_model_positions[model_id] = pos
+		# Seed rotation state so pivots measure against the model's starting facing
+		var rot = float(model.get("rotation", 0.0))
+		original_model_rotations[model_id] = rot
+		current_model_rotations[model_id] = rot
 		print("[FightController] Stored position for model ", model_id, " at ", pos)
 
 	# T4-5: Detect models already in base contact with an enemy and lock them
@@ -2330,9 +2368,14 @@ func _disable_pile_in_mode() -> void:
 	pile_in_dialog_ref = null
 	original_model_positions.clear()
 	current_model_positions.clear()
+	original_model_rotations.clear()
+	current_model_rotations.clear()
 	locked_base_contact_models.clear()
 	dragging_model = null
 	drag_model_id = ""
+	pile_in_rotating_model = false
+	rotation_model_id = ""
+	pile_in_last_touched_model = ""
 
 	# Clean up visual indicators
 	_clear_pile_in_visuals()
@@ -2602,21 +2645,23 @@ func get_pile_in_movements() -> Dictionary:
 	return movements
 
 func reset_pile_in_movements() -> void:
-	"""Reset all model positions to original"""
+	"""Reset all model positions AND facings to original"""
 	print("[FightController] reset_pile_in_movements called - STACK TRACE:")
 	print_stack()
 
 	for model_id in original_model_positions:
 		current_model_positions[model_id] = original_model_positions[model_id]
+	for model_id in original_model_rotations:
+		current_model_rotations[model_id] = original_model_rotations[model_id]
 
-	# Move visual models back to original positions
+	# Move visual models back to original positions and facings
 	_apply_model_positions_to_scene()
 	_update_pile_in_visuals()
 
 	print("[FightController] Pile-in movements reset")
 
 func _apply_model_positions_to_scene() -> void:
-	"""Apply current_model_positions to the actual model tokens in the scene"""
+	"""Apply current_model_positions (and rotations) to the actual tokens in the scene"""
 	if pile_in_unit_id == "":
 		return
 
@@ -2625,13 +2670,16 @@ func _apply_model_positions_to_scene() -> void:
 	if not token_layer:
 		return
 
-	# Update each model token's position
+	# Update each model token's position and facing
 	for model_id in current_model_positions:
 		# Find the token with matching metadata
 		for token in token_layer.get_children():
 			if token.has_meta("unit_id") and token.has_meta("model_id"):
 				if token.get_meta("unit_id") == pile_in_unit_id and token.get_meta("model_id") == model_id:
 					token.position = current_model_positions[model_id]
+					if current_model_rotations.has(model_id) and "model_data" in token and token.model_data is Dictionary:
+						token.model_data["rotation"] = current_model_rotations[model_id]
+						token.queue_redraw()
 					break
 
 # T-093: Compute snap-to-base-contact target for the dragging model. Returns
@@ -2707,10 +2755,27 @@ func _handle_pile_in_input(event: InputEvent) -> void:
 			# End dragging
 			print("[FightController] Mouse up")
 			_end_model_drag_pile_in()
+	elif event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT:
+		# Right-click for pivoting (mirrors the movement phase rotation UX)
+		var mouse_pos = board_root.get_local_mouse_position()
+		if event.pressed:
+			_start_model_rotation_pile_in(mouse_pos)
+		elif pile_in_rotating_model:
+			_end_model_rotation_pile_in()
+	elif event is InputEventMouseMotion and pile_in_rotating_model:
+		# Update rotation
+		var mouse_pos = board_root.get_local_mouse_position()
+		_update_model_rotation_pile_in(mouse_pos)
 	elif event is InputEventMouseMotion and dragging_model:
 		# Update drag
 		var mouse_pos = board_root.get_local_mouse_position()
 		_update_model_drag_pile_in(mouse_pos)
+	elif event is InputEventKey and event.pressed:
+		# Keyboard pivot of the last-touched model (15° per press)
+		if KeybindingManager.matches_action(event, "rotate_left"):
+			_rotate_pile_in_model_by_angle(-PI / 12.0)
+		elif KeybindingManager.matches_action(event, "rotate_right"):
+			_rotate_pile_in_model_by_angle(PI / 12.0)
 
 func _start_model_drag_pile_in(mouse_pos: Vector2) -> void:
 	"""Start dragging a model during pile-in"""
@@ -2757,6 +2822,7 @@ func _start_model_drag_pile_in(mouse_pos: Vector2) -> void:
 						drag_model_id = model_id
 						drag_start_pos = model_pos
 						drag_offset = model_pos - mouse_pos
+						pile_in_last_touched_model = model_id
 
 						print("[FightController] Started dragging model token ", model_id)
 						return
@@ -2897,18 +2963,22 @@ func _end_model_drag_pile_in() -> void:
 
 		# If not reverted, check distance limits
 		if not reverted:
-			# Check if movement exceeds 3" (with floating-point tolerance)
-			if distance > 3.0 + 0.02:
-				# Snap back to maximum 3" distance in the same direction
+			# A pivoted model spends part of its 3" budget on the pivot cost, so
+			# the positional move is capped at (3" − pivot cost). See
+			# _effective_pile_in_cap_inches().
+			var effective_cap = _effective_pile_in_cap_inches(drag_model_id)
+			# Check if movement exceeds the effective cap (with float tolerance)
+			if distance > effective_cap + 0.02:
+				# Snap back to the maximum allowed distance in the same direction
 				var direction = (final_pos - original_pos).normalized()
-				var max_distance_px = Measurement.inches_to_px(3.0)
+				var max_distance_px = Measurement.inches_to_px(effective_cap)
 				var clamped_pos = original_pos + direction * max_distance_px
 				current_model_positions[drag_model_id] = clamped_pos
 
 				if dragging_model:
 					dragging_model.position = clamped_pos
 
-				print("[FightController] Clamped movement to 3\" limit")
+				print("[FightController] Clamped movement to %.1f\" limit (pivot-aware)" % effective_cap)
 
 	# P3-101: Send final corrected position to remote player after revert/clamp
 	# Without this, the remote player's last drag preview shows the pre-revert position
@@ -2934,6 +3004,209 @@ func _end_model_drag_pile_in() -> void:
 	# Update dialog
 	if pile_in_dialog_ref and pile_in_dialog_ref.has_method("update_movements"):
 		pile_in_dialog_ref.update_movements(get_pile_in_movements())
+
+# ============================================================================
+# PILE-IN / CONSOLIDATE MODEL ROTATION (pivoting)
+# ============================================================================
+# Models on non-circular bases (e.g. bikes on oval bases) may be pivoted about
+# their centre during a pile-in / consolidate move, exactly as they can in the
+# movement phase. The pivot cost (2") is deducted from the model's 3" move — see
+# _effective_pile_in_cap_inches().
+
+func _model_can_pivot(model: Dictionary) -> bool:
+	"""Mirror of MovementController's rotation gate: only non-circular bases (or a
+	round base >32mm with a flying stem on a VEHICLE) can be pivoted."""
+	if model.is_empty():
+		return false
+	var base_type = model.get("base_type", "circular")
+	if base_type != "circular":
+		return true
+	# Round base >32mm with a flying stem — VEHICLE only (mirrors pivot value rules)
+	var base_mm = int(model.get("base_mm", 32))
+	var has_flying_stem = model.get("flying_stem", false)
+	if base_mm > 32 and has_flying_stem:
+		var unit = current_phase.get_unit(pile_in_unit_id) if current_phase else {}
+		var keywords = unit.get("meta", {}).get("keywords", [])
+		if "VEHICLE" in keywords:
+			return true
+	return false
+
+func _pivot_cost_inches(model: Dictionary) -> float:
+	"""Cost in inches a pivot deducts from the 3" move. All non-round bases (and
+	eligible round >32mm flying-stem VEHICLE bases) cost 2" per Pariah Nexus."""
+	return 2.0 if _model_can_pivot(model) else 0.0
+
+func _find_pile_in_model(model_id: String) -> Dictionary:
+	"""Look up a model dict in the piling-in unit by id."""
+	if not current_phase or pile_in_unit_id == "":
+		return {}
+	var unit = current_phase.get_unit(pile_in_unit_id)
+	for m in unit.get("models", []):
+		if m.get("id", "") == model_id:
+			return m
+	return {}
+
+func _is_model_pivoted(model_id: String) -> bool:
+	"""True if the model's rotation has changed from its start-of-move facing."""
+	if not current_model_rotations.has(model_id):
+		return false
+	var start = original_model_rotations.get(model_id, 0.0)
+	return abs(current_model_rotations[model_id] - start) > 0.001
+
+func _effective_pile_in_cap_inches(model_id: String) -> float:
+	"""The positional distance a model may still move: 3" minus the pivot cost if
+	it has been pivoted this move."""
+	if _is_model_pivoted(model_id):
+		var model = _find_pile_in_model(model_id)
+		return max(0.0, PILE_IN_MAX_INCHES - _pivot_cost_inches(model))
+	return PILE_IN_MAX_INCHES
+
+func _model_id_at_pos(mouse_pos: Vector2) -> String:
+	"""Return the id of the (unlocked) model nearest the cursor within its base
+	(plus a small grab margin), or "" if none. The hit radius scales with the
+	model's base so large oval/rectangular vehicles are grabbable."""
+	var best_id := ""
+	var best_dist := INF
+	for model_id in current_model_positions:
+		if model_id in locked_base_contact_models:
+			continue
+		var d = mouse_pos.distance_to(current_model_positions[model_id])
+		var model = _find_pile_in_model(model_id)
+		var hit_radius = max(50.0, Measurement.base_radius_px(int(model.get("base_mm", 32))) + 20.0)
+		if d <= hit_radius and d < best_dist:
+			best_dist = d
+			best_id = model_id
+	return best_id
+
+func _start_model_rotation_pile_in(mouse_pos: Vector2) -> void:
+	"""Begin pivoting the model under the cursor (right-click)."""
+	if pile_in_unit_id == "":
+		return
+	var model_id = _model_id_at_pos(mouse_pos)
+	if model_id == "":
+		return
+	var model = _find_pile_in_model(model_id)
+	if not _model_can_pivot(model):
+		print("[FightController] Model %s has a circular base — no pivot needed" % model_id)
+		return
+
+	pile_in_rotating_model = true
+	rotation_model_id = model_id
+	pile_in_last_touched_model = model_id
+	var model_pos = current_model_positions.get(model_id, Vector2.ZERO)
+	rotation_start_angle = (mouse_pos - model_pos).angle()
+	rotation_model_start = current_model_rotations.get(model_id, 0.0)
+	print("[FightController] Started pivoting model %s (base_type=%s)" % [model_id, model.get("base_type", "circular")])
+
+func _update_model_rotation_pile_in(mouse_pos: Vector2) -> void:
+	"""Track the cursor while pivoting — rotate about the model's centre."""
+	if not pile_in_rotating_model or rotation_model_id == "":
+		return
+	var model_pos = current_model_positions.get(rotation_model_id, Vector2.ZERO)
+	var current_angle = (mouse_pos - model_pos).angle()
+	var new_rotation = rotation_model_start + (current_angle - rotation_start_angle)
+	_apply_pile_in_rotation(rotation_model_id, new_rotation)
+
+func _end_model_rotation_pile_in() -> void:
+	"""Finish a pivot: settle budget/overlap and refresh the dialog."""
+	if not pile_in_rotating_model:
+		return
+	var model_id = rotation_model_id
+	pile_in_rotating_model = false
+	rotation_model_id = ""
+
+	# Pivoting consumes budget, so an already-moved model may now exceed its
+	# (3" − pivot cost) allowance. Pull the position back along the move line so
+	# the state stays legal, exactly as the movement phase reduces the move cap.
+	_enforce_effective_cap_after_pivot(model_id)
+
+	# An oval base can swing into a neighbour without its centre moving; if the
+	# pivot causes an overlap, revert the rotation.
+	if _check_model_overlaps(model_id, current_model_positions.get(model_id, Vector2.ZERO)):
+		print("[FightController] Pivot causes overlap — reverting rotation for %s" % model_id)
+		_apply_pile_in_rotation(model_id, original_model_rotations.get(model_id, 0.0))
+
+	print("[FightController] Ended pivot for %s — rotation %.2f rad" % [model_id, current_model_rotations.get(model_id, 0.0)])
+	_update_pile_in_visuals()
+	if pile_in_dialog_ref and pile_in_dialog_ref.has_method("update_movements"):
+		pile_in_dialog_ref.update_movements(get_pile_in_movements())
+	if pile_in_dialog_ref and pile_in_dialog_ref.has_method("update_rotations"):
+		pile_in_dialog_ref.update_rotations(get_pile_in_rotations())
+
+func _rotate_pile_in_model_by_angle(angle: float) -> void:
+	"""Keyboard pivot: nudge the last-touched model by `angle` radians."""
+	if pile_in_unit_id == "":
+		return
+	var model_id = pile_in_last_touched_model
+	if model_id == "" or model_id in locked_base_contact_models:
+		return
+	var model = _find_pile_in_model(model_id)
+	if not _model_can_pivot(model):
+		return
+	var new_rotation = current_model_rotations.get(model_id, 0.0) + angle
+	_apply_pile_in_rotation(model_id, new_rotation)
+	_enforce_effective_cap_after_pivot(model_id)
+	if _check_model_overlaps(model_id, current_model_positions.get(model_id, Vector2.ZERO)):
+		_apply_pile_in_rotation(model_id, current_model_rotations.get(model_id, 0.0) - angle)
+	_update_pile_in_visuals()
+	if pile_in_dialog_ref and pile_in_dialog_ref.has_method("update_movements"):
+		pile_in_dialog_ref.update_movements(get_pile_in_movements())
+	if pile_in_dialog_ref and pile_in_dialog_ref.has_method("update_rotations"):
+		pile_in_dialog_ref.update_rotations(get_pile_in_rotations())
+
+func _enforce_effective_cap_after_pivot(model_id: String) -> void:
+	"""After a pivot reduces the budget, clamp the model's position so its move
+	distance still fits within (3" − pivot cost)."""
+	var original_pos = original_model_positions.get(model_id, Vector2.ZERO)
+	var current_pos = current_model_positions.get(model_id, original_pos)
+	var distance = Measurement.distance_inches(original_pos, current_pos)
+	var cap = _effective_pile_in_cap_inches(model_id)
+	if distance > cap + 0.02:
+		var direction = (current_pos - original_pos).normalized()
+		var clamped = original_pos + direction * Measurement.inches_to_px(cap)
+		current_model_positions[model_id] = clamped
+		_apply_single_model_position_to_scene(model_id, clamped)
+		print("[FightController] Pivot cost clamped %s move to %.1f\"" % [model_id, cap])
+
+func _apply_pile_in_rotation(model_id: String, new_rotation: float) -> void:
+	"""Store the new facing and redraw the model's token immediately. Mirrors
+	MovementController._update_model_token_visual so the token re-renders the
+	rotated base exactly as it does in the movement phase."""
+	current_model_rotations[model_id] = new_rotation
+
+	var token_layer = SceneRefs.token_layer()
+	if not token_layer:
+		return
+	for token in token_layer.get_children():
+		if token.has_meta("unit_id") and token.has_meta("model_id"):
+			if token.get_meta("unit_id") == pile_in_unit_id and token.get_meta("model_id") == model_id:
+				if "model_data" in token and token.model_data is Dictionary:
+					token.model_data["rotation"] = new_rotation
+					# Rebuild base_shape + redraw the same way the movement phase does
+					if token.has_method("set_model_data"):
+						token.set_model_data(token.model_data)
+				token.queue_redraw()
+				break
+
+func _apply_single_model_position_to_scene(model_id: String, pos: Vector2) -> void:
+	"""Move one model's token to `pos` (used when the pivot clamp adjusts it)."""
+	var token_layer = SceneRefs.token_layer()
+	if not token_layer:
+		return
+	for token in token_layer.get_children():
+		if token.has_meta("unit_id") and token.has_meta("model_id"):
+			if token.get_meta("unit_id") == pile_in_unit_id and token.get_meta("model_id") == model_id:
+				token.position = pos
+				break
+
+func get_pile_in_rotations() -> Dictionary:
+	"""Return {model_id: rotation} for every model whose facing changed."""
+	var rotations = {}
+	for model_id in current_model_rotations:
+		var start = original_model_rotations.get(model_id, 0.0)
+		if abs(current_model_rotations[model_id] - start) > 0.001:
+			rotations[model_id] = current_model_rotations[model_id]
+	return rotations
 
 func _enable_consolidate_mode(unit_id: String, dialog: Node) -> void:
 	"""Enable interactive consolidate mode (uses same system as pile-in)"""
@@ -2980,9 +3253,13 @@ func _check_model_overlaps(moving_model_id: String, new_pos: Vector2) -> bool:
 	if not moving_model:
 		return false
 
-	# Create a temporary model dict with the new position for overlap checking
+	# Create a temporary model dict with the new position (and live pivot facing)
+	# for overlap checking. Rotation matters for non-circular bases: an oval base
+	# can swing into a neighbour even when its centre stays put.
 	var check_model = moving_model.duplicate()
 	check_model["position"] = new_pos
+	if current_model_rotations.has(moving_model_id):
+		check_model["rotation"] = current_model_rotations[moving_model_id]
 
 	# Check against all other models in all units
 	var all_units = current_phase.game_state_snapshot.get("units", {})
@@ -3011,6 +3288,8 @@ func _check_model_overlaps(moving_model_id: String, new_pos: Vector2) -> bool:
 				var other_id = other_model.get("id", "")
 				if other_id in current_model_positions:
 					other_model_check["position"] = current_model_positions[other_id]
+				if other_id in current_model_rotations:
+					other_model_check["rotation"] = current_model_rotations[other_id]
 
 			# Check for overlap using Measurement system
 			if Measurement.models_overlap(check_model, other_model_check):

--- a/40k/tests/scenarios/sp/pile_in_model_rotation.json
+++ b/40k/tests/scenarios/sp/pile_in_model_rotation.json
@@ -1,0 +1,45 @@
+{
+  "id": "pile_in_model_rotation",
+  "covers": [
+    "fight.pile_in.model_rotation",
+    "scripts.FightController.pile_in_rotation",
+    "phases.FightPhase.pile_in_pivot_cost"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Models on non-circular bases can be pivoted about their centre during a pile-in, exactly as in the movement phase. Drives the real FightController rotation path on the oval-based Caladius Grav-tank: enters pile-in mode, runs the right-click-drag rotation entry points, and asserts (a) the pivot is allowed only for non-circular bases (oval Caladius yes, round-base Boyz no), (b) the new facing lands in the token's model_data AND the get_pile_in_rotations() submission payload, (c) the 2\" pivot cost is deducted from the 3\" pile-in move so the effective positional cap becomes 1\", and (d) the FightPhase validator rejects a 2\" move+pivot that exceeds the reduced cap. Regression for the feature that lets bikes/vehicles turn to face when piling in.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().pile_in_step_11e", "equals": 1 },
+
+    { "act": "execute_script", "script": "main.fight_controller._enable_pile_in_mode(\"U_CALADIUS_GRAV-TANK_E\", null)" },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_active", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller._find_pile_in_model(\"m1\").get(\"base_type\")", "equals": "oval" },
+    { "act": "execute_script", "script": "main.fight_controller._model_can_pivot(main.fight_controller._find_pile_in_model(\"m1\"))", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller._pivot_cost_inches(main.fight_controller._find_pile_in_model(\"m1\"))", "equals": 2.0 },
+
+    { "act": "execute_script", "script": "main.fight_controller._model_can_pivot(GameState.get_unit(\"U_BOYZ_K\").models[0])", "equals": false },
+
+    { "act": "screenshot", "label": "01_pile_in_oval_before_pivot" },
+
+    { "act": "execute_script", "script": "main.fight_controller._start_model_rotation_pile_in(main.fight_controller.current_model_positions[\"m1\"] + Vector2(130, 0))" },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_rotating_model", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller._update_model_rotation_pile_in(main.fight_controller.current_model_positions[\"m1\"] + Vector2(30, 140))" },
+    { "act": "execute_script", "script": "main.fight_controller._end_model_rotation_pile_in()" },
+
+    { "act": "execute_script", "script": "main.fight_controller.get_pile_in_rotations().has(\"m1\")", "equals": true },
+    { "act": "execute_script", "script": "abs(main.fight_controller.current_model_rotations[\"m1\"] - (-0.5236)) > 0.5", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller._is_model_pivoted(\"m1\")", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller._effective_pile_in_cap_inches(\"m1\")", "expect_min": 0.99 },
+    { "act": "execute_script", "script": "main.fight_controller._effective_pile_in_cap_inches(\"m1\")", "expect_max": 1.01 },
+
+    { "act": "wait_frames", "frames": 6 },
+    { "act": "screenshot", "label": "02_pile_in_oval_after_pivot" },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().validate_action({\"type\":\"PILE_IN\",\"unit_id\":\"U_CALADIUS_GRAV-TANK_E\",\"movements\":{\"m1\": main.fight_controller.original_model_positions[\"m1\"] + Vector2(Measurement.inches_to_px(2.0), 0)},\"rotations\":{\"m1\": main.fight_controller.current_model_rotations[\"m1\"]}}).get(\"valid\")", "equals": false }
+  ]
+}

--- a/40k/tests/test_pile_in_pivot_rotation.gd
+++ b/40k/tests/test_pile_in_pivot_rotation.gd
@@ -1,0 +1,96 @@
+extends SceneTree
+
+# Unit tests for the pile-in / consolidate MODEL PIVOT logic added so models on
+# non-circular bases (bikes, vehicles) can rotate about their centre while
+# piling in — mirroring the movement phase, with the pivot cost counted against
+# the 3" move.
+#
+# Covers the pure-state helpers on FightPhase:
+#   • _fight_pivot_cost_for_model — 2" for any non-round base (or round >32mm
+#     flying-stem VEHICLE); 0" otherwise / for AIRCRAFT.
+#   • _fight_effective_move_cap — 3" normally, 3"−pivot when the action rotates
+#     the model past its stored facing.
+#   • _fight_rotations_from_action — normalises the rotations payload.
+#   • _fight_rotation_for_key — resolves index or model-id keys.
+#
+# Usage: godot --headless --path . -s tests/test_pile_in_pivot_rotation.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _unit(keywords: Array) -> Dictionary:
+	return {"meta": {"keywords": keywords}}
+
+func _model(base_type: String, base_mm: int = 60, flying_stem: bool = false) -> Dictionary:
+	var m := {"id": "m1", "alive": true, "base_mm": base_mm, "position": {"x": 0, "y": 0}, "rotation": 0.0}
+	if base_type != "circular":
+		m["base_type"] = base_type
+	if flying_stem:
+		m["flying_stem"] = true
+	return m
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_pile_in_pivot_rotation ===\n")
+	var fp = load("res://phases/FightPhase.gd").new()
+
+	# --- Pivot cost by base type (Pariah Nexus: all non-round bases cost 2") ---
+	var vehicle = _unit(["VEHICLE"])
+	_check("oval base costs 2\"",
+		fp._fight_pivot_cost_for_model(vehicle, _model("oval", 170)) == 2.0)
+	_check("rectangular base costs 2\"",
+		fp._fight_pivot_cost_for_model(vehicle, _model("rectangular", 180)) == 2.0)
+	_check("standard round base costs 0\"",
+		fp._fight_pivot_cost_for_model(_unit(["INFANTRY"]), _model("circular", 32)) == 0.0)
+	_check("round base >32mm WITHOUT flying stem costs 0\"",
+		fp._fight_pivot_cost_for_model(vehicle, _model("circular", 60)) == 0.0)
+	_check("round base >32mm WITH flying stem on VEHICLE costs 2\"",
+		fp._fight_pivot_cost_for_model(vehicle, _model("circular", 60, true)) == 2.0)
+	_check("round flying-stem base on non-VEHICLE costs 0\"",
+		fp._fight_pivot_cost_for_model(_unit(["INFANTRY"]), _model("circular", 60, true)) == 0.0)
+	_check("AIRCRAFT never pays a pivot cost",
+		fp._fight_pivot_cost_for_model(_unit(["AIRCRAFT", "VEHICLE"]), _model("oval", 170)) == 0.0)
+
+	# --- Effective move cap: pivot cost is deducted only when the model rotates ---
+	var oval := _model("oval", 170)   # stored rotation 0.0
+	# Rotation entry that differs from the stored facing -> pivoted -> cap 1"
+	_check("rotated oval: cap = 3\" - 2\" = 1\"",
+		abs(fp._fight_effective_move_cap(vehicle, oval, {"m1": 1.2}, "m1") - 1.0) < 0.001)
+	# Rotation entry equal to the stored facing -> not pivoted -> full 3"
+	_check("un-rotated (same facing) oval: cap stays 3\"",
+		abs(fp._fight_effective_move_cap(vehicle, oval, {"m1": 0.0}, "m1") - 3.0) < 0.001)
+	# No rotation entry at all -> full 3"
+	_check("no rotation payload: cap stays 3\"",
+		abs(fp._fight_effective_move_cap(vehicle, oval, {}, "m1") - 3.0) < 0.001)
+	# A pivoting round base has 0 cost, so its cap stays 3" even when rotated
+	_check("rotated round base: cap stays 3\" (0 pivot cost)",
+		abs(fp._fight_effective_move_cap(_unit(["INFANTRY"]), _model("circular", 32), {"m1": 1.0}, "m1") - 3.0) < 0.001)
+
+	# --- Rotation payload plumbing ---
+	var act := {"type": "PILE_IN", "unit_id": "U", "rotations": {"0": 0.7, "m2": -0.3}}
+	var rots = fp._fight_rotations_from_action(act)
+	_check("rotations extracted from action", rots.size() == 2 and rots.get("0") == 0.7)
+	_check("rotation_for_key resolves index key", fp._fight_rotation_for_key(rots, "0") == 0.7)
+	_check("rotation_for_key resolves model-id key", fp._fight_rotation_for_key(rots, "m2") == -0.3)
+	_check("rotation_for_key returns null for unrotated model",
+		fp._fight_rotation_for_key(rots, "m9") == null)
+	_check("empty action yields empty rotations",
+		fp._fight_rotations_from_action({"type": "PILE_IN"}).is_empty())
+
+	_finish()
+
+func _finish():
+	print("\n=== %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)


### PR DESCRIPTION
## Summary

Models on **non-circular bases** — bikes on oval bases, vehicles like the Caladius Grav-tank, a rectangular Battlewagon — can now be **pivoted about their centre while piling in**, mirroring the Movement-phase rotation the game already supports. The same base-type restrictions apply, and the pivot cost is counted against the model's 3" pile-in move (so a model that turns can only shuffle ~1" of ground). Standard round infantry bases don't need to pivot and are unaffected. Rotation works the same way in the end-of-phase Consolidate step.

## Changes

**`FightController.gd`**
- Right-click-drag (matching the Movement phase) and the **Q/E** rotate keybinds pivot the model under the cursor during pile-in / consolidate.
- Only turnable bases can pivot: any non-round base, or a round base >32 mm on a flying stem for a `VEHICLE`. The hit test scales with base size so large ovals/rectangles are grabbable.
- The 2" pivot cost is deducted from the 3" move (effective cap → 1"); an over-budget move+pivot is clamped/rejected, and a pivot that would overlap a neighbour is reverted. Token re-renders via `set_model_data` — the same path the Movement phase uses. Reset restores original facings.
- Rotations are threaded through the `PILE_IN` / `CONSOLIDATE` actions as an index-keyed `{model: radians}` payload alongside movements, and surfaced to the Pile-In / Consolidate dialogs for client-side validation.

**`FightPhase.gd`**
- New per-model pivot-cost helpers deduct 2" for non-round bases (or a round >32 mm flying-stem `VEHICLE`; `AIRCRAFT` never pay) and reduce the effective pile-in / consolidate cap in both the 11e and legacy validators (pile-in and consolidate).
- The process handlers persist the new facings to `GameState`, and the AFTER-condition simulation applies rotations so engagement reach for a non-circular base reflects its new orientation.

## Testing

- **Headless** `tests/test_pile_in_pivot_rotation.gd` — 16/16 pass (pivot cost by base type, effective-cap math, payload plumbing).
- **Windowed** `tests/scenarios/sp/pile_in_model_rotation.json` via the ScenarioRunner — **22/22 pass**: drives the real `FightController` rotation path on the oval Caladius end-to-end (oval pivots, round-base Boyz cannot, the facing lands in `model_data` + the submission payload, the cap drops to 1", and the validator rejects a 2" move+pivot).
- **No regressions**: `test_pile_in_overlap_model_id_keys` (14/14) and `test_global_pile_in_11e` (28/28) still pass. The 2 pre-existing `iss066` failures were verified identical on the base branch (not caused by this change).

A `version_history.json` entry (0.44.0) documents the player-facing change.

> Note on visuals: in the headless/xvfb + llvmpipe CI container the board render freezes between screenshot captures (a throttling limitation the capture handler warns about), so a screenshot can't visibly show the token turning. The rotation is proven applied via state assertions + base-geometry checks, and it renders through the same shared `TokenVisual` path the Movement phase uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jpAiHGd5whe7T5eVyCJYi

---
_Generated by [Claude Code](https://claude.ai/code/session_012jpAiHGd5whe7T5eVyCJYi)_