### PR TITLE
Fix AI charge models not moving on board until end of charge phase

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -1444,6 +1444,34 @@ func repro_ai_pile_in_move(unit_id: String, nx: float, ny: float) -> bool:
 	}])
 	return true
 
+# Charge-phase analogue of repro_ai_pile_in_move. Reproduces the exact ordering
+# AIPlayer._execute_next_action uses for a charge move: it emits ai_action_taken
+# (-> Main._on_ai_action_taken) with an APPLY_CHARGE_MOVE action BEFORE routing
+# the action that writes the move, then the ChargePhase writes the model move in
+# route_action. The bug: nothing in _on_ai_action_taken handled APPLY_CHARGE_MOVE,
+# so the token stayed at its pre-charge position until END_CHARGE synced the whole
+# board — i.e. the charging unit only appeared to move AFTER the AI finished ALL
+# its charges. The fix defers a token sync on APPLY_CHARGE_MOVE so the token reads
+# the post-move state. Returns true if the handler + move were driven. Callable
+# from execute_script.
+func repro_ai_charge_move(unit_id: String, nx: float, ny: float) -> bool:
+	var scene := get_tree().current_scene
+	if scene == null or not scene.has_method("_on_ai_action_taken"):
+		return false
+	var unit = GameState.get_unit(unit_id)
+	if unit.is_empty() or unit.get("models", []).is_empty():
+		return false
+	var owner := int(unit.get("owner", 1))
+	# (1) AI emits ai_action_taken BEFORE the action is routed:
+	scene._on_ai_action_taken(owner, {"type": "APPLY_CHARGE_MOVE", "actor_unit_id": unit_id}, "repro charge move")
+	# (2) the ChargePhase then writes the charge move in route_action / apply_state_changes:
+	GameState.apply_state_changes([{
+		"op": "set",
+		"path": "units.%s.models.0.position" % unit_id,
+		"value": {"x": nx, "y": ny}
+	}])
+	return true
+
 # Distance in px between a unit's model ON-SCREEN token and that model's current
 # GameState position. ~0 == the visual is in sync with state; a large value ==
 # the token was left stranded at a stale position. Callable from execute_script,

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.3",
+			"date": "2026-07-17",
+			"summary": "Fixed AI charges not showing on the board until the end of the charge phase. When the AI made a successful charge, its models used to stay put visually while it declared its remaining charges — only snapping into engagement range once the whole phase ended. Each AI charging unit now moves into engagement range immediately, right after its charge succeeds, so you can follow the AI's charges one unit at a time.",
+			"changes": [
+				"Fixed: a successful AI charge now moves the charging unit's models on the board straight away, before the AI declares its next charge (previously they only appeared to move at the end of the charge phase).",
+				"Attached characters riding along with a charging unit, and any enemy models slain by a charge-move mortal wound (e.g. Spiked Ram, Piston-driven Brutality), now update on the board at the same moment.",
+				"Also covers the AI's Heroic Intervention counter-charge move."
+			]
+		},
+		{
 			"version": "0.54.2",
 			"date": "2026-07-17",
 			"summary": "Dice now show as die-face icons (pips) instead of raw numbers in the last places that still printed numbers: the wound-allocation 'Save rolls' summary and its Command Re-roll chips, the shooting resolution dock's re-roll chips, and the Grenade / Tank Shock / Command Re-roll result popups. Dice look the same everywhere now.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -784,6 +784,25 @@ func _on_ai_action_taken(_player: int, action: Dictionary, _description: String)
 			# moved)" while the tokens never moved on the board.
 			call_deferred("update_unit_visuals", unit_id)
 
+	# Charge moves change model positions too, but the AI applies them directly
+	# via NetworkIntegration.route_action — NOT through the ChargeController — so
+	# the human charge path's refresh (_on_charge_action_requested ->
+	# update_after_charge_action -> _recreate_unit_visuals) never runs for AI
+	# charges. The result was the reported bug: a successful AI charge updated
+	# GameState but the tokens only appeared to move at END_CHARGE (via the
+	# _sync_all_token_positions call below), i.e. AFTER the AI had finished ALL of
+	# its charges. Sync now so the charging unit (and any attached CHARACTER
+	# riding along, plus target models killed by a charge-move mortal wound such
+	# as Spiked Ram / Piston-driven Brutality) visibly moves into engagement
+	# range BEFORE the AI declares its next charge. Deferred for the same reason
+	# as the movement block above: ai_action_taken fires BEFORE route_action
+	# applies the move, so GameState still holds the pre-move positions right now
+	# — a synchronous sync would be a no-op. _sync_all_token_positions() (rather
+	# than update_unit_visuals) tweens EVERY token to its state position, so the
+	# rider character and any freshly-dead target models are handled in one pass.
+	if action_type in ["APPLY_CHARGE_MOVE", "APPLY_HEROIC_INTERVENTION_MOVE"]:
+		call_deferred("_sync_all_token_positions")
+
 	# Phase-ending actions: sync ALL token positions to catch any missed updates
 	if action_type in ["END_MOVEMENT", "END_CHARGE", "END_FIGHT", "END_SHOOTING"]:
 		_sync_all_token_positions()

--- a/40k/tests/scenarios/sp/ai_charge_move_token_sync.json
+++ b/40k/tests/scenarios/sp/ai_charge_move_token_sync.json
@@ -1,0 +1,27 @@
+{
+  "id": "ai_charge_move_token_sync",
+  "covers": [
+    "scripts.Main.on_ai_action_taken.charge_move_deferred_token_sync",
+    "charge.ai_charge_move_visual_sync"
+  ],
+  "fixture": "audit_372_charge_modifier",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Regression: when the AI made a charge it updated GameState and the game log said the charge succeeded, but the models did NOT move on the board until END_CHARGE — i.e. AFTER the AI had finished ALL of its charges (reported bug: 'Orc Unit A charges Custodes Unit B, successful, but the models don't move until the Orc player has done all of their charges'). Root cause: AI charges are routed directly through NetworkIntegration.route_action (not the ChargeController), so the human path's update_after_charge_action() -> _recreate_unit_visuals() never ran, and _on_ai_action_taken did not handle APPLY_CHARGE_MOVE (only the movement/fight action types). AIPlayer._execute_next_action also emits ai_action_taken BEFORE routing the action, so any synchronous sync would be a no-op. This scenario drives the REAL Main._on_ai_action_taken for an APPLY_CHARGE_MOVE in that exact order (Ork Warboss, owner 2, charging toward the owner-1 Custodian Guard), then applies the model move the ChargePhase would apply, and asserts the on-screen token catches up to the new GameState position instead of being stranded until end of phase. Fix: defer _sync_all_token_positions() on APPLY_CHARGE_MOVE / APPLY_HEROIC_INTERVENTION_MOVE so the charging unit visibly moves before the next charge is declared.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_token_visible", "unit_id": "U_WARBOSS_B" },
+    { "act": "expect_token_visible", "unit_id": "U_CUSTODIAN_GUARD_B" },
+    { "act": "execute_script", "script": "token_desync_from_state_px(\"U_WARBOSS_B\", \"m1\")", "expect_max": 2.0 },
+    { "act": "screenshot", "label": "01_before_charge_token_in_sync" },
+    { "act": "execute_script", "script": "repro_ai_charge_move(\"U_WARBOSS_B\", 470.0, 1260.0)", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "screenshot", "label": "02_after_charge_token_followed_state" },
+    { "act": "execute_script", "script": "token_desync_from_state_px(\"U_WARBOSS_B\", \"m1\")", "expect_max": 2.0 }
+  ]
+}


### PR DESCRIPTION
## Summary

When the AI made a successful charge, its models updated in `GameState` (and the game log said the charge succeeded), but the tokens **did not move on the board until `END_CHARGE`** — i.e. only after the AI had declared *all* of its charges for the phase. Reported example: "Orc Unit A charges Custodes Unit B, successful, but the models don't move until the Orc player has done all of their charges."

Each AI charging unit now moves into engagement range **immediately**, right after its charge succeeds and before the next unit's charge is declared.

## Root cause

AI charges are routed directly through `NetworkIntegration.route_action`, bypassing the `ChargeController`. The **human** charge path recreates visuals via `_on_charge_action_requested → update_after_charge_action → _recreate_unit_visuals`, but the AI path had no equivalent. `Main._on_ai_action_taken` refreshed tokens for the movement/fight action types (`CONFIRM_UNIT_MOVE`, `PILE_IN`, `CONSOLIDATE`, …) but **not** `APPLY_CHARGE_MOVE`, so nothing re-synced the tokens until `END_CHARGE`'s `_sync_all_token_positions()` ran at the end of the phase.

## Change

- **`40k/scripts/Main.gd`** — in `_on_ai_action_taken`, defer `_sync_all_token_positions()` for `APPLY_CHARGE_MOVE` / `APPLY_HEROIC_INTERVENTION_MOVE`. Deferred because `ai_action_taken` fires *before* `route_action` applies the move, so a synchronous sync would read the pre-move state and be a no-op. `_sync_all_token_positions()` tweens every token to its state position, so the charging unit — plus any attached CHARACTER riding along and any target models slain by a charge-move mortal wound (e.g. Spiked Ram, Piston-driven Brutality) — all update in one pass.
- **`40k/autoloads/ScenarioRunner.gd`** — added a `repro_ai_charge_move` helper (charge-phase analogue of the existing `repro_ai_pile_in_move`) that reproduces the exact AI ordering (`ai_action_taken` emitted before routing).
- **`40k/tests/scenarios/sp/ai_charge_move_token_sync.json`** — new windowed regression scenario.
- **`40k/data/version_history.json`** — new player-facing entry `0.53.1`.

## Validation

- **Windowed scenario** (`ai_charge_move_token_sync`): drives the real `Main._on_ai_action_taken` in the real AI action ordering and asserts the on-screen token catches up to GameState. **Fails without the fix** (token stranded **807px** from state); **passes with the fix** (**≤2px**).
- **Live end-to-end**: real `AIDecisionMaker._compute_charge_move` → real `ChargePhase.route_action` moved the Warboss token **337px into engagement range with 0px desync while still in the charge phase** (before `END_CHARGE`).
- No `ERROR`/`SCRIPT ERROR` in the debug log; the pile-in sync, charge-declaration, and heroic-intervention scenarios still pass.

## Notes

- Scope is the two AI charge-move actions. Tank Shock mortal-wound *deaths* (a separate action) were out of scope; the charging vehicle's *movement* is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YVhkG65phExmcbxHN8NHS

---
_Generated by [Claude Code](https://claude.ai/code/session_012YVhkG65phExmcbxHN8NHS)_