### PR TITLE
Fix "Unknown shooting resolved" game-log line

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.2",
+			"date": "2026-07-17",
+			"summary": "Fixed the game log showing 'Unknown shooting resolved' instead of the firing unit's name when the AI (or any path that didn't attach a unit id) resolved a shooting attack. The shooting unit is now always named in the log.",
+			"changes": [
+				"Fixed: 'P2: Unknown shooting resolved' log lines — the resolving unit's name is now stamped onto the shooting action at the single point every dispatch path flows through, so AI, player, network and test-driven shooting all name the shooter."
+			]
+		},
+		{
 			"version": "0.54.1",
 			"date": "2026-07-17",
 			"summary": "Fight phase now enforces the core rule that a model fights with ONE melee weapon. Models with multiple melee weapons or profiles (Blade Champion's Vaultswords, a Warboss's Big choppa vs Power klaw) must choose which one to swing — they no longer attack with everything they carry. [EXTRA ATTACKS] weapons are still used in addition.",
@@ -55,10 +63,10 @@
 		{
 			"version": "0.53.1",
 			"date": "2026-07-17",
-			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) \u2014 so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",
+			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) — so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",
 			"changes": [
 				"Fixed: holding Ctrl (or Cmd) and clicking a second unit in the Eligible Targets list now toggles it in/out of the charge, so you can declare a charge against several units as the hint describes.",
-				"The charge target list no longer relies on the click carrying the Ctrl modifier (which some systems don't attach to mouse clicks) \u2014 it now also reads the live keyboard state, so Ctrl+Click works consistently across platforms.",
+				"The charge target list no longer relies on the click carrying the Ctrl modifier (which some systems don't attach to mouse clicks) — it now also reads the live keyboard state, so Ctrl+Click works consistently across platforms.",
 				"Plain click still selects exactly one target, clicking empty space still clears the selection, and the target rows still lock once the charge is declared."
 			]
 		},

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -1293,6 +1293,20 @@ func _continue_after_reactive_stratagems() -> Dictionary:
 	return initial_result
 
 func _process_resolve_shooting(action: Dictionary) -> Dictionary:
+	# Stamp the shooting unit onto the action dict so downstream consumers can
+	# name it. Several dispatch paths build a bare {"type": "RESOLVE_SHOOTING"}
+	# with no actor id — notably AIDecisionMaker (both difficulty tiers) — which
+	# made GameEventLog fall back to "Unknown shooting resolved". execute_action()
+	# emits THIS SAME dict via action_taken (Godot dicts are by-reference), so
+	# stamping here fixes the log/replay for every caller (AI, UI, network, tests)
+	# rather than relying on each one to remember the field. active_shooter_id is
+	# the phase's authoritative shooter for this resolution (it drives the
+	# animation, combat header and verbose log below). Don't clobber a caller-
+	# supplied id, and skip the throwaway {} passed by the internal auto-resolve
+	# calls (which never reach action_taken).
+	if active_shooter_id != "" and str(action.get("actor_unit_id", "")) == "" and str(action.get("unit_id", "")) == "":
+		action["actor_unit_id"] = active_shooter_id
+
 	# Trigger attack animation on the shooting unit
 	_trigger_unit_animation(active_shooter_id, "attack")
 

