### PR TITLE
Fix W-key collision: unbind Weapon Range Comparison panel by default

### DIFF
--- a/40k/autoloads/KeybindingManager.gd
+++ b/40k/autoloads/KeybindingManager.gd
@@ -94,7 +94,11 @@ func _register_defaults() -> void:
 	# Default C, not T: T is the measuring tape. Chat is networked-only, so it
 	# yields the more-used key to the tape (which the player expects on T).
 	_register("toggle_chat_panel", "Toggle Chat Panel", CATEGORY_PANELS, KEY_C)
-	_register("weapon_range_panel", "Toggle Weapon Range Panel", CATEGORY_PANELS, KEY_W)
+	# Weapon Range Comparison panel: intentionally UNBOUND by default. It used to
+	# default to W, which is ALSO camera_pan_up — so pressing W to pan the camera up
+	# also toggled this panel unintentionally. No key is bound out of the box now;
+	# players can assign one in Settings › Keybindings if they want it on a hotkey.
+	_register("weapon_range_panel", "Toggle Weapon Range Panel", CATEGORY_PANELS, KEY_NONE)
 	_register("datasheet_modal", "Open Unit Datasheet", CATEGORY_PANELS, KEY_I)
 	_register("toggle_roster_strip", "Toggle Roster Strip", CATEGORY_PANELS, KEY_B)
 	_register("toggle_mathhammer", "Toggle Mathhammer", CATEGORY_PANELS, KEY_H)
@@ -151,6 +155,11 @@ func matches_action(event: InputEventKey, action_id: String) -> bool:
 	if not bindings.has(action_id):
 		return false
 	var b = bindings[action_id]
+	# An unbound action (no primary key AND no alt key) never matches any event.
+	# Guards against edge-case keycode-0 events (e.g. some IME/dead-key presses)
+	# accidentally triggering a deliberately-unbound action like weapon_range_panel.
+	if b.key == 0 and b.get("alt_key", 0) == 0:
+		return false
 	# Check modifier requirements (strict: modifier state must match exactly)
 	if b.shift != event.shift_pressed:
 		return false
@@ -172,6 +181,9 @@ func is_action_pressed(action_id: String) -> bool:
 	if not bindings.has(action_id):
 		return false
 	var b = bindings[action_id]
+	# An unbound action (no primary key AND no alt key) is never "pressed".
+	if b.key == 0 and b.get("alt_key", 0) == 0:
+		return false
 	# For held-key checks, verify modifiers if required
 	if b.shift and not Input.is_key_pressed(KEY_SHIFT):
 		return false
@@ -358,6 +370,18 @@ func load_bindings() -> void:
 			bindings[action_id].ctrl = cfg.get_value(action_id, "ctrl", bindings[action_id].default_ctrl)
 			bindings[action_id].alt = cfg.get_value(action_id, "alt", bindings[action_id].default_alt)
 			bindings[action_id].meta = cfg.get_value(action_id, "meta", bindings[action_id].get("default_meta", false))
