### PR TITLE
Fix attached leader shown twice in Movement unit list

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.53.2",
+			"date": "2026-07-17",
+			"summary": "Fixed a Movement-phase unit-list label that showed an attached leader twice. A squad with an attached CHARACTER (e.g. a Blade Champion leading a Custodian Guard squad) was listed as 'Custodian Guard Alpha + Blade Champion + Blade Champion' — the leader's name was printed twice. It now reads 'Custodian Guard Alpha + Blade Champion' once. This was purely a display bug; only one leader was ever attached.",
+			"changes": [
+				"Fixed: in the Movement phase 'Units (Move / Disembark)' list, a bodyguard squad's attached leader appeared twice in the row label (e.g. '+ Blade Champion + Blade Champion'). The movement controller was appending the attached-character names to the row twice; it now appends them once."
+			]
+		},
+		{
 			"version": "0.53.1",
 			"date": "2026-07-17",
 			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) \u2014 so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -925,16 +925,10 @@ func _refresh_unit_list() -> void:
 			var unit_name = _uname_meta.get("display_name", _uname_meta.get("name", unit_id))
 			var action_type = action.get("type", "")
 
-			# Show attached character name alongside bodyguard unit
-			var attached_chars = unit.get("attachment_data", {}).get("attached_characters", [])
-			if attached_chars.size() > 0:
-				var char_names = []
-				for char_id in attached_chars:
-					var char_unit = current_phase.get_unit(char_id)
-					if not char_unit.is_empty():
-						char_names.append(char_unit.get("meta", {}).get("name", char_id))
-				if char_names.size() > 0:
-					unit_name += " + " + ", ".join(char_names)
+			# NOTE: attached character names are appended below via `attach_info`
+			# (just before add_item). Do NOT also append them to unit_name here —
+			# doing both double-printed the leader, e.g.
+			# "Custodian Guard Alpha + Blade Champion + Blade Champion".
 
 			var status = _get_unit_movement_status(unit_id)
 			var status_text = ""

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2932,6 +2932,15 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "movementcontroller.unit_list_attached_leader_rendered_once",
+      "description": "In the Movement phase 'Units (Move / Disembark)' list, a bodyguard squad with an attached CHARACTER (e.g. a Blade Champion leading a Custodian Guard squad) names its leader exactly once in the row label. Regression for a bug where MovementController._refresh_unit_list() appended the attached-character names to the row twice (rendering 'Custodian Guard Alpha + Blade Champion + Blade Champion').",
+      "scenarios": [
+        "duplicate_leader_movement_list"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/duplicate_leader_movement_list.json
+++ b/40k/tests/scenarios/sp/duplicate_leader_movement_list.json
@@ -1,0 +1,42 @@
+{
+ "id": "duplicate_leader_movement_list",
+ "covers": [
+  "movementcontroller.unit_list_attached_leader_rendered_once"
+ ],
+ "fixture": "custodian_guard_dupes",
+ "transition_to_phase": 7,
+ "disable_ai": true,
+ "description": "Regression for the double-printed leader bug (branch claude/duplicate-blade-champion): the Movement-phase unit-list row for a bodyguard squad with an attached CHARACTER showed the leader TWICE, e.g. 'Custodian Guard Alpha + Blade Champion + Blade Champion', because _refresh_unit_list() appended the attached-character names into BOTH `unit_name` (block 1) and `attach_info` (block 2) and then concatenated both. Setup: attach a 'Blade Champion' CHARACTER to Custodian Guard Alpha (U_BOYZ_E) via the real CharacterAttachmentManager, refresh the live movement unit list, and assert the squad's row (a) still names the squad and its leader, and (b) names 'Blade Champion' exactly ONCE.",
+ "steps": [
+  {
+   "act": "wait_seconds",
+   "seconds": 0.8
+  },
+  {
+   "act": "expect_phase",
+   "equals": 7
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var bg = GameState.get_unit(\"U_BOYZ_E\")\nvar bg_kw = bg.get(\"meta\", {}).get(\"keywords\", [])\nvar champ = {\n\t\"id\": \"U_BLADE_CHAMP_TEST\",\n\t\"squad_id\": \"U_BLADE_CHAMP_TEST\",\n\t\"owner\": bg.get(\"owner\", 1),\n\t\"status\": bg.get(\"status\", 0),\n\t\"meta\": {\"name\": \"Blade Champion\", \"keywords\": [\"CHARACTER\"], \"leader_data\": {\"can_lead\": bg_kw.duplicate()}, \"stats\": {\"move\": 6, \"wounds\": 6}, \"points\": 120},\n\t\"models\": [{\"id\": \"m1\", \"alive\": true, \"base_mm\": 40, \"position\": null, \"wounds\": 6, \"current_wounds\": 6}],\n\t\"attached_to\": null,\n\t\"attachment_data\": {\"attached_characters\": []},\n\t\"flags\": {}\n}\nGameState.state.units[\"U_BLADE_CHAMP_TEST\"] = champ\nCharacterAttachmentManager.attach_character(\"U_BLADE_CHAMP_TEST\", \"U_BOYZ_E\")\nreturn GameState.get_unit(\"U_BOYZ_E\").get(\"attachment_data\", {}).get(\"attached_characters\", []).size()",
+   "equals": 1
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var mc = tree.current_scene.get_node_or_null(\"MovementController\")\nif mc == null:\n\treturn false\nmc._refresh_unit_list()\nvar ul = mc.unit_list\nfor i in range(ul.get_item_count()):\n\tif str(ul.get_item_metadata(i)) == \"U_BOYZ_E\":\n\t\tvar t = ul.get_item_text(i)\n\t\treturn t.contains(\"Custodian Guard Alpha\") and t.contains(\"Blade Champion\")\nreturn false",
+   "equals": true
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var mc = tree.current_scene.get_node_or_null(\"MovementController\")\nif mc == null:\n\treturn \"NO_MOVEMENT_CONTROLLER\"\nmc._refresh_unit_list()\nvar ul = mc.unit_list\nif ul == null:\n\treturn \"NO_UNIT_LIST\"\nfor i in range(ul.get_item_count()):\n\tif str(ul.get_item_metadata(i)) == \"U_BOYZ_E\":\n\t\treturn ul.get_item_text(i).count(\"Blade Champion\")\nreturn -1",
+   "equals": 1
+  },
+  {
+   "act": "screenshot",
+   "label": "01_movement_list_single_leader"
+  }
+ ]
+}


### PR DESCRIPTION
## What & why

A bodyguard squad with an attached CHARACTER (e.g. a Blade Champion leading a Custodian Guard squad) rendered its leader **twice** in the Movement phase "Units (Move / Disembark)" list, e.g. `Custodian Guard Alpha + Blade Champion + Blade Champion`.

This was purely a display bug — only one leader was ever attached. The confirming clue: the list rows showed the leader twice, while the "Selected Unit" header (a separate code path) correctly showed it once.

## Root cause

`MovementController._refresh_unit_list()` appended the attached-character names to the row **twice**:
1. into `unit_name` (block 1), and
2. into a separate `attach_info` string (block 2),

then concatenated both in the `add_item(unit_name + attach_info + status_text)` call.

## Fix

Removed the redundant first append (left an explanatory comment). The single `attach_info` block already handles it, so the row now names the leader once: `Custodian Guard Alpha + Blade Champion`.

The other phase controllers (Shooting / Fight / Main) already append attached-character names only once, so this doubling was specific to the movement list.

## Validation

- New windowed regression scenario `tests/scenarios/sp/duplicate_leader_movement_list.json` (registered in `coverage.json`): attaches a Blade Champion to a Custodian Guard squad via the real `CharacterAttachmentManager`, refreshes the live movement unit list, and asserts the squad's row names the leader exactly once. **6/6 steps pass**, debug log had **0 errors**, and the effect screenshot shows `Custodian Guard Alpha + Blade Champion [YET TO MOVE]`.
- Sibling scenario `custodian_guard_dupe_labels` still passes **26/26** (no regression).

## Changelog

Bumped `40k/data/version_history.json` to `0.53.2` (rebased onto latest `main`).

## Notes

The `Coverage matrix validation` CI check is red, but that is a pre-existing, non-required check already failing on `main` (335 tag/tile mismatches from earlier scenarios). This PR adds its own coverage tile and is net-neutral on that check (still 335 errors, not 336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015L5aXKdXpbuau8BJuEmkdQ