### PR TITLE
Add Godot .uid companion for the transport-audit test

### DIFF
--- a/40k/tests/test_transport_audit_2026_07.gd.uid
+++ b/40k/tests/test_transport_audit_2026_07.gd.uid
@@ -1,0 +1,1 @@
+uid://bivufdaulukgi


### PR DESCRIPTION
Follow-up to #669. The transport-audit regression test (`tests/test_transport_audit_2026_07.gd`) merged there, but its Godot-generated `.uid` file — created on import — was untracked and left out. Every other `tests/*.gd` script carries its `.uid` in the repo; committing this keeps the resource id stable across machines/checkouts.

One-line addition of a generated companion file. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSwrxGppN5x9HiFJG22SHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSwrxGppN5x9HiFJG22SHs)_