### PR TITLE
Fix AI opponent never piling in during the 11e global Pile In step

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -409,21 +409,28 @@ func _human_fight_turn_pending() -> int:
 	# shown) when they have eligible units; a player with none is auto-passed by
 	# _advance_pile_in_step_11e. So an ACTIVE step pointing at a human means the
 	# human owes a pile-in decision the AI must not make for them.
+	# This is a GLOBAL step that runs BEFORE the Fight step, so we must SHORT-
+	# CIRCUIT here and never fall through to the 12.04 sequencer branch below:
+	# during the AI's OWN pile-in half the sequencer's peek reports the first
+	# fighter's owner (usually the active human), which used to make this return
+	# the human and idle the AI — the reported "AI opponent never piles in / the
+	# fight phase proceeds without the AI having piled in" bug. The only owner of
+	# this step is whoever's half it is: the human (block the AI) or nobody-human
+	# (return 0 so the AI plays its own half).
 	if "pile_in_step_11e" in fp and "piling_in_player_11e" in fp:
 		if int(fp.pile_in_step_11e) == int(fp.PileInStep11e.ACTIVE):
 			var pp = int(fp.piling_in_player_11e)
-			if pp > 0 and not is_ai_player(pp):
-				return pp
+			return pp if (pp > 0 and not is_ai_player(pp)) else 0
 
-	# 12.07 Consolidate step — same shape (skip while a 12.08 forced fight has
-	# temporarily taken the step over; that forced fight is owned by whoever
-	# holds the fighter and is handled by the fight-step branch below).
+	# 12.07 Consolidate step — same GLOBAL-step short-circuit as Pile In above
+	# (skip it only while a 12.08 forced fight has temporarily taken the step
+	# over; that forced fight is owned by whoever holds the fighter and is
+	# handled by the fight-step branch below).
 	if "consolidation_step_11e" in fp and "consolidating_player_11e" in fp:
 		if int(fp.consolidation_step_11e) == int(fp.ConsolidationStep11e.ACTIVE) \
 				and not fp._forced_fights_pending_11e():
 			var cp = int(fp.consolidating_player_11e)
