### PR TITLE
Give mixed-profile squad models distinct icons + named hover tooltips

### DIFF
--- a/40k/armies/Orks_2000.json
+++ b/40k/armies/Orks_2000.json
@@ -862,7 +862,28 @@
       "description": "9-19 Beast Snagga Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Beast Snagga Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Power snappa"
+      ],
+      "stats_override": {}
+     },
+     "boy": {
+      "label": "Beast Snagga Boy",
+      "short_label": "B",
+      "weapons": [
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -872,7 +893,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -881,7 +903,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -890,7 +913,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -899,7 +923,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -908,7 +933,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -917,7 +943,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -926,7 +953,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -935,7 +963,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -944,7 +973,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -953,7 +983,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -1773,7 +1804,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1783,7 +1834,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -1792,7 +1844,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -1801,7 +1854,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -1810,7 +1864,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -1819,7 +1874,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -1828,7 +1884,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -1837,7 +1894,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -1846,7 +1904,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -1855,7 +1914,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -1864,7 +1924,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -1873,7 +1934,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m12",
@@ -1882,7 +1944,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m13",
@@ -1891,7 +1954,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m14",
@@ -1900,7 +1964,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m15",
@@ -1909,7 +1974,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m16",
@@ -1918,7 +1984,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m17",
@@ -1927,7 +1994,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m18",
@@ -1936,7 +2004,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m19",
@@ -1945,7 +2014,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m20",
@@ -1954,7 +2024,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m21",
@@ -1963,7 +2034,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m22",
@@ -1972,7 +2044,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -2105,7 +2178,29 @@
       "description": "9 Kommando",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Big choppa"
+      ],
+      "stats_override": {}
+     },
+     "kommando": {
+      "label": "Kommando",
+      "short_label": "K",
+      "weapons": [
+       "Kustom shoota",
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2115,7 +2210,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2124,7 +2220,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m3",
@@ -2133,7 +2230,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m4",
@@ -2142,7 +2240,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m5",
@@ -2151,7 +2250,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m6",
@@ -2160,7 +2260,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m7",
@@ -2169,7 +2270,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m8",
@@ -2178,7 +2280,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m9",
@@ -2187,7 +2290,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m10",
@@ -2196,7 +2300,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     }
    ]
   },
@@ -2919,7 +3024,27 @@
       "description": "4-9 Stormboy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "stormboy": {
+      "label": "Stormboy",
+      "short_label": "S",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2929,7 +3054,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2938,7 +3064,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m3",
@@ -2947,7 +3074,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m4",
@@ -2956,7 +3084,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m5",
@@ -2965,7 +3094,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m6",
@@ -2974,7 +3104,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m7",
@@ -2983,7 +3114,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m8",
@@ -2992,7 +3124,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m9",
@@ -3001,7 +3134,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m10",
@@ -3010,7 +3144,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     }
    ]
   },
@@ -3126,7 +3261,27 @@
       "description": "5 Tankbusta",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Rokkit pistol",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "tankbusta": {
+      "label": "Tankbusta",
+      "short_label": "T",
+      "weapons": [
+       "Rokkit launcha",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3136,7 +3291,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3145,7 +3301,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m3",
@@ -3154,7 +3311,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m4",
@@ -3163,7 +3321,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m5",
@@ -3172,7 +3331,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m6",
@@ -3181,7 +3341,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     }
    ]
   },
@@ -3275,7 +3436,27 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3290,7 +3471,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3304,7 +3486,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3318,7 +3501,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3332,7 +3516,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3346,7 +3531,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3360,7 +3546,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   },
@@ -3492,7 +3679,29 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Big choppa",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3507,7 +3716,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3521,7 +3731,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3535,7 +3746,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3549,7 +3761,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3563,7 +3776,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3577,7 +3791,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   }

--- a/40k/armies/Orks_2000_upload.json
+++ b/40k/armies/Orks_2000_upload.json
@@ -862,7 +862,28 @@
       "description": "9-19 Beast Snagga Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Beast Snagga Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Power snappa"
+      ],
+      "stats_override": {}
+     },
+     "boy": {
+      "label": "Beast Snagga Boy",
+      "short_label": "B",
+      "weapons": [
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -872,7 +893,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -881,7 +903,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -890,7 +913,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -899,7 +923,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -908,7 +933,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -917,7 +943,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -926,7 +953,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -935,7 +963,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -944,7 +973,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -953,7 +983,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -1701,7 +1732,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1711,7 +1762,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -1720,7 +1772,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -1729,7 +1782,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -1738,7 +1792,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -1747,7 +1802,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -1756,7 +1812,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -1765,7 +1822,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -1774,7 +1832,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -1783,7 +1842,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -1792,7 +1852,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -1801,7 +1862,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m12",
@@ -1810,7 +1872,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m13",
@@ -1819,7 +1882,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m14",
@@ -1828,7 +1892,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m15",
@@ -1837,7 +1902,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m16",
@@ -1846,7 +1912,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m17",
@@ -1855,7 +1922,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m18",
@@ -1864,7 +1932,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m19",
@@ -1873,7 +1942,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m20",
@@ -1882,7 +1952,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m21",
@@ -1891,7 +1962,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m22",
@@ -1900,7 +1972,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -2033,7 +2106,29 @@
       "description": "9 Kommando",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Big choppa"
+      ],
+      "stats_override": {}
+     },
+     "kommando": {
+      "label": "Kommando",
+      "short_label": "K",
+      "weapons": [
+       "Kustom shoota",
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2043,7 +2138,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2052,7 +2148,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m3",
@@ -2061,7 +2158,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m4",
@@ -2070,7 +2168,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m5",
@@ -2079,7 +2178,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m6",
@@ -2088,7 +2188,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m7",
@@ -2097,7 +2198,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m8",
@@ -2106,7 +2208,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m9",
@@ -2115,7 +2218,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m10",
@@ -2124,7 +2228,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     }
    ]
   },
@@ -2631,7 +2736,27 @@
       "description": "4-9 Stormboy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "stormboy": {
+      "label": "Stormboy",
+      "short_label": "S",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2641,7 +2766,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2650,7 +2776,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m3",
@@ -2659,7 +2786,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m4",
@@ -2668,7 +2796,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m5",
@@ -2677,7 +2806,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m6",
@@ -2686,7 +2816,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m7",
@@ -2695,7 +2826,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m8",
@@ -2704,7 +2836,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m9",
@@ -2713,7 +2846,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m10",
@@ -2722,7 +2856,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     }
    ]
   },
@@ -2838,7 +2973,27 @@
       "description": "5 Tankbusta",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Rokkit pistol",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "tankbusta": {
+      "label": "Tankbusta",
+      "short_label": "T",
+      "weapons": [
+       "Rokkit launcha",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2848,7 +3003,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2857,7 +3013,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m3",
@@ -2866,7 +3023,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m4",
@@ -2875,7 +3033,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m5",
@@ -2884,7 +3043,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m6",
@@ -2893,7 +3053,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     }
    ]
   },
@@ -2987,7 +3148,27 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3002,7 +3183,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3016,7 +3198,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3030,7 +3213,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3044,7 +3228,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3058,7 +3243,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3072,7 +3258,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   },
@@ -3204,7 +3391,29 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Big choppa",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3219,7 +3428,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3233,7 +3443,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3247,7 +3458,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3261,7 +3473,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3275,7 +3488,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3289,7 +3503,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   }

--- a/40k/armies/Orks_Upload_Mar7.json
+++ b/40k/armies/Orks_Upload_Mar7.json
@@ -862,7 +862,28 @@
       "description": "9-19 Beast Snagga Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Beast Snagga Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Power snappa"
+      ],
+      "stats_override": {}
+     },
+     "boy": {
+      "label": "Beast Snagga Boy",
+      "short_label": "B",
+      "weapons": [
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -872,7 +893,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -881,7 +903,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -890,7 +913,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -899,7 +923,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -908,7 +933,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -917,7 +943,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -926,7 +953,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -935,7 +963,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -944,7 +973,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -953,7 +983,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -1701,7 +1732,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1711,7 +1762,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -1720,7 +1772,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -1729,7 +1782,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -1738,7 +1792,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -1747,7 +1802,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -1756,7 +1812,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -1765,7 +1822,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -1774,7 +1832,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -1783,7 +1842,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -1792,7 +1852,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -1801,7 +1862,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m12",
@@ -1810,7 +1872,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m13",
@@ -1819,7 +1882,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m14",
@@ -1828,7 +1892,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m15",
@@ -1837,7 +1902,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m16",
@@ -1846,7 +1912,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m17",
@@ -1855,7 +1922,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m18",
@@ -1864,7 +1932,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m19",
@@ -1873,7 +1942,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m20",
@@ -1882,7 +1952,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m21",
@@ -1891,7 +1962,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m22",
@@ -1900,7 +1972,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -2033,7 +2106,29 @@
       "description": "9 Kommando",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Big choppa"
+      ],
+      "stats_override": {}
+     },
+     "kommando": {
+      "label": "Kommando",
+      "short_label": "K",
+      "weapons": [
+       "Kustom shoota",
+       "Slugga",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2043,7 +2138,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2052,7 +2148,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m3",
@@ -2061,7 +2158,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m4",
@@ -2070,7 +2168,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m5",
@@ -2079,7 +2178,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m6",
@@ -2088,7 +2188,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m7",
@@ -2097,7 +2198,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m8",
@@ -2106,7 +2208,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m9",
@@ -2115,7 +2218,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m10",
@@ -2124,7 +2228,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     }
    ]
   },
@@ -2631,7 +2736,27 @@
       "description": "4-9 Stormboy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "stormboy": {
+      "label": "Stormboy",
+      "short_label": "S",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2641,7 +2766,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2650,7 +2776,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m3",
@@ -2659,7 +2786,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m4",
@@ -2668,7 +2796,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m5",
@@ -2677,7 +2806,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m6",
@@ -2686,7 +2816,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m7",
@@ -2695,7 +2826,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m8",
@@ -2704,7 +2836,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m9",
@@ -2713,7 +2846,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m10",
@@ -2722,7 +2856,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     }
    ]
   },
@@ -2838,7 +2973,27 @@
       "description": "5 Tankbusta",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Rokkit pistol",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "tankbusta": {
+      "label": "Tankbusta",
+      "short_label": "T",
+      "weapons": [
+       "Rokkit launcha",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2848,7 +3003,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2857,7 +3013,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m3",
@@ -2866,7 +3023,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m4",
@@ -2875,7 +3033,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m5",
@@ -2884,7 +3043,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m6",
@@ -2893,7 +3053,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     }
    ]
   },
@@ -2987,7 +3148,27 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3002,7 +3183,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3016,7 +3198,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3030,7 +3213,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3044,7 +3228,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3058,7 +3243,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3072,7 +3258,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   },
@@ -3204,7 +3391,29 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Big choppa",
+       "Choppa",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3219,7 +3428,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3233,7 +3443,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3247,7 +3458,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m4",
@@ -3261,7 +3473,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m5",
@@ -3275,7 +3488,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m6",
@@ -3289,7 +3503,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   },

