### PR TITLE
Combat/dice log fills unused right-panel space in Fight, Shooting and Charge phases

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.9",
+			"date": "2026-07-17",
+			"summary": "The combat/dice log in the right-hand panel now stretches to fill all unused space below it, instead of staying a small fixed-height box with a big empty gap underneath. More of the roll history is visible at once in the Shooting, Charge and Fight phases.",
+			"changes": [
+				"Fight phase: the COMBAT LOG box grows to fill the leftover height of the FIGHT CONTROLS panel (the FIGHT STATUS section sits at the bottom).",
+				"Shooting phase: the DICE LOG box grows the same way.",
+				"Charge phase: the DICE LOG box grows the same way (the CHARGE ACTIONS section sits below it).",
+				"When the panel content is taller than the screen, everything still scrolls exactly as before."
+			]
+		},
+		{
 			"version": "0.54.8",
 			"date": "2026-07-17",
 			"summary": "Against All Odds (Lions of the Emperor) fixes: the +1 to hit / +1 to wound now applies on the quick-resolve and Fire Overwatch shooting path too, a unit led by an attached Character is no longer wrongly denied the buff by its own leader, and friendly units hidden in Transports or Reserves no longer block it.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -807,6 +807,9 @@ func _setup_right_panel() -> void:
 	var charge_panel = VBoxContainer.new()
 	charge_panel.name = "ChargePanel"
 	charge_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	# Fill the scroll viewport vertically so the dice log (the only
+	# vertically-expanding child) can absorb any leftover panel height.
+	charge_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	scroll_container.add_child(charge_panel)
 	
 	# Unit selector
@@ -921,6 +924,8 @@ func _setup_right_panel() -> void:
 	dice_log_display = RichTextLabel.new()
 	dice_log_display.custom_minimum_size = Vector2(200, 100)
 	dice_log_display.bbcode_enabled = true
+	# Expand to fill any unused right-panel height instead of leaving dead space.
+	dice_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	charge_panel.add_child(dice_log_display)
 
 	_add_charge_gold_separator(charge_panel)

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -261,6 +261,9 @@ func _setup_right_panel() -> void:
 		fight_panel = VBoxContainer.new()
 		fight_panel.name = "FightPanel"
 		fight_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		# Fill the scroll viewport vertically so the combat log (the only
+		# vertically-expanding child) can absorb any leftover panel height.
+		fight_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
 		scroll_container.add_child(fight_panel)
 	else:
 		# Get existing fight panel
@@ -367,6 +370,8 @@ func _setup_right_panel() -> void:
 	dice_log_display.custom_minimum_size = Vector2(230, 100)
 	dice_log_display.bbcode_enabled = true
 	dice_log_display.scroll_following = true
+	# Expand to fill any unused right-panel height instead of leaving dead space.
+	dice_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	fight_panel.add_child(dice_log_display)
 
 	_add_fight_gold_separator(fight_panel)

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -431,6 +431,9 @@ func _setup_right_panel() -> void:
 		shooting_panel = VBoxContainer.new()
 		shooting_panel.name = "ShootingPanel"
 		shooting_panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		# Fill the scroll viewport vertically so the dice log (the only
+		# vertically-expanding child) can absorb any leftover panel height.
+		shooting_panel.size_flags_vertical = Control.SIZE_EXPAND_FILL
 		scroll_container.add_child(shooting_panel)
 	else:
 		# Get existing shooting panel
@@ -749,6 +752,8 @@ func _setup_right_panel() -> void:
 	dice_log_display.custom_minimum_size = Vector2(230, 180)
 	dice_log_display.bbcode_enabled = true
 	dice_log_display.scroll_following = true
+	# Expand to fill any unused right-panel height instead of leaving dead space.
+	dice_log_display.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	shooting_panel.add_child(dice_log_display)
 
 	print("ShootingController: Finished creating shooting UI - panel should be visible!")

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -178,9 +178,12 @@ Each step is a dict with an `act` field plus act-specific keys.
   { "act": "hover_node", "node": "/root/MainMenu/ScrollContainer" }
   ```
 
-- `simulate_key`: dispatch a keypress.
+- `simulate_key`: dispatch a keypress. `keycode` is resolved via
+  `OS.find_keycode_from_string`, so use the human-readable key name
+  (`"Escape"`, `"Equal"`, `"2"`), NOT the `KEY_*` enum constant name —
+  `"KEY_ESCAPE"` does not resolve and fails the step.
   ```json
-  { "act": "simulate_key", "keycode": "KEY_ESCAPE" }
+  { "act": "simulate_key", "keycode": "Escape" }
   ```
 
 - `simulate_joy_button`: dispatch a joypad button press+release through the

--- a/40k/tests/scenarios/sp/combat_log_fills_right_panel_fight.json
+++ b/40k/tests/scenarios/sp/combat_log_fills_right_panel_fight.json
@@ -1,0 +1,32 @@
+{
+  "id": "combat_log_fills_right_panel_fight",
+  "covers": ["ui.fight.combat_log_fills_panel"],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Layout guard: the fight-phase right panel used to top-align its content at natural height inside FightScrollContainer, leaving a large dead area under FIGHT STATUS while the COMBAT LOG stayed a fixed 100px box (user report 2026-07-17). FightPanel now expands vertically to fill the scroll viewport and dice_log_display is the panel's vertical expander, so the combat log absorbs all leftover height. Asserts: (1) FightPanel height >= scroll viewport height, (2) dice_log_display grew well past its 100px custom_minimum_size, (3) the bottom edge of the last visible section reaches the panel bottom (no unused strip), then screenshots the panel.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel", "timeout_s": 5.0 },
+    { "act": "wait_frames", "frames": 5 },
+
+    { "act": "execute_script",
+      "script": "var scroll = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/FightScrollContainer\")\nvar panel = scroll.get_node(\"FightPanel\")\nreturn scroll.size.y - panel.size.y",
+      "multiline": true,
+      "expect_max": 1.0 },
+
+    { "act": "execute_script",
+      "script": "main.fight_controller.dice_log_display.size.y",
+      "expect_min": 150.0 },
+
+    { "act": "execute_script",
+      "script": "var panel = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel\")\nvar last_bottom = 0.0\nfor c in panel.get_children():\n\tif c is Control and c.visible:\n\t\tlast_bottom = maxf(last_bottom, c.position.y + c.size.y)\nreturn panel.size.y - last_bottom",
+      "multiline": true,
+      "expect_max": 2.0 },
+
+    { "act": "screenshot", "label": "01_fight_combat_log_fills_panel" }
+  ]
+}

--- a/40k/tests/scenarios/sp/dice_log_fills_right_panel_charge.json
+++ b/40k/tests/scenarios/sp/dice_log_fills_right_panel_charge.json
@@ -1,0 +1,32 @@
+{
+  "id": "dice_log_fills_right_panel_charge",
+  "covers": ["ui.charge.dice_log_fills_panel"],
+  "fixture": "co_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 9,
+  "disable_ai": true,
+  "description": "Layout guard (companion to combat_log_fills_right_panel_fight): the charge-phase right panel top-aligned its content inside ChargeScrollContainer, leaving dead space while the DICE LOG stayed a fixed 100px box. ChargePanel now expands vertically to fill the scroll viewport and dice_log_display absorbs the leftover height (the CHARGE ACTIONS section sits below it, pinned toward the bottom). Asserts the panel fills the viewport, the log grew past its 100px minimum, and the last visible child's bottom reaches the panel bottom, then screenshots the panel.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 9 },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ChargeScrollContainer/ChargePanel", "timeout_s": 5.0 },
+    { "act": "wait_frames", "frames": 5 },
+
+    { "act": "execute_script",
+      "script": "var scroll = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/ChargeScrollContainer\")\nvar panel = scroll.get_node(\"ChargePanel\")\nreturn scroll.size.y - panel.size.y",
+      "multiline": true,
+      "expect_max": 1.0 },
+
+    { "act": "execute_script",
+      "script": "main.charge_controller.dice_log_display.size.y",
+      "expect_min": 150.0 },
+
+    { "act": "execute_script",
+      "script": "var panel = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/ChargeScrollContainer/ChargePanel\")\nvar last_bottom = 0.0\nfor c in panel.get_children():\n\tif c is Control and c.visible:\n\t\tlast_bottom = maxf(last_bottom, c.position.y + c.size.y)\nreturn panel.size.y - last_bottom",
+      "multiline": true,
+      "expect_max": 2.0 },
+
+    { "act": "screenshot", "label": "01_charge_dice_log_fills_panel" }
+  ]
+}

--- a/40k/tests/scenarios/sp/dice_log_fills_right_panel_shooting.json
+++ b/40k/tests/scenarios/sp/dice_log_fills_right_panel_shooting.json
@@ -1,0 +1,42 @@
+{
+  "id": "dice_log_fills_right_panel_shooting",
+  "covers": ["ui.shooting.dice_log_fills_panel"],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Layout guard (companion to combat_log_fills_right_panel_fight / dice_log_fills_right_panel_charge, which prove the live log-growth behavior end-to-end): ShootingPanel must expand vertically to fill the ShootingScrollContainer viewport, with dice_log_display as the panel's designated vertical expander and no dead strip below the last visible section. NOTE: at the 1920x1080 design resolution the shooting panel has NO spare space even with the shooter deselected — DeclarationBox alone has ~716px of fixed section minimums — so actual log growth is unobservable here (measured 2026-07-17: log sits at its exact 180px minimum, panel overflows the viewport by ~4px). The log absorbs spare height only on taller canvas aspects (stretch aspect=expand), which the fullscreen xvfb harness cannot produce. This scenario therefore asserts the layout invariants and the expander wiring; the fight and charge scenarios assert the observable growth.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel", "timeout_s": 5.0 },
+    { "act": "wait_frames", "frames": 5 },
+
+    { "act": "simulate_key", "keycode": "Escape" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script",
+      "script": "main.shooting_controller.active_shooter_id == \"\"",
+      "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script",
+      "script": "var scroll = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/ShootingScrollContainer\")\nvar panel = scroll.get_node(\"ShootingPanel\")\nreturn scroll.size.y - panel.size.y",
+      "multiline": true,
+      "expect_max": 1.0 },
+
+    { "act": "execute_script",
+      "script": "var panel = tree.root.get_node(\"Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel\")\nvar last_bottom = 0.0\nfor c in panel.get_children():\n\tif c is Control and c.visible:\n\t\tlast_bottom = maxf(last_bottom, c.position.y + c.size.y)\nreturn panel.size.y - last_bottom",
+      "multiline": true,
+      "expect_max": 2.0 },
+
+    { "act": "execute_script",
+      "script": "main.shooting_controller.dice_log_display.size_flags_vertical",
+      "equals": 3 },
+
+    { "act": "execute_script",
+      "script": "tree.root.get_node(\"Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel\").size_flags_vertical",
+      "multiline": false,
+      "equals": 3 },
+
+    { "act": "screenshot", "label": "01_shooting_dice_log_fills_panel" }
+  ]
+}


### PR DESCRIPTION
## Summary

The combat/dice log in the right-hand panel sometimes appeared as a small fixed-height box with a large unused gap underneath (reported with a Fight-phase screenshot: FIGHT STATUS sitting mid-panel with empty space below). The phase panels inside the right-hand `ScrollContainer`s only expanded horizontally, so when a panel's content was shorter than the viewport the sections sat top-aligned with dead space beneath them.

This makes each panel's VBox (`FightPanel` / `ShootingPanel` / `ChargePanel`) expand vertically to fill the scroll viewport, with `dice_log_display` as each panel's designated vertical expander. The combat/dice log now absorbs all leftover height (sections after it are pinned toward the bottom). When content is taller than the viewport, the panels scroll exactly as before.

## Changes

- **Fight phase**: `COMBAT LOG` box grows to fill the leftover height of the FIGHT CONTROLS panel (FIGHT STATUS sits at the bottom).
- **Shooting phase**: `DICE LOG` box grows the same way.
- **Charge phase**: `DICE LOG` box grows the same way (CHARGE ACTIONS sits below it).
- Version bumped to `0.54.7` with a player-facing changelog entry.
- Fixed a stale `simulate_key` example in `scenarios/_schema.md` (keycodes resolve via `OS.find_keycode_from_string`, so `"Escape"` works but `"KEY_ESCAPE"` does not).

## Validation

Windowed scenarios added (all pass), plus a panel-heavy regression net:

- `combat_log_fills_right_panel_fight` — log grows past its 100px min and the last visible section's bottom reaches the panel bottom (no dead strip). **8/8**
- `dice_log_fills_right_panel_charge` — same for the charge DICE LOG. **8/8**
- `dice_log_fills_right_panel_shooting` — invariants only: at 1920×1080 the shooting `DeclarationBox` alone has ~716px of fixed section minimums, so no spare space exists at the design resolution (observable growth is proven by the fight/charge scenarios). Asserts panel-fills-viewport, no bottom strip, and the expander wiring. **13/13**
- Regression net: `fight_dialogs_single_confirm_11e` (36/36), `resolution_log_dice_icons` (16/16), `372_ere_we_go_charge_modifier` (8/8).

Debug logs show no errors during the runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NdPfZ3fuuG6E25h9qucvS4)_