### PR TITLE
Fight phase: label the action button per step + drop the wrong Pile-In warning

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.44.5",
+			"date": "2026-07-15",
+			"summary": "Clearer Fight-phase button during Pile In: the top-right action button now reads 'Finish Pile Ins' (and 'Finish Consolidations') while you're in those steps, instead of the misleading 'End Fight Phase'. Clicking it during Pile In no longer pops the wrong 'these units haven't fought' warning — those units still fight, so there was nothing to warn about. The warning now only appears when you actually end the Fight step.",
+			"changes": [
+				"The top-right phase button is now labelled for the current Fight-phase step: '[Enter] Finish Pile Ins' during the Pile In step, '[Enter] Finish Consolidations' during the Consolidate step, and '[Enter] End Fight Phase' during the fight itself.",
+				"Finishing your Pile In (or Consolidation) moves via that button no longer shows the 'N unit(s) have not yet fought — are you sure?' confirmation. That pop-up was left over from an old code path and was misleading: ending a Pile In forfeits no fights, so your units still get to fight.",
+				"The 'unfought units' confirmation still appears when you genuinely end the Fight step early, where it correctly warns you about forfeiting fights."
+			]
+		},
+		{
 			"version": "0.44.4",
 			"date": "2026-07-14",
 			"summary": "Internal Fight-phase cleanup: the game now runs a single, current-edition Fight-phase code path — the old 10th-edition pile-in/consolidate/fight-ordering leftovers were removed so the two rule sets can no longer shadow each other. This is invisible in normal play. The one small on-screen consequence: a unit forced to 'fight last' by an ability now appears in the ordinary 'Remaining Combats' group of the fight-selection list rather than a separate 'Fights Last' group — matching the current rules, which resolve it as a normal remaining combat and have no distinct Fights Last step. Board colouring of engaged units (including the fights-last tint) is unchanged.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -4570,6 +4570,22 @@ func _is_unit_within_distance_of_enemies(unit: Dictionary, distance_inches: floa
 
 	return false
 
+func get_fight_step_11e() -> String:
+	"""Which of the three 11e Fight-phase steps is currently active:
+	  "PILE_IN"     — the global Pile In step (12.02) the phase opens with,
+	  "CONSOLIDATE" — the global Consolidate step (12.07) at the end,
+	  "FIGHT"       — the alternating Fight step (12.04), the default.
+	The Main HUD reads this to label the phase-action button and to decide
+	whether ending the current step forfeits any fights: only ending the
+	Fight step does. During the Pile In / Consolidate steps the button just
+	finishes that step (no unit is skipped), so the "units haven't fought"
+	warning must not fire there."""
+	if pile_in_step_11e == PileInStep11e.ACTIVE:
+		return "PILE_IN"
+	if consolidation_step_11e == ConsolidationStep11e.ACTIVE:
+		return "CONSOLIDATE"
+	return "FIGHT"
+
 func get_unfought_eligible_units(only_player: int = -1) -> Array:
 	"""Return array of {unit_id, unit_name, player, subphase} for units that haven't fought yet.
 	Used by the end-fight-phase confirmation dialog (T5-UX7).

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -4994,6 +4994,13 @@ func setup_fight_controller() -> void:
 		if is_fight_phase:
 			fight_controller.set_phase(phase_instance)
 			print("Connected FightController to FightPhase")
+			# Re-label the phase-action button when the Fight phase's internal
+			# step changes (Pile In → Fight → Consolidate). These transitions
+			# happen WITHIN the phase — no phase_changed fires — so update the
+			# button text/tooltip here instead of only in update_ui_for_phase.
+			if phase_instance.has_signal("subphase_transition") \
+					and not phase_instance.subphase_transition.is_connected(_on_fight_subphase_transition):
+				phase_instance.subphase_transition.connect(_on_fight_subphase_transition)
 		else:
 			print("WARNING: Phase instance is not a FightPhase, skipping signal connections")
 	else:
@@ -9270,10 +9277,24 @@ func _get_phase_button_text(phase: GameStateData.Phase) -> String:
 		GameStateData.Phase.MOVEMENT: return "[Enter] End Movement Phase"
 		GameStateData.Phase.SHOOTING: return "[Enter] End Shooting Phase"
 		GameStateData.Phase.CHARGE: return "[Enter] End Charge Phase"
-		GameStateData.Phase.FIGHT: return "[Enter] End Fight Phase"
+		GameStateData.Phase.FIGHT: return _get_fight_phase_button_text()
 		GameStateData.Phase.SCORING: return "[Enter] End Turn"
 		GameStateData.Phase.MORALE: return "[Enter] End Morale Phase"
 		_: return "[Enter] End Phase"
+
+func _get_fight_phase_button_text() -> String:
+	# The Fight phase runs three internal steps (11e): the global Pile In step
+	# (12.02) the phase opens with, the alternating Fight step (12.04), and the
+	# global Consolidate step (12.07). The action button ends whichever step is
+	# ACTIVE — but only ending the Fight step ends the phase. Labelling it
+	# "End Fight Phase" during the Pile In / Consolidate steps was misleading
+	# (pressing it there just finishes that step), so label it per step.
+	var fp = PhaseManager.get_current_phase_instance()
+	if fp and fp.has_method("get_fight_step_11e"):
+		match fp.get_fight_step_11e():
+			"PILE_IN": return "[Enter] Finish Pile Ins"
+			"CONSOLIDATE": return "[Enter] Finish Consolidations"
+	return "[Enter] End Fight Phase"
 
 func _get_phase_button_tooltip(phase: GameStateData.Phase) -> String:
 	match phase:
@@ -9283,9 +9304,19 @@ func _get_phase_button_tooltip(phase: GameStateData.Phase) -> String:
 		GameStateData.Phase.MOVEMENT: return "End Movement phase and begin Shooting (Shortcut: Enter)"
 		GameStateData.Phase.SHOOTING: return "End Shooting phase and begin Charge (Shortcut: Enter)"
 		GameStateData.Phase.CHARGE: return "End Charge phase and begin Fight (Shortcut: Enter)"
-		GameStateData.Phase.FIGHT: return "End Fight phase and proceed to scoring"
+		GameStateData.Phase.FIGHT: return _get_fight_phase_button_tooltip()
 		GameStateData.Phase.SCORING: return "End your turn and pass to your opponent"
 		_: return "Advance to the next phase"
+
+func _get_fight_phase_button_tooltip() -> String:
+	# Mirrors _get_fight_phase_button_text: describe the CURRENT Fight-phase
+	# step, since only the Fight step actually ends the phase.
+	var fp = PhaseManager.get_current_phase_instance()
+	if fp and fp.has_method("get_fight_step_11e"):
+		match fp.get_fight_step_11e():
+			"PILE_IN": return "Finish your Pile In moves and begin fighting (Shortcut: Enter)"
+			"CONSOLIDATE": return "Finish your Consolidation moves and end the Fight phase (Shortcut: Enter)"
+	return "End Fight phase and proceed to scoring"
 
 func _clear_phase_ui_artifacts() -> void:
 	# Remove any dynamically added phase-specific buttons from HUD_Bottom
@@ -9399,9 +9430,20 @@ func _on_phase_action_pressed() -> void:
 		GameStateData.Phase.CHARGE:
 			action = {"type": "END_CHARGE", "player": active_player}
 		GameStateData.Phase.FIGHT:
-			# T5-UX7: Check for unfought units and show confirmation dialog
+			# T5-UX7: Check for unfought units and show confirmation dialog.
+			# The Fight phase runs three internal steps (11e). END_FIGHT ends
+			# whichever step is active, but the "units haven't fought" warning
+			# only makes sense when ending the actual Fight step (12.04). During
+			# the global Pile In (12.02) and Consolidate (12.07) steps the button
+			# just finishes that step and NO fights are forfeited — showing the
+			# warning there (which listed every not-yet-fought unit) was the
+			# misleading pop-up players hit right after piling in. Only warn in
+			# the Fight step.
 			var fight_phase_instance = PhaseManager.get_current_phase_instance()
-			if fight_phase_instance and fight_phase_instance.has_method("get_unfought_eligible_units"):
+			var fight_step := "FIGHT"
+			if fight_phase_instance and fight_phase_instance.has_method("get_fight_step_11e"):
+				fight_step = fight_phase_instance.get_fight_step_11e()
+			if fight_step == "FIGHT" and fight_phase_instance and fight_phase_instance.has_method("get_unfought_eligible_units"):
 				# Only warn about the active player's OWN unfought units — ending
 				# your fights no longer forfeits the opponent's (12.04), so the
 				# opponent's units must not be listed as "won't fight".
@@ -10254,6 +10296,18 @@ func _on_fight_ui_update_requested() -> void:
 	# Update UI when FightController requests it
 	if current_phase == GameStateData.Phase.FIGHT:
 		update_ui()
+
+func _on_fight_subphase_transition(_from_subphase: String, _to_subphase: String) -> void:
+	# The Fight-phase action button is labelled per internal step (Pile In /
+	# Fight / Consolidate). Those steps change within the phase, so re-derive the
+	# button text + tooltip from the live step whenever a transition fires.
+	if current_phase != GameStateData.Phase.FIGHT:
+		return
+	if not phase_action_button or not is_instance_valid(phase_action_button):
+		return
+	phase_action_button.text = _get_phase_button_text(current_phase)
+	phase_action_button.tooltip_text = _get_phase_button_tooltip(current_phase)
+	print("Main: Fight subphase %s → %s — button relabelled to '%s'" % [_from_subphase, _to_subphase, phase_action_button.text])
 
 func _on_scoring_action_requested(action: Dictionary) -> void:
 	print("Main: Received scoring action request: ", action.get("type", ""))

--- a/40k/tests/integration/test_fight_e10_uses_11e_path.gd.uid
+++ b/40k/tests/integration/test_fight_e10_uses_11e_path.gd.uid
@@ -1,0 +1,1 @@
+uid://dqa0w7v8w6qj

--- a/40k/tests/scenarios/sp/pile_in_button_label_bv8yue.json
+++ b/40k/tests/scenarios/sp/pile_in_button_label_bv8yue.json
@@ -1,0 +1,56 @@
+{
+  "id": "pile_in_button_label_bv8yue",
+  "covers": [
+    "phases.FightPhase.get_fight_step_11e",
+    "scripts.Main._get_fight_phase_button_text",
+    "scripts.Main._get_fight_phase_button_tooltip",
+    "scripts.Main._on_phase_action_pressed",
+    "scripts.Main._on_fight_subphase_transition",
+    "dialogs.EndFightConfirmationDialog"
+  ],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Reported bug: during the global Pile In step (12.02) the top-right phase-action button read 'End Fight Phase' and, when clicked, popped the misleading 'units haven't fought' warning (nothing is forfeited during Pile In — the units still fight). This drives the REAL player path with clicks. At fight-phase open (Pile In step, P2 Orks active) the button now reads '[Enter] Finish Pile Ins'. Clicking the TOP-RIGHT button (the reported path) advances the Pile In step to P1's half WITHOUT any EndFightConfirmationDialog and leaves the label unchanged. After both halves the Fight step (12.04) begins and the button reverts to '[Enter] End Fight Phase' via the subphase transition; clicking it there DOES pop the confirmation, proving the warning still fires where it belongs. CP zeroed to suppress stratagem prompts; the Warboss wounds are inflated so nothing dies.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"wounds\": 99, \"current_wounds\": 99}, true)" },
+
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 2 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().get_fight_step_11e()", "equals": "PILE_IN" },
+    { "act": "expect_node_property", "node": "/root/Main/PhaseActionButton", "property": "text", "equals": "[Enter] Finish Pile Ins" },
+    { "act": "screenshot", "label": "01_pile_in_step_button_reads_finish_pile_ins" },
+
+    { "act": "click_node", "node": "/root/Main/PhaseActionButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script", "script": "main.get_tree().root.has_node(\"EndFightConfirmationDialog\")", "equals": false },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().get_fight_step_11e()", "equals": "PILE_IN" },
+    { "act": "expect_node_property", "node": "/root/Main/PhaseActionButton", "property": "text", "equals": "[Enter] Finish Pile Ins" },
+    { "act": "screenshot", "label": "02_pile_in_advanced_to_p1_no_warning" },
+
+    { "act": "expect_node_visible", "node": "/root/PileInStepDialog", "timeout_s": 5.0 },
+    { "act": "click_node", "node": "/root/PileInStepDialog/Content/EndPileInButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 2 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().get_fight_step_11e()", "equals": "FIGHT" },
+    { "act": "expect_node_property", "node": "/root/Main/PhaseActionButton", "property": "text", "equals": "[Enter] End Fight Phase" },
+    { "act": "expect_node_visible", "node": "/root/FightSelectionDialog", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "03_fight_step_button_reverts_to_end_fight_phase" },
+
+    { "act": "click_node", "node": "/root/Main/PhaseActionButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_node_visible", "node": "/root/EndFightConfirmationDialog", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "04_fight_step_warning_still_fires" }
+  ]
+}

--- a/40k/tests/test_pile_in_pivot_rotation.gd.uid
+++ b/40k/tests/test_pile_in_pivot_rotation.gd.uid
@@ -1,0 +1,1 @@
+uid://c1ufkpp72fecp


### PR DESCRIPTION
## Problem

During the Fight phase's **Pile In** step, the top-right action button always read **"End Fight Phase"**, and pressing it popped the *"N unit(s) have not yet fought — are you sure?"* confirmation. Both were misleading:

- The button doesn't end the phase during Pile In — it just finishes your pile-in moves and moves to the fighting step.
- Ending your pile-ins forfeits **no** fights, so the "haven't fought" warning was wrong; those units still fight. It was a leftover code path players hit right after piling in.

## Fix

The Fight phase runs three internal steps (11e): the global **Pile In** step (12.02), the alternating **Fight** step (12.04), and the global **Consolidate** step (12.07). The action button ends whichever step is active — but only ending the Fight step ends the phase.

- Add `FightPhase.get_fight_step_11e()` → `"PILE_IN"` | `"CONSOLIDATE"` | `"FIGHT"`.
- `Main` labels the phase-action button per step — **`[Enter] Finish Pile Ins`**, **`[Enter] Finish Consolidations`**, or **`[Enter] End Fight Phase`** (with matching tooltips) — and relabels it live on each subphase transition (these transitions happen within the phase, where no `phase_changed` fires).
- The unfought-units confirmation now only shows when ending the actual **Fight** step; during Pile In / Consolidate the button just finishes that step.

## Validation

New windowed scenario `pile_in_button_label_bv8yue` drives the real player click path:

1. At fight-phase open (Pile In step) the button reads `[Enter] Finish Pile Ins`.
2. Clicking the top-right button (the reported path) — **no** `EndFightConfirmationDialog`, the step advances to the next player's half, label unchanged.
3. Once the Fight step begins, the label reverts to `[Enter] End Fight Phase`.
4. Clicking it there **does** pop the confirmation — proving the warning still fires where it belongs.

**Result: 31/31 passed.** No regressions across `end_fight_scope_opponent_still_fights_11e`, `consolidate_menu_visibility`, `global_consolidation_step_11e`, `iss066_pile_in_consolidate_11e`, `staged_fight_reroll_ui`, `fight_dialogs_single_confirm_11e`. No script errors in the debug log.

## Player-facing changelog

Version bumped to **0.44.5** in `40k/data/version_history.json`.

## Commits

- Fight phase: label the action button per step + drop the wrong Pile-In warning
- Add missing Godot `.uid` sidecars for two test scripts (metadata only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XZPHwqSxrrMxNNJmw2CAwC

---
_Generated by [Claude Code](https://claude.ai/code/session_01XZPHwqSxrrMxNNJmw2CAwC)_