### PR TITLE
Movement: rename 'Confirm Move' button to 'End This Unit's Move'

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.2",
+			"date": "2026-07-18",
+			"summary": "Renamed the Movement phase's red 'Confirm Move' button to 'End This Unit's Move' so it is no longer confused with the 'Confirm Movement Mode' button. Previously players could pick Advance and click the red button expecting to start moving, but it just ended the unit's move.",
+			"changes": [
+				"Movement phase: the red 'Confirm Move' button is now labelled 'End This Unit's Move' — it finalises the unit's movement for the phase, distinct from the 'Confirm Movement Mode' button that starts an Advance / Remain Stationary.",
+				"Added a tooltip to the button explaining it should be used only after moving the models, and that it is not the same as 'Confirm Movement Mode'."
+			]
+		},
+		{
 			"version": "0.58.1",
 			"date": "2026-07-18",
 			"summary": "Fixed the Warbikers' Drive-by Dakka ability text. It previously read 'against A targets' — a garbled data string that made the rule unreadable — and now correctly states that the Armour Penetration bonus applies against targets within 9\", matching how the ability already works in-game.",

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -684,7 +684,12 @@ func _create_section4_actions(parent: VBoxContainer) -> void:
 	button_container.add_child(reset_button)
 
 	var confirm_button = Button.new()
-	confirm_button.text = "Confirm Move"
+	# "End This Unit's Move" (not "Confirm Move") so it is not confused with the
+	# "Confirm Movement Mode" button above: this button FINALISES the unit's move
+	# for the phase, it does NOT lock in the chosen mode. Players were clicking it
+	# right after picking Advance and ending the move without actually advancing.
+	confirm_button.text = "End This Unit's Move"
+	confirm_button.tooltip_text = "Finish and lock in this unit's movement for the phase. Do this AFTER you have moved the models. (This is not the same as 'Confirm Movement Mode', which starts an Advance / Remain Stationary.)"
 	confirm_button.pressed.connect(_on_confirm_move_pressed)
 	_WhiteDwarfTheme.apply_primary_button(confirm_button)
 	button_container.add_child(confirm_button)

--- a/40k/tests/scenarios/sp/pad_m1_cursor_basics.json
+++ b/40k/tests/scenarios/sp/pad_m1_cursor_basics.json
@@ -30,7 +30,7 @@
     { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves.size()", "expect_min": 1 },
     { "act": "screenshot", "label": "03_model_dragged" },
 
-    { "act": "pad_cursor_glide", "button_text": "Confirm Move" },
+    { "act": "pad_cursor_glide", "button_text": "End This Unit's Move" },
     { "act": "simulate_joy_button", "button_index": 0 },
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "execute_script", "script": "abs(GameState.state.units.U_BLADE_CHAMPION_A.models[0].position.y - 220.0)", "expect_max": 15 },

--- a/40k/tests/scenarios/sp/pad_m1_full_turn_cursor.json
+++ b/40k/tests/scenarios/sp/pad_m1_full_turn_cursor.json
@@ -39,7 +39,7 @@
     { "act": "pad_cursor_glide", "x": 120.0, "y": 220.0 },
     { "act": "simulate_joy_button", "button_index": 0, "state": "release" },
     { "act": "wait_seconds", "seconds": 0.4 },
-    { "act": "pad_cursor_glide", "button_text": "Confirm Move" },
+    { "act": "pad_cursor_glide", "button_text": "End This Unit's Move" },
     { "act": "wait_seconds", "seconds": 0.2 },
     { "act": "simulate_joy_button", "button_index": 0 },
     { "act": "wait_seconds", "seconds": 0.5 },

--- a/40k/tests/scenarios/sp/pad_m3_carry_move.json
+++ b/40k/tests/scenarios/sp/pad_m3_carry_move.json
@@ -182,7 +182,7 @@
     },
     {
       "act": "pad_cursor_glide",
-      "button_text": "Confirm Move"
+      "button_text": "End This Unit's Move"
     },
     {
       "act": "simulate_joy_button",


### PR DESCRIPTION
## Summary

The red **Confirm Move** button in the Movement phase was easily confused with the **Confirm Movement Mode** button directly above it. Players could pick *Advance* and then click *Confirm Move* expecting to start moving — but that button *finalises (ends)* the unit's move for the phase rather than locking in the chosen mode, so the unit never actually advanced.

This renames the button to **End This Unit's Move** (Title Case, matching the sibling *Undo Model* / *Reset Unit* buttons) and adds a clarifying tooltip so the two controls read as clearly different actions:

- **Confirm Movement Mode** (dark button, MOVEMENT MODE section) — starts an Advance / Remain Stationary.
- **End This Unit's Move** (red button, MOVEMENT ACTIONS section) — finishes and locks in the unit's move for the phase.

## Changes

- `40k/scripts/MovementController.gd` — button text `Confirm Move` → `End This Unit's Move`, plus a tooltip explaining it finalises the move and is distinct from *Confirm Movement Mode*.
- `40k/tests/scenarios/sp/{pad_m1_cursor_basics,pad_m1_full_turn_cursor,pad_m3_carry_move}.json` — updated the three pad-cursor movement scenarios that click this button by its exact text.
- `40k/data/version_history.json` — prepended a `0.57.1` entry.

Behaviour is unchanged — this is a label/tooltip change only. The separate `Confirm Move` buttons in the Scout phase, Fight dialogs, and reserve deployment are untouched (different buttons).

## Validation

Ran the `pad_m1_cursor_basics` windowed scenario against the running UI: it glides to and clicks the button by its new exact text, drags a model, and asserts the move confirmed — **24/24 steps passed, zero errors** in the debug log. A screenshot confirmed the new label renders and all three action buttons still fit on one row without overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XajNhoQmtMCskJakUKVAwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XajNhoQmtMCskJakUKVAwy)_