### PR TITLE
Add phase-start autosave named "&lt;army1&gt; vs &lt;army2&gt; - &lt;phase&gt;"

### DIFF
--- a/40k/autoloads/SaveLoadManager.gd
+++ b/40k/autoloads/SaveLoadManager.gd
@@ -48,11 +48,23 @@ var max_backups: int = 5
 var autosave_on_round_end: bool = true      # Save when a battle round completes
 var autosave_on_phase_transition: bool = false  # Save at every phase transition (off by default to avoid spam)
 
+# Phase-start named autosave (default ON). At the start of each phase the
+# controlling player creates/overwrites a save named "<army1> vs <army2> - <phase>".
+# Unlike autosave_on_phase_transition (rotating timestamped files, off by default,
+# desktop-only), this routes through save_game() so it ALSO works on the web /
+# itch.io build via CloudStorage, and uses a stable human-readable name that
+# overwrites in place instead of accumulating files.
+var autosave_on_phase_start: bool = true
+
 var autosave_timer: Timer = null
 var last_save_path: String = ""
 var _last_autosave_phase: int = -1  # Track last phase to avoid duplicate saves
 var _autosave_deferred_event: String = ""  # SAVE-6: Deferred autosave event tag when AI was thinking
 var _autosave_deferred_metadata: Dictionary = {}  # SAVE-6: Deferred autosave metadata
+# Remember the metadata of an in-flight cloud upload keyed by save_name, so the
+# async completion (_on_cloud_save_uploaded) can emit the REAL metadata (e.g. the
+# autosave flag) instead of a freshly-defaulted "manual" one.
+var _pending_cloud_metadata: Dictionary = {}
 
 func _ready() -> void:
 	is_web_platform = OS.has_feature("web")
@@ -120,6 +132,7 @@ func _connect_phase_signals() -> void:
 	if phase_manager:
 		phase_manager.phase_completed.connect(_on_phase_completed_autosave)
 		phase_manager.phase_changed.connect(_on_phase_changed_autosave)
+		phase_manager.phase_changed.connect(_on_phase_changed_named_autosave)
 		print("SaveLoadManager: Connected to PhaseManager for event-driven autosave")
 	else:
 		print("SaveLoadManager: PhaseManager not found, event-driven autosave disabled")
@@ -229,6 +242,90 @@ func _on_phase_changed_autosave(new_phase: int) -> void:
 
 	print("SaveLoadManager: Phase transition to %s — performing phase autosave" % phase_name)
 	_perform_event_autosave(event_tag, event_meta)
