### PR TITLE
Give on-foot Adeptus Custodes their missing Deep Strike ability

### DIFF
--- a/40k/armies/custodes_web_built_repro.json
+++ b/40k/armies/custodes_web_built_repro.json
@@ -1,0 +1,283 @@
+{
+ "faction": {
+  "name": "Adeptus Custodes",
+  "points": 430,
+  "detachment": "Lions of the Emperor",
+  "player_name": "",
+  "team_name": "",
+  "created_date": "2026-07-17",
+  "schema": 2,
+  "edition": 11,
+  "data_source": "repro: web-built list, Custodian Guard missing Deep Strike (40kdc gap)"
+ },
+ "units": {
+  "U_CUSTODIAN_GUARD_A": {
+   "id": "U_CUSTODIAN_GUARD_A",
+   "squad_id": "U_CUSTODIAN_GUARD_A",
+   "owner": 1,
+   "status": "UNDEPLOYED",
+   "meta": {
+    "name": "Custodian Guard",
+    "keywords": [
+     "ADEPTUS CUSTODES",
+     "BATTLELINE",
+     "CUSTODIAN GUARD",
+     "IMPERIUM",
+     "INFANTRY"
+    ],
+    "stats": {
+     "move": 6,
+     "toughness": 6,
+     "save": 2,
+     "wounds": 3,
+     "leadership": 6,
+     "objective_control": 2,
+     "invuln": 4
+    },
+    "points": 215,
+    "is_warlord": false,
+    "enhancements": [],
+    "wargear": [
+     "5x Guardian spear"
+    ],
+    "weapons": [
+     {
+      "name": "Guardian spear \u2013 Ranged",
+      "type": "Ranged",
+      "range": "24",
+      "attacks": "2",
+      "ballistic_skill": "2",
+      "strength": "4",
+      "ap": "-1",
+      "damage": "2",
+      "special_rules": "assault",
+      "abilities": [
+       {
+        "id": "assault"
+       }
+      ]
+     },
+     {
+      "name": "Guardian spear \u2013 Melee",
+      "type": "Melee",
+      "range": "Melee",
+      "attacks": "5",
+      "weapon_skill": "2",
+      "strength": "7",
+      "ap": "-2",
+      "damage": "2"
+     }
+    ],
+    "abilities": [
+     {
+      "name": "Martial Ka'tah",
+      "type": "Faction",
+      "description": "Until the end of the phase:\nSelect one of the following (Ka'tah Stance):\n  - The unit's weapons gain [SUSTAINED HITS 1].\n  - The unit's weapons gain [LETHAL HITS]."
+     },
+     {
+      "name": "Praesidium Shield",
+      "type": "Datasheet",
+      "description": "Add 1 to this model's Wounds characteristic."
+     },
+     {
+      "name": "Sentinel Storm",
+      "type": "Datasheet",
+      "description": "Once per battle, during the Shooting phase, the unit gains the Shoot Again ability."
+     },
+     {
+      "name": "Stand Vigil",
+      "type": "Datasheet",
+      "description": "You can re-roll a Wound roll of 1."
+     }
+    ],
+    "unit_composition": [
+     {
+      "description": "4-5 Custodian Guard",
+      "line": 1
+     }
+    ]
+   },
+   "models": [
+    {
+     "id": "m1",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m2",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m3",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m4",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m5",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    }
+   ]
+  },
+  "U_CUSTODIAN_GUARD_B": {
+   "id": "U_CUSTODIAN_GUARD_B",
+   "squad_id": "U_CUSTODIAN_GUARD_B",
+   "owner": 1,
+   "status": "UNDEPLOYED",
+   "meta": {
+    "name": "Custodian Guard",
+    "keywords": [
+     "ADEPTUS CUSTODES",
+     "BATTLELINE",
+     "CUSTODIAN GUARD",
+     "IMPERIUM",
+     "INFANTRY"
+    ],
+    "stats": {
+     "move": 6,
+     "toughness": 6,
+     "save": 2,
+     "wounds": 3,
+     "leadership": 6,
+     "objective_control": 2,
+     "invuln": 4
+    },
+    "points": 215,
+    "is_warlord": false,
+    "enhancements": [],
+    "wargear": [
+     "5x Guardian spear"
+    ],
+    "weapons": [
+     {
+      "name": "Guardian spear \u2013 Ranged",
+      "type": "Ranged",
+      "range": "24",
+      "attacks": "2",
+      "ballistic_skill": "2",
+      "strength": "4",
+      "ap": "-1",
+      "damage": "2",
+      "special_rules": "assault",
+      "abilities": [
+       {
+        "id": "assault"
+       }
+      ]
+     },
+     {
+      "name": "Guardian spear \u2013 Melee",
+      "type": "Melee",
+      "range": "Melee",
+      "attacks": "5",
+      "weapon_skill": "2",
+      "strength": "7",
+      "ap": "-2",
+      "damage": "2"
+     }
+    ],
+    "abilities": [
+     {
+      "name": "Martial Ka'tah",
+      "type": "Faction",
+      "description": "Until the end of the phase:\nSelect one of the following (Ka'tah Stance):\n  - The unit's weapons gain [SUSTAINED HITS 1].\n  - The unit's weapons gain [LETHAL HITS]."
+     },
+     {
+      "name": "Praesidium Shield",
+      "type": "Datasheet",
+      "description": "Add 1 to this model's Wounds characteristic."
+     },
+     {
+      "name": "Sentinel Storm",
+      "type": "Datasheet",
+      "description": "Once per battle, during the Shooting phase, the unit gains the Shoot Again ability."
+     },
+     {
+      "name": "Stand Vigil",
+      "type": "Datasheet",
+      "description": "You can re-roll a Wound roll of 1."
+     }
+    ],
+    "unit_composition": [
+     {
+      "description": "4-5 Custodian Guard",
+      "line": 1
+     }
+    ]
+   },
+   "models": [
+    {
+     "id": "m1",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m2",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m3",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m4",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    },
+    {
+     "id": "m5",
+     "wounds": 3,
+     "current_wounds": 3,
+     "base_mm": 40,
+     "position": null,
+     "alive": true,
+     "status_effects": []
+    }
+   ]
+  }
+ }
+}

--- a/40k/autoloads/ArmyListManager.gd
+++ b/40k/autoloads/ArmyListManager.gd
@@ -251,6 +251,10 @@ func load_army_list(army_name: String, player: int = 1) -> Dictionary:
 			# (must run before wargear bonuses / ability dispatch)
 			_canonicalize_ability_names(unit_id, unit)
 
+			# Backfill Deep Strike on Custodes datasheets the vendored 40kdc
+			# dataset dropped it from (Custodian Guard, Allarus, Shield-Captain…)
+			_backfill_custodes_deep_strike(unit_id, unit)
+
 			# Apply wargear stat bonuses (e.g. Praesidium Shield +1W, Vexilla +1OC, 'Ard Case +2T)
 			_apply_wargear_stat_bonuses(unit_id, unit)
 
@@ -660,6 +664,10 @@ func _process_army_data(army_data: Dictionary, player: int) -> Dictionary:
 		# Canonicalize renamed 11e ability names to the engine's spellings
 		_canonicalize_ability_names(unit_id, unit)
 
+		# Backfill Deep Strike on Custodes datasheets the vendored 40kdc
+		# dataset dropped it from (Custodian Guard, Allarus, Shield-Captain…)
+		_backfill_custodes_deep_strike(unit_id, unit)
+
 		# Apply wargear stat bonuses (e.g. Praesidium Shield +1W, Vexilla +1OC, 'Ard Case +2T)
 		_apply_wargear_stat_bonuses(unit_id, unit)
 
@@ -806,6 +814,75 @@ func _canonicalize_ability_names(unit_id: String, unit: Dictionary) -> void:
 				print("ArmyListManager: %s ability '%s' canonicalized to '%s'" % [
 					unit_id, ability.get("name", ""), canon])
 				ability["name"] = canon
+
+# ============================================================================
+# 11e CORE-ABILITY BACKFILL — Adeptus Custodes Deep Strike
+# ============================================================================
+# The vendored 40kdc 11e dataset (the source the Army Builder emits army lists
+# from — see 40k/data/40kdc/ATTRIBUTION.md, "do not hand-edit") is missing the
+# Deep Strike core ability on almost the entire on-foot Adeptus Custodes range;
+# it only tagged the Blade Champion. On the real 11e datasheets these units all
+# carry Deep Strike (wahapedia core ability 000008343). Without this, the
+# Declare Battle Formations screen offers a plain Custodian Guard squad only
+# "Strategic Reserves" when it should also offer "Deep Strike".
+#
+# Correct it at army-load time (mirroring how the bundled lists were patched) so
+# EVERY army — bundled or custom-built in the Army Builder — is right, including
+# lists the player saved before this fix.
+#
+# The set below is the 12 Adeptus Custodes datasheets that carry Deep Strike per
+# the repo's wahapedia datasheet-ability data. Mounted units (Shield-Captain on
+# Dawneagle Jetbike, Vertus/Agamatus Praetors), vehicles, dreadnoughts and the
+# Anathema Psykana / Sisters of Silence (Prosecutors, Witchseekers, Vigilators,
+# Aleya, Knight-Centura) correctly do NOT have Deep Strike and are excluded.
+const CUSTODES_DEEP_STRIKE_DATASHEETS: Array = [
+	"allarus custodians",
+	"aquilon custodians",
+	"blade champion",
+	"custodian guard",
+	"custodian guard with adrasite and pyrithite spears",
+	"custodian wardens",
+	"sagittarum custodians",
+	"shield-captain",
+	"shield-captain in allarus terminator armour",
+	"trajann valoris",
+	"valerian",
+	"venatari custodians",
+]
+
+func _backfill_custodes_deep_strike(unit_id: String, unit: Dictionary) -> void:
+	"""Grant the Deep Strike core ability to Adeptus Custodes datasheets that
+	have it in 11e but are missing it in the vendored 40kdc dataset. Idempotent:
+	a no-op if the unit already carries a Deep Strike ability."""
+	if not unit.has("meta"):
+		return
+	var meta = unit.meta
+	# Gate on the faction keyword so a same-named unit in another faction is
+	# never affected.
+	var is_custodes = false
+	for kw in meta.get("keywords", []):
+		if str(kw).to_upper() == "ADEPTUS CUSTODES":
+			is_custodes = true
+			break
+	if not is_custodes:
+		return
+	var name_l = str(meta.get("name", "")).to_lower().strip_edges()
+	if not (name_l in CUSTODES_DEEP_STRIKE_DATASHEETS):
+		return
+	if not meta.has("abilities") or not (meta.abilities is Array):
+		meta["abilities"] = []
+	# Idempotency: skip if a Deep Strike ability is already present (e.g. the
+	# bundled lists that were hand-patched, or a future fixed dataset).
+	for ab in meta.abilities:
+		var ab_name = ab.get("name", "") if ab is Dictionary else str(ab)
+		if str(ab_name) == "Deep Strike":
+			return
+	meta.abilities.append({
+		"name": "Deep Strike",
+		"type": "Core",
+		"description": "The unit has the Deep Strike ability."
+	})
+	print("ArmyListManager: Backfilled Deep Strike on %s (%s) — missing from vendored 40kdc 11e dataset" % [meta.get("name", unit_id), unit_id])
 
 func _apply_wargear_stat_bonuses(unit_id: String, unit: Dictionary) -> void:
 	"""Check unit abilities for wargear stat bonuses and apply them to stats/models."""

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.54.10",
+			"date": "2026-07-17",
+			"summary": "Custodian Guard (and the rest of the on-foot Adeptus Custodes range) can now be placed in Deep Strike when declaring battle formations. The underlying army dataset was missing the Deep Strike ability on these datasheets, so the Formations screen only offered them 'Strategic Reserves' even though they have Deep Strike in 11th edition. This is now backfilled when any army is loaded, so existing and newly-built Custodes lists are both fixed.",
+			"changes": [
+				"Fixed: Custodian Guard, Custodian Wardens, Allarus Custodians, Shield-Captains (on foot / in Allarus armour), Trajann Valoris, Valerian, Sagittarum/Venatari/Aquilon Custodians and Custodian Guard with Adrasite and Pyrithite Spears now correctly offer 'Deep Strike' on the Declare Battle Formations screen.",
+				"Mounted Custodes (Dawneagle Jetbike, Vertus/Agamatus Praetors), vehicles, dreadnoughts and the Sisters of Silence (Prosecutors, Witchseekers, Vigilators) correctly remain Deep-Strike-ineligible and can still only use Strategic Reserves.",
+				"The fix is applied at army-load time, so Custodes lists you built and saved before this update are corrected automatically — no need to rebuild them."
+			]
+		},
+		{
 			"version": "0.54.9",
 			"date": "2026-07-17",
 			"summary": "The combat/dice log in the right-hand panel now stretches to fill all unused space below it, instead of staying a small fixed-height box with a big empty gap underneath. More of the roll history is visible at once in the Shooting, Charge and Fight phases.",
@@ -140,10 +150,10 @@
 		{
 			"version": "0.53.1",
 			"date": "2026-07-17",
-			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) \u2014 so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",
+			"summary": "Fixed Ctrl+Click not selecting a second charge target. The Eligible Targets list told you to hold Ctrl+Click to charge more than one unit, but on many setups holding Ctrl and clicking did nothing (or just moved the selection) — so you could never actually declare a multi-unit charge. Ctrl+Click now reliably adds/removes extra targets.",
 			"changes": [
 				"Fixed: holding Ctrl (or Cmd) and clicking a second unit in the Eligible Targets list now toggles it in/out of the charge, so you can declare a charge against several units as the hint describes.",
-				"The charge target list no longer relies on the click carrying the Ctrl modifier (which some systems don't attach to mouse clicks) \u2014 it now also reads the live keyboard state, so Ctrl+Click works consistently across platforms.",
+				"The charge target list no longer relies on the click carrying the Ctrl modifier (which some systems don't attach to mouse clicks) — it now also reads the live keyboard state, so Ctrl+Click works consistently across platforms.",
 				"Plain click still selects exactly one target, clicking empty space still clears the selection, and the target rows still lock once the charge is declared."
 			]
 		},