+	# Migration (2026-07-18): weapon_range_panel used to default to W, colliding
+	# with camera_pan_up (also W) — pressing W to pan the camera up also toggled the
+	# Weapon Range Comparison panel. The panel is now UNBOUND by default. Clear any
+	# saved plain-W binding so the collision doesn't survive in existing config files.
+	# (A deliberate plain-W here would only recreate the collision; players who want
+	# the panel on a key can rebind it in Settings.)
+	if bindings.has("weapon_range_panel"):
+		var _wrp = bindings["weapon_range_panel"]
+		if _wrp.key == KEY_W and not _wrp.shift and not _wrp.ctrl and not _wrp.alt and not _wrp.get("meta", false):
+			_wrp.key = _wrp.default_key
+			_wrp.alt_key = _wrp.default_alt_key
+			print("[KeybindingManager] Migrated stale weapon_range_panel=W binding to unbound (new default)")
 	print("[KeybindingManager] Loaded keybindings from %s" % SAVE_PATH)
 
 # ============================================================================

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.57.1",
+			"date": "2026-07-18",
+			"summary": "Pressing W to pan the camera up no longer also opens the Weapon Range Comparison panel. That panel is now unbound by default — assign it a key in Settings › Keybindings if you want it on a hotkey.",
+			"changes": [
+				"Fixed the W-key collision: W now only pans the camera up. The Weapon Range Comparison panel used to share the W default and would toggle open every time you moved the view up.",
+				"The Weapon Range Comparison panel has no key bound by default. You can bind one yourself under Settings › Keybindings (it shows as 'None' until you do).",
+				"Existing configs that still had the old W binding for the panel are migrated to unbound automatically on load."
+			]
+		},
+		{
 			"version": "0.57.0",
 			"date": "2026-07-18",
 			"summary": "The AI now plays the Lions of the Emperor detachment properly: it spaces its Custodes units 6\"+ apart to earn Against All Odds (+1 to Hit AND +1 to Wound while no friendly is within 6\"), values that buff in its shooting and charge maths, prefers solo charges over gang-ups, and makes smarter calls with From Golden Light, Gilded Champion and the Swift as the Eagle window.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -12151,7 +12151,14 @@ func _toggle_weapon_range_comparison_panel() -> void:
 			hb.add_child(own_l)
 			list.add_child(hb)
 	var hint := Label.new()
-	hint.text = "Press W to close"
+	# The panel is toggled by whatever key is bound to weapon_range_panel (unbound
+	# by default — assign one in Settings). Reflect the live binding instead of a
+	# hardcoded "W", which no longer opens/closes this panel.
+	var _wrp_key := KeybindingManager.get_primary_key_display("weapon_range_panel") if KeybindingManager else "W"
+	if _wrp_key == "None" or _wrp_key == "":
+		hint.text = "Bind a key in Settings › Keybindings to toggle this panel"
+	else:
+		hint.text = "Press %s to close" % _wrp_key
 	hint.add_theme_font_size_override("font_size", 11)
 	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	hint.modulate = Color(1, 1, 1, 0.6)

--- a/40k/tests/scenarios/sp/weapon_range_panel_w_unbound.json
+++ b/40k/tests/scenarios/sp/weapon_range_panel_w_unbound.json
@@ -1,0 +1,55 @@
+{
+  "id": "weapon_range_panel_w_unbound",
+  "covers": ["keybindings.weapon_range_panel_unbound", "hud.weapon_range_panel"],
+  "fixture": "co_pretrigger",
+  "transition_to_phase": 7,
+  "description": "Pressing W (camera Pan Up) must NOT open the Weapon Range Comparison panel. The weapon_range_panel action is unbound by default (shows as 'None'); camera_pan_up still owns W. Positive control at the end proves the panel itself still works when its toggle is invoked directly, so only the keybinding was removed — not the feature.",
+
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script",
+      "script": "KeybindingManager.get_key_display_name(\"weapon_range_panel\")",
+      "equals": "None" },
+    { "act": "execute_script",
+      "script": "KeybindingManager.get_binding(\"weapon_range_panel\").key",
+      "equals": 0 },
+    { "act": "execute_script",
+      "script": "KeybindingManager.get_primary_key_display(\"camera_pan_up\")",
+      "equals": "W" },
+
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"WeaponRangePanel\") == null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main._weapon_range_panel == null",
+      "equals": true },
+
+    { "act": "screenshot", "label": "01_before_W_press" },
+
+    { "act": "simulate_key", "keycode": "W" },
+    { "act": "wait_frames", "frames": 5 },
+
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"WeaponRangePanel\") == null",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main._weapon_range_panel == null",
+      "equals": true },
+
+    { "act": "screenshot", "label": "02_after_W_press_no_panel" },
+
+    { "act": "execute_script", "script": "main._toggle_weapon_range_comparison_panel()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"WeaponRangePanel\") != null",
+      "equals": true },
+    { "act": "screenshot", "label": "03_panel_opens_when_invoked_directly" },
+
+    { "act": "execute_script", "script": "main._toggle_weapon_range_comparison_panel()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script",
+      "script": "main.get_node_or_null(\"WeaponRangePanel\") == null",
+      "equals": true }
+  ]
+}

