### PR TITLE
Fix Against All Odds (Lions of the Emperor) isolation rule gaps

### DIFF
--- a/40k/autoloads/FactionAbilityManager.gd
+++ b/40k/autoloads/FactionAbilityManager.gd
@@ -2886,7 +2886,11 @@ static func check_against_all_odds(attacker_unit: Dictionary, board: Dictionary)
 	"""Check if Against All Odds grants +1 Hit and +1 Wound.
 	Condition: the unit's army runs the Lions of the Emperor detachment, and the
 	unit is a non-VEHICLE ADEPTUS CUSTODES unit with no other friendly units
-	within 6\"."""
+	within 6\". Leader rules: an attached CHARACTER and its bodyguard count as
+	ONE unit — they never block each other, and the 6\" bubble is measured from
+	every model in the combined unit. Friendly units that are not on the
+	battlefield (embarked in a Transport, or in Reserves — whose models keep
+	stale coordinates) never block."""
 	var owner = attacker_unit.get("owner", -1)
 	if owner < 0:
 		return false
@@ -2908,14 +2912,45 @@ static func check_against_all_odds(attacker_unit: Dictionary, board: Dictionary)
 			is_vehicle = true
 	if not is_custodes or is_vehicle:
 		return false
-	var attacker_id = attacker_unit.get("id", "")
+	var attacker_id = str(attacker_unit.get("id", ""))
 	var units = board.get("units", {})
-	var attacker_models = attacker_unit.get("models", [])
+	# Build the attacking unit's attached group (self + attached leaders, or —
+	# when the attacker IS an attached leader — its bodyguard and that
+	# bodyguard's other leaders). Group members are the SAME unit per the
+	# Leader rules, so they are excluded from the "other friendly units" scan
+	# and their models are included in the measuring set.
+	var group_ids := {attacker_id: true}
+	for char_id in attacker_unit.get("attachment_data", {}).get("attached_characters", []):
+		group_ids[str(char_id)] = true
+	var bodyguard_id = attacker_unit.get("attached_to", null)
+	if bodyguard_id != null and str(bodyguard_id) != "":
+		group_ids[str(bodyguard_id)] = true
+		var bodyguard = units.get(str(bodyguard_id), {})
+		for char_id in bodyguard.get("attachment_data", {}).get("attached_characters", []):
+			group_ids[str(char_id)] = true
+	var group_models: Array = []
+	for m in attacker_unit.get("models", []):
+		group_models.append(m)
+	for gid in group_ids:
+		if gid == attacker_id:
+			continue
+		for m in units.get(gid, {}).get("models", []):
+			group_models.append(m)
 	for other_id in units:
-		if other_id == attacker_id:
+		if group_ids.has(str(other_id)):
 			continue
 		var other_unit = units[other_id]
 		if other_unit.get("owner", -1) != owner:
+			continue
+		# Units that are not on the battlefield cannot be within 6": embarked
+		# units and units in Reserves keep their last battlefield coordinates.
+		if other_unit.get("embarked_in", null) != null:
+			continue
+		var status_v = other_unit.get("status", -1)
+		if typeof(status_v) == TYPE_STRING:
+			if str(status_v) in ["UNDEPLOYED", "IN_RESERVES"]:
+				continue
+		elif int(status_v) == GameStateData.UnitStatus.UNDEPLOYED or int(status_v) == GameStateData.UnitStatus.IN_RESERVES:
 			continue
 		var other_alive = false
 		for m in other_unit.get("models", []):
@@ -2925,7 +2960,7 @@ static func check_against_all_odds(attacker_unit: Dictionary, board: Dictionary)
 		if not other_alive:
 			continue
 		var min_dist = INF
-		for a_model in attacker_models:
+		for a_model in group_models:
 			if not a_model.get("alive", true):
 				continue
 			var a_pos = a_model.get("position", null)
@@ -2955,8 +2990,10 @@ static func check_against_all_odds(attacker_unit: Dictionary, board: Dictionary)
 					oy = float(o_pos.get("y", 0))
 				var dx = ax - ox
 				var dy = ay - oy
-				var a_base = float(a_model.get("base_size_mm", 32)) / 2.0 * 40.0 / 25.4
-				var o_base = float(o_model.get("base_size_mm", 32)) / 2.0 * 40.0 / 25.4
+				# Model dicts carry base_mm (base_size_mm in some older test
+				# fixtures) — honour both, radius in px at 40 px/inch.
+				var a_base = float(a_model.get("base_size_mm", a_model.get("base_mm", 32))) / 2.0 * 40.0 / 25.4
+				var o_base = float(o_model.get("base_size_mm", o_model.get("base_mm", 32))) / 2.0 * 40.0 / 25.4
 				var edge_dist = (sqrt(dx * dx + dy * dy) - a_base - o_base) / 40.0
 				if edge_dist < min_dist:
 					min_dist = edge_dist

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -3886,6 +3886,11 @@ static func _resolve_assignment(assignment: Dictionary, actor_unit_id: String, b
 			hit_modifiers |= HitModifier.REROLL_ONES
 			print("RulesEngine: BLASTAJET ATTACK RUN (auto-resolve) — re-roll hit rolls of 1 for %s" % actor_unit_id)
 
+		# AGAINST ALL ODDS: +1 to Hit when no friendly units within 6" (Lions of the Emperor, auto-resolve)
+		if FactionAbilityManager.check_against_all_odds(actor_unit, board):
+			hit_modifiers |= HitModifier.PLUS_ONE
+			print("RulesEngine: AGAINST ALL ODDS (auto-resolve) — +1 to hit for %s (no friendlies within 6\")" % actor_unit_id)
+
 		# ── ISS-016/053 (11e): hit-side modifier stack — cover/STEALTH worsen
 		# BS (13.08/24.33), plunging fire improves it (22.05), [HEAVY] is +1
 		# to the hit roll (24.16). The ±1 dice-roll cap lives in ModifierStack.
@@ -4253,6 +4258,11 @@ static func _resolve_assignment(assignment: Dictionary, actor_unit_id: String, b
 	elif ar_pyromaniaks_scope == "ones":
 		ar_wound_modifiers |= WoundModifier.REROLL_ONES
 		print("RulesEngine: PYROMANIAKS (auto-resolve) — re-roll wound rolls of 1 for %s (Torrent weapon, target within 6\")" % actor_unit_id)
+
+	# AGAINST ALL ODDS: +1 to Wound when no friendly units within 6" (Lions of the Emperor, auto-resolve)
+	if FactionAbilityManager.check_against_all_odds(actor_unit, board):
+		ar_wound_modifiers |= WoundModifier.PLUS_ONE
+		print("RulesEngine: AGAINST ALL ODDS (auto-resolve) — +1 to wound for %s (no friendlies within 6\")" % actor_unit_id)
 
 	var ar_wound_modifier_net = 0
 	if ar_wound_modifiers & WoundModifier.PLUS_ONE:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.7",
+			"date": "2026-07-17",
+			"summary": "Against All Odds (Lions of the Emperor) fixes: the +1 to hit / +1 to wound now applies on the quick-resolve and Fire Overwatch shooting path too, a unit led by an attached Character is no longer wrongly denied the buff by its own leader, and friendly units hidden in Transports or Reserves no longer block it.",
+			"changes": [
+				"Against All Odds now also applies on the auto-resolve shooting path (Fire Overwatch and quick resolution) — previously only the step-by-step shooting flow got the +1 to hit and +1 to wound.",
+				"A Character attached to a unit counts as part of that unit: leader and bodyguard no longer block each other's Against All Odds buff, and the 6\" isolation check measures from the leader's models too.",
+				"Friendly units embarked in a Transport or waiting in Reserves no longer block Against All Odds via their stale battlefield positions.",
+				"The 6\" isolation check now reads each model's real base size instead of assuming 32mm bases."
+			]
+		},
+		{
 			"version": "0.54.6",
 			"date": "2026-07-17",
 			"summary": "Fight phase: picking which unit fights next no longer pops up over the middle of the board. The 'Select Unit to Fight' picker now lives in the right-hand panel — same place you pick units in every other phase and in the Pile In / Consolidate steps — so you can see the whole battlefield while choosing.",

--- a/40k/tests/scenarios/sp/aao_lions_isolated_plus_one.json
+++ b/40k/tests/scenarios/sp/aao_lions_isolated_plus_one.json
@@ -1,0 +1,42 @@
+{
+  "id": "aao_lions_isolated_plus_one",
+  "covers": [
+    "autoloads.FactionAbilityManager.check_against_all_odds",
+    "shooting.against_all_odds.plus_one_hit_and_wound",
+    "detachment.lions_of_the_emperor.against_all_odds"
+  ],
+  "fixture": "custodes_lions_pretrigger",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Against All Odds (Lions of the Emperor detachment rule): each time a model in a non-VEHICLE ADEPTUS CUSTODES unit makes an attack, if there are no other friendly units within 6\" of that unit, add 1 to the Hit roll and add 1 to the Wound roll. Teleports Prosecutors to an isolated mid-board spot (nearest friendly ~19\"+) with Boyz K in Boltgun range, asserts check_against_all_odds is TRUE for the isolated unit and FALSE for a Custodian Guard control unit standing next to friends, then drives the real staged shooting flow (SELECT_SHOOTER → ASSIGN_TARGET → CONFIRM_TARGETS → staged hit/wound rolls) and asserts the player-visible dice log renders the '+1 to hit' and 'Wound modifier: +1' annotations from the rule.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+    { "act": "execute_script", "multiline": true, "script": "var u = GameState.state[\"units\"][\"U_PROSECUTORS_A\"]\nvar xs = [300.0, 336.0, 372.0, 408.0]\nfor i in range(4):\n\tu[\"models\"][i][\"position\"] = {\"x\": xs[i], \"y\": 1200.0}\nvar b = GameState.state[\"units\"][\"U_BOYZ_K\"]\nfor i in range(b[\"models\"].size()):\n\tb[\"models\"][i][\"position\"] = {\"x\": 300.0 + float(i) * 36.0, \"y\": 1680.0}\nreturn true", "equals": true },
+    { "act": "execute_script", "script": "main._recreate_unit_visuals()" },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().enter_phase(GameState.create_snapshot())" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "multiline": true, "script": "var snap = PhaseManager.get_current_phase_instance().game_state_snapshot\nreturn FactionAbilityManager.check_against_all_odds(snap[\"units\"][\"U_PROSECUTORS_A\"], snap)", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var snap = PhaseManager.get_current_phase_instance().game_state_snapshot\nreturn FactionAbilityManager.check_against_all_odds(snap[\"units\"][\"U_CUSTODIAN_GUARD_A\"], snap)", "equals": false },
+    { "act": "screenshot", "label": "01_prosecutors_isolated_midboard" },
+    { "act": "dispatch_action", "action": { "type": "SELECT_SHOOTER", "actor_unit_id": "U_PROSECUTORS_A" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "dispatch_action", "action": { "type": "ASSIGN_TARGET", "payload": { "weapon_id": "boltgun_ranged", "target_unit_id": "U_BOYZ_K", "model_ids": ["m1", "m2", "m3", "m4"] } } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "CONFIRM_TARGETS" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_REACTIVE_STRATAGEM" } },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\").resolution_dock.is_active()", "equals": true },
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\").dice_log_display.get_parsed_text().contains(\"+1 to hit\")", "equals": true },
+    { "act": "screenshot", "label": "02_hit_stage_plus_one_annotation" },
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\").resolution_dock.primary_button.emit_signal(\"pressed\")" },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\").dice_log_display.get_parsed_text().contains(\"Wound modifier: +1\")", "equals": true },
+    { "act": "screenshot", "label": "03_wound_stage_plus_one_modifier" }
+  ]
+}

--- a/40k/tests/test_custodes_lions_silent_hunters.gd
+++ b/40k/tests/test_custodes_lions_silent_hunters.gd
@@ -292,6 +292,87 @@ func _test_against_all_odds() -> void:
 	}
 	_check("friendly within 6\" blocks AAO", not fam.check_against_all_odds(board_f.units["U_SHOOTER"], board_f))
 
+	# Attached leader (Leader rules: one unit) must NOT block the buff — in
+	# either direction (bodyguard attacking, or the attached character attacking).
+	var board_led = _make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	})
+	board_led.units["U_SHOOTER"]["attachment_data"] = {"attached_characters": ["U_LEADER"]}
+	board_led.units["U_LEADER"] = {
+		"id": "U_LEADER", "owner": 1, "attached_to": "U_SHOOTER",
+		"meta": {"name": "Leader", "keywords": ["ADEPTUS CUSTODES", "CHARACTER", "INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "ml0", "position": {"x": 0.0, "y": 150.0}, "base_mm": 32, "alive": true, "wounds": 6, "current_wounds": 6}]
+	}
+	_check("attached leader does not block AAO (bodyguard attacks)", fam.check_against_all_odds(board_led.units["U_SHOOTER"], board_led))
+	_check("bodyguard does not block AAO (attached leader attacks)", fam.check_against_all_odds(board_led.units["U_LEADER"], board_led))
+
+	# ...but a leader's models ARE part of the unit: a friendly within 6" of the
+	# LEADER model (though beyond 6" of every bodyguard model) still blocks.
+	var board_led2 = _make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	})
+	board_led2.units["U_SHOOTER"]["attachment_data"] = {"attached_characters": ["U_LEADER"]}
+	board_led2.units["U_LEADER"] = {
+		"id": "U_LEADER", "owner": 1, "attached_to": "U_SHOOTER",
+		"meta": {"name": "Leader", "keywords": ["ADEPTUS CUSTODES", "CHARACTER", "INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "ml0", "position": {"x": 0.0, "y": 400.0}, "base_mm": 32, "alive": true, "wounds": 6, "current_wounds": 6}]
+	}
+	# Friend ~4.7" edge-to-edge from the leader model (y=560 → 160px gap), but
+	# ~10" from the nearest bodyguard model (y=105 → 455px gap).
+	board_led2.units["U_FRIEND"] = {
+		"id": "U_FRIEND", "owner": 1,
+		"meta": {"name": "Friend", "keywords": ["INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "mf0", "position": {"x": 0.0, "y": 560.0}, "base_mm": 32, "alive": true, "wounds": 1, "current_wounds": 1}]
+	}
+	_check("friendly near the attached leader still blocks AAO", not fam.check_against_all_odds(board_led2.units["U_SHOOTER"], board_led2))
+
+	# Embarked friendly (stale battlefield position) must NOT block — an
+	# embarked unit is not on the battlefield.
+	var board_e = _make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	})
+	board_e.units["U_FRIEND"] = {
+		"id": "U_FRIEND", "owner": 1, "embarked_in": "U_TRANSPORT",
+		"meta": {"name": "Friend", "keywords": ["INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "mf0", "position": {"x": 80.0, "y": 0.0}, "base_mm": 32, "alive": true, "wounds": 1, "current_wounds": 1}]
+	}
+	_check("embarked friendly does not block AAO", fam.check_against_all_odds(board_e.units["U_SHOOTER"], board_e))
+
+	# Friendly in Strategic Reserves (stale position) must NOT block.
+	var board_r = _make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	})
+	board_r.units["U_FRIEND"] = {
+		"id": "U_FRIEND", "owner": 1,
+		"status": load("res://autoloads/GameState.gd").UnitStatus.IN_RESERVES,
+		"meta": {"name": "Friend", "keywords": ["INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "mf0", "position": {"x": 80.0, "y": 0.0}, "base_mm": 32, "alive": true, "wounds": 1, "current_wounds": 1}]
+	}
+	_check("friendly in reserves does not block AAO", fam.check_against_all_odds(board_r.units["U_SHOOTER"], board_r))
+
+	# base_mm must be honoured: a 60mm-base friendly at 7.5" centre-to-centre is
+	# ~5.7" edge-to-edge (blocks); assuming 32mm would put it at ~6.2" (no block).
+	var board_b = _make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	})
+	board_b.units["U_FRIEND"] = {
+		"id": "U_FRIEND", "owner": 1,
+		"meta": {"name": "Friend", "keywords": ["INFANTRY"], "stats": {}, "abilities": []},
+		"flags": {},
+		"models": [{"id": "mf0", "position": {"x": 300.0, "y": 0.0}, "base_mm": 60, "alive": true, "wounds": 1, "current_wounds": 1}]
+	}
+	_check("60mm base friendly at 5.7\" edge-to-edge blocks AAO", not fam.check_against_all_odds(board_b.units["U_SHOOTER"], board_b))
+
 	# Melee: same seed, Lions vs Shield Host — Lions must land at least as many
 	# hits and wounds (+1 to hit AND +1 to wound; seed chosen so the delta shows)
 	var melee_lions = _melee(_make_board({
@@ -307,6 +388,25 @@ func _test_against_all_odds() -> void:
 	var hits_lions = _count_successes(melee_lions, "hit_roll_melee")
 	var hits_shield = _count_successes(melee_shield, "hit_roll_melee")
 	_check("AAO melee +1 to hit (lions %d > shield %d)" % [hits_lions, hits_shield], hits_lions > hits_shield)
+	var wounds_lions = _count_successes(melee_lions, "wound_roll_melee")
+	var wounds_shield = _count_successes(melee_shield, "wound_roll_melee")
+	_check("AAO melee +1 to wound (lions %d > shield %d)" % [wounds_lions, wounds_shield], wounds_lions > wounds_shield)
+
+	# Ranged: same seed and 60 attacks — +1 to hit and +1 to wound must both show
+	var shoot_lions = _shoot(_make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": _lions_factions(1),
+	}), 4321, "bolt_rifle", 60)
+	var shoot_shield = _shoot(_make_board({
+		"shooter_keywords": ["ADEPTUS CUSTODES", "INFANTRY"],
+		"factions": {"1": {"name": "Adeptus Custodes", "detachment": "Shield Host"}},
+	}), 4321, "bolt_rifle", 60)
+	var rhits_lions = _count_successes(shoot_lions, "to_hit")
+	var rhits_shield = _count_successes(shoot_shield, "to_hit")
+	_check("AAO ranged +1 to hit (lions %d > shield %d)" % [rhits_lions, rhits_shield], rhits_lions > rhits_shield)
+	var rwounds_lions = _count_successes(shoot_lions, "to_wound")
+	var rwounds_shield = _count_successes(shoot_shield, "to_wound")
+	_check("AAO ranged +1 to wound (lions %d > shield %d)" % [rwounds_lions, rwounds_shield], rwounds_lions > rwounds_shield)
 
 # ----------------------------------------------------------------------------
 # 3. Effect-granted LANCE


### PR DESCRIPTION
## Summary

The Lions of the Emperor detachment rule **Against All Odds** — "each time a model in a non-VEHICLE ADEPTUS CUSTODES unit makes an attack, if there are no other friendly units within 6" of that unit, add 1 to the Hit roll and add 1 to the Wound roll" — was already implemented for the step-by-step (staged) shooting flow and for melee, but had four gaps. This PR closes them.

## Issues found & fixed

1. **Missing on the quick-resolve / Overwatch path.** The `+1 to hit` and `+1 to wound` were only applied in `RulesEngine._resolve_assignment_hits` / `_resolve_assignment_wounds` (the staged UI flow). The auto-resolve path (`_resolve_assignment`, used by Fire Overwatch and AI/fast resolution) never checked the rule. Added both hooks there.

2. **Attached leaders wrongly blocked the buff.** Per the Leader rules an attached CHARACTER and its bodyguard are one unit, but `check_against_all_odds` treated them as separate friendly units — so any led Custodes unit lost the buff to its own leader (and vice-versa). The check now builds the attacked group (self + attached characters, or bodyguard + its other leaders when the attacker is the character) and excludes it from the "other friendly units" scan, while including the leader's models in the 6" measurement.

3. **Embarked / Reserves units falsely blocked it.** Units embarked in a Transport or in Strategic Reserves keep stale battlefield coordinates; those were counted as friendlies within 6". They're now skipped (not on the battlefield).

4. **Base sizes assumed 32mm.** The isolation distance used a hardcoded 32mm base radius. It now reads each model's real `base_mm` / `base_size_mm`.

## Validation

- **Headless:** extended `test_custodes_lions_silent_hunters.gd` with 8 new red→green cases (attached-leader both directions, friendly near leader still blocks, embarked/reserves don't block, 60mm base honoured, ranged +1 hit/wound). 103/103 checks pass.
- **Windowed (project gate):** new scenario `tests/scenarios/sp/aao_lions_isolated_plus_one.json` drives the real staged shooting UI (SELECT_SHOOTER → ASSIGN_TARGET → CONFIRM_TARGETS → staged hit/wound rolls) with an isolated Prosecutors unit and asserts the player-visible dice log renders `+1 to hit` and `Wound modifier: +1`. Passes 27/27. Live drive also confirmed the engine prints for both hit and wound, and `verify_delivery` returned PASS with no errors.
- **Full regression:** `run_pretrigger_tests.sh` — 2027 passed, 0 failed across 101 test files.

## Files changed

- `40k/autoloads/FactionAbilityManager.gd` — attached-group handling, embarked/reserves exclusion, real base sizes in `check_against_all_odds`.
- `40k/autoloads/RulesEngine.gd` — Against All Odds hooks added to the auto-resolve hit and wound paths.
- `40k/tests/test_custodes_lions_silent_hunters.gd` — 8 new regression cases.
- `40k/tests/scenarios/sp/aao_lions_isolated_plus_one.json` — new windowed scenario.
- `40k/data/version_history.json` — 0.54.7 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVtoZEYsoMsANKy4FFAgda

---
_Generated by [Claude Code](https://claude.ai/code/session_01JVtoZEYsoMsANKy4FFAgda)_