### PR TITLE
Charge re-roll dialog: make "Keep Roll" the highlighted default

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.53.4",
+			"date": "2026-07-17",
+			"summary": "Re-roll dialogs (charge re-rolls, Command Re-roll, ability re-rolls like Swift Onslaught) now make 'Keep Roll' the highlighted default on the LEFT and 'Re-roll' the plainer button on the RIGHT. Previously the CP-spending re-roll was the prominent left-hand button, which invited an accidental click that wasted a Command Point — especially right after a successful charge, where re-rolling almost never makes sense.",
+			"changes": [
+				"Swapped the buttons in the re-roll pop-up: 'Keep Roll' is now the highlighted button on the left; 'Re-roll' is the secondary button on the right.",
+				"'Keep Roll' now also holds keyboard focus, so pressing Enter/confirm keeps your roll instead of spending a Command Point.",
+				"Applies to every re-roll prompt that uses this dialog (charge rolls, Command Re-roll, and free ability re-rolls such as Swift Onslaught)."
+			]
+		},
+		{
 			"version": "0.53.3",
 			"date": "2026-07-17",
 			"summary": "Fixed the free charge re-roll from abilities like the Blade Champion's Swift Onslaught looking unusable: the dialog offering it was branded as the 1 CP Command Re-roll stratagem, so with 0 CP it read as unaffordable. It now clearly says the re-roll is FREE, and closing the dialog with ✕ or ESC no longer leaves the charge stuck waiting for an answer.",

--- a/40k/dialogs/CommandRerollDialog.gd
+++ b/40k/dialogs/CommandRerollDialog.gd
@@ -171,25 +171,35 @@ func _build_ui() -> void:
 	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
 	button_container.add_theme_constant_override("separation", 16)
 
-	var use_button = Button.new()
-	use_button.name = "UseRerollButton"
-	use_button.text = "Re-roll (Free)" if free_ability_name != "" else "Re-roll (1 CP)"
-	use_button.custom_minimum_size = Vector2(160, 42)
-	use_button.pressed.connect(_on_use_pressed)
-	WhiteDwarfTheme.apply_primary_button(use_button)
-	button_container.add_child(use_button)
-
+	# "Keep Roll" is the safe, non-destructive choice, so it is the highlighted
+	# default on the LEFT. This prevents a player from instinctively clicking the
+	# prominent left-hand button and accidentally spending a CP (or burning a good
+	# roll on a free re-roll that might come back worse) — especially after a
+	# successful charge, where re-rolling almost never makes sense.
 	var decline_button = Button.new()
 	decline_button.name = "KeepRollButton"
 	decline_button.text = "Keep Roll"
-	decline_button.custom_minimum_size = Vector2(130, 42)
+	decline_button.custom_minimum_size = Vector2(160, 42)
 	decline_button.pressed.connect(_on_decline_pressed)
-	WhiteDwarfTheme.apply_secondary_button(decline_button)
+	WhiteDwarfTheme.apply_primary_button(decline_button)
 	button_container.add_child(decline_button)
+
+	var use_button = Button.new()
+	use_button.name = "UseRerollButton"
+	use_button.text = "Re-roll (Free)" if free_ability_name != "" else "Re-roll (1 CP)"
+	use_button.custom_minimum_size = Vector2(130, 42)
+	use_button.pressed.connect(_on_use_pressed)
+	WhiteDwarfTheme.apply_secondary_button(use_button)
+	button_container.add_child(use_button)
 
 	main_container.add_child(button_container)
 
 	add_child(main_container)
+
+	# Focus the safe default so a keyboard/controller confirm (Enter/Space) keeps
+	# the roll rather than spending a CP. Deferred because the buttons are not in
+	# the scene tree until the dialog is added and popped up by the caller.
+	decline_button.grab_focus.call_deferred()
 
 func _get_roll_type_display() -> String:
 	match roll_type:

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2941,6 +2941,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "charge.reroll.keep_roll_default_button_order",
+      "description": "CHARGE phase Command/ability re-roll dialog: after a charge roll opens CommandRerollDialog, 'Keep Roll' is the highlighted primary button on the LEFT (ButtonRow child 0) and 'Re-roll (1 CP)' is the secondary button on the RIGHT (child 1) — the reverse of the old order — so a reflexive click on the prominent left-hand button no longer wastes a Command Point after a successful charge.",
+      "scenarios": [
+        "charge_reroll_keep_default_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "dialogs.CommandRerollDialog.keep_roll_is_highlighted_default",
+      "description": "CommandRerollDialog._build_ui() builds the safe 'Keep Roll' decline button as the primary/highlighted control (font_size 16) and grabs keyboard focus on it, while the CP-spending 'Re-roll' button uses the secondary style (font_size 13). Shared by charge rolls, Command Re-roll and free ability re-rolls (e.g. Swift Onslaught), so the safe choice is the highlighted default everywhere the dialog appears.",
+      "scenarios": [
+        "charge_reroll_keep_default_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/charge_reroll_keep_default_button.json
+++ b/40k/tests/scenarios/sp/charge_reroll_keep_default_button.json
@@ -1,0 +1,74 @@
+{
+  "id": "charge_reroll_keep_default_button",
+  "covers": [
+    "dialogs.CommandRerollDialog.keep_roll_is_highlighted_default",
+    "charge.reroll.keep_roll_default_button_order"
+  ],
+  "fixture": "audit_372_charge_modifier",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Charge-success button-order fix: when a charge roll opens the Command Re-roll dialog, the safe, non-destructive 'Keep Roll' choice must be the HIGHLIGHTED DEFAULT button on the LEFT, and the CP-spending 'Re-roll (1 CP)' the secondary button on the RIGHT — the reverse of the old layout, which invited a player to instinctively click the prominent left-hand button and waste a CP after a successful charge. Player path (mirrors charge_multi_step_movement's dialog trigger): U_WARBOSS_B (owner 2) declares a charge on the Blade Champion and CHARGE_ROLLs (seed 23 -> 12), which pauses and emits command_reroll_opportunity so ChargeController spawns the real CommandRerollDialog. Asserts against the LIVE dialog: (1) ButtonRow child 0 is 'KeepRollButton' and child 1 is 'UseRerollButton' (Keep Roll now on the left); (2) KeepRollButton carries the primary/highlighted style (font_size 16) and UseRerollButton the secondary style (font_size 13) — proving the highlight moved to Keep Roll; (3) KeepRollButton holds keyboard focus so an Enter/confirm keeps the roll rather than spending a CP. Finally the real 'Keep Roll' button is clicked and the dialog frees itself, confirming the safe default path still declines the re-roll.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_WARBOSS_B\"].models[0].merge({\"position\": {\"x\": 300.0, \"y\": 1880.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].merge({\"position\": {\"x\": 300.0, \"y\": 2160.0}, \"rotation\": 0.0}, true)" },
+    { "act": "execute_script",
+      "script": "GameState.state.units[\"U_WARBOSS_B\"].merge({\"flags\": {}}, true)" },
+    { "act": "execute_script", "script": "main.update_unit_visuals(\"U_WARBOSS_B\")" },
+    { "act": "execute_script", "script": "main.update_unit_visuals(\"U_BLADE_CHAMPION_A\")" },
+    { "act": "wait_for_tweens" },
+    { "act": "wait_frames", "frames": 8 },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DECLARE_CHARGE",
+      "actor_unit_id": "U_WARBOSS_B",
+      "payload": { "target_unit_ids": ["U_BLADE_CHAMPION_A"] }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": {
+      "type": "CHARGE_ROLL",
+      "actor_unit_id": "U_WARBOSS_B",
+      "payload": { "rng_seed": 23 }
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "expect_node_visible", "node": "/root/CommandRerollDialog", "timeout_s": 3.0 },
+    { "act": "wait_frames", "frames": 6 },
+    { "act": "screenshot", "label": "01_reroll_dialog_keep_roll_left_and_highlighted" },
+
+    { "act": "execute_script",
+      "script": "str(get_tree().root.get_node(\"CommandRerollDialog/Content/ButtonRow\").get_child(0).name)",
+      "equals": "KeepRollButton" },
+    { "act": "execute_script",
+      "script": "str(get_tree().root.get_node(\"CommandRerollDialog/Content/ButtonRow\").get_child(1).name)",
+      "equals": "UseRerollButton" },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"CommandRerollDialog/Content/ButtonRow/KeepRollButton\").get_theme_font_size(\"font_size\")",
+      "equals": 16 },
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"CommandRerollDialog/Content/ButtonRow/UseRerollButton\").get_theme_font_size(\"font_size\")",
+      "equals": 13 },
+
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node(\"CommandRerollDialog/Content/ButtonRow/KeepRollButton\").has_focus()",
+      "equals": true },
+
+    { "act": "click_node",
+      "node": "/root/CommandRerollDialog/Content/ButtonRow/KeepRollButton",
+      "emit_pressed": true },
+    { "act": "wait_frames", "frames": 8 },
+    { "act": "execute_script",
+      "script": "get_tree().root.get_node_or_null(\"CommandRerollDialog\") == null",
+      "equals": true },
+    { "act": "screenshot", "label": "02_kept_roll_dialog_dismissed" }
+  ]
+}


