### PR TITLE
Show embarked units in the transport right-click context menu

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.0",
+			"date": "2026-07-18",
+			"summary": "You can now see who is riding inside a transport at a glance: right-click a vehicle that has units embarked and the context menu now has an 'Embarked Units' section listing every passenger and its model count. Click a passenger to open its stats card.",
+			"changes": [
+				"Right-clicking a transport that is carrying units adds an 'Embarked Units' section to the pop-up menu, with one row per embarked unit showing its name and alive/total model count (e.g. 'Kommandos (10/10)').",
+				"Clicking an embarked unit's row opens that unit's stats card so you can inspect the passengers without disembarking them.",
+				"The embarked list shows in every unit visual style (not just letter mode), so a loaded transport always right-clicks to reveal its cargo."
+			]
+		},
+		{
 			"version": "0.57.0",
 			"date": "2026-07-18",
 			"summary": "The AI now plays the Lions of the Emperor detachment properly: it spaces its Custodes units 6\"+ apart to earn Against All Odds (+1 to Hit AND +1 to Wound while no friendly is within 6\"), values that buff in its shooting and charge maths, prefers solo charges over gang-ups, and makes smarter calls with From Golden Light, Gilded Champion and the Swift as the Eagle window.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -12587,13 +12587,13 @@ func _force_redraw_all_tokens() -> void:
 
 var _unit_context_menu: PopupMenu = null
 var _context_unit_id: String = ""
+# Unit ids backing the "Embarked Units" rows of the current context menu, in the
+# same order they were added. A clicked embarked row maps back to its unit via
+# (item_id - EMBARKED_MENU_ID_BASE).
+var _context_embarked_ids: Array = []
+const EMBARKED_MENU_ID_BASE := 1000
 
 func _handle_right_click(event: InputEventMouseButton) -> void:
-	# Only in letter mode
-	var style = SettingsService.unit_visual_style if SettingsService else "classic"
-	if style != "letter":
-		return
-
 	# Convert screen position to world position (use event.position, same as other handlers)
 	var world_pos = screen_to_world_position(event.position)
 
@@ -12601,7 +12601,41 @@ func _handle_right_click(event: InputEventMouseButton) -> void:
 	if uid == "":
 		return
 
+	# Build/show the context menu. It only consumes the right-click when it
+	# actually shows something, so a right-click that offers nothing (e.g. a
+	# non-transport outside letter mode) still flows to the other handlers
+	# (MovementController rotation, DeploymentController cancel).
+	var menu_pos := Vector2i(int(event.global_position.x), int(event.global_position.y))
+	if _show_unit_context_menu(uid, menu_pos):
+		# Consume the event so other handlers (DeploymentController cancel,
+		# MovementController rotation) don't also process this right-click
+		get_viewport().set_input_as_handled()
+
+
+# Builds and pops up the right-click context menu for `uid` at `screen_pos`.
+# Returns true when a menu was actually shown. Split out of _handle_right_click
+# so windowed scenarios can drive the menu with a known unit id.
+#
+# Menu contents:
+#   * Change Color / Change Label / Unit Stats — letter visual style only
+#     (these edit the letter token's appearance).
+#   * "Embarked Units" section — whenever the unit is a transport carrying
+#     units, regardless of visual style. Lists each passenger (name + alive/
+#     total model count); clicking a row opens that unit's stats card.
+func _show_unit_context_menu(uid: String, screen_pos: Vector2i) -> bool:
+	var style = SettingsService.unit_visual_style if SettingsService else "classic"
+	var is_letter: bool = style == "letter"
+
+	# Passengers embarked in this transport (empty for non-transports / empty holds).
+	var embarked_entries := _get_embarked_menu_entries(uid)
+
+	# Nothing to offer: the color/label/stats items are letter-mode only, and
+	# there are no embarked units to list. Leave the right-click for other handlers.
+	if not is_letter and embarked_entries.is_empty():
+		return false
+
 	_context_unit_id = uid
+	_context_embarked_ids.clear()
 
 	# Remove existing context menu
 	if _unit_context_menu and is_instance_valid(_unit_context_menu):
@@ -12609,20 +12643,63 @@ func _handle_right_click(event: InputEventMouseButton) -> void:
 
 	_unit_context_menu = PopupMenu.new()
 	_unit_context_menu.name = "UnitContextMenu"
-	_unit_context_menu.add_item("Change Color", 0)
-	_unit_context_menu.add_item("Change Label", 1)
-	_unit_context_menu.add_item("Unit Stats", 2)
+
+	if is_letter:
+		_unit_context_menu.add_item("Change Color", 0)
+		_unit_context_menu.add_item("Change Label", 1)
+		_unit_context_menu.add_item("Unit Stats", 2)
+
+	# "Embarked Units" section: a labeled separator header followed by one row
+	# per embarked unit. Clicking a row opens that passenger's stats card so the
+	# player can both SEE who is aboard and inspect them.
+	if not embarked_entries.is_empty():
+		_unit_context_menu.add_separator("Embarked Units")
+		for i in range(embarked_entries.size()):
+			var entry: Dictionary = embarked_entries[i]
+			var row_text := "  %s  (%d/%d)" % [entry["name"], entry["alive"], entry["total"]]
+			_unit_context_menu.add_item(row_text, EMBARKED_MENU_ID_BASE + i)
+			_context_embarked_ids.append(entry["id"])
+
 	_unit_context_menu.id_pressed.connect(_on_unit_context_menu_pressed)
 	add_child(_unit_context_menu)
-	_unit_context_menu.position = Vector2i(int(event.global_position.x), int(event.global_position.y))
+	_unit_context_menu.position = screen_pos
 	_unit_context_menu.popup()
+	return true
 
-	# Consume the event so other handlers (DeploymentController cancel,
-	# MovementController rotation) don't also process this right-click
-	get_viewport().set_input_as_handled()
+
+# Returns display rows for the units embarked in `transport_id`, in embark order:
+#   [{ "id": String, "name": String, "alive": int, "total": int }, ... ]
+# Empty for non-transport units or transports with an empty hold.
+func _get_embarked_menu_entries(transport_id: String) -> Array:
+	var entries := []
+	if not TransportManager:
+		return entries
+	for eid in TransportManager.get_embarked_unit_ids(transport_id):
+		var eunit = GameState.get_unit(eid)
+		if eunit == null or eunit.is_empty():
+			continue
+		var total := 0
+		var alive := 0
+		for m in eunit.get("models", []):
+			total += 1
+			if m.get("alive", true):
+				alive += 1
+		entries.append({
+			"id": eid,
+			"name": GameState.get_unit_display_name(eid),
+			"alive": alive,
+			"total": total,
+		})
+	return entries
 
 
 func _on_unit_context_menu_pressed(id: int) -> void:
+	# Embarked-unit rows: open the clicked passenger's stats card.
+	if id >= EMBARKED_MENU_ID_BASE:
+		var idx := id - EMBARKED_MENU_ID_BASE
+		if idx >= 0 and idx < _context_embarked_ids.size():
+			_show_unit_stats_card_popup(_context_embarked_ids[idx])
+		return
 	match id:
 		0:  # Change Color
 			_show_unit_color_picker_popup(_context_unit_id)

--- a/40k/tests/scenarios/sp/transport_embarked_context_menu.json
+++ b/40k/tests/scenarios/sp/transport_embarked_context_menu.json
@@ -1,0 +1,107 @@
+{
+  "id": "transport_embarked_context_menu",
+  "covers": [
+    "ui.right_click_context.embarked_units_section",
+    "transport.embarked_units_listing",
+    "ui.main.show_unit_context_menu"
+  ],
+  "fixture": "grenade_shooting_desync",
+  "edition": 11,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "Right-clicking a transport that has units embarked adds an 'Embarked Units' section to its context menu listing each passenger (name + alive/total model count), and clicking a passenger row opens that unit's stats card. Drives the real player path against a fixture with two deployed, loaded Battlewagons: confirms the on-board token hit-tests to the transport, injects a REAL right-click InputEventMouseButton at Battlewagon Alpha's board position, and asserts _handle_right_click resolved the transport and the resulting UnitContextMenu contains a labeled 'Embarked Units' separator plus a 'Kommandos' row. Then fires the embarked row's handler and asserts a UnitStatsCardPopup opened. Also verifies the menu-entry builder lists BOTH Lootas passengers for Battlewagon Beta (in embark order) and that a non-transport unit yields no embarked entries.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 8
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.active_player",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "TransportManager.get_embarked_unit_ids(\"U_BATTLEWAGON_A\")",
+      "equals": [
+        "U_KOMMANDOS_A"
+      ]
+    },
+    {
+      "act": "execute_script",
+      "script": "main.fit_view_to_board()"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 4
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.current_scene\nvar pos = GameState.get_unit(\"U_BATTLEWAGON_A\")[\"models\"][0][\"position\"]\nreturn m._find_unit_at_world_pos(Vector2(pos[\"x\"], pos[\"y\"]))",
+      "equals": "U_BATTLEWAGON_A"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.current_scene\nvar pos = GameState.get_unit(\"U_BATTLEWAGON_A\")[\"models\"][0][\"position\"]\nvar world = Vector2(pos[\"x\"], pos[\"y\"])\nvar screen = m.world_to_screen_position(world)\nvar ev = InputEventMouseButton.new()\nev.button_index = MOUSE_BUTTON_RIGHT\nev.position = screen\nev.global_position = screen\nev.pressed = true\nev.button_mask = MOUSE_BUTTON_MASK_RIGHT\nInput.parse_input_event(ev)\nreturn {\"world\": [world.x, world.y], \"screen\": [screen.x, screen.y]}"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 8
+    },
+    {
+      "act": "execute_script",
+      "script": "main._context_unit_id",
+      "equals": "U_BATTLEWAGON_A"
+    },
+    {
+      "act": "execute_script",
+      "script": "main._unit_context_menu.get_item_count()",
+      "expect_min": 2
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.current_scene\nvar menu = m._unit_context_menu\nif menu == null:\n\treturn \"NO_MENU\"\nvar has_header = false\nvar has_kommandos = false\nfor i in range(menu.get_item_count()):\n\tvar t = menu.get_item_text(i)\n\tif t.contains(\"Embarked Units\"):\n\t\thas_header = true\n\tif t.contains(\"Kommandos\"):\n\t\thas_kommandos = true\nreturn has_header and has_kommandos",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "02_alpha_context_menu_lists_kommandos"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.current_scene\n# EMBARKED_MENU_ID_BASE + 0 -> the first embarked row (Kommandos); this is\n# exactly what the PopupMenu.id_pressed signal delivers on a real click.\nm._on_unit_context_menu_pressed(1000)\nreturn m.get_node_or_null(\"UnitStatsCardPopup\") != null",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 4
+    },
+    {
+      "act": "screenshot",
+      "label": "03_embarked_row_opens_stats_card"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.current_scene\nvar entries = m._get_embarked_menu_entries(\"U_BATTLEWAGON_B\")\nvar names = []\nfor e in entries:\n\tnames.append(e[\"name\"])\nreturn names",
+      "equals": [
+        "Lootas Beta",
+        "Lootas Alpha"
+      ]
+    },
+    {
+      "act": "execute_script",
+      "script": "main._get_embarked_menu_entries(\"U_KOMMANDOS_A\").size()",
+      "equals": 0
+    }
+  ]
+}


### PR DESCRIPTION
## What & why

When units are embarked in a transport there was no quick way to tell who was aboard. Right-clicking a transport now adds an **"Embarked Units"** section to the pop-up context menu, listing each passenger with its alive/total model count (e.g. `Kommandos (10/10)`). Clicking a passenger row opens that unit's stats card so you can inspect it without disembarking.

## Changes

- **`40k/scripts/Main.gd`**
  - Split `_handle_right_click` into a testable `_show_unit_context_menu(uid, screen_pos)` helper.
  - New `_get_embarked_menu_entries(transport_id)` builds `[{id, name, alive, total}]` from `TransportManager.get_embarked_unit_ids` (empty for non-transports / empty holds).
  - Menu now appends a labeled `Embarked Units` separator + one row per passenger; `_on_unit_context_menu_pressed` routes an embarked row to that unit's stats card.
  - The embarked section shows in **every** unit visual style; Change Color / Change Label / Unit Stats remain letter-mode only, unchanged.
- **`40k/tests/scenarios/sp/transport_embarked_context_menu.json`** — new windowed scenario.
- **`40k/data/version_history.json`** — `0.58.0` entry.

## Behaviour note

In non-letter visual styles, right-clicking a *loaded* transport now opens this menu (previously the right-click fell through to model rotation / deployment cancel). This only affects transports that are actually carrying units; keyboard rotation still works and the default style is `letter`.

## Validation

Verified end-to-end in the running (windowed) game via `run_scenarios.sh` — **18/18 steps pass**:
- Injects a real right-click `InputEventMouseButton` at a deployed, loaded Battlewagon's on-board token; asserts `_handle_right_click` resolved the transport and the menu contains an `Embarked Units` separator + `Kommandos` row.
- Fires the embarked row's handler and asserts a `UnitStatsCardPopup` opened.
- Confirms the builder lists both Lootas passengers (embark order) for a second Battlewagon and that a non-transport yields no entries.
- Screenshots captured of the menu and the passenger stats card.
- Existing right-click scenario `deployed_unit_hover_rightclick` still passes (22/22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G386LrchGJnpa38HGrKJBs

---
_Generated by [Claude Code](https://claude.ai/code/session_01G386LrchGJnpa38HGrKJBs)_