### PR TITLE
Declare Battle Formations dialog uses almost the full screen height

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.57.1",
+			"date": "2026-07-18",
+			"summary": "The Declare Battle Formations screen now uses nearly the full height of the screen. It happens before the battle starts — there is no board worth keeping visible yet — so instead of a cramped bar docked at the bottom, the form stretches from just below the top HUD bar to the usual bottom clearance, showing far more of your roster (leaders, warlord, transports, reserves) without scrolling.",
+			"changes": [
+				"Declare Battle Formations dialog is now centered and stretched to almost full screen height, instead of docked at the bottom of the screen.",
+				"It sits below the top HUD bar and above the bottom strip, overlapping neither.",
+				"The unit lists inside (leader attachments, transports, reserves) get all the extra room, so much less scrolling is needed with bigger armies.",
+				"In-battle pop-ups (rerolls, overwatch, saves, etc.) are unchanged — they still dock at the bottom so the battlefield stays visible."
+			]
+		},
+		{
 			"version": "0.57.0",
 			"date": "2026-07-18",
 			"summary": "The AI now plays the Lions of the Emperor detachment properly: it spaces its Custodes units 6\"+ apart to earn Against All Odds (+1 to Hit AND +1 to Wound while no friendly is within 6\"), values that buff in its shooting and charge maths, prefers solo charges over gang-ups, and makes smarter calls with From Golden Light, Gilded Champion and the Swift as the Eagle window.",

--- a/40k/scripts/DialogConstants.gd
+++ b/40k/scripts/DialogConstants.gd
@@ -16,3 +16,8 @@ const LARGE = Vector2(700, 500)
 ## strip stays visible — matches AllocationGroupOverlay's _BOTTOM_CLEARANCE,
 ## so every bottom bar/dialog sits on the same baseline.
 const BOTTOM_CLEARANCE := 48
+
+## Gap kept above full-height pre-battle dialogs so the top HUD bar (the
+## 100px phase/status bar that Main._restructure_ui_layout anchors to the
+## top of the screen) stays visible, plus a small breathing gap.
+const TOP_HUD_CLEARANCE := 108

--- a/40k/scripts/DialogUtils.gd
+++ b/40k/scripts/DialogUtils.gd
@@ -169,6 +169,78 @@ static func _bottom_position(vp_size: Vector2, w: int, h: int, margin_bottom: in
 	return Vector2i(max(x, 0), max(y, 0))
 
 
+## Show `dialog` centered horizontally and stretched to almost the FULL HEIGHT
+## of the screen. This is for PRE-BATTLE flows (formations declaration) where
+## the battlefield does not need to stay visible, so docking at the bottom
+## would just cramp the form: use the vertical room to show the whole roster
+## instead. Leaves `margin_top` clear for the top HUD bar and `margin_bottom`
+## for the bottom bar, so the window overlaps neither. In-battle gameplay
+## popups must keep using popup_at_bottom; menu/meta dialogs use
+## popup_centered_capped.
+##
+## The height is enforced through min_size == max_size, so the shared overflow
+## guard's reset_size() and any content-driven resize cannot collapse the
+## window back to its (much shorter) content minimum. `base_width` defaults to
+## the dialog's declared min_size width.
+static func popup_full_height(dialog: Window, base_width: float = 0.0, margin_top: int = DialogConstants.TOP_HUD_CLEARANCE, margin_bottom: int = DialogConstants.BOTTOM_CLEARANCE) -> void:
+	if dialog == null:
+		return
+	if base_width <= 0.0:
+		base_width = max(float(dialog.min_size.x), DialogConstants.MEDIUM.x)
+	if not dialog.is_inside_tree():
+		# Can't resolve the screen size before the dialog is in the tree; fall
+		# back to a plain popup rather than doing nothing.
+		dialog.popup(Rect2i(Vector2i.ZERO, Vector2i(int(base_width), int(DialogConstants.LARGE.y))))
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var max_w: int = int(vp_size.x * 0.95)
+	var w: int = min(int(base_width), max_w)
+	# Fill the vertical space between the clearances. On a viewport too small
+	# to honour both margins, fall back to the MEDIUM tier height — the shared
+	# overflow guard still backstops anything that ends up off-screen.
+	var h: int = max(int(vp_size.y) - margin_top - margin_bottom, int(DialogConstants.MEDIUM.y))
+	dialog.min_size = Vector2i(w, h)
+	dialog.max_size = Vector2i(max_w, h)
+	dialog.set_meta("wd_full_height_top", margin_top)
+	dialog.set_meta("wd_full_height_bottom", margin_bottom)
+	dialog.popup(Rect2i(_full_height_position(vp_size, w, margin_top), Vector2i(w, h)))
+	# Keep the window centered under the top HUD if its content later widens it
+	# (position-only — height is pinned by min/max, so this cannot feed back
+	# into size_changed).
+	if not dialog.size_changed.is_connected(DialogUtils._recenter_full_height.bind(dialog)):
+		dialog.size_changed.connect(DialogUtils._recenter_full_height.bind(dialog))
+
+
+static func _recenter_full_height(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var margin_top: int = int(dialog.get_meta("wd_full_height_top", DialogConstants.TOP_HUD_CLEARANCE))
+	dialog.position = _full_height_position(_screen_size(dialog), int(dialog.size.x), margin_top)
+
+
+## Recompute a full-height dialog's geometry against the CURRENT viewport —
+## used by the overflow guard when the game window shrank underneath an open
+## dialog. Sets size/position directly (no re-popup), so it cannot re-fire
+## visibility_changed and loop.
+static func _refit_full_height(dialog: Window) -> void:
+	if not is_instance_valid(dialog) or not dialog.visible or not dialog.is_inside_tree():
+		return
+	var vp_size: Vector2 = _screen_size(dialog)
+	var margin_top: int = int(dialog.get_meta("wd_full_height_top", DialogConstants.TOP_HUD_CLEARANCE))
+	var margin_bottom: int = int(dialog.get_meta("wd_full_height_bottom", DialogConstants.BOTTOM_CLEARANCE))
+	var max_w: int = int(vp_size.x * 0.95)
+	var w: int = min(int(dialog.size.x), max_w)
+	var h: int = max(int(vp_size.y) - margin_top - margin_bottom, int(DialogConstants.MEDIUM.y))
+	dialog.min_size = Vector2i(min(int(dialog.min_size.x), w), h)
+	dialog.max_size = Vector2i(max_w, h)
+	dialog.size = Vector2i(w, h)
+	dialog.position = _full_height_position(vp_size, w, margin_top)
+
+
+static func _full_height_position(vp_size: Vector2, w: int, margin_top: int) -> Vector2i:
+	return Vector2i(max(int((vp_size.x - w) / 2.0), 0), margin_top)
+
+
 ## The size of the screen/root viewport the `dialog` popup is embedded in.
 ## NOTE: a Window is itself a Viewport, so `dialog.get_viewport()` returns the
 ## dialog, not the screen — use the SceneTree root viewport instead.
@@ -217,6 +289,11 @@ static func _cap_if_overflowing(dialog: Window) -> void:
 	# re-clamping them via popup_centered would drag them back over the board.
 	if dialog.get_meta("wd_bottom_anchored", false):
 		_reanchor_bottom(dialog, int(dialog.get_meta("wd_bottom_margin", DialogConstants.BOTTOM_CLEARANCE)))
+		return
+	# Full-height pre-battle dialogs re-fit below the top HUD bar instead —
+	# re-centering would drag them up over it.
+	if dialog.has_meta("wd_full_height_top"):
+		_refit_full_height(dialog)
 		return
 	var max_w: int = int(vp_size.x * 0.95)
 	var max_h: int = int(vp_size.y * 0.9)

--- a/40k/scripts/FormationsDeclarationDialog.gd
+++ b/40k/scripts/FormationsDeclarationDialog.gd
@@ -26,7 +26,6 @@ var summary_label: RichTextLabel
 func _init():
 	title = "Declare Battle Formations"
 	min_size = Vector2(600, 500)
-	max_size = Vector2(700, 720)
 	WhiteDwarfTheme.apply_to_dialog(self)
 
 func setup(player: int) -> void:
@@ -38,13 +37,16 @@ func setup(player: int) -> void:
 	# Issue #367 fix: Main.gd instantiates this dialog via `AcceptDialog.new()`
 	# + `set_script()`, which means `_init()` above never fires (the object was
 	# constructed before the script was attached). Re-apply the window-level
-	# setup here so the dialog actually has a min_size, max_size, themed title,
-	# and gold-on-parchment chrome. Without this the dialog renders as a tiny
+	# setup here so the dialog actually has a min_size, themed title, and
+	# gold-on-parchment chrome. Without this the dialog renders as a tiny
 	# grey rectangle with an unstyled (garbled-looking) title and the children
 	# added by `_build_ui()` are clipped, producing the empty-body symptom in
 	# critique steps 2/6/11.
+	# min_size here is only the floor — this is a PRE-BATTLE dialog (the board
+	# doesn't need to stay visible), so Main shows it via
+	# DialogUtils.popup_full_height, which stretches it to nearly the full
+	# screen height. Deliberately no max_size cap: the popup helper owns it.
 	min_size = Vector2(600, 500)
-	max_size = Vector2(700, 720)
 	WhiteDwarfTheme.apply_to_dialog(self)
 
 	title = "Player %d — Declare Battle Formations" % player
@@ -60,8 +62,10 @@ func setup(player: int) -> void:
 	_build_ui()
 
 func _build_ui() -> void:
-	# Create a main vertical layout
+	# Create a main vertical layout. Stable node names so tests / the MCP
+	# bridge can address the procedurally-built controls by path.
 	var main_vbox = VBoxContainer.new()
+	main_vbox.name = "MainVBox"
 	main_vbox.add_theme_constant_override("separation", 8)
 	add_child(main_vbox)
 
@@ -116,17 +120,20 @@ func _build_ui() -> void:
 	# Custom confirm/skip buttons inside the layout (AcceptDialog's built-in buttons
 	# get clipped outside the visible area, so we manage our own)
 	var button_bar = HBoxContainer.new()
+	button_bar.name = "ButtonBar"
 	button_bar.add_theme_constant_override("separation", 12)
 	button_bar.alignment = BoxContainer.ALIGNMENT_END
 	main_vbox.add_child(button_bar)
 
 	var skip_button = Button.new()
+	skip_button.name = "SkipButton"
 	skip_button.text = "Skip (No Declarations)"
 	skip_button.pressed.connect(_on_canceled)
 	WhiteDwarfTheme.apply_secondary_button(skip_button)
 	button_bar.add_child(skip_button)
 
 	var confirm_button = Button.new()
+	confirm_button.name = "ConfirmButton"
 	confirm_button.text = "Confirm Formations"
 	confirm_button.pressed.connect(_on_confirmed)
 	WhiteDwarfTheme.apply_primary_button(confirm_button)

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7815,19 +7815,28 @@ func _setup_formations_phase() -> void:
 
 func _show_formations_dialog(player: int) -> void:
 	"""Show the formations declaration dialog for a player."""
-	# Clean up any existing dialog
+	# Clean up any existing dialog. Detach it NOW (queue_free only frees at end
+	# of frame) so its stable "FormationsDialog" name is free for the next
+	# instance — hotseat opens player 2's dialog while player 1's is still
+	# queued for deletion.
 	if formations_dialog and is_instance_valid(formations_dialog):
+		if formations_dialog.get_parent():
+			formations_dialog.get_parent().remove_child(formations_dialog)
 		formations_dialog.queue_free()
 		formations_dialog = null
 
 	var dialog_script = preload("res://scripts/FormationsDeclarationDialog.gd")
 	formations_dialog = AcceptDialog.new()
 	formations_dialog.set_script(dialog_script)
+	formations_dialog.name = "FormationsDialog"
 	formations_dialog.exclusive = true
 	add_child(formations_dialog)
 	formations_dialog.setup(player)
 	formations_dialog.formations_confirmed.connect(_on_formations_dialog_confirmed)
-	DialogUtils.popup_at_bottom(formations_dialog)
+	# Pre-battle step: the board does not need to stay visible yet, so give the
+	# declaration form nearly the full screen height (below the top HUD bar)
+	# instead of cramping it into the bottom-docked gameplay-popup slot.
+	DialogUtils.popup_full_height(formations_dialog)
 	print("Main: Showed formations dialog for Player %d" % player)
 
 # ========================================

--- a/40k/tests/scenarios/sp/formations_dialog_full_height.json
+++ b/40k/tests/scenarios/sp/formations_dialog_full_height.json
@@ -1,0 +1,69 @@
+{
+  "id": "formations_dialog_full_height",
+  "covers": [
+    "scripts.FormationsDeclarationDialog.full_height_layout",
+    "ui.dialog_positioning.formations_full_height"
+  ],
+  "fixture": "audit_378_formations",
+  "transition_to_phase": 0,
+  "description": "The Declare Battle Formations dialog is a PRE-BATTLE step: the board does not need to stay visible, so instead of docking at the bottom like in-battle popups it stretches to almost the full screen height — top edge at TOP_HUD_CLEARANCE (108, below the 100px top HUD bar), bottom edge BOTTOM_CLEARANCE (48) above the screen bottom, centered horizontally. Asserts the geometry for Player 1's dialog, confirms via the real Confirm button, asserts Player 2's dialog reopens at the same stable path with the same geometry (name-reuse of /root/Main/FormationsDialog), skips it via the real Skip button, and checks the phase advances.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node_or_null(\"Main/FormationsDialog\")\nif dlg == null:\n\treturn \"NO_DIALOG\"\nreturn dlg.visible",
+      "equals": true },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nreturn dlg.position.y",
+      "equals": 108 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nvar vp_h = int(tree.root.get_visible_rect().size.y)\nreturn dlg.size.y == vp_h - 108 - 48",
+      "equals": true },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nvar vp_h = int(tree.root.get_visible_rect().size.y)\nreturn vp_h - (dlg.position.y + dlg.size.y)",
+      "equals": 48 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nvar vp_w = int(tree.root.get_visible_rect().size.x)\nreturn abs((dlg.position.x + dlg.size.x / 2) - vp_w / 2) <= 1",
+      "equals": true },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nreturn dlg.size.y",
+      "expect_min": 900 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nreturn dlg.scroll_container.size.y",
+      "expect_min": 500 },
+
+    { "act": "screenshot", "label": "01_p1_dialog_full_height" },
+
+    { "act": "expect_node_visible", "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/ConfirmButton" },
+    { "act": "click_node", "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/ConfirmButton", "emit_pressed": true },
+
+    { "act": "wait_seconds", "seconds": 0.7 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node_or_null(\"Main/FormationsDialog\")\nif dlg == null:\n\treturn \"NO_P2_DIALOG\"\nif not dlg.visible:\n\treturn \"P2_DIALOG_HIDDEN\"\nreturn dlg.title",
+      "equals": "Player 2 — Declare Battle Formations" },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var dlg = tree.root.get_node(\"Main/FormationsDialog\")\nvar vp_h = int(tree.root.get_visible_rect().size.y)\nreturn dlg.position.y == 108 and dlg.size.y == vp_h - 108 - 48",
+      "equals": true },
+
+    { "act": "screenshot", "label": "02_p2_dialog_full_height" },
+
+    { "act": "expect_node_visible", "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/SkipButton" },
+    { "act": "click_node", "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/SkipButton", "emit_pressed": true },
+
+    { "act": "wait_seconds", "seconds": 1.2 },
+
+    { "act": "execute_script",
+      "script": "GameState.get_current_phase() != 0",
+      "equals": true },
+
+    { "act": "screenshot", "label": "03_phase_advanced_after_both_confirm" }
+  ]
+}


