### PR TITLE
Stop the AI shooting attached characters out of their bodyguard unit

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -4943,6 +4943,17 @@ static func validate_shoot(action: Dictionary, board: Dictionary) -> Dictionary:
 			if target_unit.get("owner", 0) == actor_unit.get("owner", 0):
 				errors.append("Cannot target friendly units")
 
+			# ATTACHED CHARACTER (19.02): while a CHARACTER is attached to a
+			# bodyguard the combined Attached unit is ONE unit — the character
+			# can never be selected as a separate ranged-attack target.
+			# get_eligible_targets already hides these from the UI; this is the
+			# authoritative engine gate for callers that bypass it (the AI
+			# focus-fire plan used to shoot attached leaders directly and the
+			# defender then had no bodyguard models to allocate wounds to).
+			if target_unit.get("attached_to", null) != null:
+				var attached_name = target_unit.get("meta", {}).get("display_name", target_unit.get("meta", {}).get("name", target_unit_id))
+				errors.append("Cannot target '%s' — attached character; shoot the bodyguard unit instead" % attached_name)
+
 			# 10e TARGETING RESTRICTION: Cannot target enemies in engagement with friendly units
 			# Exception: MONSTER and VEHICLE targets can always be targeted (Big Guns Never Tire)
 			if not is_monster_or_vehicle(target_unit):
@@ -14360,6 +14371,11 @@ static func get_grenade_eligible_targets(actor_unit_id: String, board: Dictionar
 
 		# Skip friendly units
 		if target_unit.get("owner", 0) == actor_owner:
+			continue
+
+		# Skip attached characters — the Attached unit is one unit (19.02);
+		# GRENADE must target the bodyguard unit, same as any ranged attack.
+		if target_unit.get("attached_to", null) != null:
 			continue
 
 		# Skip destroyed units

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.52.2",
+			"date": "2026-07-17",
+			"summary": "Characters attached to a squad can no longer be shot out of it. The AI (and any scripted attack) could previously target an attached leader \u2014 e.g. a Blade Champion leading a Custodian Guard squad \u2014 as if it were a separate unit, so the defender's Allocate Attacks dialog showed only the character and the wounds could not be put on the squad first. Attached leaders are now only reachable by shooting their unit: wounds are allocated to the squad's models first and the leader is reached last (or via PRECISION), per the 11th-edition attached-unit rules (19.02).",
+			"changes": [
+				"Fixed: the AI no longer shoots attached characters directly \u2014 its target planning now folds attached leaders into their unit, so it shoots the squad instead.",
+				"Fixed: the rules engine now rejects any ranged attack that tries to target an attached character ('Cannot target \u2026 \u2014 attached character; shoot the bodyguard unit instead'), matching what the targeting UI already enforced for human players.",
+				"Fixed: the GRENADE stratagem can no longer pick an attached character as its target either.",
+				"When the squad leading a character is shot, the Allocate Attacks dialog shows the combined unit as before: squad models first, CHARACTER group last.",
+				"Standalone (unattached) characters are still targetable exactly as before."
+			]
+		},
+		{
 			"version": "0.52.1",
 			"date": "2026-07-17",
 			"summary": "Attached characters can now be dragged during a Charge move. Before, clicking the leader of a charging squad (e.g. the Blade Champion attached to Custodian Guard) did nothing — only the squad's own models responded — and the leader was auto-placed for you after confirming. Model picking during the charge is also much more accurate.",

--- a/40k/scripts/AIDecisionMaker.gd
+++ b/40k/scripts/AIDecisionMaker.gd
@@ -10708,7 +10708,9 @@ static func _decide_shooting(snapshot: Dictionary, available_actions: Array, pla
 				"_ai_description": "Skipped %s — no ranged weapons" % unit_name
 			}
 
-		var enemies = _get_enemy_units(snapshot, player)
+		# Shootable enemies only — attached characters are targeted through
+		# their bodyguard unit, never directly (19.02).
+		var enemies = _get_shootable_enemy_units(snapshot, player)
 		if enemies.is_empty():
 			_focus_fire_plan_built = false
 			_focus_fire_plan.clear()
@@ -10856,7 +10858,10 @@ static func _build_focus_fire_plan(snapshot: Dictionary, shooter_unit_ids: Array
 	4. Iteratively assign weapons to targets by highest marginal expected value,
 	   considering kill thresholds, opportunity cost, and overkill penalties
 	"""
-	var enemies = _get_enemy_units(snapshot, player)
+	# Shootable enemies only — attached characters are folded into their
+	# bodyguard unit for targeting purposes (19.02) and must not receive
+	# weapon assignments of their own.
+	var enemies = _get_shootable_enemy_units(snapshot, player)
 	if enemies.is_empty():
 		return {}
 
@@ -17081,6 +17086,24 @@ static func _get_enemy_units(snapshot: Dictionary, player: int) -> Dictionary:
 			if has_alive:
 				result[unit_id] = unit
 	return result
+
+# Shooting-target variant of _get_enemy_units: additionally excludes CHARACTER
+# units that are attached to a bodyguard (19.02 — the Attached unit is ONE
+# unit, so the leader is never a separate ranged-attack target; it is reached
+# through its bodyguard via the allocation rules / PRECISION). Without this
+# filter the focus-fire plan happily assigned weapons to attached leaders
+# (they even get MACRO_LEADER_BUFF_BONUS) and RulesEngine.validate_shoot now
+# rejects such SHOOT actions, wasting the unit's entire activation.
+# _get_enemy_units itself stays unfiltered — movement/charge/fight scoring
+# still needs to see where attached leaders are.
+static func _get_shootable_enemy_units(snapshot: Dictionary, player: int) -> Dictionary:
+	var all_enemies = _get_enemy_units(snapshot, player)
+	var shootable = {}
+	for unit_id in all_enemies:
+		if all_enemies[unit_id].get("attached_to", null) != null:
+			continue
+		shootable[unit_id] = all_enemies[unit_id]
+	return shootable
 
 static func _get_deployment_zone_bounds(snapshot: Dictionary, player: int) -> Dictionary:
 	var zones = snapshot.get("board", {}).get("deployment_zones", [])

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2887,6 +2887,42 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "rules.11e.attached_units.no_direct_targeting",
+      "description": "11e 19.02: a CHARACTER attached to a bodyguard is part of ONE Attached unit and can never be selected as a separate ranged-attack target. RulesEngine.validate_shoot rejects the assignment, the AI shooting enumeration excludes it, and shooting the bodyguard folds the attached unit into a single allocation dialog (squad group first, CHARACTER group last).",
+      "scenarios": [
+        "attached_char_untargetable_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "autoloads.RulesEngine.validate_shoot.attached_gate",
+      "description": "RulesEngine.validate_shoot is the authoritative gate that rejects a SHOOT assignment whose target has attached_to set ('Cannot target X \u2014 attached character; shoot the bodyguard unit instead'), catching callers (the AI focus-fire plan) that bypass get_eligible_targets. Unattached characters and the bodyguard itself stay valid targets.",
+      "scenarios": [
+        "attached_char_untargetable_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "scripts.AIDecisionMaker.shootable_enemies",
+      "description": "AIDecisionMaker._get_shootable_enemy_units excludes attached characters from _build_focus_fire_plan and the _decide_shooting fallback enumeration so the AI shoots the bodyguard squad instead of wasting an activation on a now-rejected shot at the leader. _get_enemy_units stays unfiltered for movement/charge/fight scoring.",
+      "scenarios": [
+        "attached_char_untargetable_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.combined_attached_unit",
+      "description": "When the squad leading a character is shot, the 11e AllocationGroupOverlay shows the combined Attached unit as ONE dialog titled with the bodyguard's display name: the squad's models as the first allocation group and the CHARACTER as the last group (reached only after the bodyguard, or via PRECISION).",
+      "scenarios": [
+        "attached_char_untargetable_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -110,6 +110,7 @@ TESTS=(
     "tests/test_iss048_shooting_types_11e.gd"
     "tests/test_iss050_fight_phase_11e.gd"
     "tests/test_iss059_attached_units_11e.gd"
+    "tests/test_attached_char_shoot_gate_11e.gd"
     "tests/test_secondary_deck_11e.gd"
     "tests/test_secondary_interactions_11e.gd"
     "tests/test_primary_missions_11e.gd"

--- a/40k/tests/scenarios/sp/attached_char_untargetable_11e.json
+++ b/40k/tests/scenarios/sp/attached_char_untargetable_11e.json
@@ -1,0 +1,48 @@
+{
+  "id": "attached_char_untargetable_11e",
+  "covers": [
+    "rules.11e.attached_units.no_direct_targeting",
+    "autoloads.RulesEngine.validate_shoot.attached_gate",
+    "scripts.AIDecisionMaker.shootable_enemies",
+    "scripts.AllocationGroupOverlay.combined_attached_unit"
+  ],
+  "fixture": "custodes_lions_pretrigger",
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "Attached characters must never be a separate shooting target (11e 19.02). Regression for the 'AI shoots the Blade Champion directly' bug: the AI focus-fire plan enumerated attached leaders as targets and RulesEngine.validate_shoot accepted the SHOOT, so the defender's Allocate Attacks dialog opened for the Blade Champion alone and the wounds could not be put on the Custodian Guard squad first. This scenario attaches Blade Champion Beta to Custodian Guard Beta with the real CharacterAttachmentManager, gives an Ork Battlewagon clear LoS, then asserts through the LIVE shooting phase: (1) a SHOOT dispatched at the attached champion is rejected and no allocation overlay opens, (2) the AI's shootable-enemy enumeration and focus-fire plan exclude the champion, (3) targeting the bodyguard folds the attached unit into ONE allocation dialog — Custodian Guard group plus CHARACTER group, titled with the bodyguard's name.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+
+    { "act": "execute_script", "script": "GameState.set_edition(11)", "equals": 11 },
+
+    { "act": "execute_script", "script": "CharacterAttachmentManager.attach_character(\"U_BLADE_CHAMPION_B\", \"U_CUSTODIAN_GUARD_B\")" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BLADE_CHAMPION_B\").get(\"attached_to\")", "equals": "U_CUSTODIAN_GUARD_B" },
+
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BATTLEWAGON_G\").models[0].merge({\"position\": {\"x\": 820.0, \"y\": 700.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_BLADE_CHAMPION_B\").models[0].merge({\"position\": {\"x\": 900.0, \"y\": 300.0}}, true)" },
+    { "act": "execute_script", "script": "GameState.set_active_player(2)" },
+    { "act": "execute_script", "script": "PhaseManager.transition_to_phase(8)" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script", "script": "RulesEngine.get_eligible_targets(\"U_BATTLEWAGON_G\", GameState.create_snapshot()).has(\"U_BLADE_CHAMPION_B\")", "equals": false },
+    { "act": "execute_script", "script": "RulesEngine.get_eligible_targets(\"U_BATTLEWAGON_G\", GameState.create_snapshot()).has(\"U_CUSTODIAN_GUARD_B\")", "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "SHOOT", "actor_unit_id": "U_BATTLEWAGON_G", "payload": { "assignments": [ { "weapon_id": "big_shoota_ranged", "target_unit_id": "U_BLADE_CHAMPION_B", "model_ids": ["m1"] } ] } } },
+    { "act": "expect_action_result", "path": "success", "equals": false },
+    { "act": "execute_script", "script": "str(_last_action_result.get(\"errors\", [])).contains(\"attached character\")", "equals": true },
+    { "act": "execute_script", "script": "main.get_node_or_null(\"AllocationGroupOverlay\") == null", "equals": true },
+    { "act": "screenshot", "label": "01_attached_champion_shot_rejected" },
+
+    { "act": "execute_script", "script": "ResourceLoader.load(\"res://scripts/AIDecisionMaker.gd\")._get_shootable_enemy_units(GameState.create_snapshot(), 2).has(\"U_BLADE_CHAMPION_B\")", "equals": false },
+    { "act": "execute_script", "script": "str(ResourceLoader.load(\"res://scripts/AIDecisionMaker.gd\")._build_focus_fire_plan(GameState.create_snapshot(), [\"U_BATTLEWAGON_G\"], 2)).contains(\"U_BLADE_CHAMPION_B\")", "equals": false },
+
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(2, \"U_CUSTODIAN_GUARD_B\", \"U_BATTLEWAGON_G\", {\"name\": \"Big shoota\", \"ap\": 0, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/Center/Panel", "timeout_s": 3.0 },
+    { "act": "execute_script", "script": "main.get_node(\"AllocationGroupOverlay/Center/Panel/VBox/GroupList\").get_child_count()", "equals": 2 },
+    { "act": "execute_script", "script": "main.get_node(\"AllocationGroupOverlay/Center/Panel/VBox/Title\").text.contains(\"Custodian Guard Beta\")", "equals": true },
+    { "act": "screenshot", "label": "02_bodyguard_shot_folds_combined_unit" }
+  ]
+}

--- a/40k/tests/test_attached_char_shoot_gate_11e.gd
+++ b/40k/tests/test_attached_char_shoot_gate_11e.gd
@@ -1,0 +1,156 @@
+extends SceneTree
+
+# Attached-character shooting gate (19.02): while a CHARACTER unit is attached
+# to a bodyguard, the combined Attached unit is ONE unit — the character can
+# never be selected as a separate ranged-attack target.
+#
+# Regression for the "AI shoots the Blade Champion directly" bug: the AI's
+# focus-fire plan enumerated attached leaders as targets (they even score a
+# leader-buff bonus) and RulesEngine.validate_shoot did not reject the SHOOT,
+# so the defender's allocation dialog opened for the character alone and the
+# player could not put the wounds on the bodyguard squad first.
+#
+#  - validate_shoot must REJECT a SHOOT assignment targeting an attached
+#    character, must still ACCEPT the bodyguard, and must still ACCEPT a
+#    standalone (unattached) character
+#  - AIDecisionMaker._get_shootable_enemy_units must exclude attached
+#    characters (while _get_enemy_units keeps them for movement/charge)
+#  - get_grenade_eligible_targets must exclude attached characters
+#
+# Usage: godot --headless --path . -s tests/test_attached_char_shoot_gate_11e.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _model(id: String, x: float, y: float, wounds: int = 4) -> Dictionary:
+	return {"id": id, "alive": true, "wounds": wounds, "current_wounds": wounds,
+		"base_mm": 40, "base_type": "circular", "position": {"x": x, "y": y}}
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_attached_char_shoot_gate_11e ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var rules = root.get_node_or_null("RulesEngine")
+	var cam = root.get_node_or_null("CharacterAttachmentManager")
+	_check("autoloads present", gs != null and rules != null and cam != null)
+
+	GameConstants.edition = 11
+
+	# Clear any default terrain layout so the synthetic sightlines below are
+	# open — this test exercises the targeting gate, not LoS.
+	var tm = root.get_node_or_null("TerrainManager")
+	if tm != null:
+		tm.terrain_features = []
+	if gs.state.has("board"):
+		gs.state.board["terrain_features"] = []
+
+	# Ork shooter, 20" below the custodes line, clear board (no terrain in
+	# synthetic state, so LoS is open).
+	gs.state.units["U_SHOOTER_SG"] = {"id": "U_SHOOTER_SG", "owner": 2, "status": 2, "flags": {},
+		"meta": {"name": "Shoota Grots", "keywords": ["INFANTRY"],
+			"stats": {"toughness": 4, "save": 5, "wounds": 1, "move": 6},
+			"weapons": [{"name": "Test shoota", "type": "Ranged", "range": "36",
+				"attacks": "2", "ballistic_skill": "4", "strength": "4", "ap": "0",
+				"damage": "1", "keywords": [], "special_rules": ""}]},
+		"models": [_model("sg0", 800.0, 1100.0, 1)]}
+
+	# Bodyguard squad + its attached character, plus a standalone character.
+	gs.state.units["U_BG_SG"] = {"id": "U_BG_SG", "owner": 1, "status": 2, "flags": {},
+		"meta": {"name": "Guard Squad", "keywords": ["INFANTRY", "CUSTODIAN GUARD"],
+			"stats": {"toughness": 6, "save": 2, "wounds": 4, "move": 6}},
+		"models": [_model("b0", 800.0, 300.0), _model("b1", 840.0, 300.0)]}
+	gs.state.units["U_CHAR_SG"] = {"id": "U_CHAR_SG", "owner": 1, "status": 2, "flags": {}, "attached_to": null,
+		"meta": {"name": "Blade Champion T", "keywords": ["CHARACTER", "INFANTRY"],
+			"leader_data": {"can_lead": ["CUSTODIAN GUARD"]},
+			"stats": {"toughness": 6, "save": 2, "wounds": 6, "move": 6}},
+		"models": [_model("c0", 880.0, 300.0, 6)]}
+	gs.state.units["U_LONER_SG"] = {"id": "U_LONER_SG", "owner": 1, "status": 2, "flags": {}, "attached_to": null,
+		"meta": {"name": "Standalone Champion T", "keywords": ["CHARACTER", "INFANTRY"],
+			"stats": {"toughness": 6, "save": 2, "wounds": 6, "move": 6}},
+		"models": [_model("l0", 700.0, 300.0, 6)]}
+
+	cam.attach_character("U_CHAR_SG", "U_BG_SG")
+	_check("fixture: character attached to bodyguard",
+		gs.state.units["U_CHAR_SG"].get("attached_to") == "U_BG_SG",
+		str(gs.state.units["U_CHAR_SG"].get("attached_to")))
+
+	var board = gs.create_snapshot()
+
+	print("-- validate_shoot gate (19.02) --")
+	var shoot_at_char = {"type": "SHOOT", "actor_unit_id": "U_SHOOTER_SG", "payload": {"assignments": [
+		{"weapon_id": "test_shoota_ranged", "target_unit_id": "U_CHAR_SG", "model_ids": ["sg0"]}]}}
+	var v1 = rules.validate_shoot(shoot_at_char, board)
+	_check("SHOOT at attached character is rejected", not v1.valid, str(v1))
+	var mentions_attached = false
+	for e in v1.get("errors", []):
+		if "attached character" in str(e):
+			mentions_attached = true
+	_check("rejection names the attached-character rule", mentions_attached, str(v1.get("errors")))
+
+	var shoot_at_bg = {"type": "SHOOT", "actor_unit_id": "U_SHOOTER_SG", "payload": {"assignments": [
+		{"weapon_id": "test_shoota_ranged", "target_unit_id": "U_BG_SG", "model_ids": ["sg0"]}]}}
+	var v2 = rules.validate_shoot(shoot_at_bg, board)
+	_check("SHOOT at the bodyguard unit is still valid", v2.valid, str(v2))
+
+	var shoot_at_loner = {"type": "SHOOT", "actor_unit_id": "U_SHOOTER_SG", "payload": {"assignments": [
+		{"weapon_id": "test_shoota_ranged", "target_unit_id": "U_LONER_SG", "model_ids": ["sg0"]}]}}
+	var v3 = rules.validate_shoot(shoot_at_loner, board)
+	_check("SHOOT at an unattached character is still valid", v3.valid, str(v3))
+
+	print("-- eligibility mirrors the gate --")
+	var elig = rules.get_eligible_targets("U_SHOOTER_SG", board)
+	_check("get_eligible_targets omits the attached character",
+		not elig.has("U_CHAR_SG") and elig.has("U_BG_SG") and elig.has("U_LONER_SG"),
+		str(elig.keys()))
+
+	print("-- AI shooting enumeration --")
+	var aidm = load("res://scripts/AIDecisionMaker.gd")
+	var all_enemies = aidm._get_enemy_units(board, 2)
+	var shootable = aidm._get_shootable_enemy_units(board, 2)
+	_check("_get_enemy_units still sees the attached character (movement/charge)",
+		all_enemies.has("U_CHAR_SG"), str(all_enemies.keys()))
+	_check("_get_shootable_enemy_units excludes the attached character",
+		not shootable.has("U_CHAR_SG") and shootable.has("U_BG_SG") and shootable.has("U_LONER_SG"),
+		str(shootable.keys()))
+	var plan = aidm._build_focus_fire_plan(board, ["U_SHOOTER_SG"], 2)
+	var plan_hits_char = false
+	for uid in plan:
+		for a in plan[uid]:
+			if a.get("target_unit_id", "") == "U_CHAR_SG":
+				plan_hits_char = true
+	_check("focus-fire plan never assigns a weapon to the attached character",
+		not plan_hits_char, str(plan))
+
+	print("-- GRENADE eligibility --")
+	# Move the shooter to within 8" of the custodes line for the grenade check.
+	gs.state.units["U_SHOOTER_SG"].models[0].position = {"x": 820.0, "y": 500.0}
+	var gboard = gs.create_snapshot()
+	var gtargets = rules.get_grenade_eligible_targets("U_SHOOTER_SG", gboard)
+	var gids = []
+	var grenade_hits_char = false
+	for t in gtargets:
+		gids.append(t.get("unit_id", ""))
+		if t.get("unit_id", "") == "U_CHAR_SG":
+			grenade_hits_char = true
+	_check("grenade eligible targets exclude the attached character",
+		not grenade_hits_char and "U_BG_SG" in gids, str(gids))
+
+	# Cleanup synthetic units
+	for uid in ["U_SHOOTER_SG", "U_BG_SG", "U_CHAR_SG", "U_LONER_SG"]:
+		gs.state.units.erase(uid)
+
+	print("\n=== RESULTS: %d passed, %d failed ===" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_attached_char_shoot_gate_11e.gd.uid
+++ b/40k/tests/test_attached_char_shoot_gate_11e.gd.uid
@@ -1,0 +1,1 @@
+uid://d1xuq7h7xq5py


### PR DESCRIPTION
## Problem

An attached character — e.g. a Blade Champion leading a Custodian Guard squad — could be shot **directly**, as if it were a separate unit. When that happened, the defender's *Allocate Attacks* dialog opened for the character alone, so the wounds could not be put on the squad's models first. This is the bug in the reported screenshot ("Allocate Attacks — Blade Champion Beta").

The attachment itself was intact (the game state knew the champion was leading the squad, which is why Quick Assign never listed the champion). The bug was that the shot was *allowed* through two stacked gaps:

1. **`RulesEngine.validate_shoot` never rejected attached characters.** `get_eligible_targets` and the human targeting UI already exclude them, but the authoritative validation gate didn't check `attached_to`, so any caller that bypassed eligibility got through.
2. **The AI focus-fire planner enumerated enemies via `_get_enemy_units`**, which includes attached leaders — and its target scoring gives attached leaders a 1.5× `MACRO_LEADER_BUFF_BONUS`, so it actively *preferred* shooting them. The shot resolved against the character as a lone "unit".

Per 11e **19.02** the Attached unit is ONE unit; a leader is only reachable by shooting its unit (squad models allocated first, character last, or via PRECISION).

## Changes

- **`RulesEngine.validate_shoot`** — reject any assignment whose target has `attached_to` set: *"Cannot target 'X' — attached character; shoot the bodyguard unit instead."* This is the engine-level gate for every caller.
- **`AIDecisionMaker`** — new `_get_shootable_enemy_units` filters attached characters out of `_build_focus_fire_plan` and the `_decide_shooting` fallback enumeration, so the AI shoots the squad instead of wasting its activation on a now-rejected action. `_get_enemy_units` is unchanged — movement/charge/fight scoring still needs to see attached leaders.
- **`RulesEngine.get_grenade_eligible_targets`** — skip attached characters (GRENADE is a ranged attack against one unit).

After the fix, shooting the Custodian Guard squad opens the combined dialog as expected: **"1. 5 model(s) W4 Sv2+" first, "2. CHARACTER — 1 model(s) W6" last**.

## Validation

- **Reproduced live pre-fix** via the MCP bridge (`custodes_lions_pretrigger` fixture): the AI's exact shot returned `success:true` and opened the "Allocate Attacks — Blade Champion Beta" dialog, matching the report.
- **New windowed scenario** `attached_char_untargetable_11e` — 26/26 steps against the live shooting phase: SHOOT at the champion is rejected (no overlay opens), AI plan/enumeration exclude the champion, and shooting the bodyguard folds the attached unit into one dialog (squad first, CHARACTER last), with screenshots.
- **New headless test** `test_attached_char_shoot_gate_11e` — 11/11, covering the validate gate, unattached characters staying targetable, AI enumeration, and grenade eligibility; registered in `run_pretrigger_tests.sh`.
- Existing validate-pin test `t002_bgnt_eligibility_validate_pin` still passes 13/13.
- Broader headless pretrigger suite: 0 failures.

## Notes / follow-ups

- Standalone (unattached) characters remain targetable exactly as before.
- Melee/Fight-phase targeting of attached characters uses separate machinery and was not audited here — worth a follow-up check.
- AI target *valuation* doesn't yet add a bonus for squads shielding a leader (pure tuning, not correctness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CeRxv3q3Yh8B5Ny4SrB2p

---
_Generated by [Claude Code](https://claude.ai/code/session_015CeRxv3q3Yh8B5Ny4SrB2p)_