+
+# Phase-start named autosave: at the start of each phase, the controlling player
+# creates/overwrites a save named "<army1> vs <army2> - <phase>". On by default.
+# Routes through save_game() so it works on desktop AND the web / itch.io build
+# (CloudStorage). Distinct from _on_phase_changed_autosave (the rotating,
+# timestamped, off-by-default power-user autosave).
+func _on_phase_changed_named_autosave(new_phase: int) -> void:
+	if not autosave_on_phase_start:
+		return
+
+	# Don't fire under the headless unit-test / GUT harness — those transition
+	# phases with partial fixtures and must not write save files. The windowed
+	# scenario runner (--scenario-file=) is intentionally NOT excluded; exercising
+	# this player-facing behaviour is the whole point of a windowed scenario.
+	if _is_unit_test_harness():
+		return
+
+	# Only save at the start of the phases a player recognises on the phase bar.
+	var target_phases = [
+		GameStateData.Phase.DEPLOYMENT,
+		GameStateData.Phase.COMMAND,
+		GameStateData.Phase.MOVEMENT,
+		GameStateData.Phase.SHOOTING,
+		GameStateData.Phase.CHARGE,
+		GameStateData.Phase.FIGHT,
+		GameStateData.Phase.SCORING,
+	]
+	if new_phase not in target_phases:
+		return
+
+	# "By the controlling player": in a networked game only the client whose turn
+	# it is performs the save, so we don't double-write to the cloud or produce
+	# conflicting saves. Single-player is never networked, so it always saves.
+	if NetworkManager and NetworkManager.is_networked() and not NetworkManager.is_local_player_turn():
+		print("SaveLoadManager: phase-start autosave skipped — not the local player's turn")
+		return
+
+	var save_name = _phase_start_save_name(new_phase)
+	var metadata = {
+		"type": "autosave",
+		"auto_generated": true,
+		"trigger": "phase_start",
+		"phase": _phase_display_name(new_phase),
+		"active_player": GameState.get_active_player(),
+		"battle_round": GameState.get_battle_round()
+	}
+	print("SaveLoadManager: phase-start autosave → '%s'" % save_name)
+	var ok = save_game(save_name, metadata)
+	if ok:
+		# Report via the subtle "Game autosaved" toast (same channel as other
+		# autosaves). On desktop save_game() completed synchronously; on web it was
+		# queued and is very likely to succeed. The prominent "Game saved!" banner
+		# is suppressed for autosaves by Main._on_save_completed.
+		var display_path = ("cloud://" + _sanitize_filename(save_name)) if is_web_platform else (save_directory + _sanitize_filename(save_name) + SAVE_EXTENSION)
+		emit_signal("autosave_completed", display_path)
+
+# Build the "<army1> vs <army2> - <phase>" name for the phase-start autosave.
+func _phase_start_save_name(phase: int) -> String:
+	var army1 = GameState.get_faction_name(1)
+	var army2 = GameState.get_faction_name(2)
+	return "%s vs %s - %s" % [army1, army2, _phase_display_name(phase)]
+
+# Human-readable, Title-Cased phase name ("MOVEMENT" -> "Movement",
+# "FIRST_TURN_ROLLOFF" -> "First Turn Rolloff").
+func _phase_display_name(phase: int) -> String:
+	if phase < 0 or phase >= GameStateData.Phase.size():
+		return "Phase"
+	var raw = GameStateData.Phase.keys()[phase]
+	var words = []
+	for part in raw.split("_", false):
+		if part.is_empty():
+			continue
+		words.append(part.substr(0, 1).to_upper() + part.substr(1).to_lower())
+	return " ".join(words)
+
+# True only under the headless GUT / `-s` script suites (NOT the windowed
+# scenario runner, which uses --scenario-file=).
+func _is_unit_test_harness() -> bool:
+	for a in OS.get_cmdline_args() + OS.get_cmdline_user_args():
+		if typeof(a) != TYPE_STRING:
+			continue
+		if a == "-s" or a == "--script" or a.find("gut_cmdln") != -1:
+			return true
+	return false
 
 # P3-112: Perform an event-driven autosave with a descriptive filename
 func _perform_event_autosave(event_tag: String, event_metadata: Dictionary) -> bool:
@@ -554,6 +651,8 @@ func _save_game_to_cloud(save_name: String, metadata: Dictionary) -> void:
 	# Upload to cloud
 	emit_signal("operation_progress", "saving", "Uploading to cloud...")
 	if CloudStorage:
+		# Remember the real metadata so the async completion can emit it verbatim.
+		_pending_cloud_metadata[save_name] = save_metadata
 		CloudStorage.put_save(save_name, save_metadata, serialized_data)
 		# Completion handled by _on_cloud_save_uploaded signal
 	else:
@@ -580,7 +679,13 @@ func _load_game_from_cloud(save_name: String, owner_id: String = "") -> void:
 func _on_cloud_save_uploaded(save_name: String) -> void:
 	print("SaveLoadManager: [CLOUD] Save uploaded successfully: ", save_name)
 	last_save_path = "cloud://" + save_name
-	var save_metadata = _create_save_metadata({})
+	# Prefer the metadata we captured when the upload was queued (carries the
+	# autosave flag, phase, etc.); fall back to a fresh default only if missing.
+	var save_metadata = _pending_cloud_metadata.get(save_name, {})
+	if save_metadata.is_empty():
+		save_metadata = _create_save_metadata({})
+	else:
+		_pending_cloud_metadata.erase(save_name)
 	emit_signal("save_completed", last_save_path, save_metadata)
 
 func _on_cloud_save_downloaded(save_name: String, metadata: Dictionary, game_data: String) -> void:
@@ -758,6 +863,10 @@ func set_autosave_on_round_end(enabled: bool) -> void:
 func set_autosave_on_phase_transition(enabled: bool) -> void:
 	autosave_on_phase_transition = enabled
 	print("SaveLoadManager: autosave_on_phase_transition = %s" % str(enabled))