### PR DESCRIPTION
## Summary

The Declare Battle Formations step happens **before** the battle begins, so the board does not need to stay visible yet. The v0.56.0 popup-consistency pass had swept this pre-battle dialog into the bottom-docked gameplay-popup slot, and its own 720px `max_size` cap kept it cramped — forcing the player to scroll through the leader/warlord/transport/reserve lists.

This change gives the dialog nearly the full screen height instead: centered horizontally, stretched from just below the top HUD bar down to the standard bottom clearance, overlapping neither.

## Changes

- **New `DialogUtils.popup_full_height()`** — centers horizontally and stretches the window from `TOP_HUD_CLEARANCE` (108px, below the 100px top HUD bar) down to `BOTTOM_CLEARANCE` (48px). That's 924px tall at 1080p vs. the old 720px cap. Height is pinned via `min_size == max_size` so the shared overflow guard and content-driven resizes cannot collapse it back to the (much shorter) content minimum. The overflow guard now **re-fits** (not re-centers) these dialogs if the game window shrinks underneath them.
- **New `DialogConstants.TOP_HUD_CLEARANCE`** (108) so the clearance is a single named source of truth.
- **`Main._show_formations_dialog()`** shows the dialog via the new helper, under a stable node name (`FormationsDialog`). The old instance is detached immediately on reopen (not just `queue_free`d) so hotseat player 2 reuses the same node path cleanly.
- **`FormationsDeclarationDialog`** drops its 720px `max_size` cap (the popup helper now owns the height) and names its layout nodes (`MainVBox` / `ButtonBar` / `ConfirmButton` / `SkipButton`) so tests and the MCP bridge can address the procedurally-built controls.
- In-battle gameplay popups (rerolls, overwatch, saves, etc.) are **unchanged** — they still dock at the bottom via `popup_at_bottom` so the battlefield stays visible during play.
- Version bumped to **0.57.1** with a player-facing changelog entry.

## Validation

All windowed, per the project feature-validation gate:

- **New scenario `formations_dialog_full_height` (20/20 steps)** — asserts position / height / clearances / horizontal centering for **both** players' dialogs, drives the real **Confirm** and **Skip** buttons (not `dispatch_action`), and checks the phase advances afterward. Screenshots captured for P1 and P2.
- **Regression** — the 6 existing formation scenarios (378 leader pairing, 367 warlord, custodes deep strike, display names, fullauto rules, new-game-reaches-rolloff) all pass, plus the t011 warlord pin test (22/22).
- **Live MCP** — loaded a formations save in the running game; dialog measured at position (660, 108), size 600×924 on a 1920×1080 viewport; `verify_delivery` returned **PASS** with zero log errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKiHDfSh4V7usW1yPhaxwz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKiHDfSh4V7usW1yPhaxwz)_