### PR TITLE
Deployment: carry model rotation over to the next model in a unit

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.57.2",
+			"date": "2026-07-18",
+			"summary": "During deployment, rotating a model now carries that rotation over to the next model in the same unit. If you turn the first model 90° before placing it, every following model in that unit starts off already turned the same way — so you can lay out a whole squad facing a chosen direction without re-rotating each one.",
+			"changes": [
+				"Deployment: after you rotate a model, the ghost for the next model in the unit inherits that rotation instead of snapping back to the default enemy-facing.",
+				"The first model of each unit still auto-faces the opponent as before; the carry-over only kicks in once you have placed (and optionally rotated) a model, and resets when you start a new unit."
+			]
+		},
+		{
 			"version": "0.57.1",
 			"date": "2026-07-18",
 			"summary": "The Declare Battle Formations screen now uses nearly the full height of the screen. It happens before the battle starts — there is no board worth keeping visible yet — so instead of a cramped bar docked at the bottom, the form stretches from just below the top HUD bar to the usual bottom clearance, showing far more of your roster (leaders, warlord, transports, reserves) without scrolling.",

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -15,6 +15,11 @@ var model_idx: int = -1
 var temp_positions: Array = []
 var temp_rotations: Array = []  # Store rotations for each model
 var placement_order: Array = []  # MA-16: Track order of model placement for non-sequential undo
+# Rotation carry-over: when the player rotates a model during deployment, the
+# NEXT model in the same unit starts at that same rotation instead of snapping
+# back to the default enemy-facing. Reset per unit in begin_deploy(). Stays null
+# until the first model is placed, so the first model keeps the auto-face default.
+var _last_deploy_rotation = null  # float (radians) or null
 var token_layer: Node2D
 var ghost_layer: Node2D
 var ghost_sprite: Node2D = null
@@ -202,6 +207,7 @@ func begin_deploy(_unit_id: String) -> void:
 	model_idx = 0
 	temp_positions.clear()
 	temp_rotations.clear()
+	_last_deploy_rotation = null  # Reset rotation carry-over for the new unit
 	placement_order.clear()  # MA-16: Reset placement order tracking
 	combined_models.clear()
 	is_combined_deployment = false
@@ -549,6 +555,9 @@ func try_place_at(world_pos: Vector2) -> void:
 	# Store position and rotation (rotation already captured above)
 	temp_positions[model_idx] = world_pos
 	temp_rotations[model_idx] = rotation
+	# Carry this rotation over to the next model so, e.g., rotating the first
+	# model 90° makes every following model start off at that same 90°.
+	_last_deploy_rotation = rotation
 	placement_order.append(model_idx)  # MA-16: Track placement order for non-sequential undo
 	_spawn_preview_token(spawn_unit_id, spawn_model_idx, world_pos, rotation)
 
@@ -747,6 +756,7 @@ func reset_unit() -> void:
 	_clear_previews()
 	temp_positions.fill(null)
 	temp_rotations.fill(0.0)  # Reset rotations to default
+	_last_deploy_rotation = null  # Reset rotation carry-over
 	placement_order.clear()  # MA-16: Reset placement order tracking
 	model_idx = 0
 
@@ -1253,6 +1263,15 @@ func _place_character_model_adjacent(char_id: String, bodyguard_id: String) -> v
 		GameState.state.units[char_id].models[i].position = {"x": char_pos.x, "y": char_pos.y}
 		print("[DeploymentController] Placed character model %d at %s" % [i, str(char_pos)])
 
+func _initial_deploy_rotation_for(owner_player: int) -> float:
+	# The rotation a freshly-shown ghost should start at. Once the player has
+	# placed (and possibly rotated) a model this unit, carry that rotation over to
+	# the next model; otherwise fall back to the default enemy-facing so the very
+	# first model still auto-faces the opponent.
+	if _last_deploy_rotation != null:
+		return _last_deploy_rotation
+	return BoardState.get_default_facing_for_player(owner_player)
+
 func _create_ghost() -> void:
 	print("[DeploymentController] _create_ghost() called")
 	print("[DeploymentController] ghost_layer is null: ", ghost_layer == null)
@@ -1297,9 +1316,10 @@ func _create_ghost() -> void:
 		ghost_sprite.set_model_type_label(_get_model_type_label(model_data, unit_data))
 
 	# Default facing: orient the model toward the opponent's board edge so its
-	# sprite faces the enemy instead of just pointing "up". The player can still
-	# rotate freely, which overwrites this default.
-	ghost_sprite.set_base_rotation(BoardState.get_default_facing_for_player(ghost_sprite.owner_player))
+	# sprite faces the enemy instead of just pointing "up". After the first model
+	# is placed, this inherits the player's last-applied rotation instead. The
+	# player can still rotate freely, which overwrites this default.
+	ghost_sprite.set_base_rotation(_initial_deploy_rotation_for(ghost_sprite.owner_player))
 
 	if ghost_layer:
 		ghost_layer.add_child(ghost_sprite)
@@ -1420,8 +1440,9 @@ func _update_ghost_for_next_model() -> void:
 		# Keep the ghost's unit_id in sync so the facing sprite resolves for the
 		# model actually being placed (bodyguard vs attached character).
 		ghost_sprite.set_meta("unit_id", cm["unit_id"])
-		# Reset facing to the default (toward the opponent) for the new model.
-		ghost_sprite.set_base_rotation(BoardState.get_default_facing_for_player(ghost_sprite.owner_player))
+		# Carry over the last-applied rotation (falls back to the default
+		# enemy-facing before any model in this unit has been placed).
+		ghost_sprite.set_base_rotation(_initial_deploy_rotation_for(ghost_sprite.owner_player))
 		ghost_sprite.queue_redraw()
 		return
 
@@ -1430,8 +1451,9 @@ func _update_ghost_for_next_model() -> void:
 		var model_data = unit_data["models"][model_idx]
 		# Update model data for the next model
 		ghost_sprite.set_model_data(model_data)
-		# Reset facing to the default (toward the opponent) for the new model.
-		ghost_sprite.set_base_rotation(BoardState.get_default_facing_for_player(ghost_sprite.owner_player))
+		# Carry over the last-applied rotation (falls back to the default
+		# enemy-facing before any model in this unit has been placed).
+		ghost_sprite.set_base_rotation(_initial_deploy_rotation_for(ghost_sprite.owner_player))
 		ghost_sprite.queue_redraw()
 
 func _spawn_preview_token(unit_id: String, model_index: int, pos: Vector2, rotation: float = 0.0) -> void:

--- a/40k/tests/scenarios/sp/deploy_rotation_carryover.json
+++ b/40k/tests/scenarios/sp/deploy_rotation_carryover.json
@@ -1,0 +1,54 @@
+{
+  "id": "deploy_rotation_carryover",
+  "covers": [
+    "deployment.rotation_carryover_to_next_model"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "disable_ai": true,
+  "description": "Feature: during multi-model deployment, rotating a model carries that rotation over to the FOLLOWING model instead of snapping back to the default enemy-facing. Drives the real player path: begin_deploy a 3-model Custodian Guard unit, rotate the first model's ghost +90 degrees via six real 'E' keypresses (rotate_right = +15 each), place it, then assert the ghost for the SECOND model starts at that same +90 rotation (NOT the default facing). Repeats for the third model. Proves the fix in DeploymentController._update_ghost_for_next_model / _initial_deploy_rotation_for.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+    { "act": "expect_state", "path": "units.U_CUSTODIAN_GUARD_B.status", "equals": 0 },
+
+    { "act": "execute_script", "script": "Main.deployment_controller.begin_deploy('U_CUSTODIAN_GUARD_B')" },
+    { "act": "wait_frames", "frames": 4 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nif dc.ghost_sprite == null:\n\treturn \"NO_GHOST\"\nreturn abs(dc.ghost_sprite.get_base_rotation() - BoardState.get_default_facing_for_player(1)) < 0.001", "equals": true },
+    { "act": "screenshot", "label": "01_model0_default_facing" },
+
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "simulate_key", "keycode": "E" },
+    { "act": "wait_frames", "frames": 2 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nvar want = BoardState.get_default_facing_for_player(1) + PI/2.0\nreturn abs(dc.ghost_sprite.get_base_rotation() - want) < 0.02", "equals": true },
+    { "act": "screenshot", "label": "02_model0_rotated_90" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nvar z = BoardState.get_deployment_zone_for_player(1)\nvar c = Vector2.ZERO\nfor p in z:\n\tc += p\nc /= float(z.size())\ndc.try_place_at(c + Vector2(-90, 0))\nreturn dc.temp_positions[0] != null", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nvar want = BoardState.get_default_facing_for_player(1) + PI/2.0\nreturn abs(dc.temp_rotations[0] - want) < 0.02", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nif dc.ghost_sprite == null:\n\treturn \"NO_GHOST\"\nvar ghost_rot = dc.ghost_sprite.get_base_rotation()\nvar carried = abs(ghost_rot - dc.temp_rotations[0]) < 0.001\nvar not_default = abs(ghost_rot - BoardState.get_default_facing_for_player(1)) > 0.1\nreturn carried and not_default", "equals": true },
+    { "act": "screenshot", "label": "03_model1_ghost_carried_rotation" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nvar z = BoardState.get_deployment_zone_for_player(1)\nvar c = Vector2.ZERO\nfor p in z:\n\tc += p\nc /= float(z.size())\ndc.try_place_at(c)\nreturn dc.temp_positions[1] != null", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nreturn abs(dc.temp_rotations[1] - dc.temp_rotations[0]) < 0.001", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nif dc.ghost_sprite == null:\n\treturn \"NO_GHOST\"\nreturn abs(dc.ghost_sprite.get_base_rotation() - dc.temp_rotations[0]) < 0.001", "equals": true },
+    { "act": "screenshot", "label": "04_model2_ghost_still_carried" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nvar z = BoardState.get_deployment_zone_for_player(1)\nvar c = Vector2.ZERO\nfor p in z:\n\tc += p\nc /= float(z.size())\ndc.try_place_at(c + Vector2(90, 0))\nreturn dc.temp_positions[2] != null", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.root.get_node(\"Main\").deployment_controller\nreturn abs(dc.temp_rotations[2] - dc.temp_rotations[0]) < 0.001", "equals": true },
+    { "act": "screenshot", "label": "05_all_three_placed_rotated" }
+  ]
+}


### PR DESCRIPTION
## What & why

When deploying a multi-model unit, rotating a model now carries that rotation over to the **next** model in the same unit, instead of snapping back to the default enemy-facing. Rotate the first model 90° and place it, and every following model in that unit starts off already rotated the same amount — so you can lay out a whole squad facing a chosen direction without re-rotating each one.

Previously, `_update_ghost_for_next_model()` reset each new model's ghost to `get_default_facing_for_player(...)`, discarding whatever rotation the player had applied.

## Changes

- **`40k/scripts/DeploymentController.gd`**
  - Track the last-applied rotation in `_last_deploy_rotation` (`null` until the first model is placed; reset per unit in `begin_deploy()` / `reset_unit()`).
  - `try_place_at()` records the placed rotation as the carry-over value.
  - New helper `_initial_deploy_rotation_for()` returns the carried rotation, falling back to the default enemy-facing so the **first** model of each unit still auto-faces the opponent as before.
  - `_create_ghost()` and both branches of `_update_ghost_for_next_model()` now seed the ghost via that helper.
- **`40k/data/version_history.json`** — new entry, version bump `0.57.0 → 0.57.1`.
- **`40k/tests/scenarios/sp/deploy_rotation_carryover.json`** — new windowed regression scenario.

Formation (Spread/Tight) modes are unchanged — they already persist their own `formation_rotation`; the carry-over is wired only into single-model placement (the flow described in the request).

## Validation

Windowed scenario driven against the running UI (`deploy_rotation_carryover.json`): begins deploying a 3-model Custodian Guard, rotates model 0 by +90° using **six real `E` keypresses** (`rotate_right`), places it, then asserts the ghost for models 1 and 2 start at that same +90° (not the default facing).

- **30/30 steps pass, zero errors** in the debug log.
- Screenshots confirm the first model rotates 90° on keypress, the next model's ghost inherits it, and all three placed models face the same rotated direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YApoo3nLnw5qDqYWGZJphP

---
_Generated by [Claude Code](https://claude.ai/code/session_01YApoo3nLnw5qDqYWGZJphP)_