--- a/40k/armies/battlewagons.json
+++ b/40k/armies/battlewagons.json
@@ -1981,7 +1981,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1991,7 +2011,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -2000,7 +2021,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -2009,7 +2031,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -2018,7 +2041,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -2027,7 +2051,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -2036,7 +2061,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -2045,7 +2071,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -2054,7 +2081,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -2063,7 +2091,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -2072,7 +2101,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -2081,7 +2111,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -2195,7 +2226,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2205,7 +2256,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -2214,7 +2266,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -2223,7 +2276,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -2232,7 +2286,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -2241,7 +2296,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -2250,7 +2306,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -2259,7 +2316,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -2268,7 +2326,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -2277,7 +2336,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -2286,7 +2346,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -2295,7 +2356,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -2409,7 +2471,27 @@
       "description": "10-20 Gretchin",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "runtherd": {
+      "label": "Runtherd",
+      "short_label": "R",
+      "weapons": [
+       "Slugga",
+       "Runtherd tools"
+      ],
+      "stats_override": {}
+     },
+     "gretchin": {
+      "label": "Gretchin",
+      "short_label": "G",
+      "weapons": [
+       "Grot blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -2419,7 +2501,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "runtherd"
     },
     {
      "id": "m2",
@@ -2428,7 +2511,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m3",
@@ -2437,7 +2521,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m4",
@@ -2446,7 +2531,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m5",
@@ -2455,7 +2541,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m6",
@@ -2464,7 +2551,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m7",
@@ -2473,7 +2561,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m8",
@@ -2482,7 +2571,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m9",
@@ -2491,7 +2581,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m10",
@@ -2500,7 +2591,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     },
     {
      "id": "m11",
@@ -2509,7 +2601,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "gretchin"
     }
    ]
   },
@@ -3228,7 +3321,27 @@
       "description": "4-9 Stormboy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "stormboy": {
+      "label": "Stormboy",
+      "short_label": "S",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3238,7 +3351,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3247,7 +3361,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m3",
@@ -3256,7 +3371,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m4",
@@ -3265,7 +3381,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     },
     {
      "id": "m5",
@@ -3274,7 +3391,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "stormboy"
     }
    ]
   },
@@ -3385,7 +3503,27 @@
       "description": "5 Tankbusta",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Rokkit pistol",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "tankbusta": {
+      "label": "Tankbusta",
+      "short_label": "T",
+      "weapons": [
+       "Rokkit launcha",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3395,7 +3533,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3404,7 +3543,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m3",
@@ -3413,7 +3553,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m4",
@@ -3422,7 +3563,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m5",
@@ -3431,7 +3573,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m6",
@@ -3440,7 +3583,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     }
    ]
   },
@@ -3557,7 +3701,27 @@
       "description": "5 Tankbusta",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Rokkit pistol",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "tankbusta": {
+      "label": "Tankbusta",
+      "short_label": "T",
+      "weapons": [
+       "Rokkit launcha",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3567,7 +3731,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3576,7 +3741,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m3",
@@ -3585,7 +3751,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m4",
@@ -3594,7 +3761,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m5",
@@ -3603,7 +3771,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     },
     {
      "id": "m6",
@@ -3612,7 +3781,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "tankbusta"
     }
    ]
   },
@@ -3702,7 +3872,27 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3717,7 +3907,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3731,7 +3922,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3745,7 +3937,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   },
@@ -3835,7 +4028,27 @@
       "description": "2-5 Warbiker",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob on Warbike",
+      "short_label": "N",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     },
+     "warbiker": {
+      "label": "Warbiker",
+      "short_label": "B",
+      "weapons": [
+       "Twin dakkagun",
+       "Close combat weapon"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -3850,7 +4063,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -3864,7 +4078,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     },
     {
      "id": "m3",
@@ -3878,7 +4093,8 @@
      "base_dimensions": {
       "length": 42,
       "width": 75
-     }
+     },
+     "model_type": "warbiker"
     }
    ]
   }

--- a/40k/armies/orks.json
+++ b/40k/armies/orks.json
@@ -991,7 +991,41 @@
       "description": "9-19 Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Big choppa",
+       "Choppa",
+       "Power klaw",
+       "Slugga",
+       "Kombi-weapon"
+      ],
+      "stats_override": {
+       "save": 4,
+       "weapon_skill": 3
+      },
+      "transport_slots": 1
+     },
+     "boy": {
+      "label": "Boy",
+      "short_label": "B",
+      "weapons": [
+       "Choppa",
+       "Close combat weapon",
+       "Shoota",
+       "Slugga",
+       "Big shoota",
+       "Rokkit launcha"
+      ],
+      "stats_override": {
+       "weapon_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -1001,7 +1035,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -1010,7 +1045,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -1019,7 +1055,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -1028,7 +1065,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -1037,7 +1075,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -1046,7 +1085,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -1055,7 +1095,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -1064,7 +1105,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -1073,7 +1115,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -1082,7 +1125,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m11",
@@ -1091,7 +1135,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m12",
@@ -1100,7 +1145,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m13",
@@ -1109,7 +1155,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m14",
@@ -1118,7 +1165,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m15",
@@ -1127,7 +1175,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m16",
@@ -1136,7 +1185,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m17",
@@ -1145,7 +1195,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m18",
@@ -1154,7 +1205,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m19",
@@ -1163,7 +1215,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m20",
@@ -1172,7 +1225,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -1492,7 +1546,27 @@
       "description": "9 Kommando",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "kommando": {
+      "label": "Kommando",
+      "short_label": "K",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1502,7 +1576,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -1511,7 +1586,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m3",
@@ -1520,7 +1596,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m4",
@@ -1529,7 +1606,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m5",
@@ -1538,7 +1616,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m6",
@@ -1547,7 +1626,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m7",
@@ -1556,7 +1636,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m8",
@@ -1565,7 +1646,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m9",
@@ -1574,7 +1656,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m10",
@@ -1583,7 +1666,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     }
    ]
   },
@@ -1991,7 +2075,41 @@
       "description": "9-19 Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Big choppa",
+       "Choppa",
+       "Power klaw",
+       "Slugga",
+       "Kombi-weapon"
+      ],
+      "stats_override": {
+       "save": 4,
+       "weapon_skill": 3
+      },
+      "transport_slots": 1
+     },
+     "boy": {
+      "label": "Boy",
+      "short_label": "B",
+      "weapons": [
+       "Choppa",
+       "Close combat weapon",
+       "Shoota",
+       "Slugga",
+       "Big shoota",
+       "Rokkit launcha"
+      ],
+      "stats_override": {
+       "weapon_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -2001,7 +2119,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2010,7 +2129,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -2019,7 +2139,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -2028,7 +2149,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -2037,7 +2159,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -2046,7 +2169,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -2055,7 +2179,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -2064,7 +2189,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -2073,7 +2199,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -2082,7 +2209,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -2206,7 +2334,41 @@
       "description": "4-8 Loota",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "loota_deffgun": {
+      "label": "Loota (Deffgun)",
+      "short_label": "D",
+      "weapons": [
+       "Deffgun",
+       "Close combat weapon"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     },
+     "loota_kmb": {
+      "label": "Loota (Kustom Mega-blasta)",
+      "short_label": "K",
+      "weapons": [
+       "Kustom mega-blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     },
+     "spanner": {
+      "label": "Spanner",
+      "short_label": "S",
+      "weapons": [
+       "Kustom mega-blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {
+       "ballistic_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -2216,7 +2378,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m2",
@@ -2225,7 +2388,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m3",
@@ -2234,7 +2398,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m4",
@@ -2243,7 +2408,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m5",
@@ -2252,7 +2418,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m6",
@@ -2261,7 +2428,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m7",
@@ -2270,7 +2438,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m8",
@@ -2279,7 +2448,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m9",
@@ -2288,7 +2458,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_kmb"
     },
     {
      "id": "m10",
@@ -2297,7 +2468,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_kmb"
     },
     {
      "id": "m11",
@@ -2306,7 +2478,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "spanner"
     }
    ]
   },
@@ -2396,7 +2569,29 @@
       "description": "1-5 Meganob",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "meganob_klaw": {
+      "label": "Meganob (Power Klaw)",
+      "short_label": "PK",
+      "weapons": [
+       "Kustom shoota",
+       "Power klaw"
+      ],
+      "stats_override": {},
+      "transport_slots": 2
+     },
+     "meganob_saws": {
+      "label": "Meganob (Killsaws)",
+      "short_label": "KS",
+      "weapons": [
+       "Kustom shoota",
+       "Killsaw"
+      ],
+      "stats_override": {},
+      "transport_slots": 2
+     }
+    }
    },
    "models": [
     {
@@ -2406,7 +2601,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m2",
@@ -2415,7 +2611,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m3",
@@ -2424,7 +2621,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m4",
@@ -2433,7 +2631,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_saws"
     },
     {
      "id": "m5",
@@ -2442,7 +2641,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_saws"
     }
    ]
   },
@@ -2697,6 +2897,26 @@
       "MEGANOBZ",
       "NOBZ"
      ]
+    },
+    "model_profiles": {
+     "ghazghkull": {
+      "label": "Ghazghkull Thraka",
+      "short_label": "G",
+      "weapons": [
+       "Mork's Roar",
+       "Gork's Klaw – Strike",
+       "Gork's Klaw – Sweep"
+      ],
+      "stats_override": {}
+     },
+     "makari": {
+      "label": "Makari",
+      "short_label": "M",
+      "weapons": [
+       "Makari's stabba"
+      ],
+      "stats_override": {}
+     }
     }
    },
    "models": [
@@ -2707,7 +2927,8 @@
      "base_mm": 80,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "ghazghkull"
     },
     {
      "id": "m2",
@@ -2716,7 +2937,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "makari"
     }
    ]
   },

--- a/40k/armies/orks_taktikal.json
+++ b/40k/armies/orks_taktikal.json
@@ -995,7 +995,41 @@
       "description": "9-19 Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Big choppa",
