### PR TITLE
Deployment: show a transport's embarked units clearly (list + placement card)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.0",
+			"date": "2026-07-18",
+			"summary": "Transports now clearly show what is riding inside them during deployment. The deployment list gives each embarked unit its own indented line under the transport (no more overlapping, cut-off text), and that same 'Carrying:' breakdown now stays on screen while you position the transport — so you always know which units and how many models are onboard.",
+			"changes": [
+				"Deployment unit list: a transport lists every embarked unit on its own indented row (e.g. 'Mek (1 model)', 'Gretchin (11 models)') instead of one long overlapping line.",
+				"The transport's 'Carrying:' breakdown is now also shown on the unit card while you are placing the transport on the board — previously it disappeared once you started positioning it.",
+				"Each embarked unit shows its model count, so you can see exactly how many models are onboard.",
+				"Filtering the deployment list keeps a transport and its contents together, and searching an embarked unit's name still surfaces its transport."
+			]
+		},
+		{
 			"version": "0.57.0",
 			"date": "2026-07-18",
 			"summary": "The AI now plays the Lions of the Emperor detachment properly: it spaces its Custodes units 6\"+ apart to earn Against All Odds (+1 to Hit AND +1 to Wound while no friendly is within 6\"), values that buff in its shooting and charge maths, prefers solo charges over gang-ups, and makes smarter calls with From Golden Light, Gilded Champion and the Swift as the Eagle window.",

--- a/40k/scenes/Main.tscn
+++ b/40k/scenes/Main.tscn
@@ -116,6 +116,12 @@ layout_mode = 2
 text = "Models: 0/0"
 autowrap_mode = 3
 
+[node name="TransportContentsLabel" type="Label" parent="HUD_Right/VBoxContainer/UnitCard"]
+visible = false
+layout_mode = 2
+text = "Carrying:"
+autowrap_mode = 3
+
 [node name="ButtonContainer" type="HBoxContainer" parent="HUD_Right/VBoxContainer/UnitCard"]
 layout_mode = 2
 

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -35,6 +35,7 @@ var _stratagem_panel: AcceptDialog = null
 @onready var unit_name_label: Label = $HUD_Right/VBoxContainer/UnitCard/UnitNameLabel
 @onready var keywords_label: Label = $HUD_Right/VBoxContainer/UnitCard/KeywordsLabel
 @onready var models_label: Label = $HUD_Right/VBoxContainer/UnitCard/ModelsLabel
+@onready var transport_contents_label: Label = $HUD_Right/VBoxContainer/UnitCard/TransportContentsLabel
 @onready var undo_button: Button = $HUD_Right/VBoxContainer/UnitCard/ButtonContainer/UndoButton
 @onready var reset_button: Button = $HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ResetButton
 @onready var confirm_button: Button = $HUD_Right/VBoxContainer/UnitCard/ButtonContainer/ConfirmButton
@@ -3443,6 +3444,8 @@ func _apply_white_dwarf_theme() -> void:
 		_WhiteDwarfTheme.apply_to_label(keywords_label)
 	if models_label:
 		_WhiteDwarfTheme.apply_to_label(models_label)
+	if transport_contents_label:
+		_WhiteDwarfTheme.apply_to_label(transport_contents_label)
 
 	# Theme buttons in unit card — confirm is primary, others secondary
 	if undo_button:
@@ -6185,6 +6188,44 @@ func refresh_unit_list() -> void:
 	# T-104: re-apply the unit-list filter so user-typed text persists across refreshes.
 	_apply_unit_list_filter()
 
+func _get_transport_contents_lines(unit_data: Dictionary) -> Array:
+	# Returns one human-readable line per unit embarked in this transport, e.g.
+	# ["Ork Boyz (20 models)", "Warboss (1 model)"]. Empty array if the unit is
+	# not a transport or is carrying nothing. Shared by the deployment selection
+	# list and the placement card so both surfaces show identical contents.
+	var lines: Array = []
+	if not unit_data.has("transport_data"):
+		return lines
+	var embarked_ids = unit_data.get("transport_data", {}).get("embarked_units", [])
+	for emb_id in embarked_ids:
+		var emb_unit = GameState.get_unit(emb_id)
+		if emb_unit and not emb_unit.is_empty():
+			var emb_name = emb_unit.get("meta", {}).get("name", emb_id)
+			var emb_models = emb_unit.get("models", []).size()
+			var noun = "model" if emb_models == 1 else "models"
+			lines.append("%s (%d %s)" % [emb_name, emb_models, noun])
+	return lines
+
+func _append_transport_content_rows(unit_data: Dictionary, transport_id: String) -> void:
+	# Adds indented, non-selectable ItemList rows under a transport row listing
+	# each embarked unit. Sub-rows are tagged with metadata so the filter can
+	# keep them grouped with their transport. Called only during deployment.
+	var carrying_lines = _get_transport_contents_lines(unit_data)
+	var header_idx = unit_list.get_item_count()
+	if carrying_lines.size() > 0:
+		unit_list.add_item("      ⤷ Carrying:")
+	else:
+		unit_list.add_item("      ⤷ Carrying: (empty)")
+	unit_list.set_item_disabled(header_idx, true)
+	unit_list.set_item_selectable(header_idx, false)
+	unit_list.set_item_metadata(header_idx, {"_subrow": true, "parent_transport": transport_id})
+	for line in carrying_lines:
+		unit_list.add_item("          • " + line)
+		var sub_idx = unit_list.get_item_count() - 1
+		unit_list.set_item_disabled(sub_idx, true)
+		unit_list.set_item_selectable(sub_idx, false)
+		unit_list.set_item_metadata(sub_idx, {"_subrow": true, "parent_transport": transport_id})
+
 func _refresh_unit_list_inner() -> void:
 	# Update the new bottom panel unit lists (always visible for comparison)
 	if unit_stats_panel and unit_stats_panel.has_method("populate_unit_lists"):
@@ -6252,26 +6293,21 @@ func _refresh_unit_list_inner() -> void:
 								model_count += char_unit["models"].size()
 						if char_names.size() > 0:
 							attach_info = " + " + ", ".join(char_names)
-					# Show embarked unit names for transport vehicles
-					var transport_contents = ""
-					if unit_data.has("transport_data"):
-						var embarked_ids = unit_data.transport_data.get("embarked_units", [])
-						if embarked_ids.size() > 0:
-							var embarked_names = []
-							for emb_id in embarked_ids:
-								var emb_unit = GameState.get_unit(emb_id)
-								if emb_unit and not emb_unit.is_empty():
-									embarked_names.append(emb_unit.get("meta", {}).get("name", emb_id))
-							if embarked_names.size() > 0:
-								transport_contents = " [Contains: %s]" % ", ".join(embarked_names)
-						else:
-							transport_contents = " [Empty]"
-					var display_text = "%s (%d models)%s%s%s" % [unit_name, model_count, attach_info, transport_contents, ability_tag]
+					# Main selectable row: unit name, model count, attachments, tag.
+					var display_text = "%s (%d models)%s%s" % [unit_name, model_count, attach_info, ability_tag]
 					unit_list.add_item(display_text)
 					var idx = unit_list.get_item_count() - 1
 					unit_list.set_item_metadata(idx, unit_id)
 					unit_list.set_item_icon(idx, _get_status_dot(Color(0.3, 0.85, 0.3)))
 					unit_list.set_item_icon_modulate(idx, Color.WHITE)
+
+					# For transports, add one indented, non-selectable sub-row per
+					# embarked unit. ItemList can't render multi-line items (it
+					# strips newlines and truncates), so each embarked unit gets its
+					# own short row — nothing overlaps and the player sees exactly
+					# what is riding inside, even before placing it.
+					if unit_data.has("transport_data"):
+						_append_transport_content_rows(unit_data, unit_id)
 
 				# Reserves are declared during Formations phase, not Deployment.
 				# Hide the reserves button during deployment.
@@ -7113,6 +7149,12 @@ func _on_unit_selected(index: int) -> void:
 
 	var unit_id = unit_list.get_item_metadata(index)
 
+	# Defensive: transport "Carrying" sub-rows are disabled/non-selectable and
+	# carry a dict metadata, so they should never reach here — but if one does,
+	# ignore it rather than treating the dict as a unit id.
+	if not (unit_id is String) or unit_id == "":
+		return
+
 	# Show detailed stats in bottom panel
 	var unit_data = GameState.get_unit(unit_id)
 	print("Main: Unit selected - ", unit_id)
@@ -7340,7 +7382,21 @@ func show_unit_card(unit_id: String) -> void:
 	var unit_data = GameState.get_unit(unit_id)
 	unit_name_label.text = unit_data["meta"]["name"]
 	keywords_label.text = "Keywords: " + ", ".join(unit_data["meta"]["keywords"])
-	
+
+	# Show what a transport is carrying while it is being placed, matching the
+	# selection list. The label autowraps, so each embarked unit stays readable
+	# and the card simply grows taller as needed.
+	if transport_contents_label:
+		if unit_data.has("transport_data"):
+			var carrying_lines = _get_transport_contents_lines(unit_data)
+			if carrying_lines.size() > 0:
+				transport_contents_label.text = "Carrying:\n  • " + "\n  • ".join(carrying_lines)
+			else:
+				transport_contents_label.text = "Carrying: (empty)"
+			transport_contents_label.visible = true
+		else:
+			transport_contents_label.visible = false
+
 	unit_card.visible = true
 	update_unit_card_buttons()
 
@@ -13583,14 +13639,38 @@ func _apply_unit_list_filter() -> void:
 		return
 	if _unit_list_filter_text == "":
 		return
-	var i = unit_list.get_item_count() - 1
-	while i >= 0:
-		var t: String = str(unit_list.get_item_text(i)).to_lower()
-		# Preserve disabled section headers ("---") so structure stays readable.
-		var is_section_header: bool = t.begins_with("---")
-		if not is_section_header and t.find(_unit_list_filter_text) == -1:
-			unit_list.remove_item(i)
-		i -= 1
+	# Group-aware filtering: a transport row and its indented "Carrying" sub-rows
+	# form one group (sub-rows are tagged with metadata {_subrow:true}). A group
+	# is kept if ANY row in it matches, so filtering by an embarked unit's name
+	# keeps its transport, and filtering by the transport keeps its contents.
+	# Rows in other phases have no sub-rows, so each is its own group — identical
+	# to the previous per-row behavior.
+	var count = unit_list.get_item_count()
+	var to_remove: Array = []
+	var i = 0
+	while i < count:
+		# A group spans this primary row plus any following sub-rows.
+		var group_end = i + 1
+		while group_end < count and _is_subrow_item(group_end):
+			group_end += 1
+		var group_matches = false
+		for k in range(i, group_end):
+			var t: String = str(unit_list.get_item_text(k)).to_lower()
+			# Preserve disabled section headers ("---") so structure stays readable.
+			if t.begins_with("---") or t.find(_unit_list_filter_text) != -1:
+				group_matches = true
+				break
+		if not group_matches:
+			for k in range(i, group_end):
+				to_remove.append(k)
+		i = group_end
+	# Remove from the back so earlier indices stay valid.
+	for idx in range(to_remove.size() - 1, -1, -1):
+		unit_list.remove_item(to_remove[idx])
+
+func _is_subrow_item(index: int) -> bool:
+	var md = unit_list.get_item_metadata(index)
+	return md is Dictionary and md.get("_subrow", false)
 
 
 # ============================================================================

--- a/40k/tests/scenarios/sp/transport_deploy_shows_embarked_units.json
+++ b/40k/tests/scenarios/sp/transport_deploy_shows_embarked_units.json
@@ -1,0 +1,39 @@
+{
+  "id": "transport_deploy_shows_embarked_units",
+  "covers": [
+    "ui.deployment.transport_contents_visible_in_list",
+    "ui.deployment.transport_contents_visible_on_placement_card",
+    "Main.refresh_unit_list.transport_subrows",
+    "Main.show_unit_card.transport_contents_label"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "disable_ai": true,
+  "description": "A transport carrying units must make its contents clear during deployment — both in the undeployed unit list and while the transport is being positioned. The audit_374_kunnin fixture has a Battlewagon (U_BATTLEWAGON_G) carrying Kommandos (U_KOMMANDOS_H, 10 models). Godot's ItemList cannot render multi-line items (it strips newlines and truncates long lines, which caused the original overlapping/cut-off text), so each embarked unit is shown as its own indented, non-selectable sub-row under the transport. This scenario returns the Battlewagon to the undeployed deployment list for its owner, refreshes, and asserts (1) the list shows a 'Carrying:' header sub-row plus a 'Kommandos (10 models)' sub-row under the Battlewagon, and (2) selecting the Battlewagon shows the same 'Carrying:' breakdown on the placement unit card (which previously showed nothing).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_current_scene()\nvar bw = GameState.state.units[\"U_BATTLEWAGON_G\"]\nvar owner = int(bw.get(\"owner\", 2))\nGameState.state.units[\"U_BATTLEWAGON_G\"][\"status\"] = GameStateData.UnitStatus.UNDEPLOYED\nGameState.set_active_player(owner)\nmain.current_phase = GameStateData.Phase.DEPLOYMENT\nmain.refresh_unit_list()\nvar il = main.unit_list\nvar bw_idx = -1\nfor i in range(il.get_item_count()):\n\tvar md = il.get_item_metadata(i)\n\tif md is String and md == \"U_BATTLEWAGON_G\":\n\t\tbw_idx = i\n\t\tbreak\nif bw_idx == -1:\n\treturn \"FAIL: battlewagon not in undeployed list\"\nvar saw_carrying = false\nvar saw_kommandos = false\nfor i in range(bw_idx + 1, il.get_item_count()):\n\tvar md = il.get_item_metadata(i)\n\tif not (md is Dictionary and md.get(\"_subrow\", false)):\n\t\tbreak\n\tvar t = str(il.get_item_text(i))\n\tif t.find(\"Carrying\") != -1:\n\t\tsaw_carrying = true\n\tif t.find(\"Kommandos\") != -1 and t.find(\"10\") != -1:\n\t\tsaw_kommandos = true\nif saw_carrying and saw_kommandos:\n\treturn \"PASS_LIST\"\nreturn \"FAIL: carrying=%s kommandos=%s\" % [str(saw_carrying), str(saw_kommandos)]",
+      "equals": "PASS_LIST"
+    },
+    { "act": "screenshot", "label": "01_deployment_list_carrying_subrows" },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_current_scene()\nmain.show_unit_card(\"U_BATTLEWAGON_G\")\nvar lbl = main.transport_contents_label\nif lbl == null:\n\treturn \"FAIL: no transport_contents_label node\"\nif not lbl.visible:\n\treturn \"FAIL: label not visible for transport\"\nvar t = str(lbl.text)\nif t.find(\"Carrying\") != -1 and t.find(\"Kommandos\") != -1 and t.find(\"10\") != -1:\n\treturn \"PASS_CARD\"\nreturn \"FAIL: card text=\" + t",
+      "equals": "PASS_CARD"
+    },
+    { "act": "screenshot", "label": "02_placement_card_carrying" },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_current_scene()\nmain.show_unit_card(\"U_KOMMANDOS_H\")\nreturn main.transport_contents_label.visible",
+      "equals": false
+    }
+  ]
+}