--- a/40k/tests/scenarios/sp/custodes_custodian_guard_deep_strike.json
+++ b/40k/tests/scenarios/sp/custodes_custodian_guard_deep_strike.json
@@ -1,0 +1,36 @@
+{
+ "id": "custodes_custodian_guard_deep_strike",
+ "covers": [
+  "autoloads.ArmyListManager.backfill_custodes_deep_strike",
+  "scripts.FormationsDeclarationDialog.reserves_deep_strike_label"
+ ],
+ "description": "Regression for the Custodian Guard Deep Strike bug: the vendored 40kdc 11e dataset dropped the Deep Strike core ability from the on-foot Adeptus Custodes range, so a web-built Custodes list offered a plain Custodian Guard squad only 'Strategic Reserves' on the Declare Battle Formations screen. Loads the 'custodes_web_built_repro' list (whose Custodian Guard JSON has NO Deep Strike ability) through ArmyListManager, asserts the load-time backfill grants Deep Strike (unit_has_deep_strike true), that the REAL FormationsDeclarationDialog labels the squad 'deep_strike', and that Prosecutors (Sisters of Silence) correctly stay non-Deep-Strike.",
+ "steps": [
+  {
+   "act": "wait_seconds",
+   "seconds": 0.5
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var a = ArmyListManager.load_army_list(\"custodes_web_built_repro\", 1)\nif a.is_empty():\n\treturn \"LOAD_FAILED\"\nGameState.state[\"units\"] = a[\"units\"]\nreturn GameState.unit_has_deep_strike(\"U_CUSTODIAN_GUARD_A\")",
+   "equals": true
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var a = ArmyListManager.load_army_list(\"custodes_web_built_repro\", 1)\nGameState.state[\"units\"] = a[\"units\"]\nif not GameState.state.has(\"meta\"):\n\tGameState.state[\"meta\"] = {}\nGameState.state[\"meta\"][\"active_player\"] = 1\nvar dlg = AcceptDialog.new()\ndlg.set_script(load(\"res://scripts/FormationsDeclarationDialog.gd\"))\ntree.root.add_child(dlg)\ndlg.setup(1)\ndlg.popup_centered()\nvar rt = \"NOT_FOUND\"\nvar stack = [dlg]\nwhile not stack.is_empty():\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\t\tif c is CheckBox and c.has_meta(\"unit_id\") and c.get_meta(\"unit_id\") == \"U_CUSTODIAN_GUARD_A\":\n\t\t\trt = str(c.get_meta(\"reserve_type\"))\nreturn rt",
+   "equals": "deep_strike"
+  },
+  {
+   "act": "execute_script",
+   "multiline": true,
+   "script": "var a = ArmyListManager.load_army_list(\"custodes_lions\", 1)\nGameState.state[\"units\"] = a[\"units\"]\nvar res = \"NOT_FOUND\"\nfor uid in a[\"units\"]:\n\tif GameState.get_unit(uid).get(\"meta\",{}).get(\"name\",\"\") == \"Prosecutors\":\n\t\tres = str(GameState.unit_has_deep_strike(uid))\nreturn res",
+   "equals": "false"
+  },
+  {
+   "act": "screenshot",
+   "label": "custodian_guard_deep_strike_offered"
+  }
+ ]
+}


### PR DESCRIPTION
## Problem

When declaring battle formations, a Custodian Guard squad in a custom / web-built Custodes list was only offered **"Strategic Reserves"**, never **"Deep Strike"** — even though Custodian Guard have the Deep Strike core ability in 11th edition.

Validated against the game's own 11e rules data (they did *not* have Deep Strike in 10e, which is likely why the data was wrong):
- The Custodian Guard datasheet (`000001559`) carries the Deep Strike core ability (`000008343`) in `Datasheets_abilities.csv`.
- **12 Adeptus Custodes datasheets** have it — the whole on-foot range (Custodian Guard, Custodian Wardens, Allarus, Shield-Captains, Trajann, Valerian, Sagittarum/Venatari/Aquilon, Adrasite/Pyrithite variant).

## Root cause

The Formations dialog derives its label from `GameState.unit_has_deep_strike()`. The vendored 40kdc 11e dataset the Army Builder emits lists from is **missing** Deep Strike on the on-foot Custodes range — it only tagged the Blade Champion. A previous fix hand-patched only the three bundled sample armies, so any list built in the Army Builder still shipped Custodian Guard without Deep Strike, and the dialog correctly (given the bad data) showed Strategic Reserves.

## Fix

The 40kdc files are vendored ("do not hand-edit", see `40k/data/40kdc/ATTRIBUTION.md`), so the fix lives in the **load-time correction layer**: `ArmyListManager` now backfills the Deep Strike ability onto the correct Custodes datasheets whenever an army loads. This corrects **bundled, custom, and already-saved lists automatically — no rebuild needed**.

- Idempotent (skips units that already carry Deep Strike).
- Gated on the `ADEPTUS CUSTODES` keyword and matched to an explicit set of 12 datasheets.
- Mounted Custodes (Dawneagle Jetbike, Vertus/Agamatus Praetors), vehicles, dreadnoughts and the Sisters of Silence (Prosecutors, Witchseekers, Vigilators) are excluded and correctly remain Strategic-Reserves-only.

## Validation

Live via the godot_mcp bridge against the real `FormationsDeclarationDialog`:
- Repro list (Custodian Guard JSON with **no** Deep Strike) — before: `Custodian Guard Alpha (215 pts) — Strategic Reserves`; after: `— Deep Strike`. No ERROR lines in the debug log.
- Negative control: Prosecutors (Sisters of Silence) stay non-Deep-Strike.
- New windowed regression scenario `custodes_custodian_guard_deep_strike` passes **5/5**.
- `test_custodes_lions_silent_hunters` passes **94/0** (no regression to Custodes army loading).

## Changes
- `40k/autoloads/ArmyListManager.gd` — load-time Deep Strike backfill for Custodes datasheets.
- `40k/tests/scenarios/sp/custodes_custodian_guard_deep_strike.json` — windowed regression scenario.
- `40k/armies/custodes_web_built_repro.json` — test-fixture army (Custodian Guard without Deep Strike) used by the scenario.
- `40k/data/version_history.json` — v0.54.6 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqQE4U3nqqAWqeHoRdea8h

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqQE4U3nqqAWqeHoRdea8h)_