### PR TITLE
Fix AI auto-removing the human's out-of-coherency models at end of its turn

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.4",
+			"date": "2026-07-17",
+			"summary": "Fixed the AI removing YOUR out-of-coherency models for you. When the AI's turn ended with some of your units out of coherency (e.g. after casualties), the 'Regaining Coherency' popup appeared but the AI instantly picked and removed your models before you could click. The choice of which models to remove is now yours: the popup waits for you, the AI's turn pauses until you've chosen, and only then does the turn end.",
+			"changes": [
+				"Fixed: at the end of the AI's turn, out-of-coherency removals for YOUR units are no longer auto-picked by the AI — the 'Regaining Coherency' dialog now waits for you to choose which model(s) to remove.",
+				"The AI's turn stays paused while your coherency dialog is open, then ends normally after your choice restores coherency.",
+				"The AI's own out-of-coherency units are still resolved automatically, as before."
+			]
+		},
+		{
 			"version": "0.54.3",
 			"date": "2026-07-17",
 			"summary": "Fixed AI charges not showing on the board until the end of the charge phase. When the AI made a successful charge, its models used to stay put visually while it declared its remaining charges — only snapping into engagement range once the whole phase ended. Each AI charging unit now moves into engagement range immediately, right after its charge succeeds, so you can follow the AI's charges one unit at a time.",

--- a/40k/phases/ScoringPhase.gd
+++ b/40k/phases/ScoringPhase.gd
@@ -156,8 +156,20 @@ func get_available_actions() -> Array:
 
 	# 03.03 coherency removals when awaiting: one action per offender model.
 	# Mandatory — nothing else (incl. END_TURN) is offered until resolved.
+	# Only list actions for AI-owned entries: the AI turn loop consumes
+	# whatever appears here, and at the end of an AI turn the pending units
+	# belong to the HUMAN opponent — listing theirs let the AI answer the
+	# 03.03 choice and delete the human's models within a second of the
+	# CoherencyRemovalDialog opening (user report 2026-07-17). Human owners
+	# act via the dialog, which dispatches REMOVE_MODEL_FOR_COHERENCY
+	# directly; returning empty blocks the AI/harness from ending the turn
+	# while the dialog is open (same pattern as the Acrobatic Escape and
+	# card-action gates below).
 	if _awaiting_coherency_removal and not _coherency_removal_pending.is_empty():
+		var coh_ai_node = get_node_or_null("/root/AIPlayer")
 		for entry in _coherency_removal_pending:
+			if not (coh_ai_node and coh_ai_node.is_ai_player(int(entry.player))):
+				continue
 			for model_id in entry.offenders:
 				actions.append({
 					"type": "REMOVE_MODEL_FOR_COHERENCY",
@@ -507,6 +519,7 @@ func _get_incoherent_human_units() -> Array:
 	var out: Array = []
 	var gc = GameState.state.get("meta", {}).get("game_config", {})
 	var units = GameState.state.get("units", {})
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
 	for unit_id in units:
 		var unit = units[unit_id]
 		var alive := 0
@@ -518,6 +531,12 @@ func _get_incoherent_human_units() -> Array:
 		var owner := int(unit.get("owner", 0))
 		var ptype := str(gc.get("player%d_type" % owner, "HUMAN")).to_upper()
 		if ptype != "HUMAN":
+			continue
+		# game_config defaults to HUMAN when player types are missing (e.g.
+		# older fixtures); if AIPlayer actually controls this owner there is
+		# no human to make the 03.03 choice — leave the unit to the
+		# PhaseManager auto-pick backstop instead of pausing the turn.
+		if ai_player_node and ai_player_node.is_ai_player(owner):
 			continue
 		var coh = AttackSequence.check_unit_coherency(unit)
 		if not coh.coherent:

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1935,18 +1935,20 @@
     },
     {
       "id": "phases.ScoringPhase.coherency_removal_choice_03_03",
-      "description": "11e 03.03 Regaining Coherency (audit #16): END_TURN pauses while a human-owned unit is out of coherency; REMOVE_MODEL_FOR_COHERENCY applies the player's chosen removal (destroyed, no on-death triggers); END_TURN is blocked until coherent. PhaseManager auto-pick hook remains the AI/backstop.",
+      "description": "11e 03.03 Regaining Coherency (audit #16): END_TURN pauses while a human-owned unit is out of coherency; REMOVE_MODEL_FOR_COHERENCY applies the player's chosen removal (destroyed, no on-death triggers); END_TURN is blocked until coherent. PhaseManager auto-pick hook remains the AI/backstop. The removal actions are only listed to the AI turn loop for AI-owned units — at the end of an AI turn the human's pending removals block with an empty action list so the AI cannot answer the choice for them (iss042c).",
       "scenarios": [
-        "iss042b_coherency_removal_choice_11e"
+        "iss042b_coherency_removal_choice_11e",
+        "iss042c_coherency_ai_turn_no_hijack_11e"
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {
       "id": "ui.CoherencyRemovalDialog",
-      "description": "ScoringController's CoherencyRemovalDialog lists each incoherent unit's offender models as buttons; a real button press routes the removal action and the turn auto-completes once coherent.",
+      "description": "ScoringController's CoherencyRemovalDialog lists each incoherent unit's offender models as buttons; a real button press routes the removal action and the turn auto-completes once coherent. Survives the owning human's inaction while an enabled AI ends its turn (no auto-removal).",
       "scenarios": [
-        "iss042b_coherency_removal_choice_11e"
+        "iss042b_coherency_removal_choice_11e",
+        "iss042c_coherency_ai_turn_no_hijack_11e"
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"

--- a/40k/tests/scenarios/sp/iss042c_coherency_ai_turn_no_hijack_11e.json
+++ b/40k/tests/scenarios/sp/iss042c_coherency_ai_turn_no_hijack_11e.json
@@ -1,0 +1,46 @@
+{
+  "id": "iss042c_coherency_ai_turn_no_hijack_11e",
+  "covers": [
+    "phases.ScoringPhase.coherency_removal_choice_03_03",
+    "ui.CoherencyRemovalDialog",
+    "autoloads.AIPlayer.scoring_gate_ownership"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 11,
+  "disable_ai": true,
+  "description": "Guards the AI-hijacks-the-human's-03.03-removal bug (user report 2026-07-17: 'they popped up asking me to remove them, but it removed the models automatically'). At the end of the AI's (P2) turn, a HUMAN (P1) unit is out of coherency: END_TURN pauses and the CoherencyRemovalDialog opens for the human. The AI's main loop used to pick the REMOVE_MODEL_FOR_COHERENCY actions straight out of get_available_actions() and delete the human's models within a second of the dialog opening. This scenario displaces a P1 Custodian Guard model 15\" from its unit during P2's Scoring phase, enables the AI for P2 (which ends its own turn, opening the human's dialog), waits past several AI evaluation cycles, and asserts all three human models are still alive and the gate still awaits the human; then the human clicks the real dialog button, the chosen model is removed, and the turn ends. Pre-fix this fails at the '03_human_models_survive_ai_cycles' asserts.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 11 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_CUSTODIAN_GUARD_B\")[\"models\"][0].merge({\"position\": {\"x\": 370.0, \"y\": 500.0}}, true)" },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance()._get_incoherent_human_units().size()", "equals": 1 },
+    { "act": "screenshot", "label": "01_p1_guard_broken_coherency_during_p2_turn" },
+
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"AI\"})" },
+    { "act": "execute_script", "script": "AIPlayer._request_evaluation()" },
+
+    { "act": "expect_node_visible", "node": "/root/CoherencyRemovalDialog", "timeout_s": 8.0 },
+    { "act": "screenshot", "label": "02_dialog_open_during_ai_turn" },
+
+    { "act": "wait_seconds", "seconds": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var alive := 0\nfor m in GameState.get_unit(\"U_CUSTODIAN_GUARD_B\").models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive", "equals": 3 },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_CUSTODIAN_GUARD_B\")[\"models\"][0][\"alive\"]", "equals": true },
+    { "act": "expect_phase_property", "property": "_awaiting_coherency_removal", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_available_actions().size()", "equals": 0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 11 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_node_visible", "node": "/root/CoherencyRemovalDialog", "timeout_s": 1.0 },
+    { "act": "screenshot", "label": "03_human_models_survive_ai_cycles" },
+
+    { "act": "click_node", "node": "/root/CoherencyRemovalDialog/Content/Row_U_CUSTODIAN_GUARD_B/Remove_U_CUSTODIAN_GUARD_B_m1", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 1.5 },
+
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_CUSTODIAN_GUARD_B\")[\"models\"][0][\"alive\"]", "equals": false },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "screenshot", "label": "04_player_choice_removed_turn_ended" }
+  ]
+}


### PR DESCRIPTION
## Summary

At the End of Turn step (11e 03.03 "Regaining Coherency"), when the AI's turn ended with one of **your** units out of coherency (e.g. after taking casualties), the game correctly paused `END_TURN` and opened the `CoherencyRemovalDialog` for you — but `ScoringPhase.get_available_actions()` still listed the `REMOVE_MODEL_FOR_COHERENCY` actions unconditionally. Because it was the AI's turn, the AI's action loop (`AIDecisionMaker._decide_scoring`) grabbed those actions and removed your models for you within ~1s of the dialog opening, then ended the turn. This matches the user report: *"They popped up asking me to remove them, but before I could act it appears to have removed the models automatically."*

## Root cause

The coherency-removal gate exposed its actions to whoever was the active player. At the end of an AI turn the pending out-of-coherency units belong to the **human** opponent, so the AI loop consumed the human's choice.

## Changes

- **`ScoringPhase.get_available_actions()`** — while the coherency gate is awaiting, only list removal actions for **AI-owned** pending entries. Human-owned entries yield an empty action list, which blocks the AI loop from acting (the same pattern already used by the Acrobatic Escape and primary-card-action gates). The human resolves via the dialog, which dispatches `REMOVE_MODEL_FOR_COHERENCY` directly, and the controller re-dispatches `END_TURN` once coherent.
- **`ScoringPhase._get_incoherent_human_units()`** — also skip owners actually controlled by `AIPlayer` even when `game_config` player types are missing (they default to `HUMAN`). Those units belong to the `PhaseManager` deterministic auto-pick backstop, not the pause gate.

## Validation

- **New windowed scenario** `iss042c_coherency_ai_turn_no_hijack_11e` drives the exact reported situation: P2 (AI) ends its turn with a P1 (human) Custodian Guard out of coherency. It **reproduces the hijack pre-fix** (AI removed model `m1` and ended the turn during the 3s wait) and **passes 24/24 post-fix** — the dialog survives multiple AI evaluation cycles, all human models stay alive, `get_available_actions()` is empty, and the human's button click removes the chosen model before the turn ends.
- `iss042b_coherency_removal_choice_11e` (the original human-turn coherency scenario): 20/20 still passing.
- `first_turn_p2_no_reserves_turn_one` (adjacent END_TURN path): passing.
- Headless `tests/test_iss042_coherency_11e.gd`: 11/11 still passing.
- The AI's own out-of-coherency units are still auto-resolved by the existing `PhaseManager._enforce_coherency_11e` backstop, unchanged.

## Notes / out of scope

- Multiplayer `END_TURN` uses a separate `GameManager` path that already relies on the deterministic auto-pick backstop by design — not modified.
- In an AI-vs-AI spectator game both sides' removals stay automatic, as before.
- `iss064d_triangulate_prompt_11e` has one pre-existing failing step (unrelated CardActionDialog board-pick) that fails identically on `main` without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NFqYskppaNHTWCNrXwGrsc

---
_Generated by [Claude Code](https://claude.ai/code/session_01NFqYskppaNHTWCNrXwGrsc)_