### PR TITLE
Move all in-battle popups to a consistent bottom-anchored bar

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,19 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.56.0",
+			"date": "2026-07-18",
+			"summary": "No more pop-ups covering the middle of the battlefield. Every in-battle window — coherency removal, re-rolls, overwatch, weapon order, stratagems, transports, phase confirmations and more — now docks as a bar along the bottom of the screen (the same slot as the armour-save bar), so the board, game log and side panels always stay visible while you decide.",
+			"changes": [
+				"All in-battle pop-ups moved from the center of the screen to a consistent bottom-anchored bar, 48px above the phase breadcrumb — matching the armour-save allocation bar.",
+				"Covered: coherency removal (03.03), end-of-turn card actions, command/ability re-rolls, overwatch, heroic intervention, tank shock, weapon order / next weapon, reactive stratagems, grenades, split fire, epic challenge, counter-offensive, katah stances, fight sequence, sweeping advance, acrobatic escape, rapid ingress, scatter, disembark/embark prompts, firing deck, deployment (combat squads, character attach, transport), battle formations, the deployment roll-off, battle-shock / end-fight / end-phase confirmations, mission discard, the [S] stratagem browser, and surrender.",
+				"Bottom pop-ups without scrolling lists now shrink to their real content height — a slim command bar instead of a half-empty panel.",
+				"If a pop-up's content grows while it is open, it grows UPWARD from the bottom edge instead of sliding off-screen.",
+				"The legacy per-wound save panel (pre-11e games) moved into the same bottom slot.",
+				"Menu-level windows (main menu, save/load manager, game over, connection lost) stay centered — they are not battle decisions."
+			]
+		},
+		{
 			"version": "0.55.0",
 			"date": "2026-07-17",
 			"summary": "Armour saves now always tell you WHO is attacking — and let you watch the battlefield while you decide. The Allocate Attacks window names the attacking unit ('Shot by Battlewagon Alpha'), sits as a slim command bar along the bottom of the screen instead of covering the board or any menus, and the battlefield itself outlines the attacker (red, with an arrow) and your unit under fire (gold).",

--- a/40k/dialogs/FightSequenceDialog.gd
+++ b/40k/dialogs/FightSequenceDialog.gd
@@ -335,7 +335,7 @@ func _add_to_dice_log(text: String, color: Color) -> void:
 func _on_stage_paused(stage: String, info: Dictionary) -> void:
 	current_stage = stage
 	if not visible:
-		popup_centered()
+		DialogUtils.popup_at_bottom(self)
 	if stage == "complete":
 		staged_continue_button.visible = false
 		reroll_label.visible = false

--- a/40k/dialogs/MissionDiscardDialog.gd
+++ b/40k/dialogs/MissionDiscardDialog.gd
@@ -19,8 +19,9 @@ var _mission_scroll: ScrollContainer = null
 var _mission_list: VBoxContainer = null
 
 # Factory: build a ready-to-show dialog (script attached + UI built). The caller
-# connects the signals, adds it to the tree, and calls popup_centered(). Shared
-# by Main.gd and the windowed regression scenario so both exercise one path.
+# connects the signals, adds it to the tree, and shows it (in-battle callers use
+# DialogUtils.popup_at_bottom so the board stays visible). Shared by Main.gd and
+# the windowed regression scenario so both exercise one path.
 static func create(p_active_missions: Array, p_can_gain_cp: bool) -> AcceptDialog:
 	var dialog := AcceptDialog.new()
 	dialog.set_script(load("res://dialogs/MissionDiscardDialog.gd"))
@@ -115,7 +116,7 @@ func _build_ui() -> void:
 func _ready() -> void:
 	# Re-fit the scroll to the list's real (in-tree) height, which is a few px
 	# taller than the pre-tree estimate used while building. Runs before the
-	# caller's popup_centered(), so the dialog sizes correctly the first time and
+	# caller's popup call, so the dialog sizes correctly the first time and
 	# short lists don't show a spurious scrollbar.
 	if _mission_scroll and _mission_list:
 		_mission_scroll.custom_minimum_size.y = _clamped_list_height()

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -7824,7 +7824,7 @@ func _show_embark_prompt(unit_id: String, transport_id: String) -> void:
 	)
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _get_unit_center_position(unit_id: String) -> Vector2:
 	"""Get the center position of a unit (average of all alive models)"""
