### PR TITLE
Hide terrain cover labels by default, add Settings > Visual toggle

### DIFF
--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -63,6 +63,12 @@ var terrain_debug_labels: bool = false
 # footprints, borders and walls, for a cleaner/less cluttered look.
 var show_terrain_scatter: bool = true
 
+# Terrain cover labels — the per-tile shield glyph chips (LB / +2 / +1) that
+# TerrainCoverOverlay draws at the centroid of every terrain piece. Defaults OFF
+# so the board is uncluttered; players who want the cover-type reference can turn
+# it on via Settings > Visual.
+var show_terrain_cover_labels: bool = false
+
 # Gameplay settings
 # When true, the computer automatically chooses which wounded/destroyed models
 # are removed during wound allocation instead of prompting the local player.
@@ -113,6 +119,7 @@ signal unit_style_changed(new_style: String)
 signal unit_color_display_changed(new_mode: String)
 signal terrain_debug_labels_changed(enabled: bool)
 signal terrain_scatter_changed(enabled: bool)
+signal terrain_cover_labels_changed(enabled: bool)
 
 # P3-111: Settings config file path
 const SETTINGS_FILE_PATH: String = "user://settings.cfg"
@@ -408,6 +415,12 @@ func set_show_terrain_scatter(enabled: bool) -> void:
 	_save_settings()
 	print("[SettingsService] show_terrain_scatter set to %s" % str(enabled))
 
+func set_show_terrain_cover_labels(enabled: bool) -> void:
+	show_terrain_cover_labels = enabled
+	terrain_cover_labels_changed.emit(show_terrain_cover_labels)
+	_save_settings()
+	print("[SettingsService] show_terrain_cover_labels set to %s" % str(enabled))
+
 # ============================================================================
 # P3-111: Settings Persistence
 # ============================================================================
@@ -431,6 +444,7 @@ func _save_settings() -> void:
 	config.set_value("visual", "show_unit_labels", show_unit_labels)
 	config.set_value("visual", "terrain_debug_labels", terrain_debug_labels)
 	config.set_value("visual", "show_terrain_scatter", show_terrain_scatter)
+	config.set_value("visual", "show_terrain_cover_labels", show_terrain_cover_labels)
 	config.set_value("visual", "board_style", board_style)
 	config.set_value("visual", "ruins_style", ruins_style)
 
@@ -478,6 +492,7 @@ func _load_settings() -> void:
 	show_unit_labels = config.get_value("visual", "show_unit_labels", true)
 	terrain_debug_labels = config.get_value("visual", "terrain_debug_labels", false)
 	show_terrain_scatter = config.get_value("visual", "show_terrain_scatter", true)
