### PR TITLE
Fix Warbikers Drive-by Dakka ability description text

### DIFF
--- a/40k/armies/Orks_2000.json
+++ b/40k/armies/Orks_2000.json
@@ -3263,7 +3263,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -3480,7 +3480,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [

--- a/40k/armies/Orks_2000_upload.json
+++ b/40k/armies/Orks_2000_upload.json
@@ -2975,7 +2975,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -3192,7 +3192,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [

--- a/40k/armies/Orks_Upload_Mar7.json
+++ b/40k/armies/Orks_Upload_Mar7.json
@@ -2975,7 +2975,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -3192,7 +3192,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [

--- a/40k/armies/battlewagons.json
+++ b/40k/armies/battlewagons.json
@@ -3690,7 +3690,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -3823,7 +3823,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [

--- a/40k/armies/recon_stomps.json
+++ b/40k/armies/recon_stomps.json
@@ -1289,7 +1289,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -1456,7 +1456,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -1623,7 +1623,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [
@@ -1835,7 +1835,7 @@
      {
       "name": "Drive-by Dakka",
       "type": "Datasheet",
-      "description": "During the Shooting phase against A targets, subtract 1 from the unit's Armour Penetration characteristic."
+      "description": "During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic."
      }
     ],
     "unit_composition": [

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.1",
+			"date": "2026-07-18",
+			"summary": "Fixed the Warbikers' Drive-by Dakka ability text. It previously read 'against A targets' — a garbled data string that made the rule unreadable — and now correctly states that the Armour Penetration bonus applies against targets within 9\", matching how the ability already works in-game.",
+			"changes": [
+				"Warbikers 'Drive-by Dakka' now reads: 'During the Shooting phase against targets within 9\", subtract 1 from the unit's Armour Penetration characteristic.' (previously the nonsensical 'against A targets').",
+				"Text-only correction across the bundled Ork army lists — the underlying rule (improve this unit's AP by 1 against targets within 9\" while shooting) was already implemented correctly and is unchanged."
+			]
+		},
+		{
 			"version": "0.58.0",
 			"date": "2026-07-18",
 			"summary": "Transports now clearly show what is riding inside them during deployment. The deployment list gives each embarked unit its own indented line under the transport (no more overlapping, cut-off text), and that same 'Carrying:' breakdown now stays on screen while you position the transport — so you always know which units and how many models are onboard.",


### PR DESCRIPTION
## Ask
The Warbikers datasheet ability **Drive-by Dakka** read _"During the Shooting phase against **A targets**, subtract 1 from the unit's Armour Penetration characteristic."_ — the "A targets" is meaningless and confused players about when the ability applies.

## Root cause
"A targets" is a garbled data-generation artifact: a bogus `target-has-keyword: "A"` condition rendered into the human-readable description string. There is no "A" keyword in Warhammer 40k. The real trigger is a **9″ range**, which is already captured correctly in the data (`abilities.json` `scope.range: "aura-9"`) and, crucially, in the **actual game logic** — `RulesEngine.get_drive_by_dakka_ap_bonus()` / `is_target_within_range_inches(…, 9.0)` improve AP by 1 against targets within 9″. So the rule already worked; only the displayed text was wrong.

## Change
Corrected the description string to:
> _"During the Shooting phase against targets within 9″, subtract 1 from the unit's Armour Penetration characteristic."_

- 12 Warbikers unit instances across 5 bundled Ork army lists (`Orks_2000`, `Orks_2000_upload`, `Orks_Upload_Mar7`, `battlewagons`, `recon_stomps`).
- Matches the existing house style for inches in these files (`within 6\"`, `within 12\"`).
- Prepended a `version_history.json` entry (0.57.1) per the changelog rule.
- **Text-only** — no rule/logic change.

## Validation
Ran the game windowed (llvmpipe) and drove the real player path via the MCP bridge:
- The real army loader yields the corrected string for `U_WARBIKERS_A` (no "A targets").
- Both `UnitStatsPanel` and the datasheet card popup render the corrected text (`has_garble_text: false`); screenshot confirms the Warbikers card showing _"…against targets within 9″…"_.
- `read_debug_log`: **0 errors, 0 warnings** while exercising the path.
- All 6 modified JSON files parse cleanly.

## Flags / follow-up
The same `against A targets` garble affects **other abilities** (e.g. _Dat's Our Loot!_) and there are ~50 `keyword: "A"` conditions in `40k/data/40kdc/abilities.json` — a **systemic generation bug**. This PR deliberately leaves those untouched: each ability's correct condition needs separate validation, and only Drive-by Dakka's 9″ rule was verified here. Worth a dedicated follow-up (ideally fixing the export/generation tooling at the source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjLhHaATPX5FCELBrLr4BH

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjLhHaATPX5FCELBrLr4BH)_