+       "Choppa",
+       "Power klaw",
+       "Slugga",
+       "Kombi-weapon"
+      ],
+      "stats_override": {
+       "save": 4,
+       "weapon_skill": 3
+      },
+      "transport_slots": 1
+     },
+     "boy": {
+      "label": "Boy",
+      "short_label": "B",
+      "weapons": [
+       "Choppa",
+       "Close combat weapon",
+       "Shoota",
+       "Slugga",
+       "Big shoota",
+       "Rokkit launcha"
+      ],
+      "stats_override": {
+       "weapon_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -1005,7 +1039,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -1014,7 +1049,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -1023,7 +1059,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -1032,7 +1069,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -1041,7 +1079,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -1050,7 +1089,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -1059,7 +1099,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -1068,7 +1109,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -1077,7 +1119,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -1086,7 +1129,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m11",
@@ -1095,7 +1139,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m12",
@@ -1104,7 +1149,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m13",
@@ -1113,7 +1159,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m14",
@@ -1122,7 +1169,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m15",
@@ -1131,7 +1179,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m16",
@@ -1140,7 +1189,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m17",
@@ -1149,7 +1199,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m18",
@@ -1158,7 +1209,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m19",
@@ -1167,7 +1219,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m20",
@@ -1176,7 +1229,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -1496,7 +1550,27 @@
       "description": "9 Kommando",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     },
+     "kommando": {
+      "label": "Kommando",
+      "short_label": "K",
+      "weapons": [
+       "Slugga",
+       "Choppa"
+      ],
+      "stats_override": {}
+     }
+    }
    },
    "models": [
     {
@@ -1506,7 +1580,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -1515,7 +1590,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m3",
@@ -1524,7 +1600,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m4",
@@ -1533,7 +1610,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m5",
@@ -1542,7 +1620,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m6",
@@ -1551,7 +1630,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m7",
@@ -1560,7 +1640,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m8",
@@ -1569,7 +1650,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m9",
@@ -1578,7 +1660,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     },
     {
      "id": "m10",
@@ -1587,7 +1670,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "kommando"
     }
    ]
   },
@@ -1995,7 +2079,41 @@
       "description": "9-19 Boy",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "boss_nob": {
+      "label": "Boss Nob",
+      "short_label": "N",
+      "weapons": [
+       "Big choppa",
+       "Choppa",
+       "Power klaw",
+       "Slugga",
+       "Kombi-weapon"
+      ],
+      "stats_override": {
+       "save": 4,
+       "weapon_skill": 3
+      },
+      "transport_slots": 1
+     },
+     "boy": {
+      "label": "Boy",
+      "short_label": "B",
+      "weapons": [
+       "Choppa",
+       "Close combat weapon",
+       "Shoota",
+       "Slugga",
+       "Big shoota",
+       "Rokkit launcha"
+      ],
+      "stats_override": {
+       "weapon_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -2005,7 +2123,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boss_nob"
     },
     {
      "id": "m2",
@@ -2014,7 +2133,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m3",
@@ -2023,7 +2143,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m4",
@@ -2032,7 +2153,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m5",
@@ -2041,7 +2163,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m6",
@@ -2050,7 +2173,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m7",
@@ -2059,7 +2183,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m8",
@@ -2068,7 +2193,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m9",
@@ -2077,7 +2203,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     },
     {
      "id": "m10",
@@ -2086,7 +2213,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "boy"
     }
    ]
   },
@@ -2210,7 +2338,41 @@
       "description": "4-8 Loota",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "loota_deffgun": {
+      "label": "Loota (Deffgun)",
+      "short_label": "D",
+      "weapons": [
+       "Deffgun",
+       "Close combat weapon"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     },
+     "loota_kmb": {
+      "label": "Loota (Kustom Mega-blasta)",
+      "short_label": "K",
+      "weapons": [
+       "Kustom mega-blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     },
+     "spanner": {
+      "label": "Spanner",
+      "short_label": "S",
+      "weapons": [
+       "Kustom mega-blasta",
+       "Close combat weapon"
+      ],
+      "stats_override": {
+       "ballistic_skill": 4
+      },
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -2220,7 +2382,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m2",
@@ -2229,7 +2392,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m3",
@@ -2238,7 +2402,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m4",
@@ -2247,7 +2412,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m5",
@@ -2256,7 +2422,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m6",
@@ -2265,7 +2432,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m7",
@@ -2274,7 +2442,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m8",
@@ -2283,7 +2452,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_deffgun"
     },
     {
      "id": "m9",
@@ -2292,7 +2462,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_kmb"
     },
     {
      "id": "m10",
@@ -2301,7 +2472,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "loota_kmb"
     },
     {
      "id": "m11",
@@ -2310,7 +2482,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "spanner"
     }
    ]
   },
@@ -2400,7 +2573,29 @@
       "description": "1-5 Meganob",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "meganob_klaw": {
+      "label": "Meganob (Power Klaw)",
+      "short_label": "PK",
+      "weapons": [
+       "Kustom shoota",
+       "Power klaw"
+      ],
+      "stats_override": {},
+      "transport_slots": 2
+     },
+     "meganob_saws": {
+      "label": "Meganob (Killsaws)",
+      "short_label": "KS",
+      "weapons": [
+       "Kustom shoota",
+       "Killsaw"
+      ],
+      "stats_override": {},
+      "transport_slots": 2
+     }
+    }
    },
    "models": [
     {
@@ -2410,7 +2605,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m2",
@@ -2419,7 +2615,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m3",
@@ -2428,7 +2625,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_klaw"
     },
     {
      "id": "m4",
@@ -2437,7 +2635,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_saws"
     },
     {
      "id": "m5",
@@ -2446,7 +2645,8 @@
      "base_mm": 40,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "meganob_saws"
     }
    ]
   },
@@ -2701,6 +2901,26 @@
       "MEGANOBZ",
       "NOBZ"
      ]
+    },
+    "model_profiles": {
+     "ghazghkull": {
+      "label": "Ghazghkull Thraka",
+      "short_label": "G",
+      "weapons": [
+       "Mork's Roar",
+       "Gork's Klaw \u2013 Strike",
+       "Gork's Klaw \u2013 Sweep"
+      ],
+      "stats_override": {}
+     },
+     "makari": {
+      "label": "Makari",
+      "short_label": "M",
+      "weapons": [
+       "Makari's stabba"
+      ],
+      "stats_override": {}
+     }
     }
    },
    "models": [
@@ -2711,7 +2931,8 @@
      "base_mm": 80,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "ghazghkull"
     },
     {
      "id": "m2",
@@ -2720,7 +2941,8 @@
      "base_mm": 25,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "makari"
     }
    ]
   },

--- a/40k/armies/space_marines.json
+++ b/40k/armies/space_marines.json
@@ -122,7 +122,31 @@
       "description": "4-9 Intercessor",
       "line": 2
      }
-    ]
+    ],
+    "model_profiles": {
+     "intercessor_sergeant": {
+      "label": "Intercessor Sergeant",
+      "short_label": "S",
+      "weapons": [
+       "Bolt rifle",
+       "Bolt pistol",
+       "Power fist"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     },
+     "intercessor": {
+      "label": "Intercessor",
+      "short_label": "I",
+      "weapons": [
+       "Bolt rifle",
+       "Bolt pistol",
+       "Close combat weapon"
+      ],
+      "stats_override": {},
+      "transport_slots": 1
+     }
+    }
    },
    "models": [
     {
@@ -132,7 +156,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "intercessor_sergeant"
     },
     {
      "id": "m2",
@@ -141,7 +166,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "intercessor"
     },
     {
      "id": "m3",
@@ -150,7 +176,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "intercessor"
     },
     {
      "id": "m4",
@@ -159,7 +186,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "intercessor"
     },
     {
      "id": "m5",
@@ -168,7 +196,8 @@
      "base_mm": 32,
      "position": null,
      "alive": true,
-     "status_effects": []
+     "status_effects": [],
+     "model_type": "intercessor"
     }
    ]
   },

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -4,13 +4,13 @@
 		{
 			"version": "0.59.0",
 			"date": "2026-07-18",
-			"summary": "The game now auto-saves at the start of every phase, so you can always pick a battle back up where you left it — even in the browser build on itch.io. Each auto-save is named after the two armies and the phase that is starting (e.g. \"Space Marines vs Orks - Movement\"), and overwrites the previous one for that phase instead of piling up. It's on by default and can be turned off under Settings > Gameplay > Auto-Save.",
+			"summary": "Squad leaders now look and read like leaders. The Runtherd in every Gretchin mob (and the Boss Nob, Spanner, Makari and friends in other squads) gets its own board icon instead of a scaled-up copy of the rank-and-file art, and hovering it names the model with its own wounds and weapons instead of claiming it is just another squad member.",
 			"changes": [
-				"New auto-save: at the start of each phase (Deployment, Command, Movement, Shooting, Charge, Fight, Scoring) the game saves automatically, named \"<first army> vs <second army> - <phase>\".",
-				"On by default; turn it off any time via Settings > Gameplay > \"Auto-save at the start of each phase\".",
-				"Works on the browser / itch.io build too — these auto-saves go to your cloud saves just like a manual save (previous phase-based auto-saves only worked on the desktop build).",
-				"In online/LAN games only the player whose turn it is writes the auto-save, so the two players don't clash or double-save.",
-				"Auto-saves show a small \"Game autosaved\" toast instead of the big \"Game saved!\" banner, so the browser build isn't interrupted every phase."
+				"All shipped Ork army lists (Battlewagons, Orks 2000, uploads, Taktikal) now tag their mixed-squad models: Gretchin get their Runtherd, Stormboyz/Warbikers/Tankbustas/Kommandos/Beast Snaggas their Boss Nob, Boyz mobs their Nob, Lootas their Spanner and KMB grots, Meganobz their klaw/killsaw split, and Ghazghkull's unit distinguishes Makari (who now only swings Makari's stabba, not Gork's Klaw).",
+				"Distinct top-down art renders for models with their own profile where it exists (Runtherd, Stormboyz/Warbikers Boss Nob); other leaders show their model-type ring and short label.",
+				"Hovering any model in a mixed squad shows that specific model's role, its OWN wounds when they differ from the squad stat line (e.g. Runtherd W:2/2 in a W:1 mob), and its personal weapon loadout.",
+				"Deploying these squads now offers the model-type picker so you choose where the leader stands, and per-model weapon restrictions apply in shooting and melee (the Runtherd fires his slugga, the grots their blastas).",
+				"Space Marine Intercessors likewise mark their Sergeant (power fist) apart from the rank-and-file."
 			]
 		},
 		{

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7041,6 +7041,14 @@ func _build_model_profile_hover_text(unit: Dictionary, model_id: String) -> Stri
 	var mid_str = model.get("id", model_id)
 	var block = "\n[color=#D49761]──────────[/color]\n"
 	block += "[b][color=#E8C86A]%s[/color][/b] [color=#888888](%s)[/color]" % [label, mid_str]
+	# The hovered model's OWN wounds, when they differ from the squad stat line
+	# above (e.g. a 2W Runtherd in a W:1 Gretchin mob) — otherwise the header's
+	# unit-level "W:1" misrepresents this model.
+	var m_w_max = int(model.get("wounds", 0))
+	var m_w_cur = int(model.get("current_wounds", m_w_max))
+	var unit_w = int(unit.get("meta", {}).get("stats", {}).get("wounds", 0))
+	if m_w_max > 0 and (m_w_max != unit_w or m_w_cur != m_w_max):
+		block += "  [color=#9BD49B]W:%d/%d[/color]" % [m_w_cur, m_w_max]
 	# Model-specific stat overrides (BS/WS/Sv/W/OC differing from the squad).
 	var overrides = profile.get("stats_override", {})
 	if not overrides.is_empty():

--- a/40k/tests/scenarios/sp/model_profile_icon_hover.json
+++ b/40k/tests/scenarios/sp/model_profile_icon_hover.json
@@ -1,0 +1,43 @@
+{
+  "id": "model_profile_icon_hover",
+  "covers": ["ui.model_profile_distinct_icon", "ui.token_hover_model_profile"],
+  "fixture": "shooting_phase",
+  "description": "MA-20 player-facing check: in a squad with heterogeneous profiles (Gretchin mob with Runtherds), the profiled model renders DIFFERENT top-down art from the rank-and-file (gretchin_runtherd.png vs gretchin.png), and hovering it names the profile ('Runtherd' + its own weapons) instead of claiming it is just another Gretchin. Fixture has U_GRETCHIN_A deployed with m1/m2 = runtherd, m3+ = gretchin. Regression test for armies that shipped the Runtherd as an untagged model (same icon, generic tooltip).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "units.U_GRETCHIN_A.models.0.model_type", "equals": "runtherd" },
+
+    { "act": "execute_script", "script": "main.fit_view_to_selection('U_GRETCHIN_A')", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var layer = tree.root.get_node('Main/BoardRoot/TokenLayer')\nvar runtherd_tex = null\nvar grot_tex = null\nfor t in layer.get_children():\n\tif t.has_meta('unit_id') and str(t.get_meta('unit_id')) == 'U_GRETCHIN_A':\n\t\tif str(t.get_meta('model_id')) == 'm1':\n\t\t\truntherd_tex = t._get_unit_sprite_texture()\n\t\tif str(t.get_meta('model_id')) == 'm3':\n\t\t\tgrot_tex = t._get_unit_sprite_texture()\nif runtherd_tex == null or grot_tex == null:\n\treturn 'missing texture'\nif runtherd_tex == grot_tex:\n\treturn 'same texture'\nreturn 'distinct:' + runtherd_tex.resource_path.get_file() + ' vs ' + grot_tex.resource_path.get_file()",
+      "equals": "distinct:gretchin_runtherd.png vs gretchin.png" },
+
+    { "act": "hover_board_at", "x": 617.76, "y": 38.7 },
+    { "act": "expect_node_visible", "node": "/root/Main/TokenHoverTooltip", "timeout_s": 2.0 },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('Runtherd')",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('(m1)')",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('Slugga')",
+      "equals": true },
+    { "act": "screenshot", "label": "01_runtherd_hover_named" },
+
+    { "act": "hover_board_at", "x": 698.5, "y": 38.7 },
+    { "act": "expect_node_visible", "node": "/root/Main/TokenHoverTooltip", "timeout_s": 2.0 },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('(m3)')",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('Grot blasta')",
+      "equals": true },
+    { "act": "execute_script",
+      "script": "main.get_node('TokenHoverTooltip/TokenHoverLabel').get_parsed_text().contains('Runtherd')",
+      "equals": false },
+    { "act": "screenshot", "label": "02_rankandfile_hover_named" }
+  ]
+}