+	show_terrain_cover_labels = config.get_value("visual", "show_terrain_cover_labels", false)
 	board_style = config.get_value("visual", "board_style", "grass")
 	ruins_style = config.get_value("visual", "ruins_style", "concrete")
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.4",
+			"date": "2026-07-18",
+			"summary": "The little cover-type chips on terrain (LB / +2 / +1) are now hidden by default so the board is less cluttered. If you want them back, turn on Settings > Visual > 'Terrain Cover Labels'.",
+			"changes": [
+				"Terrain cover labels (the LB / +2 / +1 shield chips drawn on each terrain piece) are OFF by default.",
+				"Added a 'Terrain Cover Labels (LB / +2 / +1 chips on terrain)' checkbox to Settings > Visual to turn them on or off; the choice is saved and applies to the board immediately."
+			]
+		},
+		{
 			"version": "0.58.3",
 			"date": "2026-07-18",
 			"summary": "Disembark fixes: the 3\" set-up border now hugs the transport's actual hull — rotated with the vehicle, with rounded corners — and switching units mid-placement no longer leaves a ghost placement measuring distances from the wrong transport.",

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -33,6 +33,7 @@ var _board_style_dropdown: OptionButton
 var _ruins_style_dropdown: OptionButton
 var _terrain_debug_checkbox: CheckBox
 var _terrain_scatter_checkbox: CheckBox
+var _terrain_cover_checkbox: CheckBox
 
 var _auto_allocate_checkbox: CheckBox
 
@@ -172,6 +173,7 @@ func _build_ui() -> void:
 	_colorblind_dropdown = _add_dropdown_row(visual_content, "Colorblind Mode:", ["None", "Protanopia (Red-Green)", "Deuteranopia (Green-Red)", "Tritanopia (Blue-Yellow)"], "_on_colorblind_changed")
 	_terrain_debug_checkbox = _add_checkbox_row(visual_content, "Terrain Debug Labels (internal ids + LoS badges)", "_on_terrain_debug_labels_toggled")
 	_terrain_scatter_checkbox = _add_checkbox_row(visual_content, "Terrain Scatter Props (crates, sandbags, trees)", "_on_terrain_scatter_toggled")
+	_terrain_cover_checkbox = _add_checkbox_row(visual_content, "Terrain Cover Labels (LB / +2 / +1 chips on terrain)", "_on_terrain_cover_labels_toggled")
 
 	# ── Gameplay Tab ──
 	var gameplay_scroll = _create_tab_scroll()
@@ -536,6 +538,8 @@ func _load_current_settings() -> void:
 		_terrain_debug_checkbox.button_pressed = SettingsService.terrain_debug_labels
 	if _terrain_scatter_checkbox:
 		_terrain_scatter_checkbox.button_pressed = SettingsService.show_terrain_scatter
+	if _terrain_cover_checkbox:
+		_terrain_cover_checkbox.button_pressed = SettingsService.show_terrain_cover_labels
 
 	# Gameplay
 	if _auto_allocate_checkbox:
@@ -637,6 +641,9 @@ func _on_terrain_debug_labels_toggled(pressed: bool) -> void:
 
 func _on_terrain_scatter_toggled(pressed: bool) -> void:
 	SettingsService.set_show_terrain_scatter(pressed)
+
+func _on_terrain_cover_labels_toggled(pressed: bool) -> void:
+	SettingsService.set_show_terrain_cover_labels(pressed)
 
 # ============================================================================
 # Gameplay Callbacks

--- a/40k/scripts/TerrainCoverOverlay.gd
+++ b/40k/scripts/TerrainCoverOverlay.gd
@@ -27,6 +27,21 @@ func _ready() -> void:
 		if not tm.is_connected("terrain_loaded", _on_terrain_loaded):
 			tm.connect("terrain_loaded", _on_terrain_loaded)
 
+	# The cover glyph chips (LB / +2 / +1) are OFF by default — they add a lot of
+	# on-board clutter. A player opts in via Settings > Visual > "Terrain Cover
+	# Labels", which flips SettingsService.show_terrain_cover_labels and fires the
+	# signal below so the whole overlay shows/hides live without a board reload.
+	var ss = get_node_or_null("/root/SettingsService")
+	if ss != null:
+		visible = ss.show_terrain_cover_labels
+		if ss.has_signal("terrain_cover_labels_changed"):
+			if not ss.is_connected("terrain_cover_labels_changed", _on_cover_labels_changed):
+				ss.connect("terrain_cover_labels_changed", _on_cover_labels_changed)
+
+
+func _on_cover_labels_changed(enabled: bool) -> void:
+	visible = enabled
+
 
 func _on_terrain_loaded(_features: Array) -> void:
 	_rebuild_icons()

--- a/40k/tests/scenarios/visual/T07_terrain_cover_icons.json
+++ b/40k/tests/scenarios/visual/T07_terrain_cover_icons.json
@@ -1,9 +1,9 @@
 {
   "id": "T07_terrain_cover_icons",
-  "covers": ["design_guidelines.T07", "board.terrain.cover_icons"],
+  "covers": ["design_guidelines.T07", "board.terrain.cover_icons", "settings.show_terrain_cover_labels", "ui.settings_menu.visual"],
   "fixture": "co_pretrigger",
   "transition_to_phase": 6,
-  "description": "Per-tile cover icons rendered on top of every terrain piece. Each icon node named TerrainCoverIcon_<terrain_id> with a Label whose text matches the derived cover_type (+1 / +2 / LB). Asserts overlay node tree, at least one icon present, the label text matches, and the centroid position is within tolerance of the terrain piece's center. pixel_diff confirms the board region differs from a baseline where the overlay is hidden.",
+  "description": "Per-tile cover icons rendered on top of every terrain piece. Each icon node named TerrainCoverIcon_<terrain_id> with a Label whose text matches the derived cover_type (+1 / +2 / LB). The overlay is now OFF by default (uncluttered board) and is opt-in via Settings > Visual > 'Terrain Cover Labels' (SettingsService.show_terrain_cover_labels). Asserts: one icon per terrain feature is built, the first icon's Label is a valid cover glyph with the expected alpha and a centroid within tolerance of its feature, at least one 'LB' (line-block) chip is present, the overlay defaults hidden, enabling the setting shows it live and disabling hides it again. pixel_diff confirms the board region differs between the overlay-off and overlay-on captures.",
 
   "regions": {
     "board": [0, 0, 1920, 1080]
@@ -17,6 +17,14 @@
       "equals": true },
 
     { "act": "execute_script",
+      "script": "SettingsService.show_terrain_cover_labels",
+      "equals": false },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").visible",
+      "equals": false },
+
+    { "act": "execute_script",
       "script": "TerrainManager.terrain_features.size()",
       "expect_min": 1 },
 
@@ -24,31 +32,41 @@
       "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").get_child_count() == TerrainManager.terrain_features.size()",
       "equals": true },
 