--- a/40k/tests/test_weapon_range_panel_unbound.gd
+++ b/40k/tests/test_weapon_range_panel_unbound.gd
@@ -1,0 +1,71 @@
+extends SceneTree
+
+# Headless verification for the weapon_range_panel keybinding fix.
+# Run: godot --headless --path 40k --script tests/test_weapon_range_panel_unbound.gd
+#
+# Verifies:
+#   1. weapon_range_panel is UNBOUND by default (key == 0, alt_key == 0).
+#   2. camera_pan_up still owns W (unchanged).
+#   3. matches_action() returns false for a plain W press on weapon_range_panel,
+#      true for camera_pan_up.
+#   4. matches_action() returns false even for an edge-case keycode-0 event.
+#   5. The load-time migration clears a stale saved weapon_range_panel=W binding.
+
+var _failures := 0
+
+func _check(label: String, cond: bool) -> void:
+	if cond:
+		print("  PASS: %s" % label)
+	else:
+		print("  FAIL: %s" % label)
+		_failures += 1
+
+func _make_key_event(keycode: int) -> InputEventKey:
+	var e := InputEventKey.new()
+	e.keycode = keycode
+	e.pressed = true
+	return e
+
+func _init() -> void:
+	var KBM = load("res://autoloads/KeybindingManager.gd").new()
+	KBM._register_defaults()  # defaults only; do not touch the on-disk config
+
+	print("== weapon_range_panel keybinding fix ==")
+
+	# 1. Unbound by default
+	var wrp = KBM.get_binding("weapon_range_panel")
+	_check("weapon_range_panel exists", wrp.size() > 0)
+	_check("weapon_range_panel primary key is 0 (unbound)", wrp.get("key", -1) == 0)
+	_check("weapon_range_panel alt_key is 0 (unbound)", wrp.get("alt_key", -1) == 0)
+	_check("weapon_range_panel default_key is 0", wrp.get("default_key", -1) == 0)
+	_check("weapon_range_panel displays as 'None'", KBM.get_key_display_name("weapon_range_panel") == "None")
+	_check("weapon_range_panel is NOT modified vs default", not KBM.is_modified("weapon_range_panel"))
+
+	# 2. camera_pan_up unchanged (W primary, Up arrow alt)
+	var cpu = KBM.get_binding("camera_pan_up")
+	_check("camera_pan_up primary key is W", cpu.get("key", -1) == KEY_W)
+	_check("camera_pan_up alt key is Up", cpu.get("alt_key", -1) == KEY_UP)
+
+	# 3. Pressing W matches camera_pan_up but NOT weapon_range_panel
+	var w_event = _make_key_event(KEY_W)
+	_check("W matches camera_pan_up", KBM.matches_action(w_event, "camera_pan_up"))
+	_check("W does NOT match weapon_range_panel", not KBM.matches_action(w_event, "weapon_range_panel"))
+
+	# 4. Edge-case: a keycode-0 event must not trigger the unbound action
+	var zero_event = _make_key_event(0)
+	_check("keycode-0 event does NOT match weapon_range_panel", not KBM.matches_action(zero_event, "weapon_range_panel"))
+
+	# 5. Migration: simulate a stale saved binding of plain W, then re-run the
+	#    migration branch by mutating in place the way load_bindings() would.
+	KBM.bindings["weapon_range_panel"].key = KEY_W
+	KBM.bindings["weapon_range_panel"].alt_key = 0
+	# Reproduce the migration block from load_bindings():
+	var _wrp = KBM.bindings["weapon_range_panel"]
+	if _wrp.key == KEY_W and not _wrp.shift and not _wrp.ctrl and not _wrp.alt and not _wrp.get("meta", false):
+		_wrp.key = _wrp.default_key
+		_wrp.alt_key = _wrp.default_alt_key
+	_check("migration clears stale W back to unbound", KBM.bindings["weapon_range_panel"].key == 0)
+	_check("W still matches camera_pan_up after migration", KBM.matches_action(w_event, "camera_pan_up"))
+
+	print("== %s (%d failure(s)) ==" % ["OK" if _failures == 0 else "FAILURES", _failures])
+	quit(1 if _failures > 0 else 0)


### PR DESCRIPTION
## Problem

The **W** key defaulted to two actions at once in `KeybindingManager`:

- `camera_pan_up` (Pan Up) → `KEY_W`
- `weapon_range_panel` (Toggle Weapon Range Comparison panel) → `KEY_W`

So pressing **W** to pan the camera up also toggled the Weapon Range Comparison window open/closed. By default no key should open that window.

## Fix

Make the Weapon Range Comparison panel **unbound by default** so no key opens it out of the box — **W now only pans the camera**. The panel is still fully functional and rebindable: players can assign a key in Settings › Keybindings (it shows as "None" until they do).

### Changes
- **KeybindingManager**: default `weapon_range_panel` to `KEY_NONE` (was `KEY_W`).
- Guard `matches_action` / `is_action_pressed` so an unbound action (no primary **and** no alt key) never matches — protects against edge-case keycode-0 events.
- **Migration**: clear a saved plain-`W` binding for `weapon_range_panel` on load, so the collision doesn't survive in existing config files. Any non-W custom binding is preserved.
- Panel close-hint now reflects the live binding instead of a hardcoded "W".
- Version bumped to `0.57.1`.

## Validation
- **Headless logic test** (`test_weapon_range_panel_unbound.gd`) — 13/13: default unbound, `W` matches camera pan *not* the panel, migration clears stale `W`.
- **Windowed scenario** (`weapon_range_panel_w_unbound.json`) — 19/19: a real `simulate_key "W"` through `Main._input` does **not** open the panel; the panel still opens when its toggle is invoked directly (feature intact). Screenshots confirm both states.
- No script errors in the debug log.
- Regression: existing `keybindings_menu` scenario 67/0 and `shooting_phase_shortcuts` 50/0 still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNTNkYdeDMdzt6G9dJdth8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNTNkYdeDMdzt6G9dJdth8)_