### PR TITLE
Fix empty FIRING ORDER box in single-weapon shooting dialog

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -990,30 +990,66 @@ func _do_execute_script(step: Dictionary) -> Dictionary:
 	if code == "":
 		return {"pass": false, "error": "execute_script needs `script`"}
 
-	# Build input name/value pairs:
-	#   - every autoload child of /root (referenced by node name)
-	#   - common engine singletons (Engine, OS, Time, Input, RenderingServer)
-	#   - `main` -> the live battle scene root, if loaded
-	var input_names: Array = []
-	var input_values: Array = []
-	var root := get_tree().root
-	for child in root.get_children():
-		input_names.append(child.name)
-		input_values.append(child)
-	# ResourceLoader/ClassDB let a scenario instantiate a script-backed node
-	# (e.g. a dialog) for windowed validation: ResourceLoader.load(path).new().
-	input_names.append_array(["Engine", "OS", "Time", "Input", "RenderingServer", "ProjectSettings", "ResourceLoader", "ClassDB", "main"])
-	input_values.append_array([Engine, OS, Time, Input, RenderingServer, ProjectSettings, ResourceLoader, ClassDB, get_tree().current_scene])
+	var actual
+	# Statement mode is EXPLICIT-only (`"multiline": true`) — unlike the MCP
+	# bridge we must not auto-detect on "\n", because existing scenario scripts
+	# legitimately embed newlines inside string literals and rely on the
+	# Expression path (e.g. resolution_log_dice_icons.json).
+	var multiline: bool = bool(step.get("multiline", false))
+	if multiline:
+		# Multi-line / statement mode — parity with the MCP bridge's
+		# execute_script (testing_handlers.gd): the snippet is compiled into a
+		# throwaway GDScript so full statements work (`var`, `if`, `for`,
+		# `return`). The snippet receives `node` (the node at the optional `node`
+		# step key, default /root) and `tree` (the SceneTree); autoloads are
+		# reachable by their global names. `return <value>` feeds the
+		# equals/not_equals/exists expectation below.
+		var target: Node = get_tree().root
+		if step.has("node"):
+			target = get_node_or_null(str(step["node"]))
+			if target == null:
+				return {"pass": false, "error": "no node at %s" % str(step["node"])}
+		var indented := ""
+		for line in code.split("\n"):
+			indented += "\t" + line + "\n"
+		if indented.strip_edges() == "":
+			indented = "\treturn null\n"
+		var src := "extends RefCounted\nfunc _run(node, tree):\n" + indented
+		var gds := GDScript.new()
+		gds.source_code = src
+		if gds.reload() != OK:
+			return {"pass": false, "error": "multiline compile failed — call node methods on `node`/`tree`, not bare"}
+		var inst = gds.new()
+		if inst == null or not inst.has_method("_run"):
+			return {"pass": false, "error": "failed to instantiate compiled snippet"}
+		actual = inst.call("_run", target, get_tree())
+	else:
+		# Single-line Expression mode. Build input name/value pairs:
+		#   - every child of /root (autoloads AND root-level dialogs, by node name)
+		#   - common engine singletons (Engine, OS, Time, Input, RenderingServer)
+		#   - `main` -> the live battle scene root, if loaded
+		var input_names: Array = []
+		var input_values: Array = []
+		var root := get_tree().root
+		for child in root.get_children():
+			input_names.append(child.name)
+			input_values.append(child)
+		# ResourceLoader/ClassDB let a scenario instantiate a script-backed node
+		# (e.g. a dialog) for windowed validation: ResourceLoader.load(path).new().
+		# `tree`/`node` match the multiline-mode bindings (SceneTree / root) so the
+		# same `tree.root...` idiom works in both modes.
+		input_names.append_array(["Engine", "OS", "Time", "Input", "RenderingServer", "ProjectSettings", "ResourceLoader", "ClassDB", "main", "tree", "node"])
+		input_values.append_array([Engine, OS, Time, Input, RenderingServer, ProjectSettings, ResourceLoader, ClassDB, get_tree().current_scene, get_tree(), root])
 