-			if cp > 0 and not is_ai_player(cp):
-				return cp
+			return cp if (cp > 0 and not is_ai_player(cp)) else 0
 
 	# 12.04 Fight step (11e sequencer only; 10e keeps its existing behavior).
 	# A human's fighter mid-activation, or a human whose turn it is to select

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.45.1",
+			"date": "2026-07-15",
+			"summary": "Fixed the AI opponent skipping its Pile In moves in the Fight phase. In 11th edition Pile In is a shared step — you pile in all your eligible units, then your opponent piles in all of theirs, and only then does the fighting begin. On your turn the AI's engaged units were never getting their pile-in: the game correctly handed the Pile In step to the AI, but an internal 'whose turn is it?' check wrongly decided it was still your turn, so the AI sat idle and the step could stall on the AI's half. The AI now plays its half of the Pile In (and Consolidate) step correctly.",
+			"changes": [
+				"During your turn's Fight phase, after you finish your Pile In moves the AI opponent now actually piles in its engaged units toward your models before the fighting starts, as the 11th-edition rules require.",
+				"Root cause: the AI's 'does a human currently owe this fight-phase decision?' guard fell through to the fight-selection order — which starts with the active player (you) — during the AI's OWN Pile In / Consolidate half, so the AI was told to wait and never moved. It now correctly recognises when the AI owns that half.",
+				"No change to your own pile-ins, or to how fights are resolved after everyone has piled in."
+			]
+		},
+		{
 			"version": "0.45.0",
 			"date": "2026-07-15",
 			"summary": "Charge phase now shows each model's actual charge-move reach while you drag. After you roll the 2D6 charge distance, the single 12\" range circle is replaced with a per-model reach ring (radius = the distance you rolled) centred on every charging model, so you can see exactly how far each model is allowed to move instead of a 12\" circle that no longer applies.",

--- a/40k/tests/test_ai_pile_in_autoload_trigger_11e.gd
+++ b/40k/tests/test_ai_pile_in_autoload_trigger_11e.gd
@@ -1,0 +1,127 @@
+extends SceneTree
+
+# 11e 12.02 — REGRESSION guard for the AIPlayer AUTOLOAD trigger.
+#
+# The AI decision ladder (AIDecisionMaker._decide_fight producing a PILE_IN) was
+# already covered by test_ai_pile_in.gd / test_global_consolidation_ai_11e.gd,
+# but those drive the decision maker DIRECTLY and never exercise the autoload
+# trigger. The reported bug lived in the trigger: during the AI's OWN half of the
+# global Pile In step, AIPlayer._human_fight_turn_pending() fell through the
+# (correct) Pile-In branch into the 12.04 Fight-step sequencer branch, which
+# peeks the FIRST fighter — the active human — and reported "the human owns this
+# turn". So _evaluate_and_act idled ("fight-phase turn belongs to human, AI
+# waits") and the AI opponent never piled in; the global step stalled on its
+# half. This test pins _human_fight_turn_pending()'s return across both halves.
+#
+# Usage: godot --headless --path . -s tests/test_ai_pile_in_autoload_trigger_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + str(detail) if str(detail) != "" else ""])
+
+func _init():
+	create_timer(0.1).timeout.connect(_run)
+
+func _board(gs) -> void:
+	# P1 (human) charged into P2 (AI); both engaged (25mm bases, 60px apart
+	# center ~= 0.5" edge-to-edge). Mirrors the reported screenshot.
+	gs.state["units"] = {
+		"U_A": {"id": "U_A", "owner": 1, "status": 2, "flags": {"charged_this_turn": true},
+			"meta": {"name": "P1 charger", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 1}},
+			"models": [{"id": "m0", "alive": true, "wounds": 1, "current_wounds": 1, "base_mm": 25, "base_type": "circular", "position": {"x": 500, "y": 500}}]},
+		"U_B": {"id": "U_B", "owner": 2, "status": 2, "flags": {},
+			"meta": {"name": "P2 AI target", "keywords": ["INFANTRY"], "stats": {"move": 6, "wounds": 1}},
+			"models": [{"id": "e0", "alive": true, "wounds": 1, "current_wounds": 1, "base_mm": 25, "base_type": "circular", "position": {"x": 560, "y": 500}}]},
+	}
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["phase"] = 10
+
+func _run():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_ai_pile_in_autoload_trigger_11e ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var pm = root.get_node_or_null("PhaseManager")
+	var ai = root.get_node_or_null("AIPlayer")
+	if gs == null or pm == null or ai == null:
+		_check("autoloads present (GameState/PhaseManager/AIPlayer)", false)
+		return _finish()
+	var prev_state = gs.state.duplicate(true)
+	var prev_edition = GameConstants.edition
+
+	GameConstants.edition = 11
+	ai.configure({1: "HUMAN", 2: "AI"})
+	# Keep the test deterministic: drive the fight steps ourselves rather than
+	# racing the autoload's frame-paced _process (the trigger's return value is
+	# what we assert; the end-to-end autoload path is covered by the live
+	# windowed bridge run).
+	ai.set_process(false)
+	_board(gs)
+	pm.transition_to_phase(10)
+	var fp = pm.get_current_phase_instance()
+
+	_check("phase opens on the global Pile In step, active human (P1) first",
+		fp.pile_in_step_11e == fp.PileInStep11e.ACTIVE and fp.piling_in_player_11e == 1,
+		"step=%s player=%s" % [fp.pile_in_step_11e, fp.piling_in_player_11e])
+	_check("both units are eligible to pile in (engaged)",
+		fp._pile_in_eligible_units_11e(1) == ["U_A"] and fp._pile_in_eligible_units_11e(2) == ["U_B"])
+
+	# During the HUMAN's half the AI must idle and yield to the human.
+	_check("during the HUMAN's pile-in half, _human_fight_turn_pending() == 1 (yield to human)",
+		ai._human_fight_turn_pending() == 1, ai._human_fight_turn_pending())
+
+	# Human ends their half -> the AI's half begins.
+	var r = fp.execute_action({"type": "END_PILE_IN", "player": 1})
+	_check("END_PILE_IN(player 1) succeeds", r.get("success", false), r)
+	_check("the AI (P2) now owns the pile-in half",
+		fp.piling_in_player_11e == 2 and fp.pile_in_step_11e == fp.PileInStep11e.ACTIVE,
+		"step=%s player=%s" % [fp.pile_in_step_11e, fp.piling_in_player_11e])
+
+	# THE REGRESSION: during the AI's OWN half the trigger must NOT report a
+	# human. Pre-fix this returned 1 (fell through to the fight sequencer, which
+	# peeked P1 as the first fighter) and the AI idled forever.
+	_check("during the AI's pile-in half, _human_fight_turn_pending() == 0 (nobody-human blocks the AI)",
+		ai._human_fight_turn_pending() == 0, ai._human_fight_turn_pending())
+	_check("_is_any_ai_player_active() is TRUE so the AI (and watchdog) will act",
+		ai._is_any_ai_player_active() == true)
+
+	# And the AI can actually play + complete its half from the offered actions.
+	var guard := 0
+	while fp.pile_in_step_11e == fp.PileInStep11e.ACTIVE and guard < 8:
+		var acts = fp.get_available_actions()
+		if acts.is_empty():
+			break
+		var d = AIDecisionMaker._decide_fight(gs.state, acts, fp.current_selecting_player)
+		if d.is_empty():
+			_check("AI produced a decision for its offered pile-in actions", false, str(acts))
+			break
+		var rr = fp.execute_action(d)
+		if not rr.get("success", false) and d.get("type", "") == "PILE_IN" and not d.get("movements", {}).is_empty():
+			d["movements"] = {}
+			rr = fp.execute_action(d)
+		if not rr.get("success", false):
+			_check("AI action %s executed" % d.get("type", "?"), false, str(rr))
+			break
+		guard += 1
+	_check("Pile In step completes and the Fight step begins (no stall)",
+		fp.pile_in_step_11e == fp.PileInStep11e.DONE, "step=%s guard=%d" % [fp.pile_in_step_11e, guard])
+	_check("the AI's unit U_B actually piled in",
+		fp.units_that_piled_in.has("U_B"), fp.units_that_piled_in.keys())
+	var ub_x = float(gs.state["units"]["U_B"]["models"][0]["position"]["x"])
+	_check("U_B physically moved toward the enemy (x < 560, was 560)",
+		ub_x < 559.5, "x=%.2f" % ub_x)
+
+	gs.state = prev_state
+	GameConstants.edition = prev_edition
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_consolidate_terrain_objective_11e.gd.uid
+++ b/40k/tests/test_consolidate_terrain_objective_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://by30fw8diod35

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-The warhammer core rules that this game is replicating can be found here: https://wahapedia.ru/wh40k10ed/the-rules/core-rules/
+The warhammer core rules that this game is replicating can be found here: https://wahapedia.ru/wh40k11ed/the-rules/core-rules/ (11th edition — the current edition, released June 2026)
 
 The Godot documentation can be found here: https://docs.godotengine.org/en/4.4/
 


