### PR TITLE
Fix attached leader token not moving when the AI piles in first

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -1472,6 +1472,50 @@ func repro_ai_charge_move(unit_id: String, nx: float, ny: float) -> bool:
 	}])
 	return true
 
+# Attached-unit (19.03) analogue of repro_ai_pile_in_move. A fight-phase
+# PILE_IN / CONSOLIDATE moves the chosen unit AND its attached characters'
+# models in ONE action, but the action dict carries only the BODYGUARD's
+# unit_id (the AI merges the leader's moves via
+# _merge_attached_char_fight_movements). The bug: _on_ai_action_taken synced
+# visuals with update_unit_visuals(unit_id), which only walks that one unit's
+# tokens — the leader's token stayed stranded at its pre-move position (its
+# desync equalled its full state displacement) while GameState and the combat
+# used the new one. This helper links char_id to unit_id as an attached
+# character, drives the REAL Main handler in the exact AI order, then applies
+# the model-0 move of BOTH units the phase would apply in route_action. The
+# fix defers _sync_all_token_positions() so every token in the group catches
+# up. Returns true if the handler + moves were driven. Callable from
+# execute_script.
+func repro_ai_pile_in_group_move(unit_id: String, char_id: String, nx: float, ny: float, cnx: float, cny: float) -> bool:
+	var scene := get_tree().current_scene
+	if scene == null or not scene.has_method("_on_ai_action_taken"):
+		return false
+	var unit = GameState.get_unit(unit_id)
+	var chr_unit = GameState.get_unit(char_id)
+	if unit.is_empty() or unit.get("models", []).is_empty() \
+			or chr_unit.is_empty() or chr_unit.get("models", []).is_empty():
+		return false
+	# 19.03 linkage, both directions — matching how formations write it.
+	GameState.state.units[unit_id]["attachment_data"] = {"attached_characters": [char_id]}
+	GameState.state.units[char_id]["attached_to"] = unit_id
+	var owner := int(unit.get("owner", 1))
+	# (1) AI emits ai_action_taken BEFORE the action is routed:
+	scene._on_ai_action_taken(owner, {"type": "PILE_IN", "unit_id": unit_id}, "repro group pile-in")
+	# (2) the FightPhase then writes the WHOLE GROUP's move in route_action:
+	GameState.apply_state_changes([
+		{
+			"op": "set",
+			"path": "units.%s.models.0.position" % unit_id,
+			"value": {"x": nx, "y": ny}
+		},
+		{
+			"op": "set",
+			"path": "units.%s.models.0.position" % char_id,
+			"value": {"x": cnx, "y": cny}
+		}
+	])
+	return true
+
 # Distance in px between a unit's model ON-SCREEN token and that model's current
 # GameState position. ~0 == the visual is in sync with state; a large value ==
 # the token was left stranded at a stale position. Callable from execute_script,

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.7",
+			"date": "2026-07-17",
+			"summary": "Fixed attached leaders not moving on the board when the opponent's AI piles in first. At the start of the Fight phase the player whose turn it is piles in first (11e 12.02) — when that was the AI and it piled in a unit with an attached character (e.g. a Blade Champion leading Custodian Guard), the bodyguard's models moved on the board but the leader's token stayed put, even though the leader had really moved in the game state. The whole group now visibly moves together the moment the AI piles in or consolidates.",
+			"changes": [
+				"Fixed: when the AI piles in or consolidates an attached unit (leader + bodyguard), the leader's token now moves on the board at the same moment as the bodyguard's models (previously it was left stranded at its old position until a later board refresh).",
+				"The combat itself always used the correct positions — this was purely a display issue, but it made it look like the opponent never piled in before your own Pile In step began."
+			]
+		},
+		{
 			"version": "0.54.6",
 			"date": "2026-07-17",
 			"summary": "Fight phase: picking which unit fights next no longer pops up over the middle of the board. The 'Select Unit to Fight' picker now lives in the right-hand panel — same place you pick units in every other phase and in the Pile In / Consolidate steps — so you can see the whole battlefield while choosing.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -767,22 +767,31 @@ func _on_ai_action_taken(_player: int, action: Dictionary, _description: String)
 			print("[Main] T7-58: Triggered AI charge arrows for %s -> %s" % [charger_id, str(target_ids)])
 
 	# Movement-related actions that change model positions
-	if action_type in ["CONFIRM_UNIT_MOVE", "REMAIN_STATIONARY", "CHARGE", "PILE_IN", "CONSOLIDATE"]:
+	if action_type in ["CONFIRM_UNIT_MOVE", "REMAIN_STATIONARY", "CHARGE"]:
 		if unit_id != "":
 			# T-091: Capture pre-move token positions and spawn AI path visual
 			# (token positions still hold the OLD positions; GameState already has the NEW)
 			if action_type == "CONFIRM_UNIT_MOVE":
 				_show_ai_movement_paths(unit_id, _player)
-			# Fight-phase PILE_IN / CONSOLIDATE (and any move dispatched via
-			# AIPlayer._execute_next_action) emit ai_action_taken BEFORE the action is
+			# AIPlayer._execute_next_action emits ai_action_taken BEFORE the action is
 			# routed, so GameState still holds the PRE-move positions right now. A
 			# synchronous update_unit_visuals() would sync tokens to the old state — a
-			# no-op — and nothing re-syncs after the phase applies the move (the
-			# FightPhase.pile_in_preview signal has no listeners). Defer the token sync
-			# to the end of the frame so it reads the post-move state the phase writes
-			# in route_action; without this the AI's Lootas pile-in logged "(N models
-			# moved)" while the tokens never moved on the board.
+			# no-op. Defer the token sync to the end of the frame so it reads the
+			# post-move state the phase writes in route_action.
 			call_deferred("update_unit_visuals", unit_id)
+
+	# Fight-phase PILE_IN / CONSOLIDATE move the chosen unit AND its attached
+	# characters' models in ONE action (19.03 group move), but the action dict
+	# carries only the BODYGUARD's unit_id. update_unit_visuals(unit_id) walked
+	# that one unit's tokens, so an attached leader's token stayed stranded at
+	# its pre-move position while GameState (and the combat) used the new one —
+	# e.g. a Blade Champion attached to Custodian Guard never visibly piled in
+	# when the AI's half of the Pile In step (12.02) ran first. Sync ALL tokens
+	# in one pass instead (same approach as the AI charge-move fix): it tweens
+	# every token to its state position, covering the leader with the
+	# bodyguard. Deferred for the same pre-move-state reason as above.
+	if action_type in ["PILE_IN", "CONSOLIDATE"]:
+		call_deferred("_sync_all_token_positions")
 
 	# Charge moves change model positions too, but the AI applies them directly
 	# via NetworkIntegration.route_action — NOT through the ChargeController — so

--- a/40k/tests/scenarios/sp/ai_pile_in_attached_char_token_sync.json
+++ b/40k/tests/scenarios/sp/ai_pile_in_attached_char_token_sync.json
@@ -1,0 +1,27 @@
+{
+  "id": "ai_pile_in_attached_char_token_sync",
+  "covers": [
+    "scripts.Main.on_ai_action_taken.pile_in_group_token_sync",
+    "fight.ai_pile_in_attached_character_visual_sync"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Regression: when the AI piled in an Attached unit (19.03 — bodyguard + leader move as ONE unit in ONE action), the bodyguard's tokens moved on the board but the attached CHARACTER's token stayed stranded at its pre-move position; its desync equalled its full state displacement (live repro: Blade Champion attached to Custodian Guard, champion token 11.35px behind state — exactly the whole move — while all five guard tokens were at 0px). Root cause: the PILE_IN/CONSOLIDATE action dict carries only the bodyguard's unit_id, and Main._on_ai_action_taken synced visuals with update_unit_visuals(unit_id), which walks only that one unit's tokens. This scenario links U_BLADE_CHAMPION_A to U_CUSTODIAN_GUARD_B as its attached character, drives the REAL Main._on_ai_action_taken in the exact AI order (emit, THEN apply the group's moves), and asserts the CHARACTER token catches up to its new GameState position along with the bodyguard's. Fix: PILE_IN/CONSOLIDATE now defer _sync_all_token_positions() — the same one-pass tween sync the AI charge fix uses — instead of the single-unit update.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "expect_token_visible", "unit_id": "U_BLADE_CHAMPION_A" },
+    { "act": "expect_token_visible", "unit_id": "U_CUSTODIAN_GUARD_B" },
+    { "act": "execute_script", "script": "token_desync_from_state_px(\"U_BLADE_CHAMPION_A\", \"m1\")", "expect_max": 2.0 },
+    { "act": "screenshot", "label": "01_before_group_pile_in_tokens_in_sync" },
+    { "act": "execute_script", "script": "repro_ai_pile_in_group_move(\"U_CUSTODIAN_GUARD_B\", \"U_BLADE_CHAMPION_A\", 370.43, 990.83, 520.43, 1093.95)", "equals": true },
+    { "act": "wait_for_tweens", "timeout_s": 5.0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "screenshot", "label": "02_after_group_pile_in_char_token_followed_state" },
+    { "act": "execute_script", "script": "token_desync_from_state_px(\"U_CUSTODIAN_GUARD_B\", \"m1\")", "expect_max": 2.0 },
+    { "act": "execute_script", "script": "token_desync_from_state_px(\"U_BLADE_CHAMPION_A\", \"m1\")", "expect_max": 2.0 }
+  ]
+}


### PR DESCRIPTION
## Summary

Investigating the report that "Player 1 always piles in before Player 2 no matter whose turn it is" turned up **no ordering bug** — the active player genuinely piles in first (11e rule 12.02), verified live on both a hotseat P2 turn and an AI P2 turn. But driving the AI-first path live surfaced a **real visual bug**: when the AI piled in first, regular units' tokens moved (thanks to the recent 0.49.2 fix), but an **attached leader's token stayed stranded at its pre-move position** — so it looked like the opponent never piled in.

## Issue / root cause

A fight-phase `PILE_IN` / `CONSOLIDATE` moves the chosen unit **and its attached characters'** models in one action (19.03 group move), but the action dict carries only the **bodyguard's** `unit_id`. `Main._on_ai_action_taken` synced visuals with `update_unit_visuals(unit_id)`, which walks only that one unit's tokens — so the attached leader's token was never told to move.

Live measurement (Blade Champion attached to Custodian Guard, AI on Player 2's turn): the leader token sat at its **full state displacement** behind GameState while all five bodyguard tokens were at 0px. The combat itself always used the correct positions — this was purely display.

## Change

`Main._on_ai_action_taken` now defers `_sync_all_token_positions()` for `PILE_IN` / `CONSOLIDATE` (the same one-pass tween sync the AI charge-move fix uses) instead of the single-unit `update_unit_visuals`. Every token in the group — leader included — tweens to its state position the moment the AI's move lands.

- `40k/scripts/Main.gd` — route AI pile-in/consolidate through the full-board tween sync.
- `40k/autoloads/ScenarioRunner.gd` — new `repro_ai_pile_in_group_move` helper that drives the real handler in the exact AI ordering for an attached (leader + bodyguard) group.
- `40k/tests/scenarios/sp/ai_pile_in_attached_char_token_sync.json` — new windowed regression scenario.
- `40k/data/version_history.json` — changelog entry 0.54.4.

## Validation

- **New windowed scenario is discriminating:** fails without the fix at **200px** leader-token desync, passes at **≤2px** with it. The existing `ai_pile_in_token_sync` scenario still passes.
- **Live end-to-end** with the real AI on Player 2's turn: leader token desync went from 11.35px → **0.0px**; `verify_delivery` PASS with no log errors; screenshot confirms the whole group piled in and the log reads "(5 models moved)".
- Related headless tests green (`test_ai_pile_in_autoload_trigger_11e` 10/10, `test_global_pile_in_11e` 27/27). The 3 failures in `test_audit_already_done_pin` pre-exist on a clean tree (ChargePhase/MovementPhase print gating) and are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VF7C5Fj2fh6wPs2fhzxezZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VF7C5Fj2fh6wPs2fhzxezZ)_