@@ -8084,7 +8084,7 @@ func _show_disembark_dialog(unit_id: String) -> void:
 	dialog.disembark_confirmed.connect(_on_disembark_confirmed.bind(unit_id))
 	dialog.disembark_canceled.connect(_on_disembark_canceled.bind(unit_id))
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 	"""Handle disembark confirmation - start placement.

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -5198,9 +5198,9 @@ func _show_firing_deck_dialog(transport_id: String) -> void:
 	dialog.models_selected.connect(_on_firing_deck_models_selected.bind(transport_id))
 
 	get_tree().root.add_child(dialog)
-	# Cap to the viewport so the firing-deck instructions can't push the
-	# Confirm button off-screen (see DialogUtils.popup_centered_capped).
-	DialogUtils.popup_centered_capped(dialog)
+	# Bottom-anchored + capped to the viewport so the firing-deck instructions
+	# can't push the Confirm button off-screen (see DialogUtils.popup_at_bottom).
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 func _on_firing_deck_models_selected(selected_weapons: Array, transport_id: String) -> void:
 	"""Handle selection of weapons from embarked units for firing deck"""

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -3916,7 +3916,7 @@ func _on_ability_reroll_opportunity(unit_id: String, player: int, roll_context: 
 	dialog.command_reroll_used.connect(_on_ability_reroll_used)
 	dialog.command_reroll_declined.connect(_on_ability_reroll_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("ChargeController: Ability reroll dialog shown for player %d (%s)" % [player, ability_name])
 
 func _on_ability_reroll_used(unit_id: String, player: int) -> void:
@@ -3988,7 +3988,7 @@ func _on_command_reroll_opportunity(unit_id: String, player: int, roll_context: 
 	dialog.command_reroll_used.connect(_on_command_reroll_used)
 	dialog.command_reroll_declined.connect(_on_command_reroll_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("ChargeController: Command Re-roll dialog shown for player %d" % player)
 
 func _on_command_reroll_used(unit_id: String, player: int) -> void:
@@ -4052,7 +4052,7 @@ func _on_overwatch_opportunity(charging_unit_id: String, defending_player: int, 
 	dialog.fire_overwatch_used.connect(_on_fire_overwatch_used)
 	dialog.fire_overwatch_declined.connect(_on_fire_overwatch_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	# MA-42: Show blocking overlay to active player
 	var main_node = SceneRefs.main()
@@ -4134,7 +4134,7 @@ func _on_heroic_intervention_opportunity(player: int, eligible_units: Array, cha
 	dialog.heroic_intervention_used.connect(_on_heroic_intervention_used)
 	dialog.heroic_intervention_declined.connect(_on_heroic_intervention_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("ChargeController: Heroic Intervention dialog shown for player %d" % player)
 
 	# MA-42: Show blocking overlay to active player
@@ -4247,7 +4247,7 @@ func _on_tank_shock_opportunity(player: int, vehicle_unit_id: String, eligible_t
 	dialog.tank_shock_used.connect(_on_tank_shock_used)
 	dialog.tank_shock_declined.connect(_on_tank_shock_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("ChargeController: Tank Shock dialog shown for player %d" % player)
 
 func _on_tank_shock_used(target_unit_id: String, player: int) -> void:
@@ -4310,7 +4310,7 @@ func _on_tank_shock_result(vehicle_unit_id: String, target_unit_id: String, resu
 		"target_unit_id": target_unit_id,
 	})
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 # --- T7-58: Charge Arrow Visual Management ---
 

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -1021,7 +1021,7 @@ func _on_command_reroll_opportunity(unit_id: String, player: int, roll_context: 
 	dialog.command_reroll_used.connect(_on_command_reroll_used)
 	dialog.command_reroll_declined.connect(_on_command_reroll_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("CommandController: Command Re-roll dialog shown for player %d" % player)
 
 func _on_command_reroll_used(unit_id: String, player: int) -> void:
@@ -1088,13 +1088,9 @@ func _show_drawn_missions_review_dialog() -> void:
 	dialog.review_completed.connect(_on_mission_review_completed)
 	_active_review_dialog = dialog
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
-	# Cap dialog to viewport so the Continue button stays reachable
-	var vp_size = get_tree().root.size
-	var max_h = vp_size.y - 40
-	if dialog.size.y > max_h:
-		dialog.size = Vector2i(dialog.size.x, max_h)
-		dialog.position = Vector2i(dialog.position.x, 20)
+	# Bottom-anchored; popup_at_bottom also caps to the viewport so the
+	# Continue button stays reachable.
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_mission_replacement_requested(mission_id: String) -> void:
 	"""Handle player requesting to replace a drawn mission (spend 1 CP)."""
@@ -1362,8 +1358,8 @@ func _show_condemn_dialog(pending: Dictionary, player: int) -> void:
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
 	# Cap to the viewport so the dynamic Punishment description can't push the
-	# confirm/skip buttons off-screen (see DialogUtils.popup_centered_capped).
-	DialogUtils.popup_centered_capped(dialog)
+	# confirm/skip buttons off-screen (see DialogUtils.popup_at_bottom).
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 # ============================================================================
 # 11e GDM EXTRACT RELIC / LOCATE AND DENY — MARKER SETUP CHOICE
@@ -1519,8 +1515,8 @@ func _show_relic_setup_dialog(pending: Dictionary, player: int) -> void:
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
 	# Cap to the viewport so the relic description can't push the confirm/skip
-	# buttons off-screen (see DialogUtils.popup_centered_capped).
-	DialogUtils.popup_centered_capped(dialog)
+	# buttons off-screen (see DialogUtils.popup_at_bottom).
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 func _on_mission_drawn(player: int, mission_id: String) -> void:
 	"""Handle SecondaryMissionManager mission_drawn signal — rebuild the secondary missions UI."""
@@ -1595,7 +1591,7 @@ func _show_marked_for_death_dialog(drawing_player: int, opponent: int, details: 
 	dialog.marked_for_death_resolved.connect(_on_marked_for_death_resolved.bind(drawing_player))
 	_wire_marked_for_death_board_pick(dialog)
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 	print("CommandController: Marked for Death dialog shown — P%d (opponent) selects Alpha, P%d (card holder) selects Gamma" % [opponent, drawing_player])
 
 func _on_marked_for_death_resolved(alpha_targets: Array, gamma_target: String, drawing_player: int) -> void:
@@ -1679,7 +1675,7 @@ func _on_ai_alpha_targets_selected(drawing_player: int, alpha_targets: Array, el
 	dialog.marked_for_death_resolved.connect(_on_marked_for_death_resolved.bind(drawing_player))
 	_wire_marked_for_death_board_pick(dialog)
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 	print("CommandController: Marked for Death gamma-only dialog shown for P%d (card holder)" % drawing_player)
 
 func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: Dictionary) -> void:
@@ -1726,7 +1722,7 @@ func _show_tempting_target_dialog(drawing_player: int, opponent: int, details: D
 					dialog.select_objective(obj_id),
 		}))
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 	print("CommandController: A Tempting Target dialog shown for player %d to select objective" % opponent)
 
 func _on_tempting_target_resolved(objective_id: String, drawing_player: int) -> void:
@@ -1859,7 +1855,7 @@ func _show_beacon_dialog(drawing_player: int) -> void:
 	# and the prompt reopens on the next Command phase entry.
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 	print("CommandController: Beacon designation dialog shown for player %d (%d eligible units)" % [drawing_player, eligible.size()])
 
 # ============================================================================
@@ -2073,13 +2069,13 @@ func _show_guard_dialog(pending: Dictionary, player: int) -> void:
 
 	# Cap the dialog to the viewport so the Confirm / Keep buttons can never be
 	# pushed off the bottom of the screen. The autowrap description Label reports
-	# a very tall minimum height during the initial popup_centered() (before it
+	# a very tall minimum height during the initial popup (before it
 	# has been laid out to a width), which previously sized the AcceptDialog
 	# window to thousands of pixels tall and scrolled the action buttons
 	# off-screen — the player could see the objective pickers but had no way to
 	# confirm. Height grows with the objective count but never past 90% of the
 	# viewport; the inner ObjectiveScroll absorbs any overflow.
-	DialogUtils.popup_centered_capped(dialog, DialogConstants.MEDIUM, 230.0 + float(objectives.size()) * 40.0)
+	DialogUtils.popup_at_bottom(dialog, Vector2(DialogConstants.MEDIUM.x, 230.0 + float(objectives.size()) * 40.0))
 	print("CommandController: Burden of Trust guard dialog shown for player %d (%d objectives)" % [player, objectives.size()])
 
 

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -422,7 +422,7 @@ func _maybe_offer_combat_squad_split(p_unit_id: String) -> bool:
 	if parent == null:
 		parent = self
 	parent.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	return true
 
 
@@ -871,7 +871,7 @@ func _show_character_attach_dialog() -> void:
 	# Add to scene tree FIRST so _ready() runs before setup()
 	get_tree().root.add_child(dialog)
 	dialog.setup(unit_id)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_attach_characters_selected(character_ids: Array) -> void:
 	DebugLogger.info("Character attach dialog closed", {
@@ -897,7 +897,7 @@ func _show_transport_embark_dialog() -> void:
 	# Add to scene tree FIRST so _ready() runs before setup()
 	get_tree().root.add_child(dialog)
 	dialog.setup(unit_id)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_embark_units_selected(unit_ids: Array) -> void:
 	DebugLogger.info("Embark dialog closed", {

--- a/40k/scripts/DeploymentTransportDialog.gd
+++ b/40k/scripts/DeploymentTransportDialog.gd
@@ -80,8 +80,9 @@ func show_for_unit(unit_id_: String, deployment_controller: Node) -> void:
 			transport_list.add_item(text)
 			transport_list.set_item_metadata(transport_list.get_item_count() - 1, transport.id)
 
-	# Show dialog (capped to the viewport so the Deploy buttons stay on-screen)
-	DialogUtils.popup_centered_capped(self)
+	# Show dialog bottom-anchored (capped to the viewport so the Deploy
+	# buttons stay on-screen)
+	DialogUtils.popup_at_bottom(self, DialogConstants.MEDIUM)
 
 func _on_transport_selected(index: int) -> void:
 	selected_transport_id = transport_list.get_item_metadata(index)

--- a/40k/scripts/DialogConstants.gd
+++ b/40k/scripts/DialogConstants.gd
@@ -11,3 +11,8 @@ const MEDIUM = Vector2(550, 400)
 
 ## Large: complex multi-section forms, detailed results with logs
 const LARGE = Vector2(700, 500)
+
+## Gap kept below bottom-anchored gameplay dialogs so the phase-breadcrumb
+## strip stays visible — matches AllocationGroupOverlay's _BOTTOM_CLEARANCE,
+## so every bottom bar/dialog sits on the same baseline.
+const BOTTOM_CLEARANCE := 48

--- a/40k/scripts/DialogUtils.gd
+++ b/40k/scripts/DialogUtils.gd
@@ -72,17 +72,33 @@ static func _refit_to_viewport(dialog: Window) -> void:
 
 
 ## Show `dialog` anchored to the BOTTOM-CENTER of the screen instead of the
-## middle. Used by the interactive drag-to-move Fight steps (Pile In /
-## Consolidate): their modal must stay OUT of the way of the battlefield the
-## player is dragging models across, so it hugs the bottom edge like a docked
-## control bar rather than sitting on top of the action.
+## middle. This is the CANONICAL way to show an in-battle popup: gameplay
+## decisions (rerolls, overwatch, coherency removal, weapon order, ...) must
+## stay OUT of the way of the battlefield, hugging the bottom edge like a
+## docked control bar — the same slot as the armour-save allocation bar —
+## rather than sitting on top of the action. Centered popups are reserved for
+## menu/meta contexts (main menu, save manager, game over, disconnects).
 ##
-## Clamped to the viewport, then re-anchored one frame later (once the content
-## has settled its real height) so the window keeps hugging the bottom no matter
-## how its content measures. `margin_bottom` is the gap left below the window.
-static func popup_at_bottom(dialog: Window, base_size: Vector2 = DialogConstants.SMALL, margin_bottom: int = 24) -> void:
+## `base_size` defaults to Vector2.ZERO which means "derive from the dialog's
+## own min_size (at least the SMALL tier)" so call sites don't restate a size
+## the dialog already declares. Clamped to the viewport, then re-anchored one
+## frame later (once the content has settled its real height) so the window
+## keeps hugging the bottom no matter how its content measures. It also stays
+## pinned: if the dialog later grows (staged flows swapping content), it is
+## re-anchored so it grows UP from the bottom edge instead of spilling
+## off-screen. `margin_bottom` is the gap left below the window — the default
+## keeps the phase-breadcrumb strip visible, matching the allocation bar.
+static func popup_at_bottom(dialog: Window, base_size: Vector2 = Vector2.ZERO, margin_bottom: int = DialogConstants.BOTTOM_CLEARANCE) -> void:
 	if dialog == null:
 		return
+	if base_size == Vector2.ZERO:
+		base_size = Vector2(
+			max(float(dialog.min_size.x), DialogConstants.SMALL.x),
+			max(float(dialog.min_size.y), DialogConstants.SMALL.y))
+	# Mark the window so the shared overflow guard re-pins it to the bottom
+	# instead of re-centering it (see _cap_if_overflowing).
+	dialog.set_meta("wd_bottom_anchored", true)
+	dialog.set_meta("wd_bottom_margin", margin_bottom)
 	if not dialog.is_inside_tree():
 		# Can't resolve the screen size before the dialog is in the tree; fall
 		# back to a plain popup rather than doing nothing.
@@ -96,10 +112,22 @@ static func popup_at_bottom(dialog: Window, base_size: Vector2 = DialogConstants
 	var w: int = min(int(base_size.x), max_w)
 	var h: int = min(int(base_size.y), max_h)
 	dialog.popup(Rect2i(_bottom_position(vp_size, w, h, margin_bottom), Vector2i(w, h)))
+	# Keep the window pinned to the bottom if its content later resizes it
+	# (e.g. staged dialogs swapping panels while open). Repositions only —
+	# never resizes — so it cannot feed back into size_changed.
+	if not dialog.size_changed.is_connected(DialogUtils._repin_bottom_on_resize.bind(dialog)):
+		dialog.size_changed.connect(DialogUtils._repin_bottom_on_resize.bind(dialog))
 	# Re-anchor once the content has been laid out to its real height.
 	var t := dialog.get_tree()
 	if t != null:
 		t.process_frame.connect(DialogUtils._reanchor_bottom.bind(dialog, margin_bottom), CONNECT_ONE_SHOT)
+
+
+static func _repin_bottom_on_resize(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var margin: int = int(dialog.get_meta("wd_bottom_margin", DialogConstants.BOTTOM_CLEARANCE))
+	dialog.position = _bottom_position(_screen_size(dialog), int(dialog.size.x), int(dialog.size.y), margin)
 
 
 static func _reanchor_bottom(dialog: Window, margin_bottom: int) -> void:
@@ -111,10 +139,28 @@ static func _reanchor_bottom(dialog: Window, margin_bottom: int) -> void:
 	# Snap to the real content size, clamp to the viewport, then re-pin to the
 	# bottom edge so it never spills off-screen and never drifts to the middle.
 	dialog.reset_size()
+	# Bottom popups should read as a slim command bar, not a half-screen panel
+	# with dead space: dialogs that declared a tall min_size (e.g. the MEDIUM
+	# tier) but whose content is shorter shrink to their real content height.
+	# Dialogs with an internal ScrollContainer keep their declared height —
+	# their content min is meaningless (the scroll collapses), so shrinking
+	# would crush the scroll area into unusability.
+	if int(dialog.min_size.y) > 0 and not _has_scroll_container(dialog):
+		dialog.min_size = Vector2i(int(dialog.min_size.x), 0)
+		dialog.reset_size()
 	var w: int = min(int(dialog.size.x), max_w)
 	var h: int = min(int(dialog.size.y), max_h)
 	dialog.size = Vector2i(w, h)
 	dialog.position = _bottom_position(vp_size, w, h, margin_bottom)
+
+
+static func _has_scroll_container(n: Node) -> bool:
+	if n is ScrollContainer:
+		return true
+	for c in n.get_children():
+		if _has_scroll_container(c):
+			return true
+	return false
 
 
 static func _bottom_position(vp_size: Vector2, w: int, h: int, margin_bottom: int) -> Vector2i:
@@ -167,6 +213,11 @@ static func _cap_if_overflowing(dialog: Window) -> void:
 		or dialog.position.y + dialog.size.y > vp_size.y)
 	if not overflows:
 		return  # fits on-screen — leave well-sized dialogs alone
+	# Bottom-anchored gameplay dialogs must stay pinned to the bottom edge —
+	# re-clamping them via popup_centered would drag them back over the board.
+	if dialog.get_meta("wd_bottom_anchored", false):
+		_reanchor_bottom(dialog, int(dialog.get_meta("wd_bottom_margin", DialogConstants.BOTTOM_CLEARANCE)))
+		return
 	var max_w: int = int(vp_size.x * 0.95)
 	var max_h: int = int(vp_size.y * 0.9)
 	dialog.max_size = Vector2i(max_w, max_h)

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -1793,7 +1793,7 @@ func _on_epic_challenge_opportunity(unit_id: String, player: int) -> void:
 	dialog.epic_challenge_used.connect(_on_epic_challenge_used)
 	dialog.epic_challenge_declined.connect(_on_epic_challenge_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("[FightController] Epic Challenge dialog shown")
 
 func _on_epic_challenge_used(unit_id: String, player: int) -> void:
@@ -1843,7 +1843,7 @@ func _on_counter_offensive_opportunity(player: int, eligible_units: Array) -> vo
 	dialog.counter_offensive_used.connect(_on_counter_offensive_used)
 	dialog.counter_offensive_declined.connect(_on_counter_offensive_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("[FightController] Counter-Offensive dialog shown")
 
 	# MA-42: Show blocking overlay to active player
@@ -1920,7 +1920,7 @@ func _on_katah_stance_required(unit_id: String, player: int) -> void:
 	dialog.setup(unit_id, player, master_available)
 	dialog.stance_selected.connect(_on_katah_stance_selected)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("[FightController] Ka'tah stance dialog shown for %s (master_of_stances: %s)" % [unit_id, str(master_available)])
 
 func _on_katah_stance_selected(unit_id: String, stance: String, player: int) -> void:
@@ -2078,7 +2078,7 @@ func _on_attack_assignment_required(unit_id: String, targets: Dictionary) -> voi
 	dialog.skip_fight_requested.connect(_on_attack_dialog_skip_requested)
 	get_tree().root.add_child(dialog)
 	print("[FightController] Showing attack assignment dialog...")
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_attack_dialog_skip_requested(unit_id: String) -> void:
 	"""Escape hatch from an AttackAssignmentDialog with no eligible targets:
