### PR TITLE
Track Godot .uid for weapon_range_panel_unbound test

### DIFF
--- a/40k/tests/test_weapon_range_panel_unbound.gd.uid
+++ b/40k/tests/test_weapon_range_panel_unbound.gd.uid
@@ -1,0 +1,1 @@
+uid://cktqbnpd8ryw


### PR DESCRIPTION
Follow-up to #679.

Godot generated `40k/tests/test_weapon_range_panel_unbound.gd.uid` on import **after** the original commit landed, so it was left untracked. This repo tracks `.gd.uid` companion files by convention (390 already tracked; they keep resource UIDs stable across checkouts), so this commits the missing one alongside the test script it belongs to.

- One new file, 19 bytes (`uid://cktqbnpd8ryw`). No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNTNkYdeDMdzt6G9dJdth8

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNTNkYdeDMdzt6G9dJdth8)_