-	var expr := Expression.new()
-	var parse_err := expr.parse(code, input_names)
-	if parse_err != OK:
-		return {"pass": false, "error": "parse failed: %s" % expr.get_error_text()}
-	# Pass self as base instance so `self.foo` works and any singletons not in
-	# input_names fall through to the runner's context.
-	var actual = expr.execute(input_values, self, true)
-	if expr.has_execute_failed():
-		return {"pass": false, "error": "execute failed: %s" % expr.get_error_text()}
+		var expr := Expression.new()
+		var parse_err := expr.parse(code, input_names)
+		if parse_err != OK:
+			return {"pass": false, "error": "parse failed: %s" % expr.get_error_text()}
+		# Pass self as base instance so `self.foo` works and any singletons not in
+		# input_names fall through to the runner's context.
+		actual = expr.execute(input_values, self, true)
+		if expr.has_execute_failed():
+			return {"pass": false, "error": "execute failed: %s" % expr.get_error_text()}
 
 	# Tolerate "no expectation" — caller may just want to drive a side effect.
 	if not (step.has("equals") or step.has("not_equals") or step.has("exists")

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.49.2",
+			"date": "2026-07-16",
+			"summary": "Fixed the confusing empty 'FIRING ORDER' box in the shooting roll dialog. When a unit fires a single weapon type, the step-by-step roll dialog now shows the weapon being fired under a 'WEAPON' header; with multiple weapon types, the ordering list disappears completely once the sequence starts instead of leaving an empty box behind.",
+			"changes": [
+				"Single-weapon shooting: the roll dialog now shows the firing weapon (name, model count and stats) under a 'WEAPON' header instead of an empty 'FIRING ORDER' area.",
+				"Multi-weapon shooting: once 'Start Sequence' is pressed, the whole firing-order section is hidden during resolution (previously an empty 'FIRING ORDER' header and box remained on screen).",
+				"The dice log now says 'Single weapon - rolling step by step...' when only one weapon type fires, instead of the misleading 'Multiple weapon types detected - choose firing order...'."
+			]
+		},
+		{
 			"version": "0.49.1",
 			"date": "2026-07-16",
 			"summary": "The Declare Battle Formations screen now tells identically-named units apart. Before, if your army had several units with the same name (e.g. six Custodian Guard squads, three Blade Champions), the leader-attachment dropdowns, warlord picker, transport/reserves lists and summary all just read 'Custodian Guard (5 models)' over and over, so you couldn't tell which squad you were attaching a leader to. Every unit now shows its distinguishing suffix — 'Custodian Guard Alpha', 'Custodian Guard Beta', etc. — matching the labels used everywhere else in the game.",

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -2856,9 +2856,16 @@ func _on_weapon_order_required(assignments: Array) -> void:
 		print("========================================")
 		return
 
-	# Show feedback in dice log
+	# Show feedback in dice log (message must match the actual weapon count —
+	# a single weapon auto-starts step-by-step rolling, there is no order to choose)
 	if dice_log_display:
-		dice_log_display.append_text("[b][color=cyan]Multiple weapon types detected - choose firing order...[/color][/b]\n")
+		var unique_weapon_ids = {}
+		for assignment in assignments:
+			unique_weapon_ids[str(assignment.get("weapon_id", ""))] = true
+		if unique_weapon_ids.size() >= 2:
+			dice_log_display.append_text("[b][color=cyan]Multiple weapon types detected - choose firing order...[/color][/b]\n")
+		else:
+			dice_log_display.append_text("[b][color=cyan]Single weapon - rolling step by step...[/color][/b]\n")
 
 	# Close any existing AcceptDialog instances
 	print("ShootingController: Checking for existing dialogs...")

--- a/40k/scripts/WeaponOrderDialog.gd
+++ b/40k/scripts/WeaponOrderDialog.gd
@@ -22,6 +22,8 @@ var is_resolving: bool = false  # Track if sequence is currently resolving
 # UI Nodes
 var vbox: VBoxContainer
 var instruction_label: Label
+var firing_order_label: Label        # "FIRING ORDER" section header ("WEAPON" when single)
+var weapon_scroll: ScrollContainer   # scroll area wrapping weapon_list_container
 var weapon_list_container: VBoxContainer
 var weapon_items: Array = []  # Array of weapon item panels for reordering
 var button_hbox: HBoxContainer
@@ -70,19 +72,22 @@ func _ready() -> void:
 	_add_weapon_order_gold_separator(vbox)
 
 	# Weapon list section
-	var list_label = Label.new()
-	list_label.text = "FIRING ORDER"
-	list_label.add_theme_font_size_override("font_size", 13)
-	list_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
-	vbox.add_child(list_label)
+	firing_order_label = Label.new()
+	firing_order_label.name = "FiringOrderLabel"
+	firing_order_label.text = "FIRING ORDER"
+	firing_order_label.add_theme_font_size_override("font_size", 13)
+	firing_order_label.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+	vbox.add_child(firing_order_label)
 
-	var scroll_container = ScrollContainer.new()
-	scroll_container.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 220)
-	vbox.add_child(scroll_container)
+	weapon_scroll = ScrollContainer.new()
+	weapon_scroll.name = "WeaponScroll"
+	weapon_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 220)
+	vbox.add_child(weapon_scroll)
 
 	weapon_list_container = VBoxContainer.new()