--- a/40k/tests/test_model_profiles.gd
+++ b/40k/tests/test_model_profiles.gd
@@ -10,6 +10,8 @@ var _failed = 0
 var _army_data = {}
 var _sm_data = {}
 var _ran_ma8 = false
+# Lootas model_profiles dict — set in _init, read by the MA-31 tests in _process.
+var mp = null
 
 func _init():
 	print("\n=== Test Model Profiles (MA-1, MA-5, MA-8, MA-10, MA-11, MA-24, MA-26, MA-30, MA-31) ===\n")
@@ -34,7 +36,7 @@ func _init():
 
 	# --- Test 2: model_profiles is a Dictionary ---
 	print("\n--- Test 2: model_profiles is a Dictionary ---")
-	var mp = _army_data.get("units", {}).get("U_LOOTAS_A", {}).get("meta", {}).get("model_profiles", null)
+	mp = _army_data.get("units", {}).get("U_LOOTAS_A", {}).get("meta", {}).get("model_profiles", null)
 	if mp is Dictionary:
 		print("  PASS: model_profiles is a Dictionary")
 		_passed += 1
@@ -417,7 +419,7 @@ func _process(_delta):
 
 	# --- Test 15: MA-11 Boyz unit has model_profiles with weapon_skill overrides ---
 	print("\n--- Test 15: MA-11 Boyz unit has model_profiles with weapon_skill overrides ---")
-	var boyz_f = army_data.get("units", {}).get("U_BOYZ_F", {})
+	var boyz_f = _army_data.get("units", {}).get("U_BOYZ_F", {})
 	var boyz_f_meta = boyz_f.get("meta", {})
 	var boyz_f_profiles = boyz_f_meta.get("model_profiles", {})
 	if boyz_f_profiles.has("boss_nob") and boyz_f_profiles.has("boy"):
@@ -425,13 +427,13 @@ func _process(_delta):
 		var boy_ws = boyz_f_profiles["boy"].get("stats_override", {}).get("weapon_skill", null)
 		if nob_ws != null and int(nob_ws) == 3 and boy_ws != null and int(boy_ws) == 4:
 			print("  PASS: boss_nob WS=3, boy WS=4")
-			passed += 1
+			_passed += 1
 		else:
 			print("  FAIL: Expected boss_nob WS=3 boy WS=4, got nob=%s boy=%s" % [str(nob_ws), str(boy_ws)])
-			failed += 1
+			_failed += 1
 	else:
 		print("  FAIL: U_BOYZ_F missing boss_nob or boy profiles (keys: %s)" % str(boyz_f_profiles.keys()))
-		failed += 1
+		_failed += 1
 
 	# --- Test 16: MA-11 Boyz models have correct model_type ---
 	print("\n--- Test 16: MA-11 Boyz models have correct model_type ---")
@@ -442,14 +444,14 @@ func _process(_delta):
 		boyz_type_counts[mt] = boyz_type_counts.get(mt, 0) + 1
 	if boyz_type_counts.get("boss_nob", 0) == 1 and boyz_type_counts.get("boy", 0) == 19:
 		print("  PASS: 1x boss_nob, 19x boy")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected 1x boss_nob, 19x boy, got %s" % str(boyz_type_counts))
-		failed += 1
+		_failed += 1
 
 	# --- Test 17: MA-24 Meganobz unit exists with transport_slots: 2 ---
 	print("\n--- Test 17: MA-24 Meganobz unit has transport_slots: 2 ---")
-	var meganobz = army_data.get("units", {}).get("U_MEGANOBZ_L", {})
+	var meganobz = _army_data.get("units", {}).get("U_MEGANOBZ_L", {})
 	var mega_meta = meganobz.get("meta", {})
 	var mega_profiles = mega_meta.get("model_profiles", {})
 	if mega_profiles.has("meganob_klaw") and mega_profiles.has("meganob_saws"):
@@ -457,23 +459,23 @@ func _process(_delta):
 		var saws_slots = int(mega_profiles["meganob_saws"].get("transport_slots", 0))
 		if klaw_slots == 2 and saws_slots == 2:
 			print("  PASS: meganob_klaw and meganob_saws both have transport_slots=2")
-			passed += 1
+			_passed += 1
 		else:
 			print("  FAIL: Expected transport_slots=2 for both, got klaw=%d saws=%d" % [klaw_slots, saws_slots])
-			failed += 1
+			_failed += 1
 	else:
 		print("  FAIL: U_MEGANOBZ_L missing meganob_klaw or meganob_saws profiles")
-		failed += 1
+		_failed += 1
 
 	# --- Test 18: MA-24 Meganobz has MEGA ARMOUR keyword ---
 	print("\n--- Test 18: MA-24 Meganobz has MEGA ARMOUR keyword ---")
 	var mega_keywords = mega_meta.get("keywords", [])
 	if "MEGA ARMOUR" in mega_keywords:
 		print("  PASS: Meganobz has MEGA ARMOUR keyword")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Meganobz missing MEGA ARMOUR keyword (got: %s)" % str(mega_keywords))
-		failed += 1
+		_failed += 1
 
 	# --- Test 19: MA-24 Meganobz has 5 models with correct types ---
 	print("\n--- Test 19: MA-24 Meganobz has 5 models with correct model_type ---")
@@ -484,10 +486,10 @@ func _process(_delta):
 		mega_type_counts[mt] = mega_type_counts.get(mt, 0) + 1
 	if mega_models.size() == 5 and mega_type_counts.get("meganob_klaw", 0) == 3 and mega_type_counts.get("meganob_saws", 0) == 2:
 		print("  PASS: 5 models with 3x meganob_klaw, 2x meganob_saws")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected 5 models (3 klaw, 2 saws), got %d models: %s" % [mega_models.size(), str(mega_type_counts)])
-		failed += 1
+		_failed += 1
 
 	# --- Test 20: MA-24 Regular Boyz profiles have transport_slots: 1 ---
 	print("\n--- Test 20: MA-24 Regular Boyz profiles have transport_slots: 1 ---")
@@ -500,11 +502,11 @@ func _process(_delta):
 			boyz_slots_ok = false
 	if boyz_slots_ok and boyz_profiles.size() > 0:
 		print("  PASS: All Boyz profiles have transport_slots=1")
-		passed += 1
+		_passed += 1
 	else:
 		if boyz_profiles.size() == 0:
 			print("  FAIL: No Boyz profiles found")
-		failed += 1
+		_failed += 1
 
 	# --- Test 21: MA-24 Slot-aware counting logic ---
 	print("\n--- Test 21: MA-24 Slot-aware counting logic (simulated) ---")
@@ -517,10 +519,10 @@ func _process(_delta):
 			mega_slot_count += int(profile.get("transport_slots", 1))
 	if mega_slot_count == 10:
 		print("  PASS: 5 Meganobz = 10 transport slots")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected 10 transport slots for 5 Meganobz, got %d" % mega_slot_count)
-		failed += 1
+		_failed += 1
 
 	# --- Test 22: MA-24 Mixed unit slot counting ---
 	print("\n--- Test 22: MA-24 Mixed slot counting (Boyz vs Meganobz) ---")
@@ -538,18 +540,18 @@ func _process(_delta):
 		var partial_boyz = 10  # 10 Boyz slots
 		if combined > 22 and (partial_boyz + mega_slot_count) <= 22:
 			print("  PASS: 20 Boyz + 5 Meganobz = 30 slots (exceeds 22), but 10 Boyz + 5 Meganobz = 20 slots (fits)")
-			passed += 1
+			_passed += 1
 		else:
 			print("  FAIL: Capacity math incorrect")
-			failed += 1
+			_failed += 1
 	else:
 		print("  FAIL: Slot counts wrong (boyz=%d mega=%d)" % [boyz_slot_count, mega_slot_count])