+
+func set_autosave_on_phase_start(enabled: bool) -> void:
+	autosave_on_phase_start = enabled
+	print("SaveLoadManager: autosave_on_phase_start = %s" % str(enabled))
 
 # Save file management
 func get_save_files() -> Array:

--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -31,6 +31,11 @@ var save_measurements: bool = false  # Whether to persist measurement lines in s
 var autosave_on_round_end: bool = true      # Auto-save when a battle round completes
 var autosave_on_phase_transition: bool = false  # Auto-save at every phase transition
 
+# Phase-start named autosave — creates/overwrites a save named
+# "<army1> vs <army2> - <phase>" at the start of each phase. On by default;
+# players can turn it off from Settings → Gameplay. Works on web/itch.io.
+var autosave_on_phase_start: bool = true
+
 # P3-111: Audio settings
 var master_volume: float = 1.0   # 0.0 to 1.0
 var music_volume: float = 0.7    # 0.0 to 1.0
@@ -193,6 +198,7 @@ func _ready() -> void:
 	if SaveLoadManager:
 		SaveLoadManager.set_autosave_on_round_end(autosave_on_round_end)
 		SaveLoadManager.set_autosave_on_phase_transition(autosave_on_phase_transition)
+		SaveLoadManager.set_autosave_on_phase_start(autosave_on_phase_start)
 
 	print("[SettingsService] Ready — ui_scale=%.2f, animation_speed=%.2f, colorblind=%s" % [ui_scale, animation_speed, colorblind_mode])
 
@@ -334,6 +340,13 @@ func set_autosave_on_phase_transition(enabled: bool) -> void:
 	_save_settings()
 	print("[SettingsService] autosave_on_phase_transition set to %s" % str(enabled))
 
+func set_autosave_on_phase_start(enabled: bool) -> void:
+	autosave_on_phase_start = enabled
+	if SaveLoadManager:
+		SaveLoadManager.set_autosave_on_phase_start(enabled)
+	_save_settings()
+	print("[SettingsService] autosave_on_phase_start set to %s" % str(enabled))
+
 func set_show_unit_labels(visible: bool) -> void:
 	show_unit_labels = visible
 	unit_labels_visibility_changed.emit(show_unit_labels)
@@ -440,6 +453,7 @@ func _save_settings() -> void:
 	config.set_value("save_load", "save_measurements", save_measurements)
 	config.set_value("save_load", "autosave_on_round_end", autosave_on_round_end)
 	config.set_value("save_load", "autosave_on_phase_transition", autosave_on_phase_transition)
+	config.set_value("save_load", "autosave_on_phase_start", autosave_on_phase_start)
 
 	# Gameplay
 	config.set_value("gameplay", "auto_allocate_wounds", auto_allocate_wounds)
@@ -487,6 +501,7 @@ func _load_settings() -> void:
 	save_measurements = config.get_value("save_load", "save_measurements", false)
 	autosave_on_round_end = config.get_value("save_load", "autosave_on_round_end", true)
 	autosave_on_phase_transition = config.get_value("save_load", "autosave_on_phase_transition", false)