+	weapon_list_container.name = "WeaponListContainer"
 	weapon_list_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
-	scroll_container.add_child(weapon_list_container)
+	weapon_scroll.add_child(weapon_list_container)
 
 	_add_weapon_order_gold_separator(vbox)
 
@@ -354,6 +359,10 @@ func _rebuild_weapon_list() -> void:
 
 	weapon_items.clear()
 
+	# With a single weapon there is nothing to reorder — render the row without
+	# the position number and up/down arrows (it just shows what is firing).
+	var single_weapon = weapon_order.size() == 1
+
 	# Create UI item for each weapon in order
 	for i in range(weapon_order.size()):
 		var weapon_id = weapon_order[i]
@@ -367,11 +376,12 @@ func _rebuild_weapon_list() -> void:
 		panel.add_child(hbox)
 
 		# Position indicator
-		var position_label = Label.new()
-		position_label.text = str(i + 1) + "."
-		position_label.custom_minimum_size = Vector2(30, 0)
-		position_label.add_theme_font_size_override("font_size", 16)
-		hbox.add_child(position_label)
+		if not single_weapon:
+			var position_label = Label.new()
+			position_label.text = str(i + 1) + "."
+			position_label.custom_minimum_size = Vector2(30, 0)
+			position_label.add_theme_font_size_override("font_size", 16)
+			hbox.add_child(position_label)
 
 		# Weapon info
 		var info_vbox = VBoxContainer.new()
@@ -393,26 +403,27 @@ func _rebuild_weapon_list() -> void:
 		stats_label.modulate = Color(0.8, 0.8, 0.8)
 		info_vbox.add_child(stats_label)
 
-		# Up/Down buttons
-		var button_vbox = VBoxContainer.new()
-		button_vbox.custom_minimum_size = Vector2(60, 0)
-		hbox.add_child(button_vbox)
+		# Up/Down buttons (only when there is actually an order to change)
+		if not single_weapon:
+			var button_vbox = VBoxContainer.new()
+			button_vbox.custom_minimum_size = Vector2(60, 0)
+			hbox.add_child(button_vbox)
 
-		var up_button = Button.new()
-		up_button.text = "▲"
-		up_button.custom_minimum_size = Vector2(50, 25)
-		up_button.disabled = (i == 0)  # Can't move first item up
-		up_button.pressed.connect(_on_move_up_pressed.bind(i))
-		_WhiteDwarfTheme.apply_to_button(up_button)
-		button_vbox.add_child(up_button)
+			var up_button = Button.new()
+			up_button.text = "▲"
+			up_button.custom_minimum_size = Vector2(50, 25)
+			up_button.disabled = (i == 0)  # Can't move first item up
+			up_button.pressed.connect(_on_move_up_pressed.bind(i))
+			_WhiteDwarfTheme.apply_to_button(up_button)
+			button_vbox.add_child(up_button)
 