--- a/40k/tests/scenarios/sp/shooting_resolved_names_unit.json
+++ b/40k/tests/scenarios/sp/shooting_resolved_names_unit.json
@@ -1,0 +1,30 @@
+{
+  "id": "shooting_resolved_names_unit",
+  "covers": ["shooting.log.resolve_names_unit"],
+  "fixture": "shooting_phase",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "Regression for the 'Unknown shooting resolved' game-log bug. A discrete RESOLVE_SHOOTING action dispatched WITHOUT an actor id (exactly what AIDecisionMaker builds, and what produced 'P2: Unknown shooting resolved') must still name the firing unit in the game log. Drives Battlewagon Alpha assigning its Lobba at the Blade Champion via the real SELECT/ASSIGN flow, then resolves via a bare RESOLVE_SHOOTING (the AI path — the human resolution dock is deactivated first, and CONFIRM->DECLINE->RESOLVE run synchronously so the dock's deferred auto-start cannot race it). Asserts the GameEventLog 'shooting resolved' entry names 'Battlewagon Alpha' and that NO 'shooting resolved' entry says 'Unknown'.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_phase", "equals": 8 },
+    { "act": "screenshot", "label": "01_shooting_phase" },
+
+    { "act": "dispatch_action", "action": { "type": "SELECT_SHOOTER", "actor_unit_id": "U_BATTLEWAGON_A" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "dispatch_action", "action": { "type": "ASSIGN_TARGET", "actor_unit_id": "U_BATTLEWAGON_A", "payload": { "weapon_id": "lobba_ranged", "target_unit_id": "U_BLADE_CHAMPION_A", "model_ids": ["m1"] } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var main = tree.root.get_node_or_null(\"Main\")\nvar phase = PhaseManager.current_phase_instance\nvar c = phase.execute_action({\"type\": \"CONFIRM_TARGETS\"})\nif not c.get(\"success\", false):\n\treturn \"CONFIRM_FAILED:\" + str(c.get(\"error\", \"\"))\nif phase.awaiting_reactive_stratagem:\n\tphase.execute_action({\"type\": \"DECLINE_REACTIVE_STRATAGEM\"})\nif main and main.shooting_controller and main.shooting_controller.has_method(\"_deactivate_resolution_dock\"):\n\tmain.shooting_controller._deactivate_resolution_dock()\nvar r = phase.execute_action({\"type\": \"RESOLVE_SHOOTING\"})\nreturn \"RESOLVE_SUCCESS=\" + str(r.get(\"success\", false))", "equals": "RESOLVE_SUCCESS=true" },
+
+    { "act": "execute_script", "multiline": true, "script": "var hit = \"\"\nfor e in GameEventLog.entries:\n\tvar t = str(e.get(\"text\", \"\"))\n\tif \"shooting resolved\" in t:\n\t\thit = t\nreturn hit", "not_equals": "" },
+
+    { "act": "execute_script", "multiline": true, "script": "var found = false\nfor e in GameEventLog.entries:\n\tvar t = str(e.get(\"text\", \"\"))\n\tif \"shooting resolved\" in t and \"Battlewagon Alpha\" in t:\n\t\tfound = true\nreturn found", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var bad = false\nfor e in GameEventLog.entries:\n\tvar t = str(e.get(\"text\", \"\"))\n\tif \"shooting resolved\" in t and \"Unknown\" in t:\n\t\tbad = true\nreturn bad", "equals": false },
+
+    { "act": "screenshot", "label": "02_resolved" }
+  ]
+}


### PR DESCRIPTION
## Summary

The game log showed **"Unknown shooting resolved"** (e.g. `P2: Unknown shooting resolved`) whenever the AI resolved a shooting attack.

`GameEventLog` names the shooter from the `RESOLVE_SHOOTING` action's `unit_id` / `actor_unit_id`, falling back to the literal `"Unknown"` when neither is present. `AIDecisionMaker` (both difficulty tiers) dispatches a bare `{"type": "RESOLVE_SHOOTING"}` with no id — which is why it only ever appeared for the AI. The shooting itself always resolved correctly (the phase reads the shooter from its own `active_shooter_id`, not the action), so this was purely a cosmetic log defect.

## Fix

Stamp `active_shooter_id` — the phase's authoritative shooter for the resolution — onto the action dict at the top of `ShootingPhase._process_resolve_shooting`. `execute_action()` emits that same dict via `action_taken` (Godot dicts are by-reference, the same pattern already used for `action["player"]`), so this fixes the log and replay for **every** dispatch path (AI, player, network, tests) at the single choke point they all flow through — no reliance on each caller to supply the field. A caller-supplied id is never clobbered, and the throwaway `{}` from the internal auto-resolve calls is skipped.

## Validation

Added windowed regression scenario `shooting_resolved_names_unit.json` (drives Battlewagon Alpha's Lobba at the Blade Champion via the real select/assign flow, then resolves via the AI-style bare `RESOLVE_SHOOTING`):

- **Without the fix:** `P1: Unknown shooting resolved` → scenario fails (reproduces the bug).
- **With the fix:** `P1: Battlewagon Alpha shooting resolved` → 12/12 pass.
- Ran windowed with the real UI; the 3 existing shooting scenarios still pass (20/0, 35/0, 8/0).

## Files changed

- `40k/phases/ShootingPhase.gd` — the stamp.
- `40k/tests/scenarios/sp/shooting_resolved_names_unit.json` — regression scenario.
- `40k/data/version_history.json` — changelog entry `0.53.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8aLzwHuVLbCMLYfTxiabT

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8aLzwHuVLbCMLYfTxiabT)_