+	autosave_on_phase_start = config.get_value("save_load", "autosave_on_phase_start", true)
 
 	# Gameplay
 	# Defender-control migration: configs written BEFORE the interactive

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.0",
+			"date": "2026-07-18",
+			"summary": "The game now auto-saves at the start of every phase, so you can always pick a battle back up where you left it — even in the browser build on itch.io. Each auto-save is named after the two armies and the phase that is starting (e.g. \"Space Marines vs Orks - Movement\"), and overwrites the previous one for that phase instead of piling up. It's on by default and can be turned off under Settings > Gameplay > Auto-Save.",
+			"changes": [
+				"New auto-save: at the start of each phase (Deployment, Command, Movement, Shooting, Charge, Fight, Scoring) the game saves automatically, named \"<first army> vs <second army> - <phase>\".",
+				"On by default; turn it off any time via Settings > Gameplay > \"Auto-save at the start of each phase\".",
+				"Works on the browser / itch.io build too — these auto-saves go to your cloud saves just like a manual save (previous phase-based auto-saves only worked on the desktop build).",
+				"In online/LAN games only the player whose turn it is writes the auto-save, so the two players don't clash or double-save.",
+				"Auto-saves show a small \"Game autosaved\" toast instead of the big \"Game saved!\" banner, so the browser build isn't interrupted every phase."
+			]
+		},
+		{
 			"version": "0.57.0",
 			"date": "2026-07-18",
 			"summary": "The AI now plays the Lions of the Emperor detachment properly: it spaces its Custodes units 6\"+ apart to earn Against All Odds (+1 to Hit AND +1 to Wound while no friendly is within 6\"), values that buff in its shooting and charge maths, prefers solo charges over gang-ups, and makes smarter calls with From Golden Light, Gilded Champion and the Swift as the Eagle window.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -8728,6 +8728,13 @@ func _on_save_completed(file_path: String, metadata: Dictionary) -> void:
 	print("Save completed: %s" % file_path)
 	# SAVE-20: Dismiss progress indicator on save completion
 	_dismiss_save_load_progress()
+	# Auto-generated saves (e.g. the phase-start autosave) report via the subtle
+	# "Game autosaved" toast (the autosave_completed signal); don't ALSO flash the
+	# prominent "Game saved!" status banner, which on the itch.io web build would
+	# otherwise fire at the start of every phase.
+	var is_autosave = metadata.get("save_info", {}).get("save_type", "") == "autosave" or metadata.get("auto_generated", false)
+	if is_autosave:
+		return
 	if OS.has_feature("web"):
 		_show_save_notification("Game saved!", Color.GREEN)
 

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -35,6 +35,7 @@ var _terrain_debug_checkbox: CheckBox
 var _terrain_scatter_checkbox: CheckBox
 
 var _auto_allocate_checkbox: CheckBox
+var _autosave_phase_start_checkbox: CheckBox
 
 var _close_button: Button
 var _return_to_menu_button: Button
@@ -189,6 +190,16 @@ func _build_ui() -> void:
 	auto_alloc_help.add_theme_font_size_override("font_size", 12)
 	auto_alloc_help.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
 	gameplay_content.add_child(auto_alloc_help)
+
+	_add_section_header(gameplay_content, "Auto-Save")
+	_autosave_phase_start_checkbox = _add_checkbox_row(gameplay_content, "Auto-save at the start of each phase", "_on_autosave_phase_start_toggled")
+	var autosave_help = Label.new()
+	autosave_help.text = "On by default. Saves the game automatically at the start of every phase, named after the two armies and the phase that is starting (e.g. \"Space Marines vs Orks - Movement\"). Works in the browser build on itch.io too."
+	autosave_help.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	autosave_help.custom_minimum_size = Vector2(620, 0)
+	autosave_help.add_theme_font_size_override("font_size", 12)
+	autosave_help.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
+	gameplay_content.add_child(autosave_help)
 
 	# ── Controls Tab ──
 	var controls_scroll = _create_tab_scroll()
@@ -540,6 +551,8 @@ func _load_current_settings() -> void:
 	# Gameplay
 	if _auto_allocate_checkbox:
 		_auto_allocate_checkbox.button_pressed = SettingsService.auto_allocate_wounds
+	if _autosave_phase_start_checkbox:
+		_autosave_phase_start_checkbox.button_pressed = SettingsService.autosave_on_phase_start
 
 	# Controls
 	if _menu_scroll_speed_slider:
@@ -644,6 +657,9 @@ func _on_terrain_scatter_toggled(pressed: bool) -> void:
 
 func _on_auto_allocate_wounds_toggled(pressed: bool) -> void:
 	SettingsService.set_auto_allocate_wounds(pressed)
+
+func _on_autosave_phase_start_toggled(pressed: bool) -> void:
+	SettingsService.set_autosave_on_phase_start(pressed)
 
 # ============================================================================
 # Button Callbacks

--- a/40k/tests/scenarios/sp/auto_save_phase_start.json
+++ b/40k/tests/scenarios/sp/auto_save_phase_start.json
@@ -1,0 +1,33 @@
+{
+  "id": "auto_save_phase_start",
+  "covers": [
+    "save.autosave_on_phase_start",
+    "SaveLoadManager._on_phase_changed_named_autosave",
+    "SettingsService.set_autosave_on_phase_start"
+  ],
+  "fixture": "audit_382_cp_grant",
+  "transition_to_phase": 6,
+  "description": "Phase-start autosave: at the start of each phase the controlling player writes/overwrites a save named '<army1> vs <army2> - <phase>'. On by default with a Settings > Gameplay toggle. This drives real PhaseManager transitions (the same signal a player's End Phase triggers) and asserts the named save appears when ON, does NOT appear when the toggle is OFF, and reappears when turned back ON.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+
+    { "act": "execute_script", "multiline": true, "script": "DirAccess.remove_absolute(ProjectSettings.globalize_path(\"user://settings.cfg\"))\nSettingsService._load_settings()\nSaveLoadManager.set_autosave_on_phase_start(SettingsService.autosave_on_phase_start)\nreturn (SettingsService.autosave_on_phase_start and SaveLoadManager.autosave_on_phase_start)", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn true", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
+    { "act": "screenshot", "label": "01_movement_autosave_written" },
+
+    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(false)\nvar n = \"%s vs %s - Command\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(6)\nreturn SaveLoadManager.autosave_on_phase_start", "equals": false },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Command\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": false },
+    { "act": "screenshot", "label": "02_toggle_off_no_autosave" },
+
+    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(true)\nvar n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn true", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
+    { "act": "screenshot", "label": "03_reenabled_autosave_written" }
+  ]
+}