-    { "act": "execute_script",
-      "script": "get_node_or_null(\"/root/Main/BoardRoot/TerrainCoverOverlay/TerrainCoverIcon_ruins_1\") != null",
+    { "act": "execute_script", "multiline": true,
+      "script": "var ov = node.get_node(\"Main/BoardRoot/TerrainCoverOverlay\")\nreturn ov.get_child(0).get_node(\"Label\").text in [\"LB\", \"+2\", \"+1\"]",
       "equals": true },
 
-    { "act": "execute_script",
-      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay/TerrainCoverIcon_ruins_1\").modulate.a",
+    { "act": "execute_script", "multiline": true,
+      "script": "var ov = node.get_node(\"Main/BoardRoot/TerrainCoverOverlay\")\nvar n = 0\nfor c in ov.get_children():\n\tvar l = c.get_node_or_null(\"Label\")\n\tif l != null and l.text == \"LB\":\n\t\tn += 1\nreturn n",
+      "expect_min": 1 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "return node.get_node(\"Main/BoardRoot/TerrainCoverOverlay\").get_child(0).modulate.a",
       "expect_min": 0.8 },
 
-    { "act": "execute_script",
-      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay/TerrainCoverIcon_ruins_1/Label\").text",
-      "equals": "LB" },
+    { "act": "execute_script", "multiline": true,
+      "script": "var icon = node.get_node(\"Main/BoardRoot/TerrainCoverOverlay\").get_child(0)\nreturn icon.position.distance_to(TerrainManager.terrain_features[0].position)",
+      "expect_max": 8.0 },
+
+    { "act": "screenshot", "label": "T07_overlay_off" },
 
     { "act": "execute_script",
-      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay/TerrainCoverIcon_ruins_1\").position.distance_to(TerrainManager.terrain_features[0].position)",
-      "expect_max": 8.0 },
+      "script": "SettingsService.set_show_terrain_cover_labels(true)" },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script",
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").visible",
+      "equals": true },
 
     { "act": "screenshot", "label": "T07_overlay_on" },
 
     { "act": "execute_script",
-      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").set(\"visible\", false)" },
-    { "act": "wait_frames", "frames": 4 },
-    { "act": "screenshot", "label": "T07_overlay_off" },
+      "script": "SettingsService.set_show_terrain_cover_labels(false)" },
+    { "act": "wait_frames", "frames": 6 },
 
     { "act": "execute_script",
-      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").set(\"visible\", true)" },
+      "script": "get_node(\"/root/Main/BoardRoot/TerrainCoverOverlay\").visible",
+      "equals": false },
 
     { "act": "pixel_diff",
       "before": "T07_overlay_off",


### PR DESCRIPTION
## Summary

The per-tile cover glyph chips (`LB` / `+2` / `+1`) that `TerrainCoverOverlay` draws on every terrain piece are now **OFF by default** so the board is less cluttered. Players can turn them back on via a new **"Terrain Cover Labels"** checkbox in **Settings → Visual**; the choice is saved and applies to the board immediately.

(`LB` = *line block* — obscuring/tall terrain that blocks line of sight; `+2` = heavy cover; `+1` = light cover.)

## Changes

- **`SettingsService`** — new persisted `show_terrain_cover_labels` (default `false`) with a setter + `terrain_cover_labels_changed` signal, stored under `[visual]` in `settings.cfg`.
- **`TerrainCoverOverlay`** — reads the setting on `_ready()` to set initial visibility and connects to the change signal, so the overlay shows/hides live without a board reload.
- **`SettingsMenu`** — new checkbox in the Visual tab wired to the setter, alongside the existing terrain debug/scatter toggles.
- **`T07` windowed scenario** — asserts default-hidden, live enable/disable via the setting, and the presence of an `LB` chip. Also made fixture-agnostic (drives the first built icon instead of a stale hardcoded terrain id that no longer existed in the fixture), so it now passes **20/0** instead of leaving 4 pre-existing failures.
- **`version_history.json`** — new `0.58.4` changelog entry.

## Validation

- T07 windowed scenario: **20 passed, 0 failed**. Proves default-hidden, live enable→visible / disable→hidden, an `LB` chip renders (36 present), and a pixel_diff confirms the board changes between off/on.
- Live-drove the real Settings UI via the in-game MCP bridge: opened Settings → Visual, confirmed the new checkbox renders unchecked by default, and that toggling it flips the setting ON→`true` / OFF→`false`. **0 errors** in the debug log.
- Verified the pre-existing 4 T07 failures were not caused by this change (ran the original code stashed — same 4 failures) before fixing them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGHc5x2gVod7Jp4EyNppHq