### PR DESCRIPTION
## Summary

When a charge roll (or any Command/ability re-roll) opens the re-roll dialog, the safe **"Keep Roll"** choice is now the highlighted **primary** button on the **LEFT**, and the CP-spending **"Re-roll (1 CP)"** is the plainer **secondary** button on the **RIGHT** — the reverse of the old layout.

The old order put the prominent, highlighted left-hand button on the *re-roll* action. A player who instinctively clicked it — especially right after a **successful** charge, where re-rolling makes no sense — would waste a Command Point. "Keep Roll" also now grabs keyboard focus, so pressing Enter/confirm keeps the roll instead of spending CP.

Because `CommandRerollDialog` is shared, this applies to every re-roll prompt that uses it: charge rolls, Command Re-roll, and free ability re-rolls such as Swift Onslaught.

## Changes

- `40k/dialogs/CommandRerollDialog.gd` — swapped button order + primary/secondary styling in `_build_ui()`; deferred `grab_focus()` on "Keep Roll".
- `40k/tests/scenarios/sp/charge_reroll_keep_default_button.json` — new windowed scenario.
- `40k/data/version_history.json` — changelog entry `0.53.1`.

## Before / after

| | Left (highlighted) | Right (secondary) |
|---|---|---|
| Before | Re-roll (1 CP) | Keep Roll |
| After | **Keep Roll** | Re-roll (1 CP) |

## Validation

- **New windowed scenario** drives a live charge roll, opens the real dialog, and asserts: "Keep Roll" is `ButtonRow` child 0 with the primary style (font_size 16) and keyboard focus; "Re-roll" is child 1 with the secondary style (font_size 13); clicking "Keep Roll" declines and frees the dialog. **26/26 assertions pass, no script errors.** Screenshot confirms the visual.
- **Regression**: the 5 existing scenarios that drive this dialog (`iss040_movement_11e`, `charge_multi_step_movement`, `charge_per_model_range_rings`, `charge_group_drag_multi_select`, `attached_char_charge_drag_leader`) all still pass — they address the button by name, so the child reorder doesn't affect them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn3V2cXSnP1ZDJYdAPUMtB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dn3V2cXSnP1ZDJYdAPUMtB)_