### PR TITLE
Fix Ctrl+Click not selecting a second charge target on some platforms

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -502,6 +502,34 @@ func _do_click_item_list(step: Dictionary) -> Dictionary:
 		local_pos = list.get_item_rect(index).get_center()
 
 	var screen_pos: Vector2 = list.get_global_transform() * local_pos
+
+	# `ctrl_via_key`: faithfully reproduce a player holding the physical Ctrl key
+	# while clicking. It presses a real InputEventKey Ctrl DOWN (updating the
+	# global Input.is_key_pressed(KEY_CTRL) state), clicks WITHOUT stamping the
+	# modifier onto the mouse event, then releases Ctrl. This is the real-world
+	# path on platforms/window-managers that do not stamp ctrl_pressed onto the
+	# mouse button event — where relying on event.ctrl_pressed (as Godot's
+	# built-in ItemList SELECT_MULTI toggle does) silently fails to toggle.
+	# `ctrl` (the old mode) instead stamps ctrl_pressed directly on the mouse
+	# event, which a real OS also does but some do not.
+	var ctrl_via_key: bool = bool(step.get("ctrl_via_key", false))
+	if ctrl_via_key:
+		var kdown := InputEventKey.new()
+		kdown.keycode = KEY_CTRL
+		kdown.physical_keycode = KEY_CTRL
+		kdown.pressed = true
+		Input.parse_input_event(kdown)
+		await get_tree().process_frame
+		await _send_click(screen_pos, false)
+		var kup := InputEventKey.new()
+		kup.keycode = KEY_CTRL
+		kup.physical_keycode = KEY_CTRL
+		kup.pressed = false
+		Input.parse_input_event(kup)
+		await get_tree().process_frame
+		return {"pass": true, "screen_position": [screen_pos.x, screen_pos.y],
+				"ctrl_via_key": true, "ctrl_key_seen": Input.is_key_pressed(KEY_CTRL)}
+
 	await _send_click(screen_pos, ctrl)
 	return {"pass": true, "screen_position": [screen_pos.x, screen_pos.y], "ctrl": ctrl}
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.53.1",
+			"date": "2026-07-17",
+			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) \u2014 so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",
+			"changes": [
+				"Fixed: holding Ctrl (or Cmd) and clicking a second unit in the Eligible Targets list now toggles it in/out of the charge, so you can declare a charge against several units as the hint describes.",
+				"The charge target list no longer relies on the click carrying the Ctrl modifier (which some systems don't attach to mouse clicks) \u2014 it now also reads the live keyboard state, so Ctrl+Click works consistently across platforms.",
+				"Plain click still selects exactly one target, clicking empty space still clears the selection, and the target rows still lock once the charge is declared."
+			]
+		},
+		{
 			"version": "0.53.0",
 			"date": "2026-07-17",
 			"summary": "Multi-target shooting overhaul, part 1: declaring targets is now one click for the common case. Clicking an enemy with no weapon selected sends EVERYTHING at it; clicking with a weapon selected commits all of that weapon's eligible bearers instantly (no popup). Splitting fire is the exception you opt into: click a second target and the game offers to move some shots across. Engaged vehicles can also declare targets they are not engaged with again (10.06), and the game no longer shows error banners for assignments it auto-attempted itself.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -846,6 +846,17 @@ func _setup_right_panel() -> void:
 	# appended every clicked row to selected_targets without ever removing the
 	# previous one, so clicking target B after target A silently declared a
 	# charge against BOTH while only B stayed highlighted.
+	#
+	# We OWN left-clicks via gui_input rather than leaning on the built-in
+	# SELECT_MULTI toggle: Godot's built-in reads only the mouse event's
+	# ctrl_pressed field, so on platforms/WMs that do not stamp the Ctrl
+	# modifier onto the mouse button event, holding Ctrl and clicking did
+	# nothing (the reported "Ctrl+Click doesn't select a second target" bug).
+	# Our handler detects Ctrl from BOTH the event AND the live key state
+	# (Input.is_key_pressed) so a held Ctrl toggles regardless of platform.
+	# multi_selected stays connected so KEYBOARD selection (arrows + space)
+	# still syncs; empty_clicked handles right-clicks on empty space.
+	target_list.gui_input.connect(_on_target_list_gui_input)
 	target_list.multi_selected.connect(_on_target_multi_selected)
 	target_list.empty_clicked.connect(_on_target_list_empty_clicked)
 	_WhiteDwarfTheme.apply_to_item_list(target_list)
@@ -1358,12 +1369,57 @@ func _refresh_target_list() -> void:
 	
 	print("DEBUG: Target list now has ", target_list.get_item_count(), " items")
 
+func _on_target_list_gui_input(event: InputEvent) -> void:
+	# Own the LEFT-click selection so multi-target charge works on every platform.
+	# Godot's built-in ItemList SELECT_MULTI toggle only fires when the mouse
+	# event itself carries ctrl_pressed; some platforms/WMs never stamp that onto
+	# the button event, so a player holding Ctrl and clicking got a plain single
+	# select and could never build a multi-charge. Here we read Ctrl from BOTH the
+	# event AND the live keyboard state, so a held Ctrl always toggles.
+	if not (event is InputEventMouseButton):
+		return
+	var mb := event as InputEventMouseButton
+	if mb.button_index != MOUSE_BUTTON_LEFT:
+		return
+	# Rows are locked once the charge is declared — let nothing change then.
+	if awaiting_roll or awaiting_movement:
+		return
+	# Act on press; consume press+release so the built-in selection never also
+	# runs (which would fight our own select/deselect below).
+	get_viewport().set_input_as_handled()
+	target_list.accept_event()
+	if not mb.pressed:
+		return
+	target_list.grab_focus()  # normal list behaviour: click focuses it for keyboard nav
+
+	var idx: int = target_list.get_item_at_position(mb.position, true)
+	if idx < 0:
+		# Clicked empty space inside the list — clear the selection.
+		target_list.deselect_all()
+		_sync_selected_targets_from_list()
+		return
+
+	# Ctrl / Cmd (or Shift) held → toggle this row in/out for a multi-charge;
+	# no modifier → select only this row. Detect the modifier from the event
+	# and, as a platform-robust fallback, from the live key state.
+	var additive: bool = mb.ctrl_pressed or mb.meta_pressed or mb.shift_pressed \
+		or Input.is_key_pressed(KEY_CTRL) or Input.is_key_pressed(KEY_META) \
+		or Input.is_key_pressed(KEY_SHIFT)
+
+	if additive:
+		if target_list.is_selected(idx):
+			target_list.deselect(idx)
+		else:
+			target_list.select(idx, false)  # false = keep existing selection
+	else:
+		target_list.select(idx, true)  # true = single-select (clears others)
+	_sync_selected_targets_from_list()
+
 func _on_target_multi_selected(_index: int, _selected: bool) -> void:
-	# Godot emits this for every selection change of a SELECT_MULTI ItemList:
-	# plain click (selects only that row), Ctrl+Click (toggles the row),
-	# Shift+Click (range select) and the deferred re-single-select on mouse
-	# release. Rebuilding from the list keeps selected_targets in lockstep with
-	# what the player sees highlighted — the old code let them drift apart.
+	# Keyboard selection (arrow keys + Space/Enter on the focused ItemList) still
+	# routes through the built-in and emits this — keep it synced. Mouse clicks
+	# are handled in _on_target_list_gui_input, which accept_event()s so the
+	# built-in never emits this for a click (no double-handling).
 	if awaiting_roll or awaiting_movement:
 		return  # declaration already committed — rows are locked
 	_sync_selected_targets_from_list()

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2923,6 +2923,15 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "charge.ux.ctrl_click_via_held_key",
+      "description": "CHARGE phase: Ctrl+Click adds a second target to a multi-charge even when the platform does not stamp ctrl_pressed onto the mouse button event. ChargeController owns target-list left-clicks via gui_input and detects Ctrl from BOTH the event and Input.is_key_pressed(KEY_CTRL), so a held Ctrl key toggles regardless of platform. Reproduced (pre-fix: held Ctrl key + unstamped click did not toggle, selection stayed at 1) and fixed via 'charge_ctrl_click_real_key' using the click_item_list ctrl_via_key mode.",
+      "scenarios": [
+        "charge_ctrl_click_real_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -115,12 +115,18 @@ Each step is a dict with an `act` field plus act-specific keys.
 - `click_item_list`: real-mouse-click one row of an `ItemList` (by item
   `index`), warping the cursor to the row's rect centre — so the list's own
   input handling (selection replace, Ctrl+Click toggle, deferred single-select)
-  runs exactly as for a player. `ctrl: true` holds Ctrl through the click
-  (multi-select toggle). `empty: true` clicks the free strip below the last
-  row instead (e.g. to assert empty-click-clears-selection).
+  runs exactly as for a player. `ctrl: true` stamps `ctrl_pressed` on the mouse
+  event (what an OS does when Ctrl is held — but some platforms/WMs don't).
+  `ctrl_via_key: true` instead presses a real Ctrl **key** down (updating the
+  global key state) and clicks WITHOUT stamping the mouse event, then releases
+  Ctrl — the faithful reproduction of a player holding Ctrl on a platform that
+  doesn't attach the modifier to the click; use it to prove modifier handling
+  reads the live key state, not just the event field. `empty: true` clicks the
+  free strip below the last row instead (e.g. to assert empty-click-clears).
   ```json
   { "act": "click_item_list", "node": "/root/Main/.../ChargeTargetList", "index": 1 }
   { "act": "click_item_list", "node": "/root/Main/.../ChargeTargetList", "index": 0, "ctrl": true }
+  { "act": "click_item_list", "node": "/root/Main/.../ChargeTargetList", "index": 0, "ctrl_via_key": true }
   { "act": "click_item_list", "node": "/root/Main/.../ChargeTargetList", "empty": true }
   ```
 

--- a/40k/tests/scenarios/sp/charge_ctrl_click_real_key.json
+++ b/40k/tests/scenarios/sp/charge_ctrl_click_real_key.json
@@ -1,0 +1,40 @@
+{
+  "id": "charge_ctrl_click_real_key",
+  "covers": ["charge.ux.ctrl_click_via_held_key"],
+  "fixture": "test_charge_two_targets",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Reproduce the reported bug: Ctrl+Click a second charge target does nothing when Ctrl is held as a real KEY (global Input state) but the platform does not stamp ctrl_pressed onto the mouse event. Godot's built-in ItemList SELECT_MULTI toggle reads only event.ctrl_pressed, so the held key alone did not toggle. After the fix the ChargeController owns the click via gui_input and checks Input.is_key_pressed(KEY_CTRL), so a real held Ctrl toggles a second target in.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller.unit_selector.select(0)" },
+    { "act": "execute_script",
+      "script": "main.charge_controller._on_unit_selected(0)" },
+    { "act": "execute_script",
+      "script": "main.charge_controller.active_unit_id", "equals": "U_CHARGER_0" },
+    { "act": "execute_script",
+      "script": "main.charge_controller.target_list.get_item_count()", "equals": 2 },
+
+    { "act": "click_item_list",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ChargeScrollContainer/ChargePanel/ChargeTargetList",
+      "index": 0 },
+    { "act": "execute_script",
+      "script": "main.charge_controller.selected_targets.size()", "equals": 1 },
+
+    { "act": "click_item_list",
+      "node": "/root/Main/HUD_Right/VBoxContainer/ChargeScrollContainer/ChargePanel/ChargeTargetList",
+      "index": 1, "ctrl_via_key": true },
+    { "act": "execute_script",
+      "script": "main.charge_controller.selected_targets.size()", "equals": 2 },
+    { "act": "execute_script",
+      "script": "\"U_TARGET_SC\" in main.charge_controller.selected_targets", "equals": true },
+    { "act": "execute_script",
+      "script": "\"U_TARGET_SC2\" in main.charge_controller.selected_targets", "equals": true },
+    { "act": "screenshot", "label": "01_ctrl_via_key_two_targets" }
+  ]
+}


### PR DESCRIPTION
## Problem

A player reported that the Eligible Targets list tells you to hold **Ctrl+Click to charge more than one unit**, but holding Ctrl and clicking a second unit does nothing — you can never actually declare a multi-unit charge.

**Root cause:** the list is a `SELECT_MULTI` `ItemList`, and Godot's built-in Ctrl-toggle only fires when the *mouse button event itself* carries `ctrl_pressed`. Some platforms/window-managers never stamp the Ctrl modifier onto the click, so the built-in did a plain single-select and the multi-charge could never be built.

The windowed test I shipped earlier passed only because it injected `ctrl_pressed` **directly onto the synthetic mouse event** — the exact field the real platform fails to set. So the test was green while the real path was broken.

## Fix

`ChargeController` now **owns** target-list left-clicks via `gui_input` and detects the modifier from **both** the event **and** the live key state (`Input.is_key_pressed(KEY_CTRL/KEY_META/KEY_SHIFT)`), so a held Ctrl toggles a target in/out regardless of whether the modifier reached the mouse event. Plain click still single-selects (replaces), empty-click clears, and rows still lock once the charge is declared. `multi_selected` stays connected so keyboard selection still syncs.

## Reproduce → fix (real held-key path)

I did **not** assume — I reproduced it. Added a `ctrl_via_key` mode to the `click_item_list` scenario act that presses a **real Ctrl key down** (updating the global key state) and clicks **without** stamping the mouse event — the faithful reproduction of a player holding Ctrl on a platform that doesn't attach the modifier to the click.

- **Against the unfixed code:** `charge_ctrl_click_real_key` failed — the second Ctrl+Click left the selection at **1** target (bug reproduced).
- **Against the fixed code:** it passes — the selection toggles to **2**. A screenshot confirms both Shield-Captains highlighted, the "Charging 2 units" hint, and `Declare Charge (2 targets)`.

## Validation

All green on the merged tree, zero script errors:
- `charge_ctrl_click_real_key` — 13/13 (the real held-Ctrl-key path)
- `charge_target_declaration` — 74/74 (plain-select, synthetic-ctrl toggle, empty-clear, locked rows)
- `snap_to_contact_button` — 40/40 (charge movement unaffected)
- `charge_group_drag_multi_select` — 53/53 (charge-movement multi-select unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198wPKqTVcpk3ERbsJUpovc

---
_Generated by [Claude Code](https://claude.ai/code/session_0198wPKqTVcpk3ERbsJUpovc)_