@@ -2173,7 +2173,7 @@ func _on_fighting_begun_staged(unit_id: String) -> void:
 	dialog.setup(current_phase, fighter_name)
 	dialog.staged_continue_requested.connect(_on_fight_staged_continue_requested)
 	dialog.staged_reroll_requested.connect(_on_fight_staged_reroll_requested)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	active_fight_sequence_dialog = dialog
 	print("[FightController] FightSequenceDialog opened for %s" % fighter_name)
 
@@ -3813,7 +3813,7 @@ func _on_sweeping_advance_available(unit_id: String, player: int, in_engagement:
 	dialog.sweeping_advance_declined.connect(_on_sweeping_advance_declined.bind(unit_id))
 	dialog.tree_exiting.connect(_on_sweeping_advance_dialog_closed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	# Enable movement mode (reuses pile-in infrastructure)
 	sweeping_advance_active = true
@@ -3902,7 +3902,7 @@ func _on_acrobatic_escape_available(unit_id: String, player: int, move_distance:
 	dialog.acrobatic_escape_declined.connect(_on_acrobatic_escape_declined.bind(unit_id))
 	dialog.tree_exiting.connect(_on_acrobatic_escape_dialog_closed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	# Enable movement mode (reuses pile-in infrastructure)
 	acrobatic_escape_active = true

--- a/40k/scripts/FiringDeckDialog.gd
+++ b/40k/scripts/FiringDeckDialog.gd
@@ -192,7 +192,7 @@ func _on_weapon_toggled(pressed: bool, weapon_data: Dictionary) -> void:
 			w.title = "Firing Deck"
 			w.dialog_text = "Each embarked model may fire only ONE weapon through the firing deck (24.14)."
 			get_tree().root.add_child(w)
-			w.popup_centered()
+			DialogUtils.popup_at_bottom(w)
 			w.confirmed.connect(func(): w.queue_free())
 			return
 		# Check capacity
@@ -206,7 +206,7 @@ func _on_weapon_toggled(pressed: bool, weapon_data: Dictionary) -> void:
 			warning_dialog.title = "Firing Deck Capacity"
 			warning_dialog.dialog_text = "Maximum firing deck capacity reached.\nOnly %d models can shoot through the firing deck." % firing_deck_capacity
 			get_tree().root.add_child(warning_dialog)
-			warning_dialog.popup_centered()
+			DialogUtils.popup_at_bottom(warning_dialog)
 			warning_dialog.confirmed.connect(func(): warning_dialog.queue_free())
 			return
 
@@ -243,7 +243,7 @@ func _on_confirm_pressed() -> void:
 		warning_dialog.title = "No Selection"
 		warning_dialog.dialog_text = "Please select at least one model to shoot through the firing deck."
 		get_tree().root.add_child(warning_dialog)
-		warning_dialog.popup_centered()
+		DialogUtils.popup_at_bottom(warning_dialog)
 		warning_dialog.confirmed.connect(func(): warning_dialog.queue_free())
 		return
 

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2049,7 +2049,7 @@ func _on_surrender_button_pressed() -> void:
 	confirm_dialog.confirmed.connect(_on_surrender_confirmed.bind(confirm_dialog))
 	confirm_dialog.canceled.connect(func(): confirm_dialog.queue_free())
 	add_child(confirm_dialog)
-	confirm_dialog.popup_centered()
+	DialogUtils.popup_at_bottom(confirm_dialog)
 
 func _on_surrender_confirmed(dialog: ConfirmationDialog) -> void:
 	"""T5-MP7: Player confirmed surrender - notify NetworkManager."""
@@ -2246,7 +2246,7 @@ func _show_deep_strike_placement_dialog(unit_id: String) -> void:
 	dialog.always_on_top = true
 	dialog.setup(unit_id, unit_name)
 	dialog.placement_chosen.connect(_on_deep_strike_placement_chosen)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_deep_strike_placement_chosen(unit_id: String, placement_type: String) -> void:
 	"""P2-80: Handle player's choice of placement type."""
@@ -5194,7 +5194,7 @@ func _show_pad_phase_confirm() -> void:
 		_pad_phase_confirm.confirmed.connect(_on_pad_phase_confirmed)
 		add_child(_pad_phase_confirm)
 	_pad_phase_confirm.dialog_text = phase_action_button.text.replace("[Enter] ", "").strip_edges() + "?"
-	_pad_phase_confirm.popup_centered()
+	DialogUtils.popup_at_bottom(_pad_phase_confirm)
 
 func _on_pad_phase_confirmed() -> void:
 	if phase_action_button and phase_action_button.visible and not phase_action_button.disabled:
@@ -7827,7 +7827,7 @@ func _show_formations_dialog(player: int) -> void:
 	add_child(formations_dialog)
 	formations_dialog.setup(player)
 	formations_dialog.formations_confirmed.connect(_on_formations_dialog_confirmed)
-	formations_dialog.popup_centered()
+	DialogUtils.popup_at_bottom(formations_dialog)
 	print("Main: Showed formations dialog for Player %d" % player)
 
 # ========================================
@@ -7882,7 +7882,7 @@ func _show_roll_off_dialog(local_player: int) -> void:
 	roll_off_dialog.choice_made.connect(_on_roll_off_choice_made)
 	roll_off_dialog.reroll_requested.connect(_on_roll_off_roll_pressed)
 	roll_off_dialog.acknowledged.connect(_on_roll_off_acknowledged)
-	roll_off_dialog.popup_centered()
+	DialogUtils.popup_at_bottom(roll_off_dialog)
 	print("Main: Showed %s roll-off dialog for Player %d" % [_roll_off_context(), local_player])
 
 	# The roll RESULT arrives via the phase's roll_off_result signal — emitted
@@ -9628,13 +9628,13 @@ func _on_phase_action_pressed() -> void:
 			# just be rejected as already completed.
 			if int(GameState.state.get("meta", {}).get("roll_off_winner", 0)) > 0:
 				if roll_off_dialog and is_instance_valid(roll_off_dialog):
-					roll_off_dialog.popup_centered()
+					DialogUtils.popup_at_bottom(roll_off_dialog)
 				return
 			action = {"type": "ROLL_OFF_DEPLOYMENT", "player": active_player}
 		GameStateData.Phase.FIRST_TURN_ROLLOFF:
 			if int(GameState.state.get("meta", {}).get("first_turn_player", 0)) > 0:
 				if roll_off_dialog and is_instance_valid(roll_off_dialog):
-					roll_off_dialog.popup_centered()
+					DialogUtils.popup_at_bottom(roll_off_dialog)
 				return
 			action = {"type": "ROLL_OFF_FIRST_TURN", "player": active_player}
 		GameStateData.Phase.COMMAND:
@@ -10299,7 +10299,7 @@ func _show_end_fight_confirmation_dialog(unfought_units: Array, active_player: i
 	dialog.end_fight_confirmed.connect(_on_end_fight_confirmed.bind(active_player))
 	dialog.end_fight_cancelled.connect(_on_end_fight_cancelled)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("Main: T5-UX7: End fight confirmation dialog shown")
 
 func _on_end_fight_confirmed(active_player: int) -> void:
@@ -10341,7 +10341,7 @@ func _show_battle_shock_confirmation_dialog(untested_units: Array, active_player
 	dialog.end_command_confirmed.connect(_on_end_command_confirmed.bind(active_player))
 	dialog.end_command_cancelled.connect(_on_end_command_cancelled)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("Main: P3-94: Battle-shock confirmation dialog shown")
 
 func _on_end_command_confirmed(active_player: int) -> void:
@@ -10381,7 +10381,7 @@ func _show_mission_discard_dialog(active_missions: Array, active_player: int) ->
 	dialog.mission_discard_requested.connect(_on_mission_discard_from_dialog.bind(active_player))
 	dialog.end_turn_without_discard.connect(_on_end_scoring_without_discard.bind(active_player))
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("Main: Mission discard dialog shown for player %d" % active_player)
 
 func _on_mission_discard_from_dialog(mission_index: int, active_player: int) -> void:
@@ -10441,7 +10441,7 @@ func _show_deployment_summary_dialog(deployment_data: Dictionary, active_player:
 	dialog.deployment_confirmed.connect(_on_deployment_confirmed.bind(active_player))
 	dialog.deployment_cancelled.connect(_on_deployment_cancelled)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("Main: T5-UX8: Deployment summary dialog shown")
 
 func _on_deployment_confirmed(active_player: int) -> void:
@@ -10494,7 +10494,7 @@ func _show_shooting_phase_summary_dialog(end_action: Dictionary, active_player: 
 	dialog.shooting_confirmed.connect(_on_shooting_summary_confirmed.bind(end_action))
 	dialog.shooting_cancelled.connect(_on_shooting_summary_cancelled)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("Main: T5-UX9: Shooting phase summary dialog shown for player %d" % active_player)
 
 func _on_shooting_summary_confirmed(end_action: Dictionary) -> void:
@@ -12375,7 +12375,7 @@ func _toggle_stratagem_panel() -> void:
 		_stratagem_panel.stratagem_use_requested.connect(_on_stratagem_panel_use_requested)
 	var active_player = GameState.get_active_player() if GameState.has_method("get_active_player") else 1
 	_stratagem_panel.populate(active_player, current_phase)
-	_stratagem_panel.popup_centered()
+	DialogUtils.popup_at_bottom(_stratagem_panel)
 	if stratagem_panel_button:
 		_WhiteDwarfTheme.apply_tab_button(stratagem_panel_button, true)
 
@@ -12513,7 +12513,7 @@ func _show_stratagem_choice_dialog(title_text: String, options: Array, on_pick: 
 		content.add_child(btn)
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 ## Audit #11: two-step target picker for attacker-driven stratagems.
 func _prompt_stratagem_targets(sid: String, player: int) -> void:
@@ -12559,7 +12559,7 @@ func _show_stratagem_pick_dialog(title_text: String, unit_ids: Array, on_pick: C
 		content.add_child(btn)
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 
 func _on_army_panel_closed() -> void:

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -2585,7 +2585,7 @@ func _handle_embarked_unit_selected(unit_id: String) -> void:
 	dialog.disembark_canceled.connect(_on_disembark_canceled.bind(unit_id))
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 	"""Handle disembark confirmation - start placement controller"""
@@ -3644,7 +3644,7 @@ func _show_unit_switch_dialog(target_unit_id: String) -> void:
 		"%s's unconfirmed move will be confirmed." % current_name)
 	dialog.switch_confirmed.connect(_on_unit_switch_confirmed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Unit switch dialog shown (%s -> %s)" % [active_unit_id, target_unit_id])
 
 func _on_unit_switch_confirmed(target_unit_id: String) -> void:
@@ -4615,7 +4615,7 @@ func _on_command_reroll_opportunity(unit_id: String, player: int, roll_context: 
 	dialog.command_reroll_used.connect(_on_command_reroll_used)
 	dialog.command_reroll_declined.connect(_on_command_reroll_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Command Re-roll dialog shown for player %d" % player)
 
 func _on_command_reroll_used(unit_id: String, player: int) -> void:
@@ -4687,7 +4687,7 @@ func _on_overwatch_opportunity(moved_unit_id: String, defending_player: int, eli
 	dialog.fire_overwatch_used.connect(_on_fire_overwatch_used)
 	dialog.fire_overwatch_declined.connect(_on_fire_overwatch_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Fire Overwatch dialog shown for player %d" % defending_player)
 
 	# MA-42: Show blocking overlay to active player
@@ -4771,7 +4771,7 @@ func _on_rapid_ingress_opportunity(player: int, eligible_units: Array) -> void:
 	dialog.rapid_ingress_used.connect(_on_rapid_ingress_used)
 	dialog.rapid_ingress_declined.connect(_on_rapid_ingress_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Rapid Ingress dialog shown for player %d (10s countdown)" % player)
 
 	# MA-42: Show blocking overlay to active player
@@ -4841,7 +4841,7 @@ func _on_krump_and_run_opportunity(player: int, eligible_units: Array, fell_back
 	dialog.krump_and_run_used.connect(_on_krump_and_run_used)
 	dialog.krump_and_run_declined.connect(_on_krump_and_run_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Krump and Run dialog shown for player %d" % player)
 
 func _on_krump_and_run_used(unit_id: String, player: int) -> void:
@@ -4898,7 +4898,7 @@ func _on_scatter_opportunity(player: int, eligible_units: Array, trigger_unit_id
 	dialog.scatter_used.connect(_on_scatter_used)
 	dialog.scatter_declined.connect(_on_scatter_declined)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("MovementController: Scatter! dialog shown for player %d" % player)
 
 func _on_scatter_used(unit_id: String, player: int) -> void:

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -752,7 +752,7 @@ func _show_coherency_removal_dialog(pending: Array) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 func _recheck_coherency_removal() -> void:
 	# After each removal: re-open the dialog while units remain incoherent;
@@ -906,7 +906,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 func _recheck_card_action() -> void:
 	# After resolve/skip the gate should be down — finish the turn the player
@@ -1019,7 +1019,7 @@ func _on_acrobatic_escape_vanish_available(unit_id: String, unit_name: String, p
 	dialog.add_child(content)
 
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 	# 60-second countdown timer
 	var time_remaining = [60.0]
@@ -1135,7 +1135,7 @@ func _on_end_turn_redeploy_available(unit_id: String, unit_name: String, player:
 	dialog.add_child(content)
 
 	get_tree().root.add_child(dialog)
-	DialogUtils.popup_centered_capped(dialog)
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 	var time_remaining = [60.0]
 	var countdown_timer = Timer.new()

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -3092,7 +3092,7 @@ func _on_weapon_order_required(assignments: Array) -> void:
 	dialog.setup(assignments, current_phase)
 
 	# Show dialog
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	print("ShootingController: WeaponOrderDialog shown and connected to phase signals")
 	print("========================================")
@@ -3300,7 +3300,7 @@ func _on_next_weapon_confirmation_required(remaining_weapons: Array, current_ind
 	dialog.setup(remaining_weapons, current_index, last_weapon_result)
 
 	# Show dialog
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	print("ShootingController: NextWeaponDialog shown with last weapon results")
 	print("========================================")
@@ -3356,7 +3356,7 @@ func _on_reactive_stratagem_opportunity(defending_player: int, available_stratag
 
 	get_tree().root.add_child(dialog)
 	dialog.setup(defending_player, available_stratagems, target_unit_ids)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	# MA-42: hot-seat only — block the shared board behind the defender's
 	# dialog so the attacker can't act mid-window. In networked play the
@@ -3439,7 +3439,7 @@ func _on_show_weapon_order_from_next_weapon_dialog(remaining_weapons: Array, fas
 	dialog.title = "Choose Next Weapon (%d remaining)" % remaining_weapons.size()
 
 	# Show dialog
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 	print("║ WeaponOrderDialog shown successfully")
 	print("║ Waiting for weapon_order_confirmed signal...")
@@ -3556,7 +3556,7 @@ func _on_sentinel_storm_available(unit_id: String, player: int) -> void:
 	dialog.setup(unit_id, player)
 	dialog.sentinel_storm_chosen.connect(_on_sentinel_storm_chosen)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_sentinel_storm_chosen(unit_id: String, use_ability: bool) -> void:
 	"""Handle player's Sentinel Storm decision."""
@@ -3650,7 +3650,7 @@ func _on_throat_slittas_available(unit_id: String, player: int, eligible_targets
 	)
 
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_unit_selected(index: int) -> void:
 	if not unit_selector or not current_phase:
@@ -3914,7 +3914,7 @@ func _on_shoot_all_remaining_pressed() -> void:
 		dialog.queue_free()
 	)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _build_auto_shoot_plan() -> Array:
 	"""Build a plan of SHOOT actions for all remaining eligible units.
@@ -4281,9 +4281,9 @@ func _show_action_choice_dialog(options: Array) -> void:
 
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
-	# Cap to the viewport so the action's description can't push the buttons
-	# off-screen (see DialogUtils.popup_centered_capped).
-	DialogUtils.popup_centered_capped(dialog)
+	# Bottom-anchored + capped to the viewport so the action's description
+	# can't push the buttons off-screen (see DialogUtils.popup_at_bottom).
+	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
 
 func _update_burn_objective_button() -> void:
 	"""Show/hide the Burn Objective button for Scorched Earth mission."""
@@ -4841,7 +4841,7 @@ func _show_unit_switch_dialog(target_unit_id: String) -> void:
 		"%s's staged target assignments will be discarded." % current_name)
 	dialog.switch_confirmed.connect(_on_unit_switch_confirmed)
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 	print("ShootingController: Unit switch dialog shown (%s -> %s)" % [active_shooter_id, target_unit_id])
 
 func _on_unit_switch_confirmed(target_unit_id: String) -> void:
@@ -5198,7 +5198,7 @@ func _open_split_fire_picker(weapon_id: String, target_id: String, split: Dictio
 	dialog.canceled.connect(func(): dialog.queue_free())
 
 	add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 # B4 (audit 2026-07): MOVE picker — every eligible bearer of this weapon is
 # already committed to other targets; offer to retarget a slice at the newly
@@ -5250,7 +5250,7 @@ func _open_move_fire_picker(weapon_id: String, new_target_id: String, split: Dic
 	dialog.canceled.connect(func(): dialog.queue_free())
 
 	add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 # B4: Retarget `moved_ids` (currently committed to other targets) at
 # `new_target_id`. Composed of existing actions: clear each touched
@@ -5419,7 +5419,7 @@ func _prompt_ability_choices(assign_payload: Dictionary, has_lethal: bool, weapo
 		_dispatch_assign_with_choices(assign_payload)  # engine defaults
 		dialog.queue_free())
 	get_tree().root.add_child(dialog)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _dispatch_assign_with_choices(assign_payload: Dictionary) -> void:
 	emit_signal("shoot_action_requested", {
@@ -5896,7 +5896,7 @@ func _on_grenade_button_pressed() -> void:
 
 	get_tree().root.add_child(dialog)
 	dialog.setup(current_player, eligible)
-	dialog.popup_centered()
+	DialogUtils.popup_at_bottom(dialog)
 
 func _on_grenade_confirmed(grenade_unit_id: String, target_unit_id: String) -> void:
 	"""Handle grenade target selection confirmed - send action."""
@@ -5962,7 +5962,7 @@ func _on_grenade_result(result: Dictionary) -> void:
 	result_dialog.result_acknowledged.connect(_on_grenade_result_acknowledged)
 	get_tree().root.add_child(result_dialog)
 	result_dialog.setup(grenade_result_data)
-	result_dialog.popup_centered()
+	DialogUtils.popup_at_bottom(result_dialog)
 
 func _on_grenade_result_acknowledged() -> void:
 	"""Handle grenade result dialog dismissed - refresh UI."""

--- a/40k/scripts/TransportEmbarkDialog.gd
+++ b/40k/scripts/TransportEmbarkDialog.gd
@@ -231,7 +231,7 @@ func _on_unit_toggled(pressed: bool, unit_id: String, model_count: int) -> void:
 			warning_dialog.title = "Capacity Exceeded"
 			warning_dialog.dialog_text = "Adding this unit would exceed transport capacity.\nCurrent: %d/%d\nUnit size: %d models" % [current_model_count, capacity, model_count]
 			get_tree().root.add_child(warning_dialog)
-			warning_dialog.popup_centered()
+			DialogUtils.popup_at_bottom(warning_dialog)
 			warning_dialog.confirmed.connect(func(): warning_dialog.queue_free())
 			return
 

--- a/40k/scripts/WoundAllocationOverlay.gd
+++ b/40k/scripts/WoundAllocationOverlay.gd
@@ -222,19 +222,23 @@ func _build_ui() -> void:
 	print("  - Is in tree: ", is_inside_tree())
 	print("  - Self path: ", get_path() if is_inside_tree() else "NOT IN TREE")
 
-	# Create centered panel
+	# Create bottom-anchored panel — same slot as the 11e allocation bar and
+	# every other in-battle popup, so the board stays visible above it.
 	print("WoundAllocationOverlay: _build_ui() [STEP 1] Creating PanelContainer...")
 	overlay_panel = PanelContainer.new()
 	print("WoundAllocationOverlay: _build_ui() [STEP 2] PanelContainer created: ", overlay_panel)
 
 	overlay_panel.custom_minimum_size = Vector2(450, 250)
 	overlay_panel.anchor_left = 0.5
-	overlay_panel.anchor_top = 0.2
+	overlay_panel.anchor_top = 1.0
 	overlay_panel.anchor_right = 0.5
-	overlay_panel.anchor_bottom = 0.2
+	overlay_panel.anchor_bottom = 1.0
 	overlay_panel.offset_left = -225  # Half of width
 	overlay_panel.offset_right = 225
-	overlay_panel.offset_bottom = 250
+	overlay_panel.offset_top = -(250 + DialogConstants.BOTTOM_CLEARANCE)
+	overlay_panel.offset_bottom = -DialogConstants.BOTTOM_CLEARANCE
+	# Taller content grows UP from the bottom edge, never off-screen below.
+	overlay_panel.grow_vertical = Control.GROW_DIRECTION_BEGIN
 	overlay_panel.z_index = 2001  # Above the overlay background
 	overlay_panel.mouse_filter = Control.MOUSE_FILTER_PASS  # FIXED: Pass clicks through panel to overlay, not to board
 	overlay_panel.visible = true

--- a/40k/tests/scenarios/sp/iss042b_coherency_removal_choice_11e.json
+++ b/40k/tests/scenarios/sp/iss042b_coherency_removal_choice_11e.json
@@ -8,7 +8,7 @@
   "edition": 11,
   "transition_to_phase": 11,
   "disable_ai": true,
-  "description": "Audit #16 (11e 03.03 Regaining Coherency): at End of Turn the PLAYER chooses which model to remove from an out-of-coherency unit, instead of the engine auto-picking. A Boyz K model is displaced 15\" from its unit; END_TURN pauses with a coherency-removal offer and the CoherencyRemovalDialog opens; a second END_TURN is blocked; a bogus removal is rejected; clicking the real dialog button for the stray model removes it (destroyed, no on-death triggers), clears the gate, and the turn can end.",
+  "description": "Audit #16 (11e 03.03 Regaining Coherency): at End of Turn the PLAYER chooses which model to remove from an out-of-coherency unit, instead of the engine auto-picking. A Boyz K model is displaced 15\" from its unit; END_TURN pauses with a coherency-removal offer and the CoherencyRemovalDialog opens; a second END_TURN is blocked; a bogus removal is rejected; clicking the real dialog button for the stray model removes it (destroyed, no on-death triggers), clears the gate, and the turn can end. The dialog is bottom-anchored (popup consistency): it must sit in the bottom half of the screen, clear of the breadcrumb strip, leaving the board visible.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -61,6 +61,16 @@
     {
       "act": "screenshot",
       "label": "02_coherency_removal_dialog_open"
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node(\"CoherencyRemovalDialog\").position.y > tree.root.size.y * 0.5",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node(\"CoherencyRemovalDialog\").position.y + tree.root.get_node(\"CoherencyRemovalDialog\").size.y <= tree.root.size.y - 40",
+      "equals": true
     },
     {
       "act": "dispatch_action",


### PR DESCRIPTION
## Summary

The **Regaining Coherency** window (and ~70 other in-battle popups) still opened in the middle of the screen, covering the board — even though the armour-save allocation panel had already been moved to a slim bottom command bar. This PR makes the bottom slot the single, canonical position for every in-battle popup, so the battlefield, game log and side panels stay visible while the player decides.

Before → after (the exact dialog from the report):

- **Before**: centered `Regaining Coherency` panel over the middle of the board.
- **After**: slim bottom-anchored bar, 48px above the phase breadcrumb, board fully visible.

## What changed

- `DialogUtils.popup_at_bottom()` is now the canonical in-battle popup entry point:
  - base size derives from the dialog's own `min_size` (call sites don't restate it),
  - default clearance is `DialogConstants.BOTTOM_CLEARANCE` (48px, matching `AllocationGroupOverlay`),
  - the window re-pins to the bottom whenever its content resizes (staged flows grow **up**, never off-screen),
  - the shared overflow guard re-pins bottom-anchored windows instead of dragging them back to center,
  - dialogs without an internal `ScrollContainer` shrink to their real content height (a slim bar, not a half-empty MEDIUM-tier panel); scroll-bearing dialogs keep their declared height so the scroll area stays usable.
- Converted ~70 call sites across every phase:
  - **Scoring**: coherency removal, end-of-turn card actions, acrobatic-escape vanish, end-of-turn redeploy.
  - **Command**: command re-roll, mission review, Condemn, Relic, Marked for Death, Tempting Target, Beacon, Burden-of-Trust guard.
  - **Shooting**: weapon order / next weapon, reactive stratagems, Sentinel Storm, Throat Slittas, shoot-all confirm, action choice, unit switch, split/move fire, ability choices, grenades.
  - **Charge**: ability/command re-roll, overwatch, heroic intervention, tank shock (+ result).
  - **Fight**: epic challenge, counter-offensive, katah stance, attack assignment, fight sequence, sweeping advance, acrobatic escape.
  - **Movement**: disembark, unit switch, command re-roll, overwatch, rapid ingress, krump-and-run, scatter.
  - **Deployment**: combat-squad split, character attach, transport embark.
  - **Phase-built / transports**: embark/disembark prompts, firing deck (+ capacity warnings), transport-embark warning.
  - **Main.gd / cross-phase**: surrender, deep strike, gamepad phase-confirm, battle formations, deployment roll-off, end-fight / battle-shock confirms, mission discard, deployment & shooting summaries, stratagem browser/choice/pick.
  - **Legacy 10e** `WoundAllocationOverlay` panel re-anchored from top-center into the same bottom band, growing upward.
- **Deliberately left centered** (menu/meta, not battle decisions): main menu dialogs, save/load manager + confirmations, game over, connection-lost modal.
- `iss042b` scenario now asserts the coherency dialog sits in the bottom half of the screen and clears the breadcrumb strip.

## Validation (windowed, per project gate)

- `iss042b_coherency_removal_choice_11e` — **22/22 PASS**, including the new bottom-position assertions + screenshot showing the reported dialog as a bottom bar with the board visible.
- 10-scenario battery across converted surfaces — **10/10 PASS**, zero ERROR lines in the per-run debug logs:
  `iss042c_coherency_ai_turn_no_hijack_11e`, `charge_reroll_keep_default_button`, `defender_control_saves_11e` (52), `fight_dialogs_single_confirm_11e` (36), `global_consolidation_step_11e` (100), `mission_discard_dialog_height`, `iss071_firing_deck_11e`, `fast_roll_two_targets_all_resolve`, `custodes_lions_stratagems`, `iss045_allocation_groups`.

## Notes / risk

- Menu-level windows stay centered by design.
- Dialogs with internal scroll lists keep their declared height (only scroll-free ones shrink) — easy to tune per-dialog if any looks too tall in play.
- All 11 windowed scenarios pass; the coherency and charge-reroll dialogs were also visually screenshot-checked. Multiplayer flows were not separately exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyBURYczgNfhDhTcr7MBar)_