### PR TITLE
Add ShootingResolutionDock.gd.uid (Godot UID sidecar)

### DIFF
--- a/40k/scripts/ShootingResolutionDock.gd.uid
+++ b/40k/scripts/ShootingResolutionDock.gd.uid
@@ -1,0 +1,1 @@
+uid://b7ebd5hkeoj2h


### PR DESCRIPTION
Follow-up to #650: the new `ShootingResolutionDock.gd` landed without its Godot-generated `.uid` sidecar (repo convention commits them — a missing sidecar makes every fresh import mint a new random UID). One-file addition, generated by the editor during the merged branch's validation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H3jQLkNCzvy6Qi424HJrPj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H3jQLkNCzvy6Qi424HJrPj)_