-		failed += 1
+		_failed += 1
 
 	# --- Test 23: MA-24 Unit without profiles defaults to 1 slot per model ---
 	print("\n--- Test 23: MA-24 Unit without profiles defaults to 1 per model ---")
-	var boyz_e_models = army_data.get("units", {}).get("U_BOYZ_E", {}).get("models", [])
-	var boyz_e_meta = army_data.get("units", {}).get("U_BOYZ_E", {}).get("meta", {})
+	var boyz_e_models = _army_data.get("units", {}).get("U_BOYZ_E", {}).get("models", [])
+	var boyz_e_meta = _army_data.get("units", {}).get("U_BOYZ_E", {}).get("meta", {})
 	var boyz_e_has_profiles = boyz_e_meta.get("model_profiles", {}).size() > 0
 	var boyz_e_slot_count = 0
 	for m in boyz_e_models:
@@ -562,10 +564,10 @@ func _process(_delta):
 				boyz_e_slot_count += 1
 	if not boyz_e_has_profiles and boyz_e_slot_count == boyz_e_models.size():
 		print("  PASS: U_BOYZ_E (no profiles) counts 1 per model (%d models = %d slots)" % [boyz_e_models.size(), boyz_e_slot_count])
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected no profiles and 1:1 model:slot ratio")
-		failed += 1
+		_failed += 1
 
 	# --- MA-26: Weapon ownership validation in shooting ---
 	# These tests verify the weapon ownership logic directly using the data structures,
@@ -574,7 +576,7 @@ func _process(_delta):
 	# for the assigned weapon name.
 
 	print("\n--- Test 24: MA-26 Assign deffgun to deffgun model — accepted ---")
-	var ma26_lootas = army_data.get("units", {}).get("U_LOOTAS_A", {}).duplicate(true)
+	var ma26_lootas = _army_data.get("units", {}).get("U_LOOTAS_A", {}).duplicate(true)
 	var ma26_profiles = ma26_lootas.get("meta", {}).get("model_profiles", {})
 	var ma26_models = ma26_lootas.get("models", [])
 	# m1 is loota_deffgun — Deffgun should be in its profile weapons
@@ -587,10 +589,10 @@ func _process(_delta):
 	var ma26_m1_weapons = ma26_profiles.get(ma26_m1_type, {}).get("weapons", [])
 	if "Deffgun" in ma26_m1_weapons:
 		print("  PASS: Deffgun is in deffgun model (m1, type=%s) profile weapons: %s" % [ma26_m1_type, str(ma26_m1_weapons)])
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Deffgun NOT in model m1 (type=%s) profile weapons: %s" % [ma26_m1_type, str(ma26_m1_weapons)])
-		failed += 1
+		_failed += 1
 
 	# --- Test 25: MA-26 Assign deffgun to mega-blasta model — rejected ---
 	print("\n--- Test 25: MA-26 Assign deffgun to mega-blasta model — rejected ---")
@@ -604,10 +606,10 @@ func _process(_delta):
 	var ma26_m9_weapons = ma26_profiles.get(ma26_m9_type, {}).get("weapons", [])
 	if "Deffgun" not in ma26_m9_weapons:
 		print("  PASS: Deffgun correctly NOT in KMB model (m9, type=%s) profile weapons: %s" % [ma26_m9_type, str(ma26_m9_weapons)])
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Deffgun unexpectedly found in KMB model m9 (type=%s) profile weapons: %s" % [ma26_m9_type, str(ma26_m9_weapons)])
-		failed += 1
+		_failed += 1
 
 	# --- Test 26: MA-26 Assign mega-blasta to spanner — accepted ---
 	print("\n--- Test 26: MA-26 Assign kustom mega-blasta to spanner — accepted ---")
@@ -621,31 +623,31 @@ func _process(_delta):
 	var ma26_m11_weapons = ma26_profiles.get(ma26_m11_type, {}).get("weapons", [])
 	if "Kustom mega-blasta" in ma26_m11_weapons:
 		print("  PASS: Kustom mega-blasta is in spanner model (m11, type=%s) profile weapons: %s" % [ma26_m11_type, str(ma26_m11_weapons)])
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Kustom mega-blasta NOT in spanner model m11 (type=%s) profile weapons: %s" % [ma26_m11_type, str(ma26_m11_weapons)])
-		failed += 1
+		_failed += 1
 
 	# --- Test 27: MA-26 Unit without profiles allows all weapons to all models ---
 	print("\n--- Test 27: MA-26 Unit without profiles allows all weapons ---")
-	var ma26_noprofile = army_data.get("units", {}).get("U_BOYZ_E", {}).duplicate(true)
+	var ma26_noprofile = _army_data.get("units", {}).get("U_BOYZ_E", {}).duplicate(true)
 	var ma26_noprofile_profiles = ma26_noprofile.get("meta", {}).get("model_profiles", {})
 	if ma26_noprofile_profiles.is_empty():
 		print("  PASS: Unit without profiles has empty model_profiles — all weapons allowed to all models")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected empty model_profiles but got: %s" % str(ma26_noprofile_profiles.keys()))
-		failed += 1
+		_failed += 1
 
 	# --- Test 28: MA-26 Validation logic matches: weapon_name checked against profile ---
 	print("\n--- Test 28: MA-26 Cross-check: deffgun model cannot fire KMB ---")
 	# m1 is loota_deffgun — Kustom mega-blasta should NOT be in its profile
 	if "Kustom mega-blasta" not in ma26_m1_weapons:
 		print("  PASS: KMB correctly NOT in deffgun model (m1) profile weapons: %s" % str(ma26_m1_weapons))
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: KMB unexpectedly found in deffgun model m1 profile weapons: %s" % str(ma26_m1_weapons))
-		failed += 1
+		_failed += 1
 
 	# ═══════════════════════════════════════════════════════════════════════
 	# MA-30: Unit tests for per-model weapon assignment
@@ -655,7 +657,7 @@ func _process(_delta):
 	# ═══════════════════════════════════════════════════════════════════════
 
 	# Build board dicts
-	var ork_board = {"units": army_data.get("units", {})}
+	var ork_board = {"units": _army_data.get("units", {})}
 
 	# --- Test 29: get_unit_weapons with model_profiles (Lootas) ---
 	print("\n--- Test 29: MA-30 get_unit_weapons with model_profiles (Lootas) ---")
@@ -686,9 +688,9 @@ func _process(_delta):
 		t29_ok = false
 	if t29_ok:
 		print("  PASS: Each Loota model gets correct profiled ranged weapons")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 30: get_unit_weapons without model_profiles (regression) ---
 	print("\n--- Test 30: MA-30 get_unit_weapons without model_profiles (U_BOYZ_E) ---")
@@ -710,9 +712,9 @@ func _process(_delta):
 				t30_ok = false
 	if t30_ok:
 		print("  PASS: All models get all ranged weapons (no profiles = no restriction)")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 31: get_unit_melee_weapons with model_profiles (Boyz_F) ---
 	print("\n--- Test 31: MA-30 get_unit_melee_weapons with model_profiles (Boyz_F) ---")
@@ -751,13 +753,13 @@ func _process(_delta):
 				t31_ok = false
 	if t31_ok:
 		print("  PASS: Melee weapons correctly assigned per model profile")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 32: get_unit_weapons with attached character (composite IDs) ---
 	print("\n--- Test 32: MA-30 get_unit_weapons with attached character on profiled unit ---")