### PR DESCRIPTION
## Summary

In 11th edition the Fight phase opens with a shared **Pile In step** (12.02): the active player piles in all their eligible units, then the opponent piles in all of theirs, and only then does the fighting begin. On a human's turn the **AI opponent's engaged units never piled in** — the step stalled on the AI's half.

## Root cause

`AIPlayer._human_fight_turn_pending()` checks the Pile In step, then the Consolidate step, then the 12.04 fight sequencer. The first two branches only returned when the step pointed at a *human* and otherwise fell through. During the AI's **own** pile-in half the code reached the sequencer branch, whose peek reports the **first fighter's owner** (the active human), so the function returned the human, `_evaluate_and_act` idled the AI (`"fight-phase turn belongs to human, AI waits"`), and the watchdog couldn't rescue it (`_is_any_ai_player_active()` was false too).

The existing AI tests drive `AIDecisionMaker._decide_fight` directly and bypass the autoload trigger, so they never caught this.

## Fix

The global Pile In and Consolidate branches now **short-circuit** — return the human on their half, else `0` — and never fall through to the sequencer, which is only meaningful once the fight step has begun.

## Validation

- **Live (in-game MCP bridge):** with a P1(human)-charged, P2(AI)-engaged setup, after `END_PILE_IN` the AI now piles in its unit (x 560 → 539.9), the step reaches DONE, and the fight begins. `verify_delivery` → **PASS**, zero log errors.
- **New regression test** `test_ai_pile_in_autoload_trigger_11e.gd` pins `_human_fight_turn_pending()` across both halves — **fails on pristine code, passes with the fix** (10/10).
- **No regressions:** 6 related fight/AI suites green (`test_ai_pile_in`, `test_global_pile_in_11e`, `test_global_consolidation_ai_11e`, `test_global_consolidation_11e`, `test_fight_phase_scope_end_fight_11e`, `test_iss066_fight_phase_wiring`).

## Also

- Updated the `CLAUDE.md` core-rules link from the 10th- to the 11th-edition Wahapedia page (the code is already on 11e fight rules).
- Changelog entry `0.45.1`.
- Committed a missing `.uid` for an already-tracked consolidation test (generated by the Godot importer; `.uid` files are tracked in this repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LTtY4uRM1MEzurnhD9QAkP)_