### PR TITLE
Tighten base-to-base contact tolerance from 0.25" to 0.1"

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -10152,7 +10152,7 @@ static func _are_units_in_engagement_range_rules(unit1: Dictionary, unit2: Dicti
 # 2. In base-to-base contact with a friendly model that is itself in
 #    base-to-base contact with an enemy model.
 # Returns an array of model indices (int) that are eligible to fight.
-const BASE_CONTACT_TOLERANCE_INCHES: float = 0.25  # Generous tolerance for digital positioning
+const BASE_CONTACT_TOLERANCE_INCHES: float = 0.1  # Tolerance for digital positioning (was 0.25 — too generous, see #base-contact-buffer-sizing)
 
 static func get_eligible_melee_model_indices(attacker_unit: Dictionary, board: Dictionary) -> Array:
 	var eligible_indices = []

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.44.3",
+			"date": "2026-07-14",
+			"summary": "Tightened the base-to-base contact tolerance during Pile In / Consolidate — the game was treating models up to a quarter-inch apart as already touching, locking them from moving even with a clearly visible gap on the board.",
+			"changes": [
+				"The 'model is already in base contact and cannot move' lock (the B2B icon during Pile In) now only triggers within 0.1\" of true base contact, down from 0.25\" — matches what the tabletop actually looks like instead of locking models with a visible gap.",
+				"Applied consistently everywhere base contact is judged: the Pile In/Consolidate move lock, the melee fight-eligibility base-contact chain, and the AI's own pile-in/consolidate movement logic."
+			]
+		},
+		{
 			"version": "0.44.2",
 			"date": "2026-07-14",
 			"summary": "Fixed Charge-phase model rotation not showing up on the actual unit token — only the green drag ghost was turning.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -3449,7 +3449,7 @@ func _find_closest_enemy_position(unit_id: String, from_pos: Vector2) -> Vector2
 
 	return closest_pos
 
-const BASE_CONTACT_TOLERANCE_INCHES: float = 0.25  # Match RulesEngine tolerance for digital positioning
+const BASE_CONTACT_TOLERANCE_INCHES: float = 0.1  # Match RulesEngine tolerance for digital positioning (was 0.25 — too generous)
 
 func _is_model_in_base_contact_with_enemy(unit_id: String, model_id: String) -> bool:
 	"""T4-5: Check if a model is currently in base-to-base contact with any enemy model.

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -14528,7 +14528,7 @@ static func _compute_pile_in_movements(snapshot: Dictionary, unit_id: String, un
 	var enemy_obstacles = obstacle_split.enemy
 
 	var pile_in_range_px = 3.0 * PIXELS_PER_INCH  # 3" in pixels
-	var base_contact_threshold_px = 0.25 * PIXELS_PER_INCH  # Match FightPhase tolerance (0.25")
+	var base_contact_threshold_px = 0.1 * PIXELS_PER_INCH  # Match FightPhase tolerance (0.1")
 
 	# Track placed positions to avoid intra-unit collisions
 	var placed_positions = []
@@ -14936,7 +14936,7 @@ static func _compute_consolidate_movements_engagement(snapshot: Dictionary, unit
 	var enemy_obstacles = obstacle_split.enemy
 
 	var consolidate_range_px = 3.0 * PIXELS_PER_INCH
-	var base_contact_threshold_px = 0.25 * PIXELS_PER_INCH
+	var base_contact_threshold_px = 0.1 * PIXELS_PER_INCH  # Match FightPhase tolerance (0.1")
 
 	# Track placed positions
 	var placed_positions = []

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -2235,7 +2235,7 @@ func _detect_locked_base_contact_models(unit: Dictionary) -> void:
 	var models = unit.get("models", [])
 	var all_units = current_phase.game_state_snapshot.get("units", {})
 	var unit_owner = unit.get("owner", 0)
-	const B2B_TOLERANCE: float = 0.25  # Match BASE_CONTACT_TOLERANCE_INCHES
+	const B2B_TOLERANCE: float = 0.1  # Match BASE_CONTACT_TOLERANCE_INCHES (was 0.25 — too generous)
 
 	for i in range(models.size()):
 		var model = models[i]

--- a/40k/tests/test_pile_in_overlap_model_id_keys.gd
+++ b/40k/tests/test_pile_in_overlap_model_id_keys.gd
@@ -65,12 +65,12 @@ func _run_tests():
 		"U_TESTENEMY": {"id": "U_TESTENEMY", "owner": 2, "status": 2, "flags": {},
 			"meta": {"name": "Test Enemy", "keywords": ["INFANTRY"]},
 			"models": [
-				# ~0.1" BELOW m2's oval edge (long axis) -> within the 0.25" b2b
+				# ~0.03" BELOW m2's oval edge (long axis) -> within the 0.1" b2b
 				# tolerance for m2, well clear of m1/m3 to the sides, and out of the
 				# way of the pile-in moves below (which all head UP / sideways).
 				{"id": "e1", "alive": true, "wounds": 2, "current_wounds": 2,
 					"base_mm": 32, "base_type": "circular",
-					"position": {"x": 500 + sp, "y": 500 + bike_half_y + enemy_r + Meas.inches_to_px(0.1)}},
+					"position": {"x": 500 + sp, "y": 500 + bike_half_y + enemy_r + Meas.inches_to_px(0.03)}},
 			]},
 	}
 	var fp = load("res://phases/FightPhase.gd").new()

--- a/40k/tests/unit/test_pile_in_b2b_enforcement.gd
+++ b/40k/tests/unit/test_pile_in_b2b_enforcement.gd
@@ -125,17 +125,17 @@ func test_pile_in_model_cannot_reach_b2b_is_valid():
 # ==========================================
 
 func test_model_within_tolerance_counts_as_b2b():
-	"""Model ending within BASE_CONTACT_TOLERANCE (0.25\") should count as b2b"""
+	"""Model ending within BASE_CONTACT_TOLERANCE (0.1\") should count as b2b"""
 	# Enemy at (200, 200), attacker starts at (330, 200) — ~2" edge-to-edge
-	# Model ends at (258.4, 200) — ~0.2" edge-to-edge (within 0.25" tolerance)
+	# Model ends at (252.8, 200) — ~0.06" edge-to-edge (within 0.1" tolerance)
 	var units = {
 		"attacker": _make_unit(1, [_make_model(330, 200)]),
 		"enemy": _make_unit(2, [_make_model(200, 200)])
 	}
 	_setup_fight_phase(units)
 
-	# 0.2" edge gap = 8px, center distance = 50.4 + 8 = 58.4
-	var movements = {"0": Vector2(258.4, 200)}
+	# 0.06" edge gap = 2.4px, center distance = 50.4 + 2.4 = 52.8
+	var movements = {"0": Vector2(252.8, 200)}
 
 	var result = fight_phase._validate_base_to_base_if_possible("attacker", movements, 3.0)
 

--- a/40k/tests/unit/test_pile_in_base_contact_locked.gd
+++ b/40k/tests/unit/test_pile_in_base_contact_locked.gd
@@ -8,7 +8,7 @@ extends "res://addons/gut/test.gd"
 # Position math for 32mm circular bases:
 #   base_radius_px ≈ 25.2 px  (32mm / 25.4 * 40 / 2)
 #   Two models touching (b2b): center distance ≈ 50.4 px (edge-to-edge ≈ 0")
-#   BASE_CONTACT_TOLERANCE = 0.25" ≈ 10px edge gap → center distance ≈ 60.4 px
+#   BASE_CONTACT_TOLERANCE = 0.1" ≈ 4px edge gap → center distance ≈ 54.4 px
 #   1" edge gap: center distance ≈ 90.4 px
 
 var fight_phase = null
@@ -83,18 +83,18 @@ func test_model_in_base_contact_detected():
 	assert_true(result, "Model touching enemy should be detected as in base contact")
 
 func test_model_within_tolerance_detected():
-	"""Model within BASE_CONTACT_TOLERANCE (0.25\") should be detected as in base contact"""
+	"""Model within BASE_CONTACT_TOLERANCE (0.1\") should be detected as in base contact"""
 	if _skip_if_no_autoloads(): return
-	# Edge-to-edge ~0.2": center distance ≈ 58.4 px (50.4 + 8)
+	# Edge-to-edge ~0.06": center distance ≈ 52.8 px (50.4 + 2.4)
 	var units = {
-		"attacker": _make_unit(1, [_make_model(258.4, 200)]),
+		"attacker": _make_unit(1, [_make_model(252.8, 200)]),
 		"enemy": _make_unit(2, [_make_model(200, 200)])
 	}
 	_setup_fight_phase(units)
 
 	var result = fight_phase._is_model_in_base_contact_with_enemy("attacker", "0")
 
-	assert_true(result, "Model within 0.25\" tolerance should count as base contact")
+	assert_true(result, "Model within 0.1\" tolerance should count as base contact")
 
 func test_model_not_in_base_contact():
 	"""Model more than 0.25\" from enemy should NOT be in base contact"""


### PR DESCRIPTION
## Summary
- The "already in base contact, cannot move" lock used during Pile In / Consolidate (and the parallel melee fight-eligibility base-contact chain check) treated models up to **0.25"** apart as touching — a clearly visible quarter-inch gap on screen, matching the reported bug where Prosecutor models were shown locked (white X) despite an obvious gap to the Ork Bikers.
- That tolerance was duplicated in five places that were all meant to agree: `RulesEngine.gd`, `FightPhase.gd`, `FightController.gd`, and `AIDecisionMaker.gd` (pile-in + consolidate). All five are now `0.1"` (~4px).
- Updated the unit-test fixtures that hardcoded a 0.2" gap as "within tolerance" to use a smaller gap consistent with the new value.

## Test plan
- [x] `tests/unit/test_ai_pile_in.gd` — 29/29 pass
- [x] `tests/test_pile_in_overlap_model_id_keys.gd` — 14/14 pass (fixture gap updated from 0.1" to 0.03" to stay clear of the new boundary)
- [x] `tests/unit/test_ai_consolidation.gd` — 40/40 pass
- [x] `tests/test_m6_base_touching_regression.gd` — 7/7 pass
- [x] `tests/unit/test_pile_in_base_contact_locked.gd`, `tests/unit/test_pile_in_b2b_enforcement.gd` — confirmed via `git stash` before/after diff that the pre-existing failures in these two files (an unrelated test-harness issue) are present on `main` too and unaffected by this change; the boundary-specific assertions I updated (`test_model_within_tolerance_detected`, `test_model_within_tolerance_counts_as_b2b`) pass with the new tolerance
- [x] Broad `tests/run_pretrigger_tests.sh` sweep (~20 fixture files, hundreds of assertions) — all completed runs passed; no regressions

Bumped `40k/data/version_history.json` to 0.44.1 per the changelog convention.

https://claude.ai/code/session_014M93zUARKPuNmEvvFPMfEv


---
_Generated by [Claude Code](https://claude.ai/code/session_014M93zUARKPuNmEvvFPMfEv)_