### PR TITLE
Fix disembark border rotation/size and stale placement controller

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -498,8 +498,18 @@ func _do_click_item_list(step: Dictionary) -> Dictionary:
 		var index: int = int(step.get("index", -1))
 		if index < 0 or index >= list.get_item_count():
 			return {"pass": false, "error": "item index %d out of range (count %d)" % [index, list.get_item_count()]}
-		# get_item_rect is in the list's local space with scroll applied.
+		# get_item_rect returns CONTENT-space coords: it does NOT subtract the
+		# list's scroll offset (verified on 4.4.1 — the rect is identical at
+		# scroll 0 and scroll 169). Projecting it naively lands the click below
+		# the control for any scrolled list (observed on the 16-row movement
+		# unit list: row 7 projected 191px under the visible rows, silently
+		# clicking the panel beneath). Subtract the v-scroll to get true local
+		# coords, and fail loudly when the row is not actually visible instead
+		# of mis-clicking whatever sits there.
 		local_pos = list.get_item_rect(index).get_center()
+		local_pos.y -= list.get_v_scroll_bar().value
+		if local_pos.y < 0.0 or local_pos.y > list.size.y:
+			return {"pass": false, "error": "item %d is outside the visible rows (local y %.1f, list height %.1f) — scroll the list into view first" % [index, local_pos.y, list.size.y]}
 
 	var screen_pos: Vector2 = list.get_global_transform() * local_pos
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.3",
+			"date": "2026-07-18",
+			"summary": "Disembark fixes: the 3\" set-up border now hugs the transport's actual hull — rotated with the vehicle, with rounded corners — and switching units mid-placement no longer leaves a ghost placement measuring distances from the wrong transport.",
+			"changes": [
+				"The disembark range border is drawn from the transport hull's real pose: it rotates with the vehicle instead of staying an axis-aligned rectangle that didn't line up with a turned tank.",
+				"The border's corners are now true 3\" arcs (rounded), so it no longer overstates the allowed area at the corners; every point of the line is exactly the set-up distance from the hull.",
+				"Oval-based transports draw the border at the correct size (it was previously half-size).",
+				"Selecting another unit while placing disembarking models cancels the old placement cleanly — previously the stale placement kept intercepting board clicks and showed 'Must be within 3\" of transport (X\" away)' errors measured from the previously selected battlewagon, while its border stayed on screen.",
+				"Only one disembark placement can ever be live at a time, and an open placement is cleaned up when the Movement phase ends."
+			]
+		},
+		{
 			"version": "0.58.2",
 			"date": "2026-07-18",
 			"summary": "Renamed the Movement phase's red 'Confirm Move' button to 'End This Unit's Move' so it is no longer confused with the 'Confirm Movement Mode' button. Previously players could pick Advance and click the red button expecting to start moving, but it just ended the unit's move.",

--- a/40k/scripts/DisembarkController.gd
+++ b/40k/scripts/DisembarkController.gd
@@ -18,7 +18,11 @@ var ghost_visuals: Array = []
 var placed_tokens: Array = []
 var current_model_idx: int = 0
 var transport_position: Vector2
+var transport_rotation: float = 0.0  # Hull facing — the range border must rotate with it
 var transport_base_shape: BaseShape = null  # Store the transport's base shape
+# Set when placement ends (completed or canceled) so a late cancel_placement()
+# from MovementController can't re-emit signals on a finished controller.
+var _finished: bool = false
 # 11e 18.04: the disembark mode drives the set-up distance (3"/6") and the
 # Combat-mode engaged-placement exception. combat_requested is set by the
 # dialog's Combat Disembark toggle (payload.can_setup_tactical=false).
@@ -50,9 +54,20 @@ func _ready() -> void:
 	range_indicator.name = "RangeIndicator"
 	add_child(range_indicator)
 
+	add_to_group("disembark_controllers")
 	print("DisembarkController initialized")
 
 func start_disembark(p_unit_id: String) -> void:
+	# Only one disembark placement may be live at a time, no matter which system
+	# spawned it (MovementController's dialog flow or MovementPhase's
+	# DISEMBARK_UNIT action path). A second live controller keeps validating
+	# board clicks against ITS transport — wrong-vehicle range errors — while
+	# its range border lingers on screen.
+	if is_inside_tree():
+		for other in get_tree().get_nodes_in_group("disembark_controllers"):
+			if other != self and is_instance_valid(other) and other.has_method("cancel_placement"):
+				other.cancel_placement()
+
 	unit_id = p_unit_id
 	unit_data = GameState.get_unit(unit_id)
 
@@ -79,6 +94,14 @@ func start_disembark(p_unit_id: String) -> void:
 	# Get transport base shape for range calculation
 	if transport_data.models.size() > 0:
 		transport_base_shape = Measurement.create_base_shape(transport_data.models[0])
+		# The set-up range is validated against models[0]'s actual pose
+		# (TransportManager.is_position_within_disembark_range), so the border
+		# must be drawn from that same position AND rotation — an unrotated
+		# border on a rotated hull doesn't match where placement is legal.
+		var transport_model = transport_data.models[0]
+		if transport_model.get("position") != null:
+			transport_position = Vector2(transport_model.position.x, transport_model.position.y)
+		transport_rotation = float(transport_model.get("rotation", 0.0))
 	else:
 		# Fallback to circular base
 		transport_base_shape = CircularBase.new(Measurement.base_radius_px(32))
@@ -159,17 +182,29 @@ func _draw_shape_based_range(range_visual: Node2D, range_px: float) -> void:
 
 	elif shape_type == "rectangular":
 		var rect_base = transport_base_shape as RectangularBase
-		# Create an expanded rectangle: original dimensions + 2 * range_px
-		var expanded_length = rect_base.length + (2 * range_px)
-		var expanded_width = rect_base.width + (2 * range_px)
-		_draw_rectangular_range(range_visual, expanded_length, expanded_width)
+		# Exact set-up boundary around a rectangular hull: edges pushed out by
+		# range_px joined by quarter-circle corners (a sharp expanded rectangle
+		# overstates the range at the corners), rotated to the hull's facing.
+		_draw_rounded_rect_range(range_visual, rect_base.length / 2.0, rect_base.width / 2.0, range_px)
 
 	elif shape_type == "oval":
 		var oval_base = transport_base_shape as OvalBase
-		# Create an expanded oval: original dimensions + 2 * range_px
-		var expanded_length = oval_base.length + (2 * range_px)
-		var expanded_width = oval_base.width + (2 * range_px)
-		_draw_oval_range(range_visual, expanded_length, expanded_width)
+		# OvalBase.length/width store SEMI-axes (its _init halves the incoming
+		# diameters). The old code treated them as diameters and halved again,
+		# drawing the border at half size. Draw the true offset curve instead.
+		_draw_oval_offset_range(range_visual, oval_base.length, oval_base.width, range_px)
+
+# Transform a point from the transport's local (hull-aligned) space to world.
+func _range_local_to_world(local_point: Vector2) -> Vector2:
+	return transport_position + local_point.rotated(transport_rotation)
+
+func _add_range_polyline(range_visual: Node2D, points: PackedVector2Array) -> void:
+	var line = Line2D.new()
+	line.points = points
+	line.default_color = RANGE_COLOR
+	line.width = 2.0
+	line.z_index = -1
+	range_visual.add_child(line)
 
 func _draw_circular_range(range_visual: Node2D, range_px: float) -> void:
 	# Fallback for when we don't have transport shape info
@@ -191,49 +226,45 @@ func _draw_circular_range_with_radius(range_visual: Node2D, radius: float) -> vo
 	line.z_index = -1
 	range_visual.add_child(line)
 
-func _draw_rectangular_range(range_visual: Node2D, length: float, width: float) -> void:
-	# Draw an expanded rectangle
-	var half_length = length / 2
-	var half_width = width / 2
-
-	var corners = [
-		Vector2(-half_length, -half_width),
-		Vector2(half_length, -half_width),
-		Vector2(half_length, half_width),
-		Vector2(-half_length, half_width),
-		Vector2(-half_length, -half_width)  # Close the shape
+func _draw_rounded_rect_range(range_visual: Node2D, half_length: float, half_width: float, range_px: float) -> void:
+	# Boundary of all points exactly range_px from the hull rectangle: four
+	# offset edges joined by quarter arcs centred on the hull corners. Built in
+	# hull-local space, then rotated/translated to the transport's pose so the
+	# border hugs the actual (possibly rotated) hull.
+	var points = PackedVector2Array()
+	var arc_segments = 12
+	# Walk the corners clockwise (local +X right, +Y down); each corner's arc
+	# sweeps 90 degrees starting where the previous offset edge ends.
+	var corner_arcs = [
+		{"center": Vector2(half_length, -half_width), "start_angle": -PI / 2.0},  # top-right
+		{"center": Vector2(half_length, half_width), "start_angle": 0.0},         # bottom-right
+		{"center": Vector2(-half_length, half_width), "start_angle": PI / 2.0},   # bottom-left
+		{"center": Vector2(-half_length, -half_width), "start_angle": PI},        # top-left
 	]
+	for arc in corner_arcs:
+		for i in range(arc_segments + 1):
+			var angle = arc.start_angle + (i / float(arc_segments)) * (PI / 2.0)
+			var local_point = arc.center + Vector2(cos(angle), sin(angle)) * range_px
+			points.append(_range_local_to_world(local_point))
+	points.append(points[0])  # close the outline (top offset edge)
+	_add_range_polyline(range_visual, points)
 
-	# Transform to world position
-	var world_points = PackedVector2Array()
-	for corner in corners:
-		world_points.append(transport_position + corner)
-
-	var line = Line2D.new()
-	line.points = world_points
-	line.default_color = RANGE_COLOR
-	line.width = 2.0
-	line.z_index = -1
-	range_visual.add_child(line)
-
-func _draw_oval_range(range_visual: Node2D, length: float, width: float) -> void:
-	# Draw an expanded oval using parametric equations
-	var oval_points = PackedVector2Array()
+func _draw_oval_offset_range(range_visual: Node2D, semi_length: float, semi_width: float, range_px: float) -> void:
+	# True offset curve of the ellipse: each edge sample pushed outward along
+	# the local normal by range_px. (Growing both semi-axes by range_px is NOT
+	# equidistant from an ellipse.) Built local, then rotated to the hull pose.
+	var points = PackedVector2Array()
 	var segments = 64
 
 	for i in range(segments + 1):
 		var t = (i / float(segments)) * TAU
-		var x = (length / 2.0) * cos(t)
-		var y = (width / 2.0) * sin(t)
-		var point = transport_position + Vector2(x, y)
-		oval_points.append(point)
+		var edge = Vector2(semi_length * cos(t), semi_width * sin(t))
+		var normal = Vector2(semi_width * cos(t), semi_length * sin(t))
+		if normal.length() > 0.001:
+			normal = normal.normalized()
+		points.append(_range_local_to_world(edge + normal * range_px))
 
-	var line = Line2D.new()
-	line.points = oval_points
-	line.default_color = RANGE_COLOR
-	line.width = 2.0
-	line.z_index = -1
-	range_visual.add_child(line)
+	_add_range_polyline(range_visual, points)
 
 func _create_ghost_for_model(idx: int) -> void:
 	# Find the actual model index (skip dead models)
@@ -499,6 +530,7 @@ func _complete_disembark() -> void:
 		return
 
 	# Just emit the completion signal - MovementPhase will handle offering movement
+	_finished = true
 	emit_signal("disembark_completed", unit_id, final_positions)
 	_cleanup()
 
@@ -545,7 +577,18 @@ func _get_placement_index(model_idx: int) -> int:
 			alive_count += 1
 	return -1
 
+## Public cancel used by MovementController when the player switches to another
+## unit (or leaves the phase) while this placement is still open. Without this,
+## a stale controller kept processing board clicks forever — validating them
+## against ITS transport and showing "Must be within 3\" of transport" errors
+## measured from the wrong vehicle, while its range border lingered on screen.
+func cancel_placement() -> void:
+	if _finished:
+		return
+	_cancel_disembark()
+
 func _cancel_disembark() -> void:
+	_finished = true
 	print("Disembark canceled for unit: ", unit_id)
 	emit_signal("disembark_canceled", unit_id)
 	_cleanup()

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -20,6 +20,12 @@ var active_unit_id: String = ""
 # 11e 18.04: unit_id -> bool, set when the DisembarkDialog's Combat
 # Disembark toggle was checked; consumed when CONFIRM_DISEMBARK is built.
 var _pending_combat_disembark: Dictionary = {}
+# The live DisembarkController placement (at most one). Selecting another unit
+# or starting a second disembark cancels the previous placement — a stale
+# controller kept processing board clicks against its OWN transport, spamming
+# "Must be within 3\" of transport" errors measured from the wrong vehicle
+# while its (unrotated) range border stayed on screen.
+var _active_disembark_controller: Node = null
 var active_mode: String = ""  # NORMAL, ADVANCE, FALL_BACK
 var move_cap_inches: float = 0.0
 var selected_model: Dictionary = {}
@@ -205,6 +211,10 @@ func _ready() -> void:
 	print("MovementController ready")
 
 func _exit_tree() -> void:
+	# A still-open disembark placement must not outlive the phase — cancel it so
+	# its input processing and range border don't leak into the next phase.
+	_cancel_active_disembark_placement()
+
 	# Clean up visuals that were added to BoardRoot
 	if path_visual and is_instance_valid(path_visual):
 		path_visual.queue_free()
@@ -988,6 +998,10 @@ func _on_unit_selected(index: int) -> void:
 	var unit = GameState.get_unit(unit_id)
 	if not unit:
 		return
+
+	# Any unit selection ends an in-progress disembark placement: the old
+	# controller must not keep validating board clicks against its transport.
+	_cancel_active_disembark_placement()
 
 	# QoL: switching to a different unit auto-confirms the previously selected
 	# unit's moved-but-unconfirmed move (same as clicking "Confirm Move"). Do this
@@ -2585,6 +2599,7 @@ func _handle_embarked_unit_selected(unit_id: String) -> void:
 	# Create and show disembark dialog
 	var dialog_script = load("res://scripts/DisembarkDialog.gd")
 	var dialog = dialog_script.new()
+	dialog.name = "DisembarkDialog"  # Stable path for tests/tooling (/root/DisembarkDialog)
 	dialog.setup(unit_id)
 	dialog.disembark_confirmed.connect(_on_disembark_confirmed.bind(unit_id))
 	dialog.disembark_canceled.connect(_on_disembark_canceled.bind(unit_id))
@@ -2595,6 +2610,11 @@ func _handle_embarked_unit_selected(unit_id: String) -> void:
 func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 	"""Handle disembark confirmation - start placement controller"""
 	print("MovementController: Starting disembark placement for unit %s (combat_mode=%s)" % [unit_id, str(combat_mode)])
+
+	# Belt-and-braces: never allow two live placement controllers. A leftover
+	# controller validates clicks against the WRONG transport (wrong-distance
+	# errors) and leaves its range border on the board.
+	_cancel_active_disembark_placement()
 
 	# Create disembark controller for model placement
 	var controller = preload("res://scripts/DisembarkController.gd").new()
@@ -2614,11 +2634,19 @@ func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 		get_tree().root.add_child(controller)
 
 	# Start disembark placement
+	_active_disembark_controller = controller
 	controller.start_disembark(unit_id)
+
+func _cancel_active_disembark_placement() -> void:
+	"""Cancel a still-open disembark placement (player switched units/phase)."""
+	if _active_disembark_controller and is_instance_valid(_active_disembark_controller):
+		_active_disembark_controller.cancel_placement()
+	_active_disembark_controller = null
 
 func _on_disembark_completed(unit_id: String, positions: Array) -> void:
 	"""Handle successful disembark - route through action system for multiplayer sync"""
 	print("MovementController: Disembark completed for unit %s with %d positions" % [unit_id, positions.size()])
+	_active_disembark_controller = null
 
 	# Serialize positions for action payload (Vector2 -> dict for network transport)
 	var serialized_positions = []
@@ -2680,6 +2708,7 @@ func _post_disembark_ui_update(unit_id: String) -> void:
 func _on_disembark_canceled(unit_id: String) -> void:
 	"""Handle canceled disembark"""
 	print("MovementController: Disembark canceled for unit %s" % unit_id)
+	_active_disembark_controller = null
 
 	# Clear selection
 	_clear_unit_highlight()

--- a/40k/tests/scenarios/sp/disembark_rotated_border_stale_controller.json
+++ b/40k/tests/scenarios/sp/disembark_rotated_border_stale_controller.json
@@ -1,0 +1,121 @@
+{
+  "id": "disembark_rotated_border_stale_controller",
+  "covers": [
+    "scripts.DisembarkController.rotated_range_border",
+    "scripts.MovementController.single_live_disembark_placement",
+    "autoloads.TransportManager"
+  ],
+  "fixture": "grenade_dupes",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Disembark UI fixes: (1) the 3\" set-up border must be drawn from the transport hull's ACTUAL pose - rotated with the hull, with rounded (Minkowski) corners - so every border point sits exactly 3\" from the hull edge; previously an axis-aligned sharp rectangle was drawn that ignored rotation and overstated the corners. (2) Selecting another unit while a disembark placement is open must CANCEL the old placement controller; previously the stale controller kept processing board clicks, validating them against ITS transport (wrong-vehicle 'X\" away' errors) while its border lingered. Flow: rotate Battlewagon A by 0.6 rad, start Kommandos disembark via real list click + dialog OK, assert the live border is an exact 3\" iso-distance contour of the rotated hull, then click Lootas Alpha (embarked in far-away Battlewagon B) and assert the Kommandos controller was canceled BEFORE the new dialog is even confirmed. Confirm, assert the single live controller targets Battlewagon B, then place all 10 Lootas with real board clicks and assert the unit fully disembarks.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "units.U_KOMMANDOS_A.embarked_in", "equals": "U_BATTLEWAGON_A" },
+    { "act": "expect_state", "path": "units.U_LOOTAS_A.embarked_in", "equals": "U_BATTLEWAGON_B" },
+    {
+      "act": "execute_script",
+      "script": "GameState.state.units[\"U_BATTLEWAGON_A\"].models[0][\"rotation\"] = 0.6\ntree.current_scene._recreate_unit_visuals()\nreturn GameState.state.units[\"U_BATTLEWAGON_A\"].models[0].rotation",
+      "multiline": true,
+      "equals": 0.6,
+      "comment": "Board setup: give Battlewagon A a rotated hull so the border fix is observable. The feature itself is driven through real UI clicks below."
+    },
+    {
+      "act": "execute_script",
+      "script": "var ul = tree.root.get_node(\"/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList\")\nvar sb = ul.get_v_scroll_bar()\nsb.value = 0.0\nvar rect7 = ul.get_item_rect(7)\nsb.value = clamp(rect7.position.y - 10.0, 0.0, sb.max_value)\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "Scroll the unit list so the embarked rows are on screen (click_item_list clicks the visible row rect; it does not auto-scroll)."
+    },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "click_item_list", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList", "index": 7 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"DisembarkDialog\")\nif d == null:\n\treturn \"NO DIALOG\"\nd.get_ok_button().emit_signal(\"pressed\")\nreturn \"ok\"",
+      "multiline": true,
+      "equals": "ok",
+      "comment": "Confirm the Kommandos disembark dialog (OK button has no stable NodePath inside ConfirmationDialog; emit pressed like other dialog scenarios)."
+    },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    {
+      "act": "execute_script",
+      "script": "var live = []\nfor c in tree.get_nodes_in_group(\"disembark_controllers\"):\n\tif is_instance_valid(c) and not c._finished:\n\t\tlive.append(c)\nif live.size() != 1:\n\treturn \"live=%d\" % live.size()\nvar c = live[0]\nif c.transport_id != \"U_BATTLEWAGON_A\":\n\treturn \"transport=%s\" % c.transport_id\nif absf(c.transport_rotation - 0.6) > 0.001:\n\treturn \"rot=%f\" % c.transport_rotation\nvar tm = c.transport_data.models[0]\nvar line = c.range_indicator.get_child(0).get_child(0)\nif line.points.size() < 40:\n\treturn \"points=%d\" % line.points.size()\nvar max_dev = 0.0\nfor p in line.points:\n\tvar dist = Measurement.model_edge_to_point_distance_px(tm, p)\n\tmax_dev = maxf(max_dev, absf(dist - Measurement.inches_to_px(3.0)))\nif max_dev > 1.5:\n\treturn \"max_dev=%f\" % max_dev\nreturn \"border-exact\"",
+      "multiline": true,
+      "equals": "border-exact",
+      "comment": "THE border assert: every drawn border point must sit exactly 3\" (120px) from the ROTATED hull edge (shape-aware distance). Old axis-aligned code fails this by up to ~50px at the corners and by far more once the hull is rotated."
+    },
+    {
+      "act": "execute_script",
+      "script": "var main = tree.current_scene\nmain.view_zoom = 1.2\nvar vps = main.get_viewport().get_visible_rect().size\nmain.view_offset = Vector2(892.5, 1877.5) - vps / (2.0 * main.view_zoom)\nmain.update_view_transform()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "Zoom the view onto rotated Battlewagon A so the screenshot actually shows the tilted border."
+    },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "01_rotated_border_battlewagon_a" },
+    { "act": "click_item_list", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList", "index": 8 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    {
+      "act": "execute_script",
+      "script": "var live = 0\nfor c in tree.get_nodes_in_group(\"disembark_controllers\"):\n\tif is_instance_valid(c) and not c._finished:\n\t\tlive += 1\nreturn live",
+      "multiline": true,
+      "equals": 0,
+      "comment": "Regression pin for the stale-controller bug: merely SELECTING another unit must cancel the open Kommandos placement - before the new dialog is even confirmed. Previously the old controller stayed live and kept erroring 'Must be within 3\" of transport (44\" away)' against clicks meant for the other battlewagon."
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"DisembarkDialog\")\nif d == null:\n\treturn \"NO DIALOG\"\nd.get_ok_button().emit_signal(\"pressed\")\nreturn \"ok\"",
+      "multiline": true,
+      "equals": "ok"
+    },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    {
+      "act": "execute_script",
+      "script": "var live = []\nfor c in tree.get_nodes_in_group(\"disembark_controllers\"):\n\tif is_instance_valid(c) and not c._finished:\n\t\tlive.append(c)\nif live.size() != 1:\n\treturn \"live=%d\" % live.size()\nreturn live[0].transport_id",
+      "multiline": true,
+      "equals": "U_BATTLEWAGON_B",
+      "comment": "Exactly one live placement, bound to Battlewagon B - the unit the player actually clicked."
+    },
+    {
+      "act": "execute_script",
+      "script": "var main = tree.current_scene\nmain.view_zoom = 0.3\nvar vps = main.get_viewport().get_visible_rect().size\nvar board_center = Vector2(SettingsService.get_board_width_px() / 2.0, SettingsService.get_board_height_px() / 2.0)\nmain.view_offset = board_center - vps / (2.0 * main.view_zoom)\nmain.update_view_transform()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "Reset to the fit view so the click_board_at projections land inside the window."
+    },
+    { "act": "screenshot", "label": "02_lootas_placement_started" },
+    { "act": "click_board_at", "x": 42.0, "y": 250.0 },
+    { "act": "click_board_at", "x": 97.0, "y": 250.0 },
+    { "act": "click_board_at", "x": 152.0, "y": 250.0 },
+    { "act": "click_board_at", "x": 207.0, "y": 250.0 },
+    { "act": "click_board_at", "x": 262.0, "y": 250.0 },
+    { "act": "click_board_at", "x": 42.0, "y": 310.0 },
+    { "act": "click_board_at", "x": 97.0, "y": 310.0 },
+    { "act": "click_board_at", "x": 152.0, "y": 310.0 },
+    { "act": "click_board_at", "x": 207.0, "y": 310.0 },
+    { "act": "click_board_at", "x": 262.0, "y": 310.0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "units.U_LOOTAS_A.embarked_in", "equals": null },
+    { "act": "expect_state", "path": "units.U_LOOTAS_A.disembarked_this_phase", "equals": true },
+    { "act": "expect_token_visible", "unit_id": "U_LOOTAS_A" },
+    {
+      "act": "execute_script",
+      "script": "var main = tree.current_scene\nmain.view_zoom = 1.2\nvar vps = main.get_viewport().get_visible_rect().size\nmain.view_offset = Vector2(152.6, 220.0) - vps / (2.0 * main.view_zoom)\nmain.update_view_transform()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "03_lootas_disembarked_near_battlewagon_b" },
+    {
+      "act": "execute_script",
+      "script": "var live = 0\nfor c in tree.get_nodes_in_group(\"disembark_controllers\"):\n\tif is_instance_valid(c) and not c._finished:\n\t\tlive += 1\nreturn live",
+      "multiline": true,
+      "equals": 0,
+      "comment": "No placement controller survives a completed disembark."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes two disembark UI issues reported from the Battlewagon Beta disembark (plus a latent oval-hull bug and a scenario-runner bug found along the way).

**Issue 1 — misaligned, oversized border.** The 3″ set-up border was drawn as an axis-aligned rectangle around the transport center: it never applied the hull's rotation and its sharp corners overstated the allowed area by up to ~1.2″ at the diagonals. With a rotated Battlewagon the outline didn't line up with the tank. (Oval-hulled transports additionally drew the border at *half* size — `OvalBase` stores semi-axes and the drawing code halved them again.)

**Issue 2 — wrong distances.** Nothing canceled an in-progress placement when the player selected a different unit, so the `DisembarkController` from the *previous* battlewagon's disembark stayed alive and kept processing board clicks — validating each against **its** transport and showing `Must be within 3" of transport (X" away)` measured from the wrong vehicle — while its border lingered on screen. The distance math itself was correct (shape- and rotation-aware).

## Changes

- **`DisembarkController.gd`** — build the range border in hull-local space and rotate it to the transport's actual pose. Rectangles get true Minkowski rounded corners; ovals get the true offset curve at full size. Every drawn point now sits exactly at the set-up distance from the hull edge. Added a public `cancel_placement()` + `_finished` guard, and enforce at-most-one live placement via a `disembark_controllers` scene group (covers the MovementPhase spawn path too).
- **`MovementController.gd`** — track the live placement controller and cancel it on any unit selection, on a new disembark confirm, and on phase exit (`_exit_tree`). Give the dialog a stable node name (`/root/DisembarkDialog`).
- **`ScenarioRunner.gd`** — fix `click_item_list` for scrolled `ItemList`s: `get_item_rect` returns content-space coords (scroll not applied, verified on 4.4.1), so clicking any scrolled-down row silently landed below the list. Now subtracts the v-scroll and fails loudly when the target row isn't visible.
- **`version_history.json`** — new `0.57.1` entry.

## Validation

Windowed scenario `disembark_rotated_border_stale_controller` (**41/41 steps**): real list clicks + dialog confirms on two battlewagons, an exactness assert that every border point measures 3″ from a 0.6-rad-rotated hull (actual max deviation 0.0001px over 53 points), a pin that merely *selecting* the second unit kills the old placement, and a full 10-model Lootas disembark via real board clicks. `verify_delivery` verdict PASS, debug log clean (0 errors).

Regressions green: `iss058_disembark_11e`, `charge_ctrl_click_real_key`, `charge_target_declaration` scenarios; headless `test_iss058_disembark_11e` (28/28) and `test_transport_audit_2026_07` (21/21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFTboFyiCc2TzJvPhpYTnE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFTboFyiCc2TzJvPhpYTnE)_