### PR TITLE
Fix attached characters overlapping their bodyguard after Advance/Charge

### DIFF
--- a/40k/autoloads/Measurement.gd
+++ b/40k/autoloads/Measurement.gd
@@ -188,6 +188,53 @@ func models_overlap(model1: Dictionary, model2: Dictionary) -> bool:
 	# Use the shape's overlaps_with method for proper collision detection
 	return shape1.overlaps_with(shape2, pos1, rotation1, pos2, rotation2)
 
+func model_overlaps_any(model: Dictionary, others: Array) -> bool:
+	# True if `model` (at its own position) overlaps any model in `others`.
+	# `others` is an Array of model dictionaries each carrying a resolved
+	# "position" (Vector2 or {x,y}).
+	for other in others:
+		if other == null or not (other is Dictionary):
+			continue
+		if models_overlap(model, other):
+			return true
+	return false
+
+func find_nearest_non_overlapping_position(model: Dictionary, ideal_pos: Vector2, occupied_models: Array, max_rings: int = 48) -> Vector2:
+	# Return `ideal_pos` if a base of `model` placed there clears every model in
+	# `occupied_models`; otherwise spiral outward and return the nearest position
+	# that does. Shape-aware (uses models_overlap, so circular/oval/rect bases all
+	# resolve correctly). Used to keep rigidly-translated attached-character models
+	# (leaders riding a bodyguard's Normal/Advance/Charge move) from stacking on
+	# top of the models they moved with. Returns `ideal_pos` unchanged if no clear
+	# spot is found within the search, so callers never throw a model far away.
+	var test = model.duplicate(true)
+	test["position"] = ideal_pos
+	if not model_overlaps_any(test, occupied_models):
+		return ideal_pos
+
+	# Advance the search radius in fine steps (~a quarter base) so we settle into
+	# the nearest snug gap rather than jumping a whole base past it. This runs once
+	# per attached-character model on move confirmation, never per-frame.
+	var my_radius := base_radius_px(model.get("base_mm", 32))
+	var step := maxf(my_radius * 0.25, mm_to_px(4.0))
+	for ring in range(1, max_rings + 1):
+		var radius := step * ring
+		var points := maxi(12, ring * 8)
+		var best_pos = null
+		var best_dist := INF
+		for p in range(points):
+			var angle := (TAU * p) / points
+			var cand := ideal_pos + Vector2(cos(angle), sin(angle)) * radius
+			test["position"] = cand
+			if not model_overlaps_any(test, occupied_models):
+				var d := ideal_pos.distance_squared_to(cand)
+				if d < best_dist:
+					best_dist = d
+					best_pos = cand
+		if best_pos != null:
+			return best_pos
+	return ideal_pos
+
 # New function to check if a model overlaps with a wall
 func model_overlaps_wall(model: Dictionary, wall: Dictionary) -> bool:
 	var pos = model.get("position", Vector2.ZERO)

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.45.1",
+			"date": "2026-07-15",
+			"summary": "Fixed attached characters (e.g. a Blade Champion leading Custodian Guard) ending up stacked on top of one of their own bodyguard models after the unit made an Advance/Normal move or a Charge. The leader rode along by a fixed offset with no collision check, so re-arranging the squad could drop it directly onto another model; it is now nudged to the nearest clear spot so bases never overlap.",
+			"changes": [
+				"When a led unit moves or charges and you re-position its bodyguard models, the attached character no longer lands on top of a bodyguard model — it is automatically shifted to the closest non-overlapping position next to where it would have gone.",
+				"Applies to Normal moves, Advances, Fall Backs and Charges. The character still moves with its unit and stays in coherency; only the final overlap is corrected.",
+				"Multiple attached characters riding the same unit are also kept from stacking on each other."
+			]
+		},
+		{
 			"version": "0.45.0",
 			"date": "2026-07-15",
 			"summary": "Charge phase now shows each model's actual charge-move reach while you drag. After you roll the 2D6 charge distance, the single 12\" range circle is replaced with a per-model reach ring (radius = the distance you rolled) centred on every charging model, so you can see exactly how far each model is allowed to move instead of a 12\" circle that no longer applies.",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -1487,6 +1487,39 @@ func _process_apply_charge_move(action: Dictionary) -> Dictionary:
 # characters — we ride the character models along by the bodyguard's movement
 # delta and grant them the same charge flags. Without this the character is
 # left behind, splitting the unit apart (it looks like the attachment broke).
+func _build_charge_occupancy(bodyguard_id: String, per_model_paths: Dictionary) -> Dictionary:
+	# Map "unit_id:model_id" -> a copy of the model at its FINAL position for this
+	# charge. Bodyguard models take their per_model_paths endpoint; every other
+	# model (friendly and enemy) stays at its live GameState position.
+	var occ := {}
+	var units = game_state_snapshot.get("units", {})
+	for uid in units:
+		var models = units[uid].get("models", [])
+		for i in range(models.size()):
+			var m = models[i]
+			if not m.get("alive", true):
+				continue
+			var mid = m.get("id", "m%d" % (i + 1))
+			var pos_val = m.get("position")
+			if uid == bodyguard_id and per_model_paths.has(mid):
+				var path = per_model_paths[mid]
+				if path is Array and path.size() > 0:
+					pos_val = {"x": path[-1][0], "y": path[-1][1]}
+			if pos_val == null:
+				continue
+			var mcopy = m.duplicate(true)
+			mcopy["position"] = pos_val
+			occ["%s:%s" % [uid, mid]] = mcopy
+	return occ
+
+func _occupancy_values_excluding(occupancy: Dictionary, exclude_key: String) -> Array:
+	var out := []
+	for k in occupancy:
+		if k == exclude_key:
+			continue
+		out.append(occupancy[k])
+	return out
+
 func _charge_attached_character_changes(bodyguard_id: String, per_model_paths: Dictionary, grant_fights_first: bool = true) -> Array:
 	var changes = []
 	var bodyguard = get_unit(bodyguard_id)
@@ -1501,6 +1534,13 @@ func _charge_attached_character_changes(bodyguard_id: String, per_model_paths: D
 		DebugLogger.info(str("ChargePhase: could not determine charge delta for attached characters of %s" % bodyguard_id))
 		return changes
 
+	# Occupancy of every alive model at its FINAL charge position (bodyguard models
+	# use their per_model_paths endpoint). Keyed by "unit:model_id" so a
+	# rigidly-translated character can be nudged off any model it would land on
+	# and later attached characters avoid each other. See fix for the "attached
+	# character overlaps its bodyguard after Charge" bug.
+	var occupancy := _build_charge_occupancy(bodyguard_id, per_model_paths)
+
 	for char_id in attached_chars:
 		var char_unit = get_unit(str(char_id))
 		if char_unit.is_empty():
@@ -1513,10 +1553,24 @@ func _charge_attached_character_changes(bodyguard_id: String, per_model_paths: D
 			if model.get("position") == null:
 				continue
 			var model_pos = _get_model_position(model)
+			var ideal_pos = Vector2(model_pos.x + move_delta.x, model_pos.y + move_delta.y)
+
+			var model_id = model.get("id", "m%d" % (i + 1))
+			var model_key = "%s:%s" % [str(char_id), model_id]
+			var others := _occupancy_values_excluding(occupancy, model_key)
+			var new_pos = Measurement.find_nearest_non_overlapping_position(model, ideal_pos, others)
+			if new_pos != ideal_pos:
+				DebugLogger.info(str("ChargePhase: attached character %s.%s nudged off overlap: ideal %s -> %s" % [str(char_id), model_id, str(ideal_pos), str(new_pos)]))
+
+			# Record this character's resolved position so later attached models avoid it too.
+			var placed = model.duplicate(true)
+			placed["position"] = new_pos
+			occupancy[model_key] = placed
+
 			changes.append({
 				"op": "set",
 				"path": "units.%s.models.%d.position" % [str(char_id), i],
-				"value": {"x": model_pos.x + move_delta.x, "y": model_pos.y + move_delta.y}
+				"value": {"x": new_pos.x, "y": new_pos.y}
 			})
 		# The whole Attached unit charged — the character gets the same flags.
 		# Heroic Intervention grants charged_this_turn but NOT fights_first.

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -4725,7 +4725,7 @@ func _process_confirm_unit_move(action: Dictionary) -> Dictionary:
 	# Skip character models that were already explicitly moved via staged moves
 	var attached_chars = _confirm_unit.get("attachment_data", {}).get("attached_characters", [])
 	if attached_chars.size() > 0:
-		changes.append_array(_move_attached_characters(unit_id, attached_chars, explicitly_moved_model_keys))
+		changes.append_array(_move_attached_characters(unit_id, attached_chars, explicitly_moved_model_keys, changes))
 
 	# Ensure all attached characters are marked as moved even if _move_attached_characters
 	# returned early (e.g. no bodyguard delta found because only character models were staged)
@@ -8329,10 +8329,52 @@ func _process_embark_unit(action: Dictionary) -> Dictionary:
 
 	return create_result(true, changes)
 
-func _move_attached_characters(bodyguard_id: String, attached_char_ids: Array, explicitly_moved_models: Dictionary = {}) -> Array:
+func _build_final_occupancy(pending_changes: Array) -> Dictionary:
+	# Map "unit_id:model_id" -> a copy of the model carrying its FINAL position for
+	# this move. Live GameState position is overridden by any pending position
+	# set-op (bodyguard drops + explicitly-staged character moves not yet applied).
+	var pending_pos := {}
+	for ch in pending_changes:
+		if not (ch is Dictionary):
+			continue
+		if ch.get("op") != "set":
+			continue
+		var p_path := str(ch.get("path", ""))
+		if p_path.ends_with(".position"):
+			pending_pos[p_path] = ch.get("value")
+	var occ := {}
+	var units = game_state_snapshot.get("units", {})
+	for uid in units:
+		var models = units[uid].get("models", [])
+		for i in range(models.size()):
+			var m = models[i]
+			if not m.get("alive", true):
+				continue
+			var mid = m.get("id", "m%d" % (i + 1))
+			var m_path := "units.%s.models.%d.position" % [uid, i]
+			var pos_val = pending_pos.get(m_path, m.get("position"))
+			if pos_val == null:
+				continue
+			var mcopy = m.duplicate(true)
+			mcopy["position"] = pos_val
+			occ["%s:%s" % [uid, mid]] = mcopy
+	return occ
+
+func _occupancy_values_excluding(occupancy: Dictionary, exclude_key: String) -> Array:
+	var out := []
+	for k in occupancy:
+		if k == exclude_key:
+			continue
+		out.append(occupancy[k])
+	return out
+
+func _move_attached_characters(bodyguard_id: String, attached_char_ids: Array, explicitly_moved_models: Dictionary = {}, pending_changes: Array = []) -> Array:
 	"""Move attached character models to maintain formation with bodyguard.
 	Calculates delta from the bodyguard's first model move and applies to character models.
-	Models in explicitly_moved_models were already positioned via staged moves and are skipped."""
+	Models in explicitly_moved_models were already positioned via staged moves and are skipped.
+	pending_changes holds the position set-ops built earlier this confirm (bodyguard
+	final positions + explicitly-staged character positions) so the rigidly-translated
+	character models can be nudged off any model they would land on."""
 	var changes = []
 	var bodyguard = get_unit(bodyguard_id)
 	if bodyguard.is_empty():
@@ -8367,6 +8409,13 @@ func _move_attached_characters(bodyguard_id: String, attached_char_ids: Array, e
 
 	DebugLogger.info(str("[MovementPhase] Moving attached characters with delta: %s" % str(move_delta)))
 
+	# Occupancy of every alive model at its FINAL position for this move (pending
+	# changes override live state). Keyed by "unit:model_id" so we can exclude the
+	# model being placed and fold each resolved character position back in, keeping
+	# multiple attached characters from stacking on each other. See fix for the
+	# "attached character overlaps its bodyguard after Advance/Charge" bug.
+	var occupancy := _build_final_occupancy(pending_changes)
+
 	for char_id in attached_char_ids:
 		var char_unit = get_unit(char_id)
 		if char_unit.is_empty():
@@ -8390,7 +8439,19 @@ func _move_attached_characters(bodyguard_id: String, attached_char_ids: Array, e
 
 			var pos_x = model_pos.get("x", 0) if model_pos is Dictionary else model_pos.x
 			var pos_y = model_pos.get("y", 0) if model_pos is Dictionary else model_pos.y
-			var new_pos = Vector2(pos_x + move_delta.x, pos_y + move_delta.y)
+			var ideal_pos = Vector2(pos_x + move_delta.x, pos_y + move_delta.y)
+
+			# Nudge off any model the rigid delta would land the character on (its
+			# own stale spot is excluded so it never blocks itself).
+			var others := _occupancy_values_excluding(occupancy, model_key)
+			var new_pos = Measurement.find_nearest_non_overlapping_position(model, ideal_pos, others)
+			if new_pos != ideal_pos:
+				DebugLogger.info(str("[MovementPhase] Attached character %s.%s nudged off overlap: ideal %s -> %s" % [char_id, model_id, str(ideal_pos), str(new_pos)]))
+
+			# Record this character's resolved position so later attached models avoid it too.
+			var placed = model.duplicate(true)
+			placed["position"] = new_pos
+			occupancy[model_key] = placed
 
 			changes.append({
 				"op": "set",

--- a/40k/tests/saves/attached_char_advance_overlap.w40ksave
+++ b/40k/tests/saves/attached_char_advance_overlap.w40ksave
@@ -1,0 +1,993 @@
+{
+	"_serialization": {
+		"game_version": "1.0.0",
+		"serializer": "StateSerializer",
+		"timestamp": 1756841967.73848,
+		"version": "1.0.0"
+	},
+	"board": {
+		"deployment_zones": [
+			{
+				"player": 1,
+				"poly": [
+					{
+						"x": 0,
+						"y": 0
+					},
+					{
+						"x": 44,
+						"y": 0
+					},
+					{
+						"x": 44,
+						"y": 12
+					},
+					{
+						"x": 0,
+						"y": 12
+					}
+				]
+			},
+			{
+				"player": 2,
+				"poly": [
+					{
+						"x": 0,
+						"y": 48
+					},
+					{
+						"x": 44,
+						"y": 48
+					},
+					{
+						"x": 44,
+						"y": 60
+					},
+					{
+						"x": 0,
+						"y": 60
+					}
+				]
+			}
+		],
+		"objectives": [],
+		"size": {
+			"height": 60,
+			"width": 44
+		},
+		"terrain": []
+	},
+	"factions": {
+		"1": {
+			"detachment": "Shield Host",
+			"name": "Adeptus Custodes",
+			"player_name": "",
+			"points": 1000.0,
+			"team_name": ""
+		},
+		"2": {
+			"detachment": "",
+			"name": "Unknown",
+			"player_name": "",
+			"points": 2000.0,
+			"team_name": ""
+		}
+	},
+	"history": [
+		{
+			"actions": [
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 54.8505859375,
+							"y": 429.028198242188
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841405.4324,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BLADE_CHAMPION_A"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 58.183837890625,
+							"y": 1959.02819824219
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841408.28288,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_STRIKE_FORCE_A"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 304.8505859375,
+							"y": 435.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 394.850341796875,
+							"y": 439.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 464.850341796875,
+							"y": 435.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841412.75235,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CUSTODIAN_GUARD_B"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 381.517333984375,
+							"y": 1972.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841415.47126,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_B"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 641.517333984375,
+							"y": 425.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 748.183837890625,
+							"y": 425.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 851.517333984375,
+							"y": 425.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841419.85635,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_C"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 551.517333984375,
+							"y": 1962.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841423.19109,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_C"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1121.51733398438,
+							"y": 429.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1244.85034179688,
+							"y": 429.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1171.51733398438,
+							"y": 369.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1298.18383789062,
+							"y": 372.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841427.22676,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_D"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 784.850341796875,
+							"y": 1972.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841430.37797,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_IN_MEGA_ARMOUR_D"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 192.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841433.26431,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CALADIUS_GRAV-TANK_E"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2355.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2279.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2215.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2082.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1594.85034179688,
+							"y": 2082.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1594.85034179688,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 2215.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 2312.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2312.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2239.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2179.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2039.02819824219
+						},
+						{
+							"_type": "Vector2",
+							"x": 1421.51733398438,
+							"y": 2042.36145019531
+						},
+						{
+							"_type": "Vector2",
+							"x": 1421.51733398438,
+							"y": 2149.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1638.18383789062,
+							"y": 1965.69470214844
+						},
+						{
+							"_type": "Vector2",
+							"x": 1718.18383789062,
+							"y": 1965.69470214844
+						},
+						{
+							"_type": "Vector2",
+							"x": 1438.18383789062,
+							"y": 2265.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841444.81906,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BOYZ_E"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1458.18383789062,
+							"y": 382.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841448.48718,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_TELEMON_HEAVY_DREADNOUGHT_I"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 494.850341796875,
+							"y": 2262.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 341.517333984375,
+							"y": 2252.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 261.517333984375,
+							"y": 2335.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 404.850341796875,
+							"y": 2325.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 428.183837890625,
+							"y": 2275.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 428.183837890625,
+							"y": 2192.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 338.183837890625,
+							"y": 2192.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 291.517333984375,
+							"y": 2222.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 134.8505859375,
+							"y": 2252.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 141.517333984375,
+							"y": 2142.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 214.8505859375,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 261.517333984375,
+							"y": 2122.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 354.8505859375,
+							"y": 2122.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 451.517333984375,
+							"y": 2119.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 501.517333984375,
+							"y": 2142.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 574.850341796875,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 614.850341796875,
+							"y": 2359.0283203125
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841458.89177,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BOYZ_F"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 978.183837890625,
+							"y": 255.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841461.87657,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1024.85034179688,
+							"y": 2152.361328125
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841474.21672,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BATTLEWAGON_G"
+				}
+			],
+			"phase": 0,
+			"turn": 1
+		}
+	],
+	"meta": {
+		"active_player": 1,
+		"created_at": 1756841391.79978,
+		"game_id": "c3998bdc-a3c9-6315-adac-2b12b62e5c00cecf",
+		"phase": 7,
+		"turn_number": 1,
+		"version": "1.0.0"
+	},
+	"phase_log": [
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {
+				"dest": [
+					79.9996948242188,
+					591.416381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {
+				"dest": [
+					118.749633789062,
+					633.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					318.749633789062,
+					518.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					318.749633789062,
+					580.166381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					386.249633789062,
+					508.916412353516
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					409.999633789062,
+					545.166381835938
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					438.749633789062,
+					517.666381835938
+				],
+				"model_id": "m3"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {
+				"dest": [
+					1603.74951171875,
+					582.666381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					644.999633789062,
+					528.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					741.249633789062,
+					548.916381835938
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					864.999633789062,
+					555.166381835938
+				],
+				"model_id": "m3"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {
+				"dest": [
+					1127.49951171875,
+					505.166412353516
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {},
+			"type": "RESET_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {
+				"dest": [
+					1587.0830078125,
+					576.416381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		}
+	],
+	"players": {
+		"1": {
+			"cp": 0,
+			"vp": 0
+		},
+		"2": {
+			"cp": 0,
+			"vp": 0
+		}
+	},
+	"units": {
+		"U_CUSTODIAN_GUARD_B": {
+			"flags": {},
+			"id": "U_CUSTODIAN_GUARD_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Specialised disciplines mastered by Custodians over decades if not centuries, each ka'tah equips its practitioner to overmaster any foe in a particular discipline or philosophy.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					},
+					{
+						"description": "Add 1 to the Objective Control characteristic of models in the bearer's unit.",
+						"name": "Vexilla",
+						"type": "Wargear"
+					},
+					{
+						"description": "Each time a model in this unit makes an attack, re-roll a Wound roll of 1. While this unit is within range of an objective marker you control, you can re-roll the Wound roll instead.",
+						"name": "Stand Vigil",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Shooting phase, after this unit has shot, it can shoot again.",
+						"name": "Sentinel Storm",
+						"type": "Datasheet"
+					}
+				],
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BATTLELINE",
+					"CUSTODIAN GUARD",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Custodian Guard",
+				"points": 170.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "4-5 Custodian Guard",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Custodian Guard",
+					"Custodian Guard (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "24",
+						"special_rules": "assault",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Misericordia",
+						"range": "Melee",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"position": {
+						"x": 520.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m2",
+					"position": {
+						"x": 680.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m3",
+					"position": {
+						"x": 600.0,
+						"y": 720.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_CUSTODIAN_GUARD_B",
+			"status": 2,
+			"attachment_data": {
+				"attached_characters": [
+					"U_BLADE_CHAMPION_A"
+				]
+			}
+		},
+		"U_BLADE_CHAMPION_A": {
+			"flags": {},
+			"id": "U_BLADE_CHAMPION_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Specialised disciplines mastered by Custodians over decades if not centuries, each ka'tah equips its practitioner to overmaster any foe in a particular discipline or philosophy.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, you can re-roll Charge rolls made for that unit",
+						"name": "Swift Onslaught",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Charge phase, this model's unit is eligible to declare a charge in a turn which it Advanced.",
+						"name": "Martial Inspiration",
+						"type": "Datasheet"
+					}
+				],
+				"enhancements": [
+					"Adamantine Talisman (+25 pts)"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BLADE CHAMPION",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Blade Champion",
+				"points": 145.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Blade Champion",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Vaultswords \u2013 Behemor",
+						"range": "Melee",
+						"special_rules": "precision",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "9",
+						"damage": "1",
+						"name": "Vaultswords \u2013 Hurricanus",
+						"range": "Melee",
+						"special_rules": "sustained hits 1",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-3",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Vaultswords \u2013 Victus",
+						"range": "Melee",
+						"special_rules": "devastating wounds",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 600.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_BLADE_CHAMPION_A",
+			"status": 2,
+			"attachment_data": {
+				"attached_to": "U_CUSTODIAN_GUARD_B"
+			}
+		}
+	}
+}

--- a/40k/tests/saves/attached_char_charge_overlap.w40ksave
+++ b/40k/tests/saves/attached_char_charge_overlap.w40ksave
@@ -1,0 +1,1024 @@
+{
+	"_serialization": {
+		"game_version": "1.0.0",
+		"serializer": "StateSerializer",
+		"timestamp": 1756841967.73848,
+		"version": "1.0.0"
+	},
+	"board": {
+		"deployment_zones": [
+			{
+				"player": 1,
+				"poly": [
+					{
+						"x": 0,
+						"y": 0
+					},
+					{
+						"x": 44,
+						"y": 0
+					},
+					{
+						"x": 44,
+						"y": 12
+					},
+					{
+						"x": 0,
+						"y": 12
+					}
+				]
+			},
+			{
+				"player": 2,
+				"poly": [
+					{
+						"x": 0,
+						"y": 48
+					},
+					{
+						"x": 44,
+						"y": 48
+					},
+					{
+						"x": 44,
+						"y": 60
+					},
+					{
+						"x": 0,
+						"y": 60
+					}
+				]
+			}
+		],
+		"objectives": [],
+		"size": {
+			"height": 60,
+			"width": 44
+		},
+		"terrain": []
+	},
+	"factions": {
+		"1": {
+			"detachment": "Shield Host",
+			"name": "Adeptus Custodes",
+			"player_name": "",
+			"points": 1000.0,
+			"team_name": ""
+		},
+		"2": {
+			"detachment": "",
+			"name": "Unknown",
+			"player_name": "",
+			"points": 2000.0,
+			"team_name": ""
+		}
+	},
+	"history": [
+		{
+			"actions": [
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 54.8505859375,
+							"y": 429.028198242188
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841405.4324,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BLADE_CHAMPION_A"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 58.183837890625,
+							"y": 1959.02819824219
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841408.28288,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_STRIKE_FORCE_A"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 304.8505859375,
+							"y": 435.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 394.850341796875,
+							"y": 439.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 464.850341796875,
+							"y": 435.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841412.75235,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CUSTODIAN_GUARD_B"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 381.517333984375,
+							"y": 1972.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841415.47126,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_B"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 641.517333984375,
+							"y": 425.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 748.183837890625,
+							"y": 425.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 851.517333984375,
+							"y": 425.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841419.85635,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_C"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 551.517333984375,
+							"y": 1962.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841423.19109,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_C"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1121.51733398438,
+							"y": 429.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1244.85034179688,
+							"y": 429.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1171.51733398438,
+							"y": 369.028198242188
+						},
+						{
+							"_type": "Vector2",
+							"x": 1298.18383789062,
+							"y": 372.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841427.22676,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WITCHSEEKERS_D"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 784.850341796875,
+							"y": 1972.36145019531
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841430.37797,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_WARBOSS_IN_MEGA_ARMOUR_D"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 192.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841433.26431,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CALADIUS_GRAV-TANK_E"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2355.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2279.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2215.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1674.85034179688,
+							"y": 2082.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1594.85034179688,
+							"y": 2082.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1594.85034179688,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 2215.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 1561.51733398438,
+							"y": 2312.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2312.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2239.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2179.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1508.18383789062,
+							"y": 2039.02819824219
+						},
+						{
+							"_type": "Vector2",
+							"x": 1421.51733398438,
+							"y": 2042.36145019531
+						},
+						{
+							"_type": "Vector2",
+							"x": 1421.51733398438,
+							"y": 2149.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 1638.18383789062,
+							"y": 1965.69470214844
+						},
+						{
+							"_type": "Vector2",
+							"x": 1718.18383789062,
+							"y": 1965.69470214844
+						},
+						{
+							"_type": "Vector2",
+							"x": 1438.18383789062,
+							"y": 2265.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841444.81906,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BOYZ_E"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1458.18383789062,
+							"y": 382.361450195312
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841448.48718,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_TELEMON_HEAVY_DREADNOUGHT_I"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 494.850341796875,
+							"y": 2262.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 341.517333984375,
+							"y": 2252.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 261.517333984375,
+							"y": 2335.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 404.850341796875,
+							"y": 2325.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 428.183837890625,
+							"y": 2275.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 428.183837890625,
+							"y": 2192.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 338.183837890625,
+							"y": 2192.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 291.517333984375,
+							"y": 2222.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 134.8505859375,
+							"y": 2252.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 141.517333984375,
+							"y": 2142.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 214.8505859375,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 261.517333984375,
+							"y": 2122.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 354.8505859375,
+							"y": 2122.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 451.517333984375,
+							"y": 2119.0283203125
+						},
+						{
+							"_type": "Vector2",
+							"x": 501.517333984375,
+							"y": 2142.361328125
+						},
+						{
+							"_type": "Vector2",
+							"x": 574.850341796875,
+							"y": 2175.69482421875
+						},
+						{
+							"_type": "Vector2",
+							"x": 614.850341796875,
+							"y": 2359.0283203125
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841458.89177,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BOYZ_F"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 978.183837890625,
+							"y": 255.69482421875
+						}
+					],
+					"phase": 0,
+					"player": 1,
+					"timestamp": 1756841461.87657,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H"
+				},
+				{
+					"model_positions": [
+						{
+							"_type": "Vector2",
+							"x": 1024.85034179688,
+							"y": 2152.361328125
+						}
+					],
+					"phase": 0,
+					"player": 2,
+					"timestamp": 1756841474.21672,
+					"type": "DEPLOY_UNIT",
+					"unit_id": "U_BATTLEWAGON_G"
+				}
+			],
+			"phase": 0,
+			"turn": 1
+		}
+	],
+	"meta": {
+		"active_player": 1,
+		"created_at": 1756841391.79978,
+		"game_id": "c3998bdc-a3c9-6315-adac-2b12b62e5c00cecf",
+		"phase": 9,
+		"turn_number": 1,
+		"version": "1.0.0"
+	},
+	"phase_log": [
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {
+				"dest": [
+					79.9996948242188,
+					591.416381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {
+				"dest": [
+					118.749633789062,
+					633.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_BLADE_CHAMPION_A",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					318.749633789062,
+					518.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					318.749633789062,
+					580.166381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					386.249633789062,
+					508.916412353516
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					409.999633789062,
+					545.166381835938
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {
+				"dest": [
+					438.749633789062,
+					517.666381835938
+				],
+				"model_id": "m3"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CUSTODIAN_GUARD_B",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {
+				"dest": [
+					1603.74951171875,
+					582.666381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					644.999633789062,
+					528.916381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					741.249633789062,
+					548.916381835938
+				],
+				"model_id": "m2"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_C",
+			"payload": {
+				"dest": [
+					864.999633789062,
+					555.166381835938
+				],
+				"model_id": "m3"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {
+				"dest": [
+					1127.49951171875,
+					505.166412353516
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_WITCHSEEKERS_D",
+			"payload": {},
+			"type": "RESET_UNIT_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "BEGIN_NORMAL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {
+				"dest": [
+					1587.0830078125,
+					576.416381835938
+				],
+				"model_id": "m1"
+			},
+			"type": "STAGE_MODEL_MOVE"
+		},
+		{
+			"actor_unit_id": "U_CALADIUS_GRAV-TANK_E",
+			"payload": {},
+			"type": "CONFIRM_UNIT_MOVE"
+		}
+	],
+	"players": {
+		"1": {
+			"cp": 0,
+			"vp": 0
+		},
+		"2": {
+			"cp": 0,
+			"vp": 0
+		}
+	},
+	"units": {
+		"U_CUSTODIAN_GUARD_B": {
+			"flags": {},
+			"id": "U_CUSTODIAN_GUARD_B",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "Specialised disciplines mastered by Custodians over decades if not centuries, each ka'tah equips its practitioner to overmaster any foe in a particular discipline or philosophy.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "Add 1 to the bearer's Wounds characteristic.",
+						"name": "Praesidium Shield",
+						"type": "Wargear"
+					},
+					{
+						"description": "Add 1 to the Objective Control characteristic of models in the bearer's unit.",
+						"name": "Vexilla",
+						"type": "Wargear"
+					},
+					{
+						"description": "Each time a model in this unit makes an attack, re-roll a Wound roll of 1. While this unit is within range of an objective marker you control, you can re-roll the Wound roll instead.",
+						"name": "Stand Vigil",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Shooting phase, after this unit has shot, it can shoot again.",
+						"name": "Sentinel Storm",
+						"type": "Datasheet"
+					}
+				],
+				"enhancements": [],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BATTLELINE",
+					"CUSTODIAN GUARD",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Custodian Guard",
+				"points": 170.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 3.0
+				},
+				"unit_composition": [
+					{
+						"description": "4-5 Custodian Guard",
+						"line": 1.0
+					}
+				],
+				"wargear": [
+					"Custodian Guard",
+					"Custodian Guard (Shield), Praesidium Shield"
+				],
+				"weapons": [
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "24",
+						"special_rules": "assault",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-1",
+						"attacks": "2",
+						"ballistic_skill": "2",
+						"damage": "2",
+						"name": "Sentinel blade",
+						"range": "12",
+						"special_rules": "assault, pistol",
+						"strength": "4",
+						"type": "Ranged"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "2",
+						"name": "Guardian spear",
+						"range": "Melee",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Misericordia",
+						"range": "Melee",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-2",
+						"attacks": "5",
+						"damage": "1",
+						"name": "Sentinel blade",
+						"range": "Melee",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m1",
+					"position": {
+						"x": 520.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m2",
+					"position": {
+						"x": 680.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				},
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 3.0,
+					"id": "m3",
+					"position": {
+						"x": 600.0,
+						"y": 720.0
+					},
+					"status_effects": [],
+					"wounds": 3.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_CUSTODIAN_GUARD_B",
+			"status": 2,
+			"attachment_data": {
+				"attached_characters": [
+					"U_BLADE_CHAMPION_A"
+				]
+			}
+		},
+		"U_BLADE_CHAMPION_A": {
+			"flags": {},
+			"id": "U_BLADE_CHAMPION_A",
+			"meta": {
+				"abilities": [
+					{
+						"description": "Some units make their way to battle via tunnelling, teleportation, high-altitude descent or other extraordinary means that allow them to appear suddenly in the thick of the fighting.",
+						"name": "Deep Strike",
+						"type": "Core"
+					},
+					{
+						"description": "",
+						"name": "Core",
+						"type": "Core"
+					},
+					{
+						"description": "Specialised disciplines mastered by Custodians over decades if not centuries, each ka'tah equips its practitioner to overmaster any foe in a particular discipline or philosophy.",
+						"name": "Martial Ka'tah",
+						"type": "Faction"
+					},
+					{
+						"description": "While this model is leading a unit, you can re-roll Charge rolls made for that unit",
+						"name": "Swift Onslaught",
+						"type": "Datasheet"
+					},
+					{
+						"description": "Once per battle, in your Charge phase, this model's unit is eligible to declare a charge in a turn which it Advanced.",
+						"name": "Martial Inspiration",
+						"type": "Datasheet"
+					}
+				],
+				"enhancements": [
+					"Adamantine Talisman (+25 pts)"
+				],
+				"is_warlord": false,
+				"keywords": [
+					"ADEPTUS CUSTODES",
+					"BLADE CHAMPION",
+					"CHARACTER",
+					"IMPERIUM",
+					"INFANTRY"
+				],
+				"name": "Blade Champion",
+				"points": 145.0,
+				"stats": {
+					"leadership": 6.0,
+					"move": 6.0,
+					"objective_control": 2.0,
+					"save": 2.0,
+					"toughness": 6.0,
+					"wounds": 6.0
+				},
+				"unit_composition": [
+					{
+						"description": "1 Blade Champion",
+						"line": 1.0
+					}
+				],
+				"wargear": [],
+				"weapons": [
+					{
+						"ap": "-2",
+						"attacks": "6",
+						"damage": "2",
+						"name": "Vaultswords \u2013 Behemor",
+						"range": "Melee",
+						"special_rules": "precision",
+						"strength": "7",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-1",
+						"attacks": "9",
+						"damage": "1",
+						"name": "Vaultswords \u2013 Hurricanus",
+						"range": "Melee",
+						"special_rules": "sustained hits 1",
+						"strength": "5",
+						"type": "Melee",
+						"weapon_skill": "2"
+					},
+					{
+						"ap": "-3",
+						"attacks": "5",
+						"damage": "3",
+						"name": "Vaultswords \u2013 Victus",
+						"range": "Melee",
+						"special_rules": "devastating wounds",
+						"strength": "6",
+						"type": "Melee",
+						"weapon_skill": "2"
+					}
+				]
+			},
+			"models": [
+				{
+					"alive": true,
+					"base_mm": 40.0,
+					"current_wounds": 6.0,
+					"id": "m1",
+					"position": {
+						"x": 600.0,
+						"y": 800.0
+					},
+					"status_effects": [],
+					"wounds": 6.0
+				}
+			],
+			"owner": 1,
+			"squad_id": "U_BLADE_CHAMPION_A",
+			"status": 2,
+			"attachment_data": {
+				"attached_to": "U_CUSTODIAN_GUARD_B"
+			}
+		},
+		"U_ENEMY_BOYZ_X": {
+			"id": "U_ENEMY_BOYZ_X",
+			"owner": 2,
+			"status": 2,
+			"squad_id": "",
+			"flags": {},
+			"meta": {
+				"name": "Boyz",
+				"keywords": [
+					"ORKS",
+					"INFANTRY"
+				]
+			},
+			"attachment_data": {
+				"attached_characters": []
+			},
+			"models": [
+				{
+					"id": "m1",
+					"alive": true,
+					"wounds": 1,
+					"current_wounds": 1,
+					"base_mm": 32,
+					"base_type": null,
+					"position": {
+						"x": 600.0,
+						"y": 592.0
+					}
+				}
+			]
+		}
+	}
+}

--- a/40k/tests/scenarios/sp/attached_char_advance_no_overlap.json
+++ b/40k/tests/scenarios/sp/attached_char_advance_no_overlap.json
@@ -1,0 +1,49 @@
+{
+  "id": "attached_char_advance_no_overlap",
+  "covers": [
+    "phases.MovementPhase.attached_character_no_overlap",
+    "movement.advance.leader_rides_without_stacking"
+  ],
+  "fixture": "attached_char_advance_overlap",
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Regression for the 'attached character overlaps its bodyguard after an Advance' bug. Custodian Guard B (3x 40mm) leads Blade Champion A (40mm, attached, sitting in the middle of the squad). The unit Advances and the player re-arranges the three bodyguard models into a tight row where model m3 ends exactly where the champion's rigid ride-along delta (taken from m1) would land it. Before the fix the champion was translated straight onto m3 (bases fully stacked); the fix nudges the champion to the nearest clear spot. Asserts the champion overlaps ZERO bodyguard models after CONFIRM_UNIT_MOVE, that it still rode along (moved off its start), and screenshots the board so the non-overlapping formation is visible.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 7 },
+    { "act": "expect_token_visible", "unit_id": "U_CUSTODIAN_GUARD_B", "timeout_s": 3.0 },
+    { "act": "expect_token_visible", "unit_id": "U_BLADE_CHAMPION_A", "timeout_s": 3.0 },
+    { "act": "expect_state", "path": "units.U_CUSTODIAN_GUARD_B.attachment_data.attached_characters.0", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "screenshot", "label": "01_before_advance" },
+
+    { "act": "dispatch_action", "action": { "type": "BEGIN_ADVANCE", "actor_unit_id": "U_CUSTODIAN_GUARD_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.2 },
+
+    { "act": "dispatch_action", "action": { "type": "STAGE_MODEL_MOVE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": { "model_id": "m1", "dest": [520, 600], "rotation": 0.0 } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "STAGE_MODEL_MOVE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": { "model_id": "m2", "dest": [680, 600], "rotation": 0.0 } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "STAGE_MODEL_MOVE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": { "model_id": "m3", "dest": [600, 600], "rotation": 0.0 } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "screenshot", "label": "02_bodyguard_staged" },
+
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_UNIT_MOVE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": {} } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "03_after_advance_confirm" },
+
+    { "act": "execute_script",
+      "script": "int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[0])) + int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[1])) + int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[2]))",
+      "equals": 0 },
+
+    { "act": "execute_script",
+      "script": "Vector2(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0].position.x, GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0].position.y).distance_to(Vector2(600, 800))",
+      "expect_min": 20.0 },
+
+    { "act": "execute_script",
+      "script": "self.min_edge_distance_between_units(\"U_BLADE_CHAMPION_A\", \"U_CUSTODIAN_GUARD_B\")",
+      "expect_max": 2.0 }
+  ]
+}

--- a/40k/tests/scenarios/sp/attached_char_charge_no_overlap.json
+++ b/40k/tests/scenarios/sp/attached_char_charge_no_overlap.json
@@ -1,0 +1,50 @@
+{
+  "id": "attached_char_charge_no_overlap",
+  "covers": [
+    "phases.ChargePhase.attached_character_no_overlap",
+    "charge.leader_rides_without_stacking"
+  ],
+  "fixture": "attached_char_charge_overlap",
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Regression for the 'attached character overlaps its bodyguard after a Charge' bug. Custodian Guard B (3x 40mm) leads Blade Champion A (attached, in the middle of the squad). The squad charges an Ork Boyz model; the player's per-model charge paths bring model m3 into base contact with the enemy at exactly where the champion's rigid ride-along delta (taken from m1) would land it. Before the fix the champion was translated straight onto m3; the fix nudges it to the nearest clear spot. Asserts the champion overlaps ZERO bodyguard models AND does not overlap the enemy after APPLY_CHARGE_MOVE, that it still rode along, and screenshots the resulting formation.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 9 },
+    { "act": "expect_token_visible", "unit_id": "U_CUSTODIAN_GUARD_B", "timeout_s": 3.0 },
+    { "act": "expect_token_visible", "unit_id": "U_BLADE_CHAMPION_A", "timeout_s": 3.0 },
+    { "act": "expect_state", "path": "units.U_CUSTODIAN_GUARD_B.attachment_data.attached_characters.0", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "screenshot", "label": "01_before_charge" },
+
+    { "act": "dispatch_action", "action": { "type": "DECLARE_CHARGE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": { "target_unit_ids": ["U_ENEMY_BOYZ_X"] } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "CHARGE_ROLL", "actor_unit_id": "U_CUSTODIAN_GUARD_B" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "APPLY_CHARGE_MOVE", "actor_unit_id": "U_CUSTODIAN_GUARD_B", "payload": { "per_model_paths": {
+      "m1": [[520, 800], [520, 650]],
+      "m2": [[680, 800], [680, 650]],
+      "m3": [[600, 720], [600, 650]]
+    } } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "screenshot", "label": "02_after_charge_move" },
+
+    { "act": "execute_script",
+      "script": "int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[0])) + int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[1])) + int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models[2]))",
+      "equals": 0 },
+
+    { "act": "execute_script",
+      "script": "int(Measurement.models_overlap(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0], GameState.get_unit(\"U_ENEMY_BOYZ_X\").models[0]))",
+      "equals": 0 },
+
+    { "act": "execute_script",
+      "script": "Vector2(GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0].position.x, GameState.get_unit(\"U_BLADE_CHAMPION_A\").models[0].position.y).distance_to(Vector2(600, 800))",
+      "expect_min": 20.0 },
+
+    { "act": "execute_script",
+      "script": "self.min_edge_distance_between_units(\"U_BLADE_CHAMPION_A\", \"U_CUSTODIAN_GUARD_B\")",
+      "expect_max": 2.0 }
+  ]
+}

--- a/40k/tests/test_consolidate_terrain_objective_11e.gd.uid
+++ b/40k/tests/test_consolidate_terrain_objective_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://c6pnm5drof3ex

--- a/40k/tests/test_repro_attached_char_overlap.gd
+++ b/40k/tests/test_repro_attached_char_overlap.gd
@@ -1,0 +1,188 @@
+extends SceneTree
+
+# Regression: an attached character (e.g. a Blade Champion leading Custodian
+# Guard) must NOT end up overlapping a bodyguard model after the unit makes a
+# Normal/Advance move (MovementPhase) or a Charge move (ChargePhase).
+#
+# Root cause (fixed): attached-character models are rigidly translated by the
+# bodyguard's first-model delta with NO overlap resolution, so when the player
+# re-arranges the bodyguard formation the character could land on top of a
+# bodyguard model. The fix nudges the character to the nearest clear position.
+#
+# Usage: godot --headless --path . -s tests/test_repro_attached_char_overlap.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run)
+
+func _mk(id: String, x: float, y: float) -> Dictionary:
+	# 40mm circular base (Custodian Guard / Blade Champion).
+	return {"id": id, "alive": true, "wounds": 2, "current_wounds": 2,
+		"base_mm": 40, "base_type": "circular", "position": {"x": x, "y": y}}
+
+func _pos(v) -> Vector2:
+	if v is Vector2: return v
+	return Vector2(v.get("x", 0), v.get("y", 0))
+
+func _overlaps_any_guard(Meas, champ_pos: Vector2, guard_models: Array) -> String:
+	var champ = {"base_mm": 40, "base_type": "circular", "position": champ_pos}
+	for gm in guard_models:
+		var g = {"base_mm": 40, "base_type": "circular", "position": _pos(gm.get("position"))}
+		if Meas.models_overlap(champ, g):
+			return gm.get("id")
+	return ""
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_repro_attached_char_overlap ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var Meas = root.get_node_or_null("Measurement")
+	if gs == null or Meas == null:
+		_check("autoloads present", false); _finish(); return
+	var prev_state = gs.state.duplicate(true)
+
+	_test_measurement_helper(Meas)
+	_test_movement_advance(gs, Meas)
+	_test_charge(gs, Meas)
+
+	gs.state = prev_state
+	_finish()
+
+# ── 1. The shared resolver keeps a clear ideal, moves an overlapping one. ──
+func _test_measurement_helper(Meas) -> void:
+	print("-- Measurement.find_nearest_non_overlapping_position --")
+	var mover = {"base_mm": 40, "base_type": "circular"}
+	var blocker = {"base_mm": 40, "base_type": "circular", "position": Vector2(500, 500)}
+
+	# Clear ideal -> returned unchanged.
+	var clear_ideal = Vector2(900, 900)
+	var r_clear = Meas.find_nearest_non_overlapping_position(mover, clear_ideal, [blocker])
+	_check("clear ideal returned unchanged", r_clear == clear_ideal, str(r_clear))
+
+	# Ideal on top of a blocker -> nudged clear, and close to ideal.
+	var r_nudge = Meas.find_nearest_non_overlapping_position(mover, Vector2(500, 500), [blocker])
+	var nudged = {"base_mm": 40, "base_type": "circular", "position": r_nudge}
+	_check("overlapping ideal is nudged clear of the blocker",
+		not Meas.models_overlap(nudged, blocker), str(r_nudge))
+	# 40mm bases: must separate ~63px; nearest clear spot should be well under 90px away.
+	_check("nudge stays near the ideal (nearest gap)",
+		Vector2(500, 500).distance_to(r_nudge) < 90.0,
+		"moved %.1fpx" % Vector2(500, 500).distance_to(r_nudge))
+
+# ── 2. MovementPhase advance: champion riding a re-arranged bodyguard. ──
+func _test_movement_advance(gs, Meas) -> void:
+	print("-- MovementPhase._move_attached_characters --")
+	var champ_start := Vector2(500, 640)
+	var m1_from := Vector2(500, 570)
+	var m1_dest := Vector2(500, 300)
+	var delta := m1_dest - m1_from            # (0,-270)
+	var champ_ideal := champ_start + delta    # (500,370) -> lands on m2
+
+	gs.state["units"] = {
+		"U_GUARD": {"id": "U_GUARD", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Custodian Guard Zeta", "keywords": ["INFANTRY"]},
+			"attachment_data": {"attached_characters": ["U_CHAMP"]},
+			"models": [
+				_mk("m1", m1_dest.x, m1_dest.y),   # 500,300 (final)
+				_mk("m2", 500, 370),               # champion's rigid ideal
+				_mk("m3", 500, 440),
+				_mk("m4", 500, 510),
+				_mk("m5", 500, 580),
+			]},
+		"U_CHAMP": {"id": "U_CHAMP", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Blade Champion Gamma", "keywords": ["INFANTRY", "CHARACTER"]},
+			"attachment_data": {"attached_to": "U_GUARD"},
+			"models": [_mk("m1", champ_start.x, champ_start.y)]},
+	}
+
+	var mp = load("res://phases/MovementPhase.gd").new()
+	get_root().add_child(mp)
+	mp.active_moves = {"U_GUARD": {"mode": "ADVANCE", "staged_moves": [],
+		"model_moves": [{"model_id": "m1", "model_source_unit_id": "U_GUARD",
+			"from": {"x": m1_from.x, "y": m1_from.y},
+			"dest": {"x": m1_dest.x, "y": m1_dest.y}, "rotation": 0.0}]}}
+
+	var changes = mp._move_attached_characters("U_GUARD", ["U_CHAMP"], {})
+	var champ_final = null
+	for ch in changes:
+		if ch.get("op") == "set" and str(ch.get("path", "")).begins_with("units.U_CHAMP.models.0.position"):
+			champ_final = _pos(ch.get("value"))
+	_check("advance: champion move produced", champ_final != null)
+	if champ_final != null:
+		var hit = _overlaps_any_guard(Meas, champ_final, gs.state["units"]["U_GUARD"]["models"])
+		_check("advance: champion does NOT overlap any bodyguard model",
+			hit == "", "champion %s overlaps guard %s (ideal was %s)" % [str(champ_final), hit, str(champ_ideal)])
+		_check("advance: champion still moved with the unit (near its rigid ideal)",
+			champ_final.distance_to(champ_ideal) < 120.0,
+			"moved %.1fpx from ideal" % champ_final.distance_to(champ_ideal))
+	mp.free()
+
+# ── 3. ChargePhase charge: champion riding a re-arranged bodyguard. ──
+func _test_charge(gs, Meas) -> void:
+	print("-- ChargePhase._charge_attached_character_changes --")
+	var champ_start := Vector2(500, 640)
+
+	# Bodyguard starts spread on a horizontal row; charges into a tight column.
+	gs.state["units"] = {
+		"U_GUARD2": {"id": "U_GUARD2", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Custodian Guard Zeta", "keywords": ["INFANTRY"]},
+			"attachment_data": {"attached_characters": ["U_CHAMP2"]},
+			"models": [
+				_mk("m1", 500, 570),
+				_mk("m2", 600, 570),
+				_mk("m3", 700, 570),
+				_mk("m4", 800, 570),
+				_mk("m5", 900, 570),
+			]},
+		"U_CHAMP2": {"id": "U_CHAMP2", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Blade Champion Gamma", "keywords": ["INFANTRY", "CHARACTER"]},
+			"attachment_data": {"attached_to": "U_GUARD2"},
+			"models": [_mk("m1", champ_start.x, champ_start.y)]},
+	}
+	# Charge paths: m1 delta (0,-270); m2 ends exactly on champion's rigid ideal.
+	var per_model_paths = {
+		"m1": [[500, 570], [500, 300]],
+		"m2": [[600, 570], [500, 370]],   # champion ideal = (500,370)
+		"m3": [[700, 570], [500, 440]],
+		"m4": [[800, 570], [500, 510]],
+		"m5": [[900, 570], [500, 580]],
+	}
+	var champ_ideal := champ_start + Vector2(0, -270)  # (500,370)
+
+	var cp = load("res://phases/ChargePhase.gd").new()
+	get_root().add_child(cp)
+
+	var changes = cp._charge_attached_character_changes("U_GUARD2", per_model_paths, true)
+	var champ_final = null
+	for ch in changes:
+		if ch.get("op") == "set" and str(ch.get("path", "")).begins_with("units.U_CHAMP2.models.0.position"):
+			champ_final = _pos(ch.get("value"))
+	_check("charge: champion move produced", champ_final != null)
+	if champ_final != null:
+		# Guard FINAL positions for the overlap check.
+		var guard_finals := []
+		for mid in ["m1", "m2", "m3", "m4", "m5"]:
+			var p = per_model_paths[mid]
+			guard_finals.append({"id": mid, "position": {"x": p[-1][0], "y": p[-1][1]}})
+		var hit = _overlaps_any_guard(Meas, champ_final, guard_finals)
+		_check("charge: champion does NOT overlap any bodyguard model",
+			hit == "", "champion %s overlaps guard %s (ideal was %s)" % [str(champ_final), hit, str(champ_ideal)])
+		_check("charge: champion still moved with the unit (near its rigid ideal)",
+			champ_final.distance_to(champ_ideal) < 120.0,
+			"moved %.1fpx from ideal" % champ_final.distance_to(champ_ideal))
+	cp.free()
+
+func _finish():
+	print("\n=== Totals: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_repro_attached_char_overlap.gd.uid
+++ b/40k/tests/test_repro_attached_char_overlap.gd.uid
@@ -1,0 +1,1 @@
+uid://fvde1r53a8bf


### PR DESCRIPTION
## Problem

An attached **CHARACTER** (e.g. a Blade Champion leading Custodian Guard) ended up stacked directly on top of one of its own bodyguard models after the unit made an **Advance/Normal move** or a **Charge** — the bases fully overlapped, which models should never do. This is the reported bug (screenshots showed a Blade Champion sitting under a Custodian Guard model after an advance, and again after a charge).

## Root cause

When a character is attached to a unit, its model is moved by a **rigid delta** copied from the bodyguard's first model, with **no collision check**:
- `MovementPhase._move_attached_characters` (Normal / Advance / Fall Back)
- `ChargePhase._charge_attached_character_changes` (Charge)

So when the player re-arranged the squad's formation, that rigid translation could drop the character exactly onto a bodyguard model. The overlap validation only covered the explicitly-dragged bodyguard models, never the ride-along character.

## Fix

- Added `Measurement.find_nearest_non_overlapping_position` — a shape-aware spiral search (works for circular/oval/rect bases via `models_overlap`).
- Both phases now build an occupancy map of every model's **final** position for the move (bodyguard drops + already-placed characters) and nudge each rigidly-translated character to the nearest clear spot. The character still rides along and stays in coherency; only the final overlap is corrected. Multiple attached characters no longer stack on each other either.

## Validation

- **Headless** `tests/test_repro_attached_char_overlap.gd` — RED→GREEN for the movement path, the charge path, and the resolver itself (9 assertions).
- **Windowed** `tests/scenarios/sp/attached_char_advance_no_overlap.json` — drives the real `BEGIN_ADVANCE → STAGE_MODEL_MOVE → CONFIRM_UNIT_MOVE` pipeline; the nudge fires in the live log (ideal `(600,600)` → `(600,663)`) and the champion overlaps **zero** bodyguard models.
- **Windowed** `tests/scenarios/sp/attached_char_charge_no_overlap.json` — drives `DECLARE_CHARGE → CHARGE_ROLL → APPLY_CHARGE_MOVE`; champion overlaps **zero** bodyguard models and **zero** enemy models.
- No regressions: `iss040_movement_11e` (52/52), `51_confirm_movement_mode` (11/11), `372_ere_we_go_charge_modifier` (8/8), `test_pile_in_overlap_model_id_keys` (14/14), `test_iss059_attached_units_11e` (18/18).

Changelog bumped to **0.45.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012geuMBwL49QiWFYG6AVLLj

---
_Generated by [Claude Code](https://claude.ai/code/session_012geuMBwL49QiWFYG6AVLLj)_