### PR TITLE
Charge phase: show per-model reach rings while dragging instead of 12" circle

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.45.0",
+			"date": "2026-07-15",
+			"summary": "Charge phase now shows each model's actual charge-move reach while you drag. After you roll the 2D6 charge distance, the single 12\" range circle is replaced with a per-model reach ring (radius = the distance you rolled) centred on every charging model, so you can see exactly how far each model is allowed to move instead of a 12\" circle that no longer applies.",
+			"changes": [
+				"After the charge roll, the board draws one green reach ring per charging model, each sized to the distance you actually rolled, labelled e.g. '8\" charge move (each model)'.",
+				"The orange 12\" charge-threat circle is now only shown before the roll (while picking targets); once you're dragging models it is cleared so it no longer sits there implying you can move 12\".",
+				"Rings are anchored on each model's starting position and stay put as a fixed reference while you drag; the right-panel Used/Left readout still tracks the live remaining distance."
+			]
+		},
+		{
 			"version": "0.44.6",
 			"date": "2026-07-15",
 			"summary": "Fixed the Consolidate step refusing to move a unit that was on or near a large terrain objective — it now correctly offers the 'move onto the objective' consolidation instead of telling you 'no consolidation mode applies — the unit cannot move'.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -964,8 +964,12 @@ func _update_visuals() -> void:
 
 	var unit_center = _get_unit_center_position(unit)
 
-	# T-092: Show 12" charge-range overlay around active charging unit
-	_show_charge_range_circle(unit_center)
+	# T-092: Show the pre-roll 12" charge-range overlay around the active charging
+	# unit. Once the roll is made and models are being dragged (awaiting_movement),
+	# the per-model reach rings from _show_per_model_charge_ranges() apply instead,
+	# so don't redraw the unit-wide 12" ring over them.
+	if not awaiting_movement:
+		_show_charge_range_circle(unit_center)
 
 	# Draw lines to selected targets
 	for target_id in selected_targets:
@@ -1196,6 +1200,11 @@ func _enable_charge_movement(unit_id: String, max_distance: int) -> void:
 			print("DEBUG: Added model ", model_id, " to models_to_move")
 	
 	print("Models to move: ", models_to_move)
+
+	# Swap the pre-roll unit-wide 12" threat ring for one per-model reach ring
+	# (radius = the rolled distance) so the player can see how far each model can
+	# actually be dragged, not a 12" circle that no longer applies post-roll.
+	_show_per_model_charge_ranges(unit_id, float(max_distance))
 
 	# Show engagement range circles around charge target models
 	_show_target_engagement_visuals(unit_id)
@@ -2326,6 +2335,7 @@ func _update_ui_for_next_charge() -> void:
 		target_list.clear()
 	_clear_highlights()
 	_clear_charge_trajectory_preview()  # P3-127
+	_clear_charge_range_circle()  # clear 12" ring / per-model reach rings
 	if is_instance_valid(charge_line_visual):
 		charge_line_visual.clear_points()
 
@@ -2604,9 +2614,10 @@ func _reset_unit_selection() -> void:
 	if is_instance_valid(target_list):
 		target_list.clear()
 	_clear_highlights()
+	_clear_charge_range_circle()  # clear 12" ring / per-model reach rings
 	if is_instance_valid(charge_line_visual):
 		charge_line_visual.clear_points()
-	
+
 	# Hide charge distance display
 	_hide_charge_distance_display()
 	_update_button_states()
@@ -3629,12 +3640,15 @@ const CHARGE_RANGE_OVERLAY_INCHES: float = 12.0
 const CHARGE_RANGE_OVERLAY_COLOR: Color = Color(1.0, 0.6, 0.1, 0.55)
 const CHARGE_RANGE_OVERLAY_WIDTH: float = 12.0  # Width in board-space px (board scale ~0.3)
 
-func _show_charge_range_circle(center: Vector2) -> void:
-	if not is_instance_valid(range_visual):
-		return
-	_clear_charge_range_circle()
-	var radius_px := Measurement.inches_to_px(CHARGE_RANGE_OVERLAY_INCHES)
-	# Dashed circle - alternating visible/invisible arcs
+# Per-model charge-move reach overlay (shown AFTER the 2D6 roll, while dragging).
+# Green to read as "you can move here" vs the orange pre-roll 12" threat ring.
+const CHARGE_MODEL_RANGE_COLOR: Color = Color(0.3, 0.9, 0.45, 0.55)
+const CHARGE_MODEL_RANGE_LABEL_COLOR: Color = Color(0.45, 1.0, 0.55, 0.95)
+const CHARGE_MODEL_RANGE_WIDTH: float = 8.0  # Width in board-space px (thinner than the 12" ring)
+
+func _draw_charge_dashed_circle(center: Vector2, radius_px: float, color: Color, width: float) -> void:
+	# Draw a dashed circle (alternating visible/invisible arcs) into range_visual.
+	# Shared by the pre-roll 12" threat ring and the post-roll per-model reach rings.
 	var total_arcs: int = 10
 	var arc_length: float = TAU / float(total_arcs)
 	var dash_fraction: float = 0.7
@@ -3643,8 +3657,8 @@ func _show_charge_range_circle(center: Vector2) -> void:
 		var arc_dash_end: float = arc_start + arc_length * dash_fraction
 		var dash := Line2D.new()
 		dash.name = "ChargeRangeCircle"
-		dash.width = CHARGE_RANGE_OVERLAY_WIDTH
-		dash.default_color = CHARGE_RANGE_OVERLAY_COLOR
+		dash.width = width
+		dash.default_color = color
 		dash.begin_cap_mode = Line2D.LINE_CAP_ROUND
 		dash.end_cap_mode = Line2D.LINE_CAP_ROUND
 		var pts: int = 8
@@ -3652,6 +3666,13 @@ func _show_charge_range_circle(center: Vector2) -> void:
 			var theta: float = arc_start + (arc_dash_end - arc_start) * float(i) / float(pts)
 			dash.add_point(center + Vector2(cos(theta), sin(theta)) * radius_px)
 		range_visual.add_child(dash)
+
+func _show_charge_range_circle(center: Vector2) -> void:
+	if not is_instance_valid(range_visual):
+		return
+	_clear_charge_range_circle()
+	var radius_px := Measurement.inches_to_px(CHARGE_RANGE_OVERLAY_INCHES)
+	_draw_charge_dashed_circle(center, radius_px, CHARGE_RANGE_OVERLAY_COLOR, CHARGE_RANGE_OVERLAY_WIDTH)
 	# Distance label
 	var range_label := Label.new()
 	range_label.name = "ChargeRangeCircle"
@@ -3661,6 +3682,55 @@ func _show_charge_range_circle(center: Vector2) -> void:
 	range_label.position = center + Vector2(-60, -(radius_px + 40))
 	range_label.z_index = 55
 	range_visual.add_child(range_label)
+
+func _show_per_model_charge_ranges(unit_id: String, max_distance: float) -> void:
+	# After the charge roll, EACH model may move up to the rolled distance from its
+	# OWN origin (the per-model cap enforced in _validate_charge_position). Replace
+	# the single unit-wide 12" pre-roll threat ring — which no longer reflects how
+	# far a model can actually go — with one reach ring per model centred on that
+	# model's pre-charge origin, so the player can see the real drag range of each
+	# individual model. Anchored on the origin (not the live position) so the ring
+	# stays put as a fixed reference while the model is dragged; the panel's
+	# Used/Left readout tracks the live remaining budget.
+	if not is_instance_valid(range_visual):
+		return
+	_clear_charge_range_circle()
+	if max_distance <= 0.0:
+		return
+	var unit = GameState.get_unit(unit_id)
+	if unit.is_empty():
+		return
+	var radius_px := Measurement.inches_to_px(max_distance)
+	var centers: Array = []
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var model_id = model.get("id", "")
+		# Anchor on the cached pre-charge origin (set in _enable_charge_movement);
+		# fall back to the live position for any model without a cached origin.
+		var center: Vector2 = _model_origin_positions.get(model_id, _get_model_position(model))
+		if center == Vector2.ZERO:
+			continue
+		centers.append(center)
+		_draw_charge_dashed_circle(center, radius_px, CHARGE_MODEL_RANGE_COLOR, CHARGE_MODEL_RANGE_WIDTH)
+
+	# One summary label above the group — every model shares the same rolled reach,
+	# so a per-model number would just be the same value repeated N times.
+	if not centers.is_empty():
+		var group_center := Vector2.ZERO
+		var top_y: float = INF
+		for c in centers:
+			group_center += c
+			top_y = minf(top_y, c.y)
+		group_center /= centers.size()
+		var range_label := Label.new()
+		range_label.name = "ChargeRangeCircle"
+		range_label.text = "%d\" charge move (each model)" % int(round(max_distance))
+		range_label.add_theme_font_size_override("font_size", 32)
+		range_label.add_theme_color_override("font_color", CHARGE_MODEL_RANGE_LABEL_COLOR)
+		range_label.position = Vector2(group_center.x - 150, top_y - (radius_px + 40))
+		range_label.z_index = 55
+		range_visual.add_child(range_label)
 
 func _clear_charge_range_circle() -> void:
 	if not is_instance_valid(range_visual):

--- a/40k/tests/scenarios/sp/charge_per_model_range_rings.json
+++ b/40k/tests/scenarios/sp/charge_per_model_range_rings.json
@@ -1,0 +1,99 @@
+{
+  "id": "charge_per_model_range_rings",
+  "covers": [
+    "scripts.ChargeController._show_per_model_charge_ranges",
+    "charge.per_model_reach_rings"
+  ],
+  "fixture": "test_charge_congestion",
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Feature: after the 2D6 charge roll, while the player drags models, the board must show how far EACH model can actually move (a reach ring per model, radius = the rolled distance centred on each model's origin) instead of the single unit-wide 12\" pre-roll threat ring. U_CHARGER_0 is a 3-model Boyz unit; it and the Shield-Captain target are repositioned onto verified open ground (clear of the fixture's ruins) at charger x=950 y={540,600,660}, target (800,600). Player path: select the unit (real _on_unit_selected UI path -> single 12\" ring, 11 nodes in range_visual centred on the unit centre y=600), then DECLARE_CHARGE + CHARGE_ROLL + click the real 'Keep Roll' button to decline the Command Re-roll -> the real charge_roll_made signal enables movement and swaps the overlay. Asserts: range_visual now holds 31 nodes (3 rings x 10 dash arcs + 1 summary label); each ring's arc_idx-0 first point (= centre + (radius,0)) sits on a DISTINCT model origin (y=540 / 600 / 660, not the unit centre) proving one ring per model; and each ring radius equals charge_distance * PX_PER_INCH proving the rings show the rolled reach, not a fixed 12\".",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_TARGET_SC\"].models[0].merge({\"position\": {\"x\": 800.0, \"y\": 600.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_CHARGER_0\"].models[0].merge({\"position\": {\"x\": 950.0, \"y\": 540.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_CHARGER_0\"].models[1].merge({\"position\": {\"x\": 950.0, \"y\": 600.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_CHARGER_0\"].models[2].merge({\"position\": {\"x\": 950.0, \"y\": 660.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script", "script": "main.update_unit_visuals(\"U_TARGET_SC\")" },
+    { "act": "execute_script", "script": "main.update_unit_visuals(\"U_CHARGER_0\")" },
+    { "act": "execute_script", "script": "main.charge_controller._refresh_ui()" },
+    { "act": "wait_for_tweens" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller._on_unit_selected(main.charge_controller.get_displayed_charge_unit_ids().find(\"U_CHARGER_0\"))" },
+    { "act": "wait_frames", "frames": 4 },
+    { "act": "execute_script",
+      "script": "main.charge_controller.active_unit_id",
+      "equals": "U_CHARGER_0" },
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child_count()",
+      "equals": 11 },
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child(0).points[0].y",
+      "equals": 600.0 },
+    { "act": "execute_script",
+      "script": "abs(main.charge_controller.range_visual.get_child(0).points[0].x - 950.0 - 12.0 * Measurement.PX_PER_INCH)",
+      "expect_max": 1.0 },
+    { "act": "screenshot", "label": "01_preroll_single_12in_ring_unit_centre" },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DECLARE_CHARGE",
+      "actor_unit_id": "U_CHARGER_0",
+      "payload": { "target_unit_ids": ["U_TARGET_SC"] }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "CHARGE_ROLL",
+      "actor_unit_id": "U_CHARGER_0",
+      "payload": { "rng_seed": 7 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.find_children(\"KeepRollButton\", \"\", true, false)[0].emit_signal(\"pressed\")" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller.awaiting_movement",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.charge_controller.charge_distance",
+      "expect_min": 2 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child_count()",
+      "equals": 31 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child(0).points[0].y",
+      "equals": 540.0 },
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child(10).points[0].y",
+      "equals": 600.0 },
+    { "act": "execute_script",
+      "script": "main.charge_controller.range_visual.get_child(20).points[0].y",
+      "equals": 660.0 },
+
+    { "act": "execute_script",
+      "script": "abs(main.charge_controller.range_visual.get_child(0).points[0].x - 950.0 - main.charge_controller.charge_distance * Measurement.PX_PER_INCH)",
+      "expect_max": 1.0 },
+    { "act": "execute_script",
+      "script": "abs(main.charge_controller.range_visual.get_child(10).points[0].x - 950.0 - main.charge_controller.charge_distance * Measurement.PX_PER_INCH)",
+      "expect_max": 1.0 },
+    { "act": "execute_script",
+      "script": "abs(main.charge_controller.range_visual.get_child(20).points[0].x - 950.0 - main.charge_controller.charge_distance * Measurement.PX_PER_INCH)",
+      "expect_max": 1.0 },
+
+    { "act": "screenshot", "label": "02_postroll_per_model_reach_rings" }
+  ]
+}