-	var t32_lootas = army_data.get("units", {}).get("U_LOOTAS_A", {}).duplicate(true)
+	var t32_lootas = _army_data.get("units", {}).get("U_LOOTAS_A", {}).duplicate(true)
 	t32_lootas["attachment_data"] = {"attached_characters": ["CHAR_WARBOSS"]}
 	var t32_char = {
 		"id": "CHAR_WARBOSS",
@@ -788,9 +790,9 @@ func _process(_delta):
 			t32_ok = false
 	if t32_ok:
 		print("  PASS: Attached character weapons use composite IDs correctly")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 33: Pistol filter with profiled unit (Boyz_F) ---
 	print("\n--- Test 33: MA-30 Pistol filter with profiled unit (Boyz_F) ---")
@@ -812,9 +814,9 @@ func _process(_delta):
 				t33_ok = false
 	if t33_ok:
 		print("  PASS: Pistol filter returns only Slugga for profiled Boyz")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 34: Heavy filter with profiled unit (Lootas) ---
 	print("\n--- Test 34: MA-30 Heavy filter with profiled unit (Lootas) ---")
@@ -836,9 +838,9 @@ func _process(_delta):
 		t34_ok = false
 	if t34_ok:
 		print("  PASS: Heavy filter returns Deffgun only for deffgun-profiled models")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 35: Rapid fire filter with profiled unit (Lootas) ---
 	print("\n--- Test 35: MA-30 Rapid fire filter with profiled unit (Lootas) ---")
@@ -856,15 +858,15 @@ func _process(_delta):
 			t35_ok = false
 	if t35_ok:
 		print("  PASS: Rapid fire filter returns Deffgun only for deffgun-profiled models")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 36: Assault filter with profiled unit (Intercessors) ---
 	print("\n--- Test 36: MA-30 Assault filter with profiled unit ---")
 	var t36_ok = true
-	if not sm_data.is_empty():
-		var t36_int = sm_data.get("units", {}).get("U_INTERCESSORS_A", {}).duplicate(true)
+	if not _sm_data.is_empty():
+		var t36_int = _sm_data.get("units", {}).get("U_INTERCESSORS_A", {}).duplicate(true)
 		t36_int["id"] = "U_INT_TEST"
 		var t36_board = {"units": {"U_INT_TEST": t36_int}}
 		var t36_assault = _filter_unit_weapons("U_INT_TEST", "assault", t36_board)
@@ -885,19 +887,19 @@ func _process(_delta):
 		t36_ok = false
 	if t36_ok:
 		print("  PASS: Assault filter returns only assault-keyword weapons per profile")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 37: Torrent filter with profiled unit (negative test) ---
 	print("\n--- Test 37: MA-30 Torrent filter with profiled unit (no torrent weapons) ---")
 	var t37_torrent = _filter_unit_weapons("U_LOOTAS_A", "torrent", ork_board)
 	if t37_torrent.is_empty():
 		print("  PASS: Torrent filter correctly returns empty for Lootas (no torrent weapons)")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected empty torrent weapons for Lootas, got: %s" % str(t37_torrent))
-		failed += 1
+		_failed += 1
 
 	# ═══════════════════════════════════════════════════════════════════════
 	# MA-31: Unit tests for per-model combat resolution
@@ -913,7 +915,7 @@ func _process(_delta):
 	var t38_deffgun_profile = {"bs": 6, "ws": 4}
 	# Build weapon profile for KMB (bs=5 from JSON ballistic_skill:"5")
 	var t38_kmb_profile = {"bs": 5, "ws": 4}
-	var t38_lootas = army_data.get("units", {}).get("U_LOOTAS_A", {})
+	var t38_lootas = _army_data.get("units", {}).get("U_LOOTAS_A", {})
 	var t38_models = t38_lootas.get("models", [])
 	# Check each model's effective BS for the Deffgun
 	for m in t38_models:
@@ -950,9 +952,9 @@ func _process(_delta):
 				t38_ok = false
 	if t38_ok:
 		print("  PASS: Mixed BS correctly resolved — spanner BS4+, loota_deffgun BS6+, loota_kmb BS5+ (weapon default)")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 39: MA-31 bs_per_attack array built correctly for mixed BS ---
 	print("\n--- Test 39: MA-31 bs_per_attack array for mixed-BS Deffgun assignment ---")
@@ -1016,14 +1018,14 @@ func _process(_delta):
 		t39_ok = false
 	if t39_ok:
 		print("  PASS: bs_per_attack correctly built — Deffgun: 16x BS6; KMB: 6x BS5 + 3x BS4")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 40: MA-31 Mixed WS melee (Boyz: boss_nob WS3+ vs boy WS4+) ---
 	print("\n--- Test 40: MA-31 Mixed WS melee (Boyz_F: boss_nob WS3+, boy WS4+) ---")
 	var t40_ok = true
-	var t40_boyz = army_data.get("units", {}).get("U_BOYZ_F", {})
+	var t40_boyz = _army_data.get("units", {}).get("U_BOYZ_F", {})
 	var t40_models = t40_boyz.get("models", [])
 	# Choppa weapon: ws=3 in JSON (weapon_skill:"3") for boss_nob-level,
 	# but the weapon WS comes from the JSON weapon data
@@ -1061,14 +1063,14 @@ func _process(_delta):
 		t40_ok = false
 	if t40_ok:
 		print("  PASS: ws_per_attack correctly built — boss_nob: 3x WS3; boys: 57x WS4")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 41: MA-31 WS override only applies to models with matching model_type ---
 	print("\n--- Test 41: MA-31 Unit without profiles uses weapon WS for all models ---")
 	var t41_ok = true
-	var t41_boyz_e = army_data.get("units", {}).get("U_BOYZ_E", {})
+	var t41_boyz_e = _army_data.get("units", {}).get("U_BOYZ_E", {})
 	var t41_models_e = t41_boyz_e.get("models", [])
 	var t41_choppa_profile = {"ws": t40_choppa_ws, "bs": 4}
 	# U_BOYZ_E has no model_profiles — all models should use weapon default WS
@@ -1082,9 +1084,9 @@ func _process(_delta):
 			break
 	if t41_ok:
 		print("  PASS: Unit without profiles uses weapon WS=%d for all models" % t40_choppa_ws)
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 42: MA-31 Rapid Fire bonus only counts models with RF weapon ---
 	print("\n--- Test 42: MA-31 Rapid Fire bonus only counts deffgun models (not KMB) ---")
@@ -1131,9 +1133,9 @@ func _process(_delta):
 		t42_ok = false
 	if t42_ok:
 		print("  PASS: Rapid Fire bonus only applies to 8 Deffgun models; 3 KMB/spanner excluded")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 43: MA-31 Rapid Fire model count matches per-model weapon assignment ---
 	print("\n--- Test 43: MA-31 RF model count from weapon assignment matches ---")
@@ -1155,9 +1157,9 @@ func _process(_delta):
 			t43_ok = false
 	if t43_ok:
 		print("  PASS: RF weapon assignment matches per-model profile (8 deffgun models only)")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 44: MA-31 Per-model save characteristics in wound allocation ---
 	print("\n--- Test 44: MA-31 Per-model save characteristics ---")
@@ -1201,9 +1203,9 @@ func _process(_delta):
 		t44_ok = false
 	if t44_ok:
 		print("  PASS: 11 model_save_profiles built, all using unit base save=5+ (no save overrides in current profiles)")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 45: MA-31 Per-model save with hypothetical save override ---
 	print("\n--- Test 45: MA-31 Per-model save with hypothetical save override ---")
@@ -1239,9 +1241,9 @@ func _process(_delta):
 		t45_ok = false
 	if t45_ok:
 		print("  PASS: Hypothetical save override correctly applied — spanner save=4+, others save=5+")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 46: MA-31 Hazardous weapon resolution — only KMB models risk hazardous ---
 	print("\n--- Test 46: MA-31 Hazardous resolution — only KMB-carrying models risk hazardous ---")
@@ -1282,9 +1284,9 @@ func _process(_delta):
 		t46_ok = false
 	if t46_ok:
 		print("  PASS: Only 3 KMB models (m9, m10, m11) risk hazardous; 8 Deffgun models safe")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 47: MA-31 Hazardous allocation target prioritizes KMB-carrying models ---
 	print("\n--- Test 47: MA-31 Hazardous allocation targets model with hazardous weapon ---")
@@ -1318,9 +1320,9 @@ func _process(_delta):
 			t47_ok = false
 	if t47_ok:
 		print("  PASS: Hazardous allocation correctly targets KMB models (m9/m10/m11), not Deffgun models")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 48: MA-31 One-shot tracking with per-model weapons ---
 	print("\n--- Test 48: MA-31 One-shot tracking per model ---")
@@ -1358,9 +1360,9 @@ func _process(_delta):
 		t48_ok = false
 	if t48_ok:
 		print("  PASS: One-shot tracking is per-model — marking m1 doesn't affect m2/m3")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 49: MA-31 One-shot filter removes fired weapons per model ---
 	print("\n--- Test 49: MA-31 One-shot filter removes fired weapons per model ---")
@@ -1391,9 +1393,9 @@ func _process(_delta):
 		t49_ok = false
 	if t49_ok:
 		print("  PASS: One-shot filter correctly removes fired weapon from m1 only, m2 keeps it")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 50: MA-31 BS override with empty model (fallback to weapon BS) ---
 	print("\n--- Test 50: MA-31 BS override fallback — empty model uses weapon BS ---")
@@ -1410,9 +1412,9 @@ func _process(_delta):
 		t50_ok = false
 	if t50_ok:
 		print("  PASS: BS fallback works — empty model and empty model_type use weapon BS")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 51: MA-31 WS override with empty model (fallback to weapon WS) ---
 	print("\n--- Test 51: MA-31 WS override fallback — empty model uses weapon WS ---")
@@ -1428,9 +1430,9 @@ func _process(_delta):
 		t51_ok = false
 	if t51_ok:
 		print("  PASS: WS fallback works — empty model and empty model_type use weapon WS")
-		passed += 1
+		_passed += 1
 	else:
-		failed += 1
+		_failed += 1
 
 	# --- Test 52: MA-12 Boss Nob has save override in stats_override ---
 	print("\n--- Test 52: MA-12 Boss Nob has save override ---")
@@ -1438,10 +1440,10 @@ func _process(_delta):
 	var nob_save = boyz_f_profiles_2.get("boss_nob", {}).get("stats_override", {}).get("save", null)
 	if nob_save != null and int(nob_save) == 4:
 		print("  PASS: boss_nob has save=4 in stats_override")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected boss_nob save=4, got %s" % str(nob_save))
-		failed += 1
+		_failed += 1
 
 	# --- Test 53: MA-12 stats_override save lookup returns correct values ---
 	print("\n--- Test 53: MA-12 stats_override save lookup logic ---")
@@ -1455,10 +1457,10 @@ func _process(_delta):
 	var boy_eff_save = boy_override_save if boy_override_save > 0 else unit_save
 	if nob_eff_save == 4 and boy_eff_save == 5:
 		print("  PASS: boss_nob effective save=4+, boy effective save=5+ (unit default)")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected nob=4, boy=5, got nob=%d boy=%d" % [nob_eff_save, boy_eff_save])
-		failed += 1
+		_failed += 1
 
 	# --- Test 54: MA-12 stats_override invuln lookup returns defaults when absent ---
 	print("\n--- Test 54: MA-12 stats_override invuln lookup defaults ---")
@@ -1466,10 +1468,10 @@ func _process(_delta):
 	var boy_override_invuln = boyz_f_profiles_2.get(boy_type, {}).get("stats_override", {}).get("invuln", -1)
 	if nob_override_invuln <= 0 and boy_override_invuln <= 0:
 		print("  PASS: No invuln overrides in stats_override for either model type")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected no invuln overrides, got nob=%s boy=%s" % [str(nob_override_invuln), str(boy_override_invuln)])
-		failed += 1
+		_failed += 1
 
 	# --- Test 55: MA-12 Model types in Boyz have different effective saves ---
 	print("\n--- Test 55: MA-12 Boyz models have differentiated saves ---")
@@ -1485,10 +1487,10 @@ func _process(_delta):
 		save_values_by_type[mt] = eff
 	if save_values_by_type.get("boss_nob", -1) == 4 and save_values_by_type.get("boy", -1) == 5:
 		print("  PASS: boss_nob effective save=4+, boy effective save=5+")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected boss_nob=4, boy=5, got %s" % str(save_values_by_type))
-		failed += 1
+		_failed += 1
 
 	# --- Test 56: MA-18 Mixed base size formation spacing math ---
 	print("\n--- Test 56: MA-18 Mixed base size formation spread spacing ---")
@@ -1506,10 +1508,10 @@ func _process(_delta):
 	var edge_to_edge = expected_center_dist - nob_extent / 2.0 - boy_extent / 2.0
 	if abs(edge_to_edge - coherency_px) < 0.01:
 		print("  PASS: Spread spacing gives 2\" edge-to-edge (%.1fpx) for 40mm+32mm bases" % edge_to_edge)
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected %.1fpx edge-to-edge, got %.1fpx" % [coherency_px, edge_to_edge])
-		failed += 1
+		_failed += 1
 
 	# --- Test 57: MA-18 Mixed base tight formation spacing ---
 	print("\n--- Test 57: MA-18 Mixed base size formation tight spacing ---")
@@ -1518,19 +1520,19 @@ func _process(_delta):
 	var tight_edge_gap = tight_center_dist - nob_extent / 2.0 - boy_extent / 2.0
 	if abs(tight_edge_gap - 1.0) < 0.01:
 		print("  PASS: Tight spacing gives 1px gap (bases touching) for 40mm+32mm bases")
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected 1px gap, got %.1fpx" % tight_edge_gap)
-		failed += 1
+		_failed += 1
 
 	# --- Test 58: MA-18 Base extents differ for different base_mm ---
 	print("\n--- Test 58: MA-18 Different base_mm produces different extents ---")
 	if nob_extent > boy_extent:
 		print("  PASS: 40mm base extent (%.1fpx) > 32mm base extent (%.1fpx)" % [nob_extent, boy_extent])
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected 40mm extent > 32mm extent, got %.1f vs %.1f" % [nob_extent, boy_extent])
-		failed += 1
+		_failed += 1
 
 	# --- Test 59: MA-18 Uniform base sizes still work (backward compat) ---
 	print("\n--- Test 59: MA-18 Uniform base sizes produce equal spacing ---")
@@ -1541,14 +1543,14 @@ func _process(_delta):
 	var expected_uniform = boy_extent + coherency_px
 	if abs(uniform_center_dist - expected_uniform) < 0.01:
 		print("  PASS: Uniform 32mm bases give same spacing as old code (%.1fpx)" % uniform_center_dist)
-		passed += 1
+		_passed += 1
 	else:
 		print("  FAIL: Expected %.1fpx, got %.1fpx" % [expected_uniform, uniform_center_dist])
-		failed += 1
+		_failed += 1
 
 	# --- Test 60: MA-18 Boyz unit (U_BOYZ_F) has mixed base sizes for formation ---
 	print("\n--- Test 60: MA-18 Boyz unit boss_nob vs boy base_mm check ---")
-	var boyz_f_unit_18 = army_data.get("units", {}).get("U_BOYZ_F", {})
+	var boyz_f_unit_18 = _army_data.get("units", {}).get("U_BOYZ_F", {})
 	var boyz_f_meta_18 = boyz_f_unit_18.get("meta", {})
 	var boyz_profiles_18 = boyz_f_meta_18.get("model_profiles", {})
 	# Check that model_profiles exist and we can look up base sizes from models
@@ -1562,11 +1564,11 @@ func _process(_delta):
 			found_boy_base = m.get("base_mm", 0)
 	if found_nob_base > 0 and found_boy_base > 0:
 		print("  PASS: boss_nob base=%dmm, boy base=%dmm (formation will use per-model sizes)" % [found_nob_base, found_boy_base])
-		passed += 1
+		_passed += 1
 	else:
 		print("  INFO: boss_nob base=%dmm, boy base=%dmm (may use same base size)" % [found_nob_base, found_boy_base])
 		# Still pass - not all units have mixed bases, the code handles uniform bases too
-		passed += 1
+		_passed += 1
 
 	# --- Summary ---
 	_print_summary()

--- a/tools/add_model_profiles.py
+++ b/tools/add_model_profiles.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""Add per-model `model_type` + unit `model_profiles` to army JSONs that
+predate the MA-20 model-attributes schema (see 40k/MODEL_ATTRIBUTES_TASKS.md).
+
+Why: units like Gretchin ship with the Runtherd as an untagged model (2W,
+32mm base) — the board then renders it with the same icon as a rank-and-file
+Gretchin and the hover tooltip claims it is "just another Gretchin". Once the
+model carries `model_type` and the unit carries `model_profiles`,
+TokenVisual resolves distinct art (`gretchin_runtherd.png`), draws the
+model-type ring/short-label, and Main's hover tooltip appends the per-model
+profile block ("Runtherd (m1)" + its own weapons).
+
+Safety rules:
+- Units that already have `model_profiles` are left untouched (recon_stomps
+  is the reference schema and stays as-is).
+- Profiles are only added when BOTH model types are actually present in the
+  unit's models array (nothing to distinguish otherwise).
+- A profile's weapon list is the datasheet template filtered to weapons the
+  unit actually has. If that leaves a whole category (Ranged/Melee) empty
+  while the unit has weapons of that category, the profile gets ALL of that
+  category instead — so no model can lose a weapon category vs. the old
+  "every model fires everything" behaviour.
+
+Run from the repo root:  python3 tools/add_model_profiles.py [--check]
+--check only reports what would change / validates invariants, exits 1 on drift.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+ARMIES_DIR = Path(__file__).resolve().parent.parent / "40k" / "armies"
+
+# Files known to use ASCII-escaped JSON (– etc.); everything else is UTF-8.
+ENSURE_ASCII = {"orks_taktikal.json"}
+
+TARGET_FILES = [
+    "battlewagons.json",
+    "Orks_2000.json",
+    "Orks_2000_upload.json",
+    "Orks_Upload_Mar7.json",
+    "orks.json",
+    "orks_taktikal.json",
+    "space_marines.json",
+]
+
+
+def _w(model):
+    return int(model.get("wounds", 1))
+
+
+def _b(model):
+    return int(model.get("base_mm", 0))
+
+
+# Registry keyed by unit meta.name. `classify` maps a model dict -> type key.
+# `profiles` carries label/short_label + the datasheet weapon template.
+REGISTRY = {
+    "Gretchin": {
+        "classify": lambda m: "runtherd" if _w(m) >= 2 or _b(m) >= 32 else "gretchin",
+        "profiles": {
+            "runtherd": {"label": "Runtherd", "short_label": "R",
+                         "weapons": ["Slugga", "Runtherd tools"]},
+            "gretchin": {"label": "Gretchin", "short_label": "G",
+                         "weapons": ["Grot blasta", "Close combat weapon"]},
+        },
+    },
+    "Stormboyz": {
+        "classify": lambda m: "boss_nob" if _w(m) >= 2 else "stormboy",
+        "profiles": {
+            "boss_nob": {"label": "Boss Nob", "short_label": "N",
+                         "weapons": ["Slugga", "Power klaw"]},
+            "stormboy": {"label": "Stormboy", "short_label": "S",
+                         "weapons": ["Slugga", "Choppa"]},
+        },
+    },
+    "Warbikers": {
+        "classify": lambda m: "boss_nob" if _w(m) >= 4 else "warbiker",
+        "profiles": {
+            "boss_nob": {"label": "Boss Nob on Warbike", "short_label": "N",
+                         "weapons": ["Twin dakkagun", "Power klaw"]},
+            "warbiker": {"label": "Warbiker", "short_label": "B",
+                         "weapons": ["Twin dakkagun", "Close combat weapon"]},
+        },
+    },
+    "Tankbustas": {
+        # All Tankbustas are 2W; the roster encodes the Boss Nob as the one
+        # 40mm base (m1, composition line 1).
+        "classify": lambda m: "boss_nob" if _b(m) >= 40 else "tankbusta",
+        "profiles": {
+            "boss_nob": {"label": "Boss Nob", "short_label": "N",
+                         "weapons": ["Rokkit pistol", "Choppa"]},
+            "tankbusta": {"label": "Tankbusta", "short_label": "T",
+                          "weapons": ["Rokkit launcha", "Close combat weapon"]},
+        },
+    },
+    "Kommandos": {
+        "classify": lambda m: "boss_nob" if _w(m) >= 2 else "kommando",
+        "profiles": {
+            "boss_nob": {"label": "Boss Nob", "short_label": "N",
+                         "weapons": ["Slugga", "Big choppa"]},
+            "kommando": {"label": "Kommando", "short_label": "K",
+                         "weapons": ["Kustom shoota", "Slugga", "Choppa",
+                                     "Close combat weapon"]},
+        },
+    },
+    "Beast Snagga Boyz": {
+        "classify": lambda m: "boss_nob" if _w(m) >= 2 else "boy",
+        "profiles": {
+            "boss_nob": {"label": "Beast Snagga Nob", "short_label": "N",
+                         "weapons": ["Slugga", "Power snappa"]},
+            "boy": {"label": "Beast Snagga Boy", "short_label": "B",
+                    "weapons": ["Slugga", "Choppa", "Close combat weapon"]},
+        },
+    },
+    "Boyz": {
+        "classify": lambda m: "boss_nob" if _w(m) >= 2 else "boy",
+        "profiles": {
+            "boss_nob": {"label": "Boss Nob", "short_label": "N",
+                         "weapons": ["Slugga", "Kombi-weapon", "Choppa",
+                                     "Big choppa", "Power klaw"]},
+            "boy": {"label": "Boy", "short_label": "B",
+                    "weapons": ["Shoota", "Big shoota", "Rokkit launcha",
+                                "Slugga", "Choppa", "Close combat weapon"]},
+        },
+    },
+    # Ghazghkull + Makari: weapon split is unambiguous from the weapon names.
+    "Ghazghkull Thraka": {
+        "classify": lambda m: "ghazghkull" if _w(m) >= 5 else "makari",
+        "profiles": {
+            "ghazghkull": {"label": "Ghazghkull Thraka", "short_label": "G",
+                           "weapons_by_prefix_not": "Makari"},
+            "makari": {"label": "Makari", "short_label": "M",
+                       "weapons_by_prefix": "Makari"},
+        },
+    },
+}
+
+# Per-unit-id overrides. The MA test suite (test_backward_compatibility.gd,
+# test_ma15_model_type_picker.gd) and the audit_baseline_postdeploy fixture
+# define the AUTHORITATIVE migrated shape of orks.json:
+#   - U_BOYZ_E stays legacy (no profiles) — it is the backward-compat control
+#     the tests drive weapon-assignment/wound-allocation through.
+#   - U_LOOTAS_A is 8x Loota (Deffgun) / 2x Loota (KMB) / 1x Spanner (BS4).
+#   - U_MEGANOBZ_L is 3x Power Klaw / 2x Killsaw nobz, transport_slots 2.
+#   - U_BOYZ_F carries the fixture's stats_override (WS3/Sv4 nob, WS4 boy).
+# A value of None means "leave this unit untouched".
+_BOYZ_FIXTURE_SPEC = {
+    "classify": lambda m: "boss_nob" if _w(m) >= 2 else "boy",
+    "profiles": {
+        "boss_nob": {"label": "Boss Nob", "short_label": "N",
+                     "weapons": ["Big choppa", "Choppa", "Power klaw",
+                                 "Slugga", "Kombi-weapon"],
+                     "stats_override": {"save": 4, "weapon_skill": 3},
+                     "transport_slots": 1},
+        "boy": {"label": "Boy", "short_label": "B",
+                "weapons": ["Choppa", "Close combat weapon", "Shoota",
+                            "Slugga", "Big shoota", "Rokkit launcha"],
+                "stats_override": {"weapon_skill": 4},
+                "transport_slots": 1},
+    },
+}
+
+_LOOTAS_FIXTURE_SPEC = {
+    # 11-model layout from the MA fixture: m1-m8 deffguns, m9-m10 KMB lootas,
+    # m11 the Spanner. Only applied when the model count matches exactly.
+    "assign_by_counts": [("loota_deffgun", 8), ("loota_kmb", 2), ("spanner", 1)],
+    "profiles": {
+        "loota_deffgun": {"label": "Loota (Deffgun)", "short_label": "D",
+                          "weapons": ["Deffgun", "Close combat weapon"],
+                          "transport_slots": 1},
+        "loota_kmb": {"label": "Loota (Kustom Mega-blasta)", "short_label": "K",
+                      "weapons": ["Kustom mega-blasta", "Close combat weapon"],
+                      "transport_slots": 1},
+        "spanner": {"label": "Spanner", "short_label": "S",
+                    "weapons": ["Kustom mega-blasta", "Close combat weapon"],
+                    "stats_override": {"ballistic_skill": 4},
+                    "transport_slots": 1},
+    },
+}
+
+_MEGANOBZ_FIXTURE_SPEC = {
+    "assign_by_counts": [("meganob_klaw", 3), ("meganob_saws", 2)],
+    "profiles": {
+        # "Killsaws"/"Killsaw" both listed so the filter keeps whichever
+        # spelling the file uses.
+        "meganob_klaw": {"label": "Meganob (Power Klaw)", "short_label": "PK",
+                         "weapons": ["Kustom shoota", "Power klaw"],
+                         "transport_slots": 2},
+        "meganob_saws": {"label": "Meganob (Killsaws)", "short_label": "KS",
+                         "weapons": ["Kustom shoota", "Killsaws", "Killsaw"],
+                         "transport_slots": 2},
+    },
+}
+
+_INTERCESSORS_FIXTURE_SPEC = {
+    # 5 identical models — the Sergeant is m1 (unit_composition line 1).
+    # test_model_profiles.gd Tests 12-13 pin this exact shape.
+    "assign_by_counts": [("intercessor_sergeant", 1), ("intercessor", 4)],
+    "profiles": {
+        "intercessor_sergeant": {"label": "Intercessor Sergeant", "short_label": "S",
+                                 "weapons": ["Bolt rifle", "Bolt pistol", "Power fist"],
+                                 "transport_slots": 1},
+        "intercessor": {"label": "Intercessor", "short_label": "I",
+                        "weapons": ["Bolt rifle", "Bolt pistol", "Close combat weapon"],
+                        "transport_slots": 1},
+    },
+}
+
+UNIT_OVERRIDES = {
+    ("space_marines.json", "U_INTERCESSORS_A"): _INTERCESSORS_FIXTURE_SPEC,
+    ("orks.json", "U_BOYZ_E"): None,
+    ("orks_taktikal.json", "U_BOYZ_E"): None,
+    ("orks.json", "U_BOYZ_F"): _BOYZ_FIXTURE_SPEC,
+    ("orks_taktikal.json", "U_BOYZ_F"): _BOYZ_FIXTURE_SPEC,
+    ("orks.json", "U_BOYZ_K"): _BOYZ_FIXTURE_SPEC,
+    ("orks_taktikal.json", "U_BOYZ_K"): _BOYZ_FIXTURE_SPEC,
+    ("orks.json", "U_LOOTAS_A"): _LOOTAS_FIXTURE_SPEC,
+    ("orks_taktikal.json", "U_LOOTAS_A"): _LOOTAS_FIXTURE_SPEC,
+    ("orks.json", "U_MEGANOBZ_L"): _MEGANOBZ_FIXTURE_SPEC,
+    ("orks_taktikal.json", "U_MEGANOBZ_L"): _MEGANOBZ_FIXTURE_SPEC,
+}
+
+
+def build_weapons(profile_spec, unit_weapons):
+    """unit_weapons: list of {name, type} dicts from unit meta."""
+    names = {w.get("name", ""): w.get("type", "") for w in unit_weapons}
+    if "weapons_by_prefix" in profile_spec:
+        return [n for n in names if n.startswith(profile_spec["weapons_by_prefix"])]
+    if "weapons_by_prefix_not" in profile_spec:
+        return [n for n in names if not n.startswith(profile_spec["weapons_by_prefix_not"])]
+
+    template = profile_spec["weapons"]
+    have = [n for n in template if n in names]
+    out = list(have)
+    for cat in ("Ranged", "Melee"):
+        cat_all = [n for n, t in names.items() if t == cat]
+        if cat_all and not any(names[n] == cat for n in have):
+            out.extend(n for n in cat_all if n not in out)
+    return out
+
+
+def patch_file(path, check_only=False):
+    raw = path.read_text(encoding="utf-8")
+    data = json.loads(raw)
+    units = data.get("units", {})
+    unit_items = units.items() if isinstance(units, dict) else [
+        (u.get("id", ""), u) for u in units]
+
+    changed = []
+    for uid, unit in unit_items:
+        meta = unit.get("meta", {})
+        name = meta.get("name", "")
+        override_key = (path.name, uid)
+        spec = None
+        if override_key in UNIT_OVERRIDES:
+            spec = UNIT_OVERRIDES[override_key]
+            if spec is None:
+                continue  # pinned legacy (backward-compat control unit)
+        elif name in REGISTRY:
+            spec = REGISTRY[name]
+        else:
+            continue
+        if meta.get("model_profiles"):
+            continue  # already migrated (recon_stomps schema) — leave alone
+        models = unit.get("models", [])
+
+        if "assign_by_counts" in spec:
+            counts = spec["assign_by_counts"]
+            if sum(c for _, c in counts) != len(models):
+                continue  # layout doesn't match the fixture spec — skip
+            assigned = []
+            for type_key, c in counts:
+                assigned.extend([type_key] * c)
+        else:
+            assigned = [spec["classify"](m) for m in models]
+        if len(set(assigned)) < 2:
+            continue  # homogeneous unit — nothing to distinguish
+
+        profiles = {}
+        for type_key, pspec in spec["profiles"].items():
+            weapons = build_weapons(pspec, meta.get("weapons", []))
+            profiles[type_key] = {
+                "label": pspec["label"],
+                "short_label": pspec["short_label"],
+                "weapons": weapons,
+                "stats_override": dict(pspec.get("stats_override", {})),
+            }
+            if "transport_slots" in pspec:
+                profiles[type_key]["transport_slots"] = pspec["transport_slots"]
+
+        if not check_only:
+            for m, type_key in zip(models, assigned):
+                m["model_type"] = type_key
+            meta["model_profiles"] = profiles
+        changed.append((uid, name, {t: assigned.count(t) for t in set(assigned)},
+                        {t: p["weapons"] for t, p in profiles.items()}))
+
+    if changed and not check_only:
+        out = json.dumps(data, indent=1,
+                         ensure_ascii=path.name in ENSURE_ASCII) + "\n"
+        path.write_text(out, encoding="utf-8")
+    return changed
+
+
+def validate(path):
+    """Invariants: every profile weapon exists on the unit; every model of a
+    profiled unit has a model_type that the profiles dict contains; each
+    profile keeps every weapon category the unit has... only for units this
+    script owns (registry names)."""
+    problems = []
+    data = json.loads(path.read_text(encoding="utf-8"))
+    units = data.get("units", {})
+    unit_items = units.items() if isinstance(units, dict) else [
+        (u.get("id", ""), u) for u in units]
+    for uid, unit in unit_items:
+        meta = unit.get("meta", {})
+        profiles = meta.get("model_profiles", {})
+        if not profiles:
+            continue
+        names = {w.get("name", ""): w.get("type", "") for w in meta.get("weapons", [])}
+        for tkey, prof in profiles.items():
+            for wn in prof.get("weapons", []):
+                if wn not in names:
+                    problems.append(f"{path.name}:{uid} profile {tkey} references unknown weapon '{wn}'")
+        for m in unit.get("models", []):
+            mt = m.get("model_type", "")
+            if mt == "":
+                problems.append(f"{path.name}:{uid} model {m.get('id')} missing model_type")
+            elif mt not in profiles:
+                problems.append(f"{path.name}:{uid} model {m.get('id')} type '{mt}' not in profiles")
+    return problems
+
+
+def main():
+    check_only = "--check" in sys.argv
+    any_change = False
+    all_problems = []
+    for fname in TARGET_FILES:
+        path = ARMIES_DIR / fname
+        if not path.exists():
+            print(f"SKIP (missing): {fname}")
+            continue
+        changed = patch_file(path, check_only=check_only)
+        for uid, name, counts, weapons in changed:
+            any_change = True
+            print(f"{'WOULD PATCH' if check_only else 'PATCHED'} {fname} {uid} ({name}) types={counts}")
+            for t, ws in weapons.items():
+                print(f"    {t}: {ws}")
+        all_problems.extend(validate(path))
+    for p in all_problems:
+        print("PROBLEM:", p)
+    if all_problems:
+        sys.exit(1)
+    if check_only and any_change:
+        sys.exit(1)
+    print("OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What & why

Units with heterogeneous models (a Gretchin mob with its Runtherd, squads with a Boss Nob, Lootas with a Spanner, Ghazghkull + Makari, Intercessors with a Sergeant) rendered **every** model with the same icon, and the board hover tooltip described the leader as just another squad member. The MA-20 per-model-profile system already supported distinct icons and per-model hover info, but only `recon_stomps.json` shipped the `model_type` / `model_profiles` data — so in every other army the Runtherd was an untagged 2W model with a bigger base, indistinguishable from a grot.

## Changes

- **`tools/add_model_profiles.py`** — repeatable migrator that tags models with `model_type` and adds `model_profiles` to army JSONs. Weapon lists are datasheet templates filtered to weapons the unit actually has, with a whole-category fallback so no model can silently lose a weapon category. Per-unit overrides pin the exact shapes the MA test suite expects (`U_BOYZ_E` stays legacy as the backward-compat control; Lootas 8/2/1, Meganobz 3/2, Boyz_F stat overrides, Intercessors sergeant).
- **Army data migrated**: `battlewagons`, `Orks_2000`, `Orks_2000_upload`, `Orks_Upload_Mar7`, `orks`, `orks_taktikal`, `space_marines`.
- **`Main.gd`** hover tooltip — the per-model profile block now shows the hovered model's **own** wounds when they differ from the unit stat line, so a 2W Runtherd no longer reads as `W:1`.
- **`tests/test_model_profiles.gd`** — repaired pre-existing parse errors (locals referenced across function scopes) so the 68-test suite runs again.

## Validation

- Headless: `test_model_profiles` 68/68, `test_backward_compatibility` 35/35, `test_ma15_model_type_picker` 11/11 — several of these were previously red because the army-data migration had never landed.
- New committed windowed scenario `model_profile_icon_hover.json` (17/17): asserts the Runtherd token resolves `gretchin_runtherd.png` while rank-and-file resolve `gretchin.png`, and that hovering names the model with its own weapons. Also drove the exact reported case live (menu → new game with battlewagons → deploy Gretchin via the model-type picker → hover) with `verify_delivery` PASS, zero log errors. Re-ran all of the above after rebasing onto latest `main` (which had merged a `Main.gd` popup refactor).

## Known gaps

- Weapon splits are datasheet-accurate where unambiguous — grots no longer fire the Runtherd's slugga, Makari can't swing Gork's Klaw. Small intentional gameplay change.
- Lootas in the 10-model and 2-model rosters remain untagged — the roster data can't say which models are Spanners.
- Boss Nobs in units without dedicated art are distinguished by their model-type ring + short label + tooltip, not unique art.
- Existing saves keep their old embedded data; the fix applies to new games.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UL3bDUWuDQgZ8xKbuKfTZZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL3bDUWuDQgZ8xKbuKfTZZ)_