### PR DESCRIPTION
## Summary

At the start of each phase the controlling player now auto-saves the game, named after the two armies and the phase that is just starting (e.g. `Adeptus Custodes vs Orks - Movement`). The save overwrites the previous one for that phase instead of piling up files.

- **On by default**; players can turn it off from **Settings → Gameplay → Auto-Save → "Auto-save at the start of each phase"** (persisted to `settings.cfg`).
- **Works on the web / itch.io build**: routes through `SaveLoadManager.save_game()`, which branches to `CloudStorage` on web. The older phase-transition autosave wrote via `FileAccess` and never worked in the browser build.
- **Multiplayer-safe**: only the client whose turn it is writes the save (`NetworkManager.is_local_player_turn`), so the two peers don't clash or double-write to the cloud.
- Fires on the seven player-facing phases (Deployment, Command, Movement, Shooting, Charge, Fight, Scoring); **skipped under the headless GUT / `-s` unit-test harness** so it never pollutes those runs.
- Autosaves show the subtle "Game autosaved" toast; the prominent "Game saved!" web banner is suppressed for auto-generated saves so the browser build isn't interrupted every phase. As part of this, cloud-upload completion now emits the real save metadata (carrying the autosave flag) instead of a freshly-defaulted "manual" one.

## Files

- `40k/autoloads/SaveLoadManager.gd` — new `autosave_on_phase_start` flag, `phase_changed` handler, army/phase name builder, harness guard, cloud-metadata carry-through.
- `40k/autoloads/SettingsService.gd` — setting + setter + persistence + startup push.
- `40k/scripts/SettingsMenu.gd` — Gameplay-tab "Auto-Save" toggle.
- `40k/scripts/Main.gd` — suppress the "Game saved!" web banner for autosaves.
- `40k/data/version_history.json` — changelog bumped to 0.58.0.
- `40k/tests/scenarios/sp/auto_save_phase_start.json` — new windowed scenario.

## Validation

- **Windowed scenario** `sp/auto_save_phase_start.json`: 16/16 asserts pass — drives real `PhaseManager` transitions, proves the named save appears when ON, is absent when toggled OFF, and reappears when turned back ON.
- **Live game (xvfb)**: Settings → Gameplay checkbox renders checked by default; a real mouse click flipped the `SettingsService` + `SaveLoadManager` flags to `false` and persisted; restart confirmed the OFF choice survives boot; 0 errors/warnings in the debug log.
- **On disk**: `Adeptus Custodes vs Orks - Movement.w40ksave` created with metadata `save_type: autosave`, `trigger: phase_start`.
- **No regressions**: 8 diverse existing scenarios pass; the single failure (`383_battleshock`) was confirmed pre-existing on the clean baseline. `_is_unit_test_harness()` verified to return `true` under `-s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MNrJmAD4cQwKzjLYBubetv

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNrJmAD4cQwKzjLYBubetv)_