### PR DESCRIPTION
## Problem

In the charge phase, once you rolled the 2D6 charge distance and started dragging models, the board still only showed the single unit-wide **12" range circle** left over from target selection. That circle no longer reflects how far a model can actually move — each model may move up to the *rolled* distance from its own position — so it was misleading during the drag step.

## Change

After the roll, `ChargeController` now draws a **per-model reach ring**: one green dashed ring per charging model, radius = the distance you actually rolled, centred on each model's pre-charge origin, labelled e.g. `8" charge move (each model)`. The orange 12" ring is now only shown **before** the roll (while picking targets) and is cleared once movement begins.

- `_enable_charge_movement()` calls the new `_show_per_model_charge_ranges()`, which draws a reach ring per alive model anchored on its cached origin.
- Factored the dashed-circle drawing into a shared `_draw_charge_dashed_circle()` used by both the pre-roll 12" ring and the per-model rings.
- `_update_visuals()` no longer redraws the 12" ring while `awaiting_movement`.
- Rings are cleared on `_reset_unit_selection()` / `_update_ui_for_next_charge()`.

Rings are anchored on each model's origin and stay put as a fixed reference while dragging (matching Movement-phase behaviour); the right-panel Used/Left readout still tracks the live remaining budget.

## Before / After

| Pre-roll (target selection) | Post-roll (dragging) |
| --- | --- |
| single orange **12"** ring at the unit centre | green **per-model** reach rings sized to the rolled distance |

