### PR TITLE
Fix disembark ghost + range ring lingering after switching units

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.58.3",
+			"date": "2026-07-18",
+			"summary": "Fixed a disembark ghost that stuck to the screen: if you picked an embarked unit to disembark and then changed your mind and selected a different unit, the transport's disembark range area and the model 'ghost' trailing your cursor used to stay on the board. They now clear the moment you switch units.",
+			"changes": [
+				"Selecting, re-selecting, or starting a move on another unit while a disembark is being placed now tears down that disembark's range ring and cursor ghost instead of leaving them on the board.",
+				"No rules impact — the leftover was purely visual; the disembark itself was already abandoned."
+			]
+		},
+		{
 			"version": "0.58.2",
 			"date": "2026-07-18",
 			"summary": "Renamed the Movement phase's red 'Confirm Move' button to 'End This Unit's Move' so it is no longer confused with the 'Confirm Movement Mode' button. Previously players could pick Advance and click the red button expecting to start moving, but it just ended the unit's move.",

--- a/40k/scripts/DisembarkController.gd
+++ b/40k/scripts/DisembarkController.gd
@@ -550,6 +550,17 @@ func _cancel_disembark() -> void:
 	emit_signal("disembark_canceled", unit_id)
 	_cleanup()
 
+func abort() -> void:
+	# External cancellation (e.g. the player switched to another unit or began a
+	# different move) rather than an in-controller ESC/right-click. Tears down the
+	# ghost model + range ring and stops input processing WITHOUT emitting
+	# disembark_canceled: the caller has already repointed its own selection state
+	# to the new unit, and firing the cancel handler here would clobber it. No
+	# GameState was mutated by starting the disembark, so there is nothing to roll
+	# back — only the visuals need clearing.
+	print("DisembarkController: aborted externally for unit ", unit_id)
+	_cleanup()
+
 func _cleanup() -> void:
 	set_process_unhandled_input(false)
 

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -20,6 +20,12 @@ var active_unit_id: String = ""
 # 11e 18.04: unit_id -> bool, set when the DisembarkDialog's Combat
 # Disembark toggle was checked; consumed when CONFIRM_DISEMBARK is built.
 var _pending_combat_disembark: Dictionary = {}
+# The live DisembarkController spawned by _on_disembark_confirmed while the player
+# is placing disembarked models. Tracked so it can be torn down when the player
+# abandons the disembark (selects/moves a different unit) — otherwise its ghost
+# model + range ring leak on screen and it keeps eating mouse input. Null when no
+# disembark placement is in progress.
+var _active_disembark_controller: Node = null
 var active_mode: String = ""  # NORMAL, ADVANCE, FALL_BACK
 var move_cap_inches: float = 0.0
 var selected_model: Dictionary = {}
@@ -989,6 +995,11 @@ func _on_unit_selected(index: int) -> void:
 	if not unit:
 		return
 
+	# Selecting any row abandons an in-progress disembark placement — tear down its
+	# ghost + range ring so they don't linger over the newly selected unit. A fresh
+	# disembark dialog is re-shown below if this row is itself an embarked unit.
+	_abort_active_disembark()
+
 	# QoL: switching to a different unit auto-confirms the previously selected
 	# unit's moved-but-unconfirmed move (same as clicking "Confirm Move"). Do this
 	# before we repoint active_unit_id so the pending unit is the one confirmed.
@@ -1658,6 +1669,11 @@ func _set_mode_radio_for_locked_mode(mode: String) -> void:
 
 func _on_unit_move_begun(unit_id: String, mode: String) -> void:
 	print("MovementController: Unit move begun - ", unit_id, " mode: ", mode)
+	# Catch-all: a move beginning for any unit means the player left the disembark
+	# placement (this fires for board/stats-panel selections that bypass
+	# _on_unit_selected). Clear its ghost + range ring. No-op once the disembark
+	# has already completed (reference cleared in _on_disembark_completed).
+	_abort_active_disembark()
 	active_unit_id = unit_id
 	active_mode = mode
 	_update_selected_unit_display()
@@ -2580,6 +2596,12 @@ func _handle_embarked_unit_selected(unit_id: String) -> void:
 	if not unit:
 		return
 
+	# Tear down any disembark already in progress (e.g. the player was placing a
+	# different unit, or re-clicked this one) before offering a new dialog. Also
+	# covers the board/stats-panel entry points that call this directly, bypassing
+	# _on_unit_selected.
+	_abort_active_disembark()
+
 	print("MovementController: Unit %s is embarked, showing disembark dialog" % unit_id)
 
 	# Create and show disembark dialog
@@ -2606,6 +2628,10 @@ func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 	controller.disembark_completed.connect(_on_disembark_completed)
 	controller.disembark_canceled.connect(_on_disembark_canceled)
 
+	# Track the live controller so switching/re-selecting units can tear it down
+	# (its ghost + range ring live under this node).
+	_active_disembark_controller = controller
+
 	# Add to scene
 	var board_root = SceneRefs.board_root()
 	if board_root:
@@ -2616,9 +2642,31 @@ func _on_disembark_confirmed(combat_mode: bool, unit_id: String) -> void:
 	# Start disembark placement
 	controller.start_disembark(unit_id)
 
+func _abort_active_disembark() -> void:
+	"""Tear down an in-progress disembark placement (ghost model + range ring) and
+	stop it processing input. Called when the player abandons the disembark by
+	selecting, re-selecting, or beginning a move on a different unit. Safe to call
+	when no disembark is active (no-op)."""
+	if _active_disembark_controller != null and is_instance_valid(_active_disembark_controller):
+		var aborting_unit_id := ""
+		if "unit_id" in _active_disembark_controller:
+			aborting_unit_id = str(_active_disembark_controller.unit_id)
+		print("MovementController: Aborting in-progress disembark for %s (player switched away)" % aborting_unit_id)
+		if _active_disembark_controller.has_method("abort"):
+			_active_disembark_controller.abort()
+		else:
+			_active_disembark_controller.queue_free()
+		if aborting_unit_id != "":
+			_pending_combat_disembark.erase(aborting_unit_id)
+	_active_disembark_controller = null
+
 func _on_disembark_completed(unit_id: String, positions: Array) -> void:
 	"""Handle successful disembark - route through action system for multiplayer sync"""
 	print("MovementController: Disembark completed for unit %s with %d positions" % [unit_id, positions.size()])
+
+	# The controller cleans itself up on completion; drop our reference so a later
+	# unit switch doesn't try to abort an already-freed node.
+	_active_disembark_controller = null
 
 	# Serialize positions for action payload (Vector2 -> dict for network transport)
 	var serialized_positions = []
@@ -2680,6 +2728,10 @@ func _post_disembark_ui_update(unit_id: String) -> void:
 func _on_disembark_canceled(unit_id: String) -> void:
 	"""Handle canceled disembark"""
 	print("MovementController: Disembark canceled for unit %s" % unit_id)
+
+	# The controller emitted this from its own ESC/right-click cleanup; drop our
+	# reference so a later unit switch doesn't try to abort an already-freed node.
+	_active_disembark_controller = null
 
 	# Clear selection
 	_clear_unit_highlight()

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1934,6 +1934,15 @@
       "status": "covered"
     },
     {
+      "id": "scripts.DisembarkController.cleanup_on_switch",
+      "description": "Abandoning an in-progress disembark by selecting/beginning a move on a different unit tears down the DisembarkController — its range ring and cursor ghost are removed (MovementController._abort_active_disembark, hooked into _on_unit_selected / _handle_embarked_unit_selected / _on_unit_move_begun; DisembarkController.abort()). Regression for the ghost-UI leak where both visuals lingered on the board after switching units.",
+      "scenarios": [
+        "iss058c_disembark_ghost_cleanup_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "phases.ScoringPhase.coherency_removal_choice_03_03",
       "description": "11e 03.03 Regaining Coherency (audit #16): END_TURN pauses while a human-owned unit is out of coherency; REMOVE_MODEL_FOR_COHERENCY applies the player's chosen removal (destroyed, no on-death triggers); END_TURN is blocked until coherent. PhaseManager auto-pick hook remains the AI/backstop. The removal actions are only listed to the AI turn loop for AI-owned units — at the end of an AI turn the human's pending removals block with an empty action list so the AI cannot answer the choice for them (iss042c).",
       "scenarios": [

--- a/40k/tests/scenarios/sp/iss058c_disembark_ghost_cleanup_11e.json
+++ b/40k/tests/scenarios/sp/iss058c_disembark_ghost_cleanup_11e.json
@@ -1,0 +1,52 @@
+{
+  "id": "iss058c_disembark_ghost_cleanup_11e",
+  "covers": ["scripts.DisembarkController.cleanup_on_switch"],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Regression for the disembark ghost-UI leak: selecting an embarked unit and confirming the DisembarkDialog spawns a DisembarkController (range ring around the transport + a ghost model that follows the cursor). Switching to a DIFFERENT unit in the unit list must tear that controller down — no lingering range ring, no cursor ghost. Before the fix the controller kept living under BoardRoot after the switch, so both visuals stayed on screen.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_phase", "equals": 7 },
+    { "act": "expect_state", "path": "units.U_KOMMANDOS_H.embarked_in", "equals": "U_BATTLEWAGON_G" },
+
+    { "act": "click_item_list", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList", "index": 4 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var dlg = null\nfor c in tree.root.get_children():\n\tif c.has_signal(\"disembark_confirmed\"):\n\t\tdlg = c\n\t\tbreak\nif dlg == null: return \"NO_DIALOG\"\ndlg.get_ok_button().emit_signal(\"pressed\")\nreturn \"OK_PRESSED\"",
+      "equals": "OK_PRESSED"
+    },
+    { "act": "wait_seconds", "seconds": 0.4 },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var br = tree.current_scene.get_node_or_null(\"BoardRoot\")\nif br == null: return -1\nvar n = 0\nfor c in br.get_children():\n\tif c.has_method(\"start_disembark\"):\n\t\tn += 1\nreturn n",
+      "equals": 1,
+      "comment": "Precondition: exactly one DisembarkController is live after confirming the dialog."
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var br = tree.current_scene.get_node_or_null(\"BoardRoot\")\nvar ctrl = null\nfor c in br.get_children():\n\tif c.has_method(\"start_disembark\"):\n\t\tctrl = c\n\t\tbreak\nif ctrl == null: return \"NO_CTRL\"\nvar ghosts = ctrl.get_node_or_null(\"GhostLayer\")\nvar ring = ctrl.get_node_or_null(\"RangeIndicator\")\nreturn \"ghosts=\" + str(ghosts.get_child_count()) + \" ring=\" + str(ring.get_child_count())",
+      "comment": "Show the live cursor-ghost + range-ring node counts while the controller is active."
+    },
+    { "act": "screenshot", "label": "01_disembark_active_ring_and_ghost" },
+
+    { "act": "click_item_list", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList", "index": 1 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var br = tree.current_scene.get_node_or_null(\"BoardRoot\")\nif br == null: return -1\nvar n = 0\nfor c in br.get_children():\n\tif is_instance_valid(c) and c.has_method(\"start_disembark\"):\n\t\tn += 1\nreturn n",
+      "equals": 0,
+      "comment": "THE FIX: after switching to U_BOYZ_E, no DisembarkController remains — the range ring and cursor ghost are gone with it."
+    },
+    { "act": "screenshot", "label": "02_after_switch_no_ghost" }
+  ]
+}


### PR DESCRIPTION
## Problem

Selecting an embarked unit to disembark, then abandoning it and selecting a different unit, left the transport's disembark **range area** and the model **ghost trailing the cursor** on the board. Reported around Battlewagon Gamma.

## Root cause

Confirming the disembark dialog spawns a `DisembarkController` under `BoardRoot` that owns both the range ring and the cursor ghost. It was created as a throwaway local with no stored reference and only tore itself down on ESC or when placement completed. Switching to another unit never cancelled it, so it stayed alive — visuals on screen and still consuming mouse input.

## Fix

- Track the live controller in `MovementController._active_disembark_controller`.
- Add `_abort_active_disembark()` + `DisembarkController.abort()` — a visual teardown that deliberately does **not** emit `disembark_canceled` (so it won't clobber the unit you just switched to).
- Invoke it from the three places the player can leave an in-progress disembark:
  - `_on_unit_selected` — unit-list selection
  - `_handle_embarked_unit_selected` — re-selecting / another embarked unit (also covers the board & stats-panel entry points)
  - `_on_unit_move_begun` — catch-all for board/panel selections that begin a move without going through `_on_unit_selected`
- Reference is cleared in the completion and cancel handlers so an external abort never touches an already-freed node.

No `GameState` is mutated by starting a disembark, so aborting only clears visuals — no rules impact.

## Validation

- **New windowed regression** `iss058c_disembark_ghost_cleanup_11e` drives the real unit-list clicks and asserts the controller (and thus its ghost + range ring) is gone after switching units. It **fails on the pre-fix code** (controller count stayed `1`) and passes after (`0`).
- Verified visually with zoomed before/after screenshots + a pixel diff isolating the removed range rectangle and cursor ghost.
- Existing `iss058` / `iss058b` disembark scenarios and movement scenarios (`click_select_unit_movement`, `iss040_movement_11e`, …) still pass; no `ERROR` / `SCRIPT ERROR` in the run.

## Changes

- `40k/scripts/DisembarkController.gd` — `abort()`
- `40k/scripts/MovementController.gd` — tracking + `_abort_active_disembark()` and its three hooks
- `40k/tests/scenarios/sp/iss058c_disembark_ghost_cleanup_11e.json` — new regression
- `40k/tests/coverage.json` — coverage tile
- `40k/data/version_history.json` — v0.58.3 changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NSPk8qodysnCPSDf3bUbd3

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSPk8qodysnCPSDf3bUbd3)_