-		var down_button = Button.new()
-		down_button.text = "▼"
-		down_button.custom_minimum_size = Vector2(50, 25)
-		down_button.disabled = (i == weapon_order.size() - 1)  # Can't move last item down
-		down_button.pressed.connect(_on_move_down_pressed.bind(i))
-		_WhiteDwarfTheme.apply_to_button(down_button)
-		button_vbox.add_child(down_button)
+			var down_button = Button.new()
+			down_button.text = "▼"
+			down_button.custom_minimum_size = Vector2(50, 25)
+			down_button.disabled = (i == weapon_order.size() - 1)  # Can't move last item down
+			down_button.pressed.connect(_on_move_down_pressed.bind(i))
+			_WhiteDwarfTheme.apply_to_button(down_button)
+			button_vbox.add_child(down_button)
 
 		weapon_list_container.add_child(panel)
 		weapon_items.append({
@@ -480,7 +491,20 @@ func _on_start_sequence_pressed() -> void:
 	# Disable ordering buttons
 	fast_roll_button.disabled = true
 	start_sequence_button.disabled = true
-	weapon_list_container.visible = false  # Hide weapon list during resolution
+	if _single_weapon_staged:
+		# Single weapon: there is no order to choose, but the player should still
+		# see WHAT is firing. Keep the one-row list visible under a "WEAPON"
+		# header (an empty "FIRING ORDER" box here looked like a bug) and shrink
+		# the scroll area to fit the single row.
+		firing_order_label.text = "WEAPON"
+		weapon_scroll.custom_minimum_size = Vector2(DialogConstants.LARGE.x - 40, 74)
+	else:
+		# Multi-weapon: the order is locked in — hide the ENTIRE ordering section
+		# (header + scroll + list), not just the inner container, so no empty
+		# "FIRING ORDER" box is left behind during resolution.
+		firing_order_label.visible = false
+		weapon_scroll.visible = false
+		weapon_list_container.visible = false
 
 	# Update instruction label
 	instruction_label.text = "Resolving weapons sequentially...\nWatch the Resolution Log below for dice rolls and results."

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -193,6 +193,24 @@ Each step is a dict with an `act` field plus act-specific keys.
 
 ### State asserts
 
+- `execute_script`: evaluate GDScript and (optionally) compare the result via
+  `equals` / `not_equals` / `exists` / `expect_min` / `expect_max`. Two modes:
+  - **Expression mode** (default): a single expression. Bound identifiers:
+    every child of `/root` by node name (autoloads AND root-level dialogs,
+    e.g. `WeaponOrderDialog`), engine singletons, `main` (the live battle
+    scene), `tree` (the SceneTree) and `node` (`/root`).
+  - **Statement mode** (`"multiline": true` — explicit, never auto-detected):
+    the snippet is compiled into a throwaway GDScript so `var` / `if` / `for`
+    / `return` work. It runs as `_run(node, tree)` — `node` is `/root` (or
+    the node at the optional `node` step key), `tree` is the SceneTree;
+    autoloads are reachable by global name, but root-level dialogs must be
+    fetched via `tree.root.get_node_or_null(...)`. `return <value>` feeds the
+    expectation.
+  ```json
+  { "act": "execute_script", "script": "WeaponOrderDialog.weapon_list_container.get_child_count()", "equals": 1 }
+  { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nreturn d.is_resolving", "multiline": true, "equals": true }
+  ```
+
 - `expect_state`: assert against `GameState.state` via dot-separated path.
   ```json
   { "act": "expect_state", "path": "units.U_CUSTODIAN_GUARD_B.flags.fights_first", "equals": true }

--- a/40k/tests/scenarios/sp/shooting_single_weapon_staged_rolls.json
+++ b/40k/tests/scenarios/sp/shooting_single_weapon_staged_rolls.json
@@ -1,11 +1,11 @@
 {
   "id": "shooting_single_weapon_staged_rolls",
-  "covers": ["shooting.staged.single_weapon_hit_pause", "shooting.WeaponOrderDialog.auto_start"],
+  "covers": ["shooting.staged.single_weapon_hit_pause", "shooting.WeaponOrderDialog.auto_start", "shooting.WeaponOrderDialog.single_weapon_row_visible"],
   "fixture": "shooting_phase",
   "rng_seed": 42,
   "transition_to_phase": 8,
   "disable_ai": true,
-  "description": "Single-weapon shooting now steps through the roll like multi-weapon shooting does. Confirming ONE weapon type opens the WeaponOrderDialog already auto-started into staged resolution: it rolls to hit and PAUSES (so the attacker can read the result and use Command Re-roll) before the wound roll. Previously a single weapon resolved hits+wounds in one shot with no pause. Drives Battlewagon Alpha firing only its Lobba at the Blade Champion (in range in the raw fixture) and asserts the dialog reaches the hit pause, then continues to the wound roll.",
+  "description": "Single-weapon shooting now steps through the roll like multi-weapon shooting does. Confirming ONE weapon type opens the WeaponOrderDialog already auto-started into staged resolution: it rolls to hit and PAUSES (so the attacker can read the result and use Command Re-roll) before the wound roll. Previously a single weapon resolved hits+wounds in one shot with no pause. Drives Battlewagon Alpha firing only its Lobba at the Blade Champion (in range in the raw fixture) and asserts the dialog reaches the hit pause, then continues to the wound roll. Also asserts the weapon section is NOT an empty box: for a single weapon the dialog must keep the one-row weapon list visible under a 'WEAPON' header (regression: the list was hidden but the 'FIRING ORDER' header + empty scroll area stayed, which looked broken).",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "expect_phase", "equals": 8 },
@@ -28,6 +28,11 @@
     { "act": "expect_node_property", "node": "/root/WeaponOrderDialog", "property": "_single_weapon_staged", "equals": true },
     { "act": "expect_node_property", "node": "/root/WeaponOrderDialog", "property": "is_resolving", "equals": true },
     { "act": "expect_node_property", "node": "/root/WeaponOrderDialog", "property": "current_stage", "equals": "hits" },
+
+    { "act": "execute_script", "script": "WeaponOrderDialog.firing_order_label.text", "equals": "WEAPON" },
+    { "act": "execute_script", "script": "WeaponOrderDialog.firing_order_label.is_visible_in_tree() and WeaponOrderDialog.weapon_scroll.is_visible_in_tree() and WeaponOrderDialog.weapon_list_container.is_visible_in_tree()", "equals": true },
+    { "act": "execute_script", "script": "WeaponOrderDialog.weapon_list_container.get_child_count()", "equals": 1 },
+
     { "act": "screenshot", "label": "01_single_weapon_hit_pause" },
 
     { "act": "dispatch_action", "action": { "type": "CONTINUE_TO_WOUNDS" } },

--- a/40k/tests/scenarios/sp/staged_shooting_reroll_ui.json
+++ b/40k/tests/scenarios/sp/staged_shooting_reroll_ui.json
@@ -3,12 +3,13 @@
   "covers": [
     "ui.shooting.staged_hit_wound_pause",
     "ui.shooting.command_reroll",
-    "ui.shooting.continue_buttons"
+    "ui.shooting.continue_buttons",
+    "ui.shooting.order_section_hidden_during_resolution"
   ],
   "fixture": "shooting_phase",
   "rng_seed": 7,
   "transition_to_phase": 8,
-  "description": "Drives the non-networked STAGED shooting sequence through the real WeaponOrderDialog: Start Sequence -> hit roll pause ('Roll to Wound' + per-die Command Re-roll) -> wound roll pause ('Continue to Saving Throws' + wound re-roll) -> wound-allocation overlay. Verifies the verbose log and that the bare 'Close' button is gone.",
+  "description": "Drives the non-networked STAGED shooting sequence through the real WeaponOrderDialog: Start Sequence -> hit roll pause ('Roll to Wound' + per-die Command Re-roll) -> wound roll pause ('Continue to Saving Throws' + wound re-roll) -> wound-allocation overlay. Verifies the verbose log and that the bare 'Close' button is gone. Also asserts the ordering UI is coherent: at the ordering stage the 'FIRING ORDER' header shows a 2-row list; once the sequence starts the ENTIRE ordering section (header + scroll + list) is hidden, not just the inner list (regression: an empty 'FIRING ORDER' box was left behind during resolution).",
   "steps": [
     {
       "act": "wait_seconds",
@@ -29,6 +30,16 @@
       "equals": true
     },
     {
+      "act": "execute_script",
+      "script": "WeaponOrderDialog.firing_order_label.text",
+      "equals": "FIRING ORDER"
+    },
+    {
+      "act": "execute_script",
+      "script": "WeaponOrderDialog.weapon_list_container.get_child_count()",
+      "equals": 2
+    },
+    {
       "act": "screenshot",
       "label": "01_weapon_order_dialog"
     },
@@ -46,6 +57,11 @@
       "script": "var d=tree.root.get_node_or_null(\"WeaponOrderDialog\")\nreturn d.staged_continue_button.visible and d.staged_continue_button.text.begins_with(\"Roll to Wound\")",
       "multiline": true,
       "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "WeaponOrderDialog.firing_order_label.is_visible_in_tree() or WeaponOrderDialog.weapon_scroll.is_visible_in_tree() or WeaponOrderDialog.weapon_list_container.is_visible_in_tree()",
+      "equals": false
     },
     {
       "act": "execute_script",


### PR DESCRIPTION
## Summary

When a unit fired only **one** weapon type, the auto-started step-by-step roll dialog hid the weapon list but left the **"FIRING ORDER"** header and its empty 220px scroll area visible — a large blank box that looked broken (see the reported screenshot). The dice log also always announced *"Multiple weapon types detected - choose firing order..."* even for a single weapon.

## Changes

- **Single weapon:** the roll dialog now keeps the one-row weapon list visible under a **"WEAPON"** header (name, model count and stats), rendered without the position number / reorder arrows, with the scroll area shrunk to fit — so the player sees exactly what is firing.
- **Multi-weapon:** once *Start Sequence* is pressed, the **entire** ordering section (header + scroll + list) is hidden during sequential resolution, instead of only the inner list. No empty "FIRING ORDER" box is left behind.
- **Dice log message** now matches the actual weapon count: *"Single weapon - rolling step by step..."* vs the existing multi-weapon message.
- **ScenarioRunner:** implemented the multiline `execute_script` mode that the `staged_shooting_reroll_ui` scenario was already written against (explicit `"multiline": true` compiles the snippet like the MCP bridge does; `tree`/`node` are now also bound in single-line Expression mode). This restores that scenario to green — it had 11 failing steps because the runner never implemented the mode. Documented in `tests/scenarios/_schema.md`.

## Validation

Driven end-to-end against the running windowed UI (Xvfb + llvmpipe), not headless-only:

- `shooting_single_weapon_staged_rolls` — 23/23 steps pass; asserts the **"WEAPON"** header, all three ordering nodes visible, and exactly 1 visible weapon row. Screenshot confirms the populated section at the hit pause.
- `staged_shooting_reroll_ui` — 25/25 steps pass; asserts the 2-row **"FIRING ORDER"** list at the ordering stage and that the whole section is hidden after *Start Sequence*.
- `resolution_log_dice_icons` — 16/16, confirming the explicit-only multiline gate did not break scripts that embed `\n` in string literals.
- Debug logs across all runs contained **zero ERROR / SCRIPT ERROR** lines.

A repo-wide scan confirmed no other scenario relies on the newly bound `tree`/`node` identifiers. `version_history.json` gets a 0.49.2 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012EbtiXqTLXu9tRad3RbcWQ

---
_Generated by [Claude Code](https://claude.ai/code/session_012EbtiXqTLXu9tRad3RbcWQ)_