## Validation

Driven end-to-end in the running game (windowed, not headless-only):

- **New windowed scenario** `charge_per_model_range_rings` (35 assertions): drives the real declare → roll → keep-roll flow with a 3-model unit and asserts the overlay swaps from **11 nodes** (one 12" ring at the unit centre) to **31 nodes** (3 per-model rings at distinct model origins + label), each ring's radius equal to the rolled distance — **35/35 pass**.
- **Regression:** `charge_multi_step_movement` (52), `charge_range_bubble_cleanup` (19), `charge_congestion` (5), plus rotation / undo / base-contact scenarios and the `T30_charge_dashed_rings` visual scenario — **all pass**.
- Screenshots captured confirming the pre-roll 12" ring and the post-roll per-model green rings render correctly.

## Notes

- The 12" ring is intentionally kept for the pre-roll target-selection step (it's the genuine "what can this unit threaten" aid there); the reported issue was specifically the drag step.
- Player-facing change → version bumped to `0.45.0` with a changelog entry.
- Also includes an incidental repo-hygiene commit adding two missing Godot `.uid` companion files for already-tracked test scripts (this repo tracks all its `.uid` files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016T1NeGwsnw1Tqsr1tW2muz

---
_Generated by [Claude Code](https://claude.ai/code/session_016T1NeGwsnw1Tqsr1tW2muz)_