### PR DESCRIPTION
## Problem

When deploying a transport that carries units, the player couldn't tell what was inside:

- On the **selection list**, a transport's contents were crammed onto one row as `[Contains: …]`, which **overlapped / got cut off**.
- On the **placement card** (while positioning the transport), the contents were shown **nowhere at all**.

Root cause of the overlap, reproduced empirically: **Godot 4.4's `ItemList` cannot render multi-line items** — it strips embedded newlines, truncates long lines, and `fixed_column_width` produces overlapping columns.

## Changes

- **Deployment unit list**: each embarked unit now gets its own indented, non-selectable sub-row under the transport — e.g. `Carrying:` then `• Kommandos (10 models)`. Nothing overlaps and every embarked unit + model count is visible. Uses more vertical space, and the list scrolls as before.
- **Placement unit card**: a new `TransportContentsLabel` shows the same `Carrying:` breakdown while the transport is being placed, so the contents no longer disappear once you start positioning it.
- **Unit-list filter** is now group-aware: a transport and its `Carrying` sub-rows are kept/removed together, and searching an embarked unit's name surfaces its transport. Non-deployment phases have no sub-rows, so filtering there is unchanged.
- Shared helper `_get_transport_contents_lines()` feeds both surfaces so they stay consistent.

## Validation

Ran the real windowed UI (not headless-only) and drove the deployment flow via the MCP bridge:

- Confirmed both surfaces render the contents cleanly with no overlap; debug log had **0 errors / 0 warnings**.
- Added windowed scenario `transport_deploy_shows_embarked_units.json` — **passes 6/6** (asserts the list sub-rows, the placement-card label, and that a non-transport hides the label).
- Regression: `deploy_confirm_button_clickable`, `blade_champion_in_zone_deploy`, `deploy_formation_ghost_sprite` all still pass.

Player-facing change → bumped version to **0.58.0** in `version_history.json`.

## Files

- `40k/scripts/Main.gd` — sub-rows, placement-card label, shared helper, group-aware filter
- `40k/scenes/Main.tscn` — `TransportContentsLabel` node
- `40k/data/version_history.json` — 0.58.0 entry
- `40k/tests/scenarios/sp/transport_deploy_shows_embarked_units.json` — new windowed scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANDVzQ2dDKSXBjNpAp9PKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANDVzQ2dDKSXBjNpAp9PKS)_