### PR TITLE
Fix 'Take to the skies' dead checkbox: mid-move toggle now applies (Deffkopta dense-terrain block)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.59.1",
+			"date": "2026-07-18",
+			"summary": "'Take to the skies' now works when ticked mid-move: FLY units (e.g. Deffkoptas) that were blocked by dense terrain with the box already ticked will now actually fly over it, the Move/Left readout updates to the -2\" cap immediately, and the dense-terrain error explains itself properly.",
+			"changes": [
+				"Fixed: ticking 'Take to the skies (-2\" move)' after selecting a unit did nothing — the drag flow had already begun the move without the declaration, so dense terrain (rule 13.06) kept blocking the path and the -2\" cap was never applied. The tick (and un-tick) now updates the in-progress move.",
+				"Un-ticking mid-move is only allowed before any model has been dragged (staged paths may rely on flying); ticking is refused with a clear message if a model already moved beyond the reduced cap — use Reset Unit first.",
+				"The checkbox now always shows the unit's actual declaration when you select a unit, instead of carrying a stale tick over from the previously selected unit.",
+				"Clearer error: 'Dense terrain blocks this model's path (rule 13.06): catwalk-58 — tick Take to the skies to fly over it' — the old '(13.06)' read like a distance in inches, and the message never mentioned the fix."
+			]
+		},
+		{
 			"version": "0.59.0",
 			"date": "2026-07-18",
 			"summary": "Squad leaders now look and read like leaders. The Runtherd in every Gretchin mob (and the Boss Nob, Spanner, Makari and friends in other squads) gets its own board icon instead of a scaled-up copy of the rank-and-file art, and hovering it names the model with its own wounds and weapons instead of claiming it is just another squad member.",

--- a/40k/phases/ChargePhase.gd
+++ b/40k/phases/ChargePhase.gd
@@ -2771,7 +2771,7 @@ func _validate_no_solid_terrain_on_paths(unit_id: String, per_model_paths: Dicti
 			var seg_to = Vector2(path[i + 1][0], path[i + 1][1])
 			var trav = tm.can_move_through_11e(model_keywords, seg_from, seg_to, [], ref.model)
 			if not trav.allowed:
-				errors.append("Model %s charge path is blocked by solid terrain (13.06): %s" % [path_key, str(trav.blockers)])
+				errors.append("Model %s charge path is blocked by solid terrain (rule 13.06): %s" % [path_key, ", ".join(PackedStringArray(trav.blockers))])
 				break
 
 	return {"valid": errors.is_empty(), "errors": errors}

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -635,6 +635,8 @@ func validate_action(action: Dictionary) -> Dictionary:
 			return _validate_remain_stationary(action)
 		"LOCK_MOVEMENT_MODE":
 			return _validate_lock_movement_mode(action)
+		"SET_TAKE_TO_SKIES":
+			return _validate_set_take_to_skies(action)
 		"SET_ADVANCE_BONUS":
 			return _validate_set_advance_bonus(action)
 		"END_MOVEMENT":
@@ -771,6 +773,8 @@ func process_action(action: Dictionary) -> Dictionary:
 			return _process_remain_stationary(action)
 		"LOCK_MOVEMENT_MODE":
 			return _process_lock_movement_mode(action)
+		"SET_TAKE_TO_SKIES":
+			return _process_set_take_to_skies(action)
 		"SET_ADVANCE_BONUS":
 			return _process_set_advance_bonus(action)
 		"END_MOVEMENT":
@@ -6612,8 +6616,100 @@ func _check_dense_terrain_gate(unit_id: String, move_data: Dictionary, from_pos:
 	var kw_54 = _terrain_rule_keywords(unit_id, move_data)
 	var trav = tm_54.can_move_through_11e(kw_54, from_pos, dest_vec, [], model)
 	if not trav.allowed:
-		return {"valid": false, "errors": ["Dense terrain blocks this model's path (13.06): %s" % str(trav.blockers)]}
+		# "(13.06)" alone reads like a distance in inches — spell out that it
+		# is a rules reference, and tell FLY units how to get across.
+		var blocker_names := ", ".join(PackedStringArray(trav.blockers))
+		var msg := "Dense terrain blocks this model's path (rule 13.06): %s" % blocker_names
+		if "FLY" in get_unit(unit_id).get("meta", {}).get("keywords", []):
+			msg += " — tick 'Take to the skies' to fly over it"
+		return {"valid": false, "errors": [msg]}
 	return {"valid": true, "errors": []}
+
+## ISS-061 (11e 21.03/24.17) — mid-move "take to the skies" toggle.
+## The drag flow auto-begins a NORMAL move the moment a unit is selected —
+## BEFORE the player can even see the take-to-the-skies checkbox — so the
+## BEGIN_* payload alone can never carry a tick made after selection. This
+## action lets the declaration be changed while the move is in progress:
+## it flips move_data.took_to_skies (read by the 13.06 dense gate and the
+## model-crossing checks) and re-derives the move cap (-2", 0 with HOVER).
+func _validate_set_take_to_skies(action: Dictionary) -> Dictionary:
+	var unit_id = action.get("actor_unit_id", "")
+	if unit_id == "":
+		return {"valid": false, "errors": ["Missing actor_unit_id"]}
+	if GameConstants.edition < 11:
+		return {"valid": false, "errors": ["Take to the skies requires edition 11"]}
+	var unit = get_unit(unit_id)
+	if unit.is_empty():
+		return {"valid": false, "errors": ["Unit not found: " + unit_id]}
+	if not "FLY" in unit.get("meta", {}).get("keywords", []):
+		return {"valid": false, "errors": ["%s does not have the FLY keyword" % unit.get("meta", {}).get("name", unit_id)]}
+	if not active_moves.has(unit_id):
+		return {"valid": false, "errors": ["No active move for unit"]}
+	var move_data = active_moves[unit_id]
+	if move_data.get("completed", false):
+		return {"valid": false, "errors": ["Unit has already completed its move"]}
+	if not str(move_data.get("mode", "")) in ["NORMAL", "ADVANCE", "FALL_BACK"]:
+		return {"valid": false, "errors": ["Take to the skies only applies to Normal, Advance and Fall Back moves"]}
+	var enabled: bool = bool(action.get("payload", {}).get("take_to_skies", false))
+	if enabled == bool(move_data.get("took_to_skies", false)):
+		return {"valid": true, "errors": []}  # no-op, nothing to check
+	if enabled:
+		# The cap shrinks (-2" unless HOVER): every model already moved must
+		# still fit under the reduced cap, else the player has to reset first.
+		var new_cap := _take_to_skies_recomputed_cap(unit_id, move_data, true)
+		for model_key in move_data.get("model_distances", {}):
+			var used: float = move_data.model_distances[model_key]
+			if used > new_cap + MOVEMENT_CAP_EPSILON:
+				return {"valid": false, "errors": ["Cannot take to the skies: a model has already moved %.1f\", over the reduced %.1f\" cap — Reset Unit first" % [used, new_cap]]}
+	else:
+		# Turning flying OFF mid-move: already-staged paths may only be legal
+		# while airborne (crossed walls/models), so require a clean slate.
+		if not move_data.get("staged_moves", []).is_empty() or not move_data.get("model_moves", []).is_empty():
+			return {"valid": false, "errors": ["Reset the unit's move before switching off Take to the skies"]}
+	return {"valid": true, "errors": []}
+
+func _process_set_take_to_skies(action: Dictionary) -> Dictionary:
+	var unit_id = action.get("actor_unit_id", "")
+	var enabled: bool = bool(action.get("payload", {}).get("take_to_skies", false))
+	var move_data = active_moves[unit_id]
+	if enabled == bool(move_data.get("took_to_skies", false)):
+		return create_result(true, [])
+	var unit = get_unit(unit_id)
+	var new_cap := _take_to_skies_recomputed_cap(unit_id, move_data, enabled)
+	move_data["took_to_skies"] = enabled
+	move_data["move_cap_inches"] = new_cap
+	var unit_name = unit.get("meta", {}).get("name", unit_id)
+	if enabled:
+		log_phase_message("[11e] %s takes to the skies (mid-move toggle): cap %.1f\" (%+.1f\"), may move through models and terrain" % [unit_name, new_cap, MoveType.take_to_skies_modifier(unit)])
+	else:
+		log_phase_message("[11e] %s will not take to the skies: cap back to %.1f\"" % [unit_name, new_cap])
+	var gel = get_node_or_null("/root/GameEventLog")
+	if gel:
+		if enabled:
+			gel.add_player_entry(int(unit.get("owner", 0)), "%s takes to the skies (21.03): -2\" move, flies over models and terrain" % unit_name)
+		else:
+			gel.add_player_entry(int(unit.get("owner", 0)), "%s stays on the ground: normal terrain rules apply" % unit_name)
+	return create_result(true, [{
+		"op": "set",
+		"path": "units.%s.flags.move_cap_inches" % unit_id,
+		"value": new_cap
+	}])
+
+## Re-derive a move's cap for the given flying declaration, mirroring how
+## the BEGIN_* processors built it: base M (flat 24" when turbo-boosting),
+## -2" (0 with HOVER) applied to M when flying, advance roll added on top.
+func _take_to_skies_recomputed_cap(unit_id: String, move_data: Dictionary, flying: bool) -> float:
+	var unit = get_unit(unit_id)
+	var m := float(get_unit_movement(unit))
+	if flying:
+		m = max(0.0, m + MoveType.take_to_skies_modifier(unit))
+	if str(move_data.get("mode", "")) == "ADVANCE":
+		# Turbo Boostas replaces M with a flat 24" (fly modifier is moot,
+		# matching _resolve_advance_roll where turbo overrides after the cap).
+		if move_data.get("turbo_boost", false):
+			m = 24.0
+		return m + float(move_data.get("advance_roll", 0))
+	return m
 
 func _path_crosses_titanic_bases(from: Vector2, to: Vector2, unit_id: String, model: Dictionary) -> bool:
 	# OA-29: Check if path crosses any TITANIC model bases (friendly or enemy).

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -101,6 +101,9 @@ var confirm_mode_button: Button
 var shw_gamble_checkbox: CheckBox = null
 # B2 (21.03): "take to the skies" toggle for FLY units at edition >= 11.
 var take_to_skies_checkbox: CheckBox = null
+# Guard so programmatic checkbox syncs (from phase move data) don't re-enter
+# _on_take_to_skies_toggled and dispatch spurious SET_TAKE_TO_SKIES actions.
+var _syncing_take_to_skies: bool = false
 # Turbo Boostas (Speedwaaagh!): "use turbo" toggle for SPEED FREEKS / TRUKK
 # units at edition >= 11 — Advance becomes a flat 24" move (no roll), ranged
 # weapons gain ASSAULT and the unit cannot charge this turn.
@@ -614,6 +617,9 @@ func _create_section3_mode_selection(parent: VBoxContainer) -> void:
 	take_to_skies_checkbox.add_theme_font_size_override("font_size", 13)
 	take_to_skies_checkbox.add_theme_color_override("font_color", Color(0.55, 0.8, 1.0))
 	take_to_skies_checkbox.add_theme_color_override("font_pressed_color", Color(0.7, 0.9, 1.0))
+	# The default drag flow auto-begins a NORMAL move at unit selection, before
+	# the player can tick this box — forward later ticks to the active move.
+	take_to_skies_checkbox.toggled.connect(_on_take_to_skies_toggled)
 	section.add_child(take_to_skies_checkbox)
 
 	# Turbo Boostas (Speedwaaagh! detachment rule): "use turbo" toggle. Shown
@@ -682,18 +688,21 @@ func _create_section4_actions(parent: VBoxContainer) -> void:
 	button_container.name = "ActionButtons"
 	
 	var undo_button = Button.new()
+	undo_button.name = "UndoModelButton"
 	undo_button.text = "Undo Model"
 	undo_button.pressed.connect(_on_undo_model_pressed)
 	_WhiteDwarfTheme.apply_secondary_button(undo_button)
 	button_container.add_child(undo_button)
 
 	var reset_button = Button.new()
+	reset_button.name = "ResetUnitButton"
 	reset_button.text = "Reset Unit"
 	reset_button.pressed.connect(_on_reset_unit_pressed)
 	_WhiteDwarfTheme.apply_secondary_button(reset_button)
 	button_container.add_child(reset_button)
 
 	var confirm_button = Button.new()
+	confirm_button.name = "ConfirmMoveButton"
 	# "End This Unit's Move" (not "Confirm Move") so it is not confused with the
 	# "Confirm Movement Mode" button above: this button FINALISES the unit's move
 	# for the phase, it does NOT lock in the chosen mode. Players were clicking it
@@ -1544,7 +1553,64 @@ func _update_take_to_skies_visibility() -> void:
 	var show := eligible and not mode_locked
 	take_to_skies_checkbox.visible = show
 	if not show:
-		take_to_skies_checkbox.button_pressed = false
+		_set_take_to_skies_checkbox_silently(false)
+	else:
+		# Reflect the unit's ACTUAL declaration: the drag flow auto-begins a
+		# NORMAL move at selection (took_to_skies=false), and a tick left over
+		# from the previously selected unit must not leak onto this one.
+		if current_phase and current_phase.has_method("get_active_move_data"):
+			var md = current_phase.get_active_move_data(active_unit_id)
+			if not md.is_empty() and not md.get("completed", false):
+				_set_take_to_skies_checkbox_silently(bool(md.get("took_to_skies", false)))
+
+func _set_take_to_skies_checkbox_silently(pressed: bool) -> void:
+	if not take_to_skies_checkbox or take_to_skies_checkbox.button_pressed == pressed:
+		return
+	_syncing_take_to_skies = true
+	take_to_skies_checkbox.button_pressed = pressed
+	_syncing_take_to_skies = false
+
+func _on_take_to_skies_toggled(pressed: bool) -> void:
+	# B2/ISS-061: the checkbox is normally folded into the BEGIN_* payload by
+	# _on_confirm_mode_pressed, but the default drag flow auto-begins a NORMAL
+	# move when the unit is selected — before the player can tick the box. A
+	# tick made while a move is already active must therefore be forwarded to
+	# the phase as SET_TAKE_TO_SKIES so the dense-terrain gate and move cap
+	# see the declaration.
+	if _syncing_take_to_skies:
+		return
+	if active_unit_id == "" or not current_phase:
+		return
+	if not current_phase.has_method("get_active_move_data"):
+		return
+	var move_data = current_phase.get_active_move_data(active_unit_id)
+	if move_data.is_empty() or move_data.get("completed", false):
+		return  # no active move yet — the tick rides the BEGIN payload instead
+	if bool(move_data.get("took_to_skies", false)) == pressed:
+		return
+	emit_signal("move_action_requested", {
+		"type": "SET_TAKE_TO_SKIES",
+		"actor_unit_id": active_unit_id,
+		"payload": {"take_to_skies": pressed}
+	})
+	# Dispatch is synchronous in single-player: re-read the authoritative move
+	# data next frame so a rejected toggle (e.g. a model already moved past the
+	# reduced cap) snaps the checkbox back while the error toast explains why.
+	call_deferred("_sync_take_to_skies_from_phase")
+
+func _sync_take_to_skies_from_phase() -> void:
+	if active_unit_id == "" or not current_phase or not take_to_skies_checkbox:
+		return
+	if not current_phase.has_method("get_active_move_data"):
+		return
+	var move_data = current_phase.get_active_move_data(active_unit_id)
+	if move_data.is_empty():
+		return
+	_set_take_to_skies_checkbox_silently(bool(move_data.get("took_to_skies", false)))
+	# The declaration changes the move cap (-2" on, back to full off) — pull the
+	# authoritative cap so the Move/Left readout matches immediately.
+	move_cap_inches = float(move_data.get("move_cap_inches", move_cap_inches))
+	_update_movement_display()
 
 func _take_to_skies_requested() -> bool:
 	return take_to_skies_checkbox != null and take_to_skies_checkbox.visible and take_to_skies_checkbox.button_pressed

--- a/40k/tests/scenarios/sp/take_to_skies_mid_move_11e.json
+++ b/40k/tests/scenarios/sp/take_to_skies_mid_move_11e.json
@@ -1,0 +1,56 @@
+{
+  "id": "take_to_skies_mid_move_11e",
+  "covers": [
+    "movement.fly.take_to_skies_mid_move_toggle",
+    "phases.MovementPhase.SET_TAKE_TO_SKIES",
+    "movementcontroller.take_to_skies_checkbox.live_toggle"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "edition": 11,
+  "description": "Deffkopta dense-terrain fix, player path: selecting a FLY unit auto-begins a NORMAL move BEFORE the 'Take to the skies (-2\" move)' checkbox can be ticked, so the tick used to do nothing — dense terrain (rule 13.06) kept blocking the path even with the box checked. Setup swaps in take_and_hold_mirror_1 and teleports the Shield-Captain on Dawneagle Jetbike (MOUNTED/FLY, M12, oval base) east of the 5\" dense wall corner-ruin-balanced-left-46. Asserts: (a) click-select then drag across the wall is refused while grounded (no staged move, model stays put); (b) a real click on the checkbox dispatches SET_TAKE_TO_SKIES — took_to_skies flips true and the cap drops to 10\"; (c) the same drag now stages; (d) Confirm Move lands the model west of the wall.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script", "script": "TerrainManager.load_terrain_layout(\"take_and_hold_mirror_1\")" },
+    { "act": "execute_script", "script": "GameState.state[\"units\"][\"U_SHIELD_CAPTAIN_JETBIKE_A\"][\"models\"][0].merge({\"position\": {\"x\": 1220.0, \"y\": 1140.0}}, true)" },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().game_state_snapshot[\"units\"][\"U_SHIELD_CAPTAIN_JETBIKE_A\"][\"models\"][0].merge({\"position\": {\"x\": 1220.0, \"y\": 1140.0}}, true)" },
+    { "act": "execute_script", "script": "main._recreate_unit_visuals()" },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_jetbike_beside_5in_wall" },
+
+    { "act": "click_unit", "unit_id": "U_SHIELD_CAPTAIN_JETBIKE_A" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.movement_controller.active_unit_id", "equals": "U_SHIELD_CAPTAIN_JETBIKE_A" },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().active_moves[\"U_SHIELD_CAPTAIN_JETBIKE_A\"][\"took_to_skies\"]", "equals": false },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section3_ModeSelection/TakeToSkiesCheckBox" },
+    { "act": "screenshot", "label": "02_selected_checkbox_unticked" },
+
+    { "act": "drag_board", "from_x": 1220, "from_y": 1140, "to_x": 1000, "to_y": 1120 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.movement_controller._has_pending_unconfirmed_move(\"U_SHIELD_CAPTAIN_JETBIKE_A\")", "equals": false },
+    { "act": "execute_script", "script": "abs(GameState.get_unit(\"U_SHIELD_CAPTAIN_JETBIKE_A\").get(\"models\")[0].get(\"position\").get(\"x\") - 1220.0) < 0.5", "equals": true },
+    { "act": "screenshot", "label": "03_grounded_crossing_refused" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section3_ModeSelection/TakeToSkiesCheckBox" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().active_moves[\"U_SHIELD_CAPTAIN_JETBIKE_A\"][\"took_to_skies\"]", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().active_moves[\"U_SHIELD_CAPTAIN_JETBIKE_A\"][\"move_cap_inches\"]", "equals": 10.0 },
+    { "act": "execute_script", "script": "main.movement_controller.move_cap_inches", "equals": 10.0 },
+    { "act": "screenshot", "label": "04_checkbox_ticked_cap_10" },
+
+    { "act": "drag_board", "from_x": 1220, "from_y": 1140, "to_x": 1000, "to_y": 1120 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.movement_controller._has_pending_unconfirmed_move(\"U_SHIELD_CAPTAIN_JETBIKE_A\")", "equals": true },
+    { "act": "screenshot", "label": "05_flying_crossing_staged" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "units.U_SHIELD_CAPTAIN_JETBIKE_A.flags.moved", "equals": true },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_SHIELD_CAPTAIN_JETBIKE_A\").get(\"models\")[0].get(\"position\").get(\"x\") < 1073.0", "equals": true },
+    { "act": "screenshot", "label": "06_landed_west_of_wall" }
+  ]
+}

--- a/40k/tests/test_take_to_skies_toggle.gd
+++ b/40k/tests/test_take_to_skies_toggle.gd
@@ -1,0 +1,202 @@
+extends SceneTree
+
+# Mid-move "take to the skies" toggle (SET_TAKE_TO_SKIES) — Deffkopta /
+# dense-terrain fix.
+#
+# Bug: the drag flow auto-begins a NORMAL move the moment a unit is selected
+# (BEGIN_NORMAL_MOVE with no payload), BEFORE the take-to-the-skies checkbox
+# can be ticked. Ticking it afterwards did nothing: the 13.06 dense-terrain
+# gate kept refusing the path ("Dense terrain blocks this model's path
+# (13.06): [catwalk-58]") and the -2" cap was never applied, even though the
+# UI showed the box checked.
+#
+# Covers the new SET_TAKE_TO_SKIES action end-to-end at the phase level:
+#   ▪ default-begun move is grounded → wall crossing refused, message cites
+#     "rule 13.06" and tells FLY units about the checkbox;
+#   ▪ SET true mid-move: took_to_skies flips, cap re-derives (M-2, +roll on
+#     Advance, -0 with HOVER), GameState flags follow, crossing now stages;
+#   ▪ SET false is refused while staged moves exist (paths may rely on
+#     flying), allowed on a clean move;
+#   ▪ SET true is refused when a model already moved beyond the reduced cap;
+#   ▪ non-FLY units and edition 10 are rejected.
+#
+# Usage: godot --headless --path . -s tests/test_take_to_skies_toggle.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, ("  --  " + detail) if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.2).timeout.connect(_run_tests)
+
+const KOPTA_KW := ["DEFFKOPTAS", "FLY", "GRENADES", "ORKS", "SPEED FREEKS", "VEHICLE"]
+
+func _seed_unit(gs, keywords: Array, base_mm: int, pos_px: Vector2, move: int, name: String) -> void:
+	gs.state["units"] = {
+		"U_TEST": {"id": "U_TEST", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": name, "keywords": keywords.duplicate(), "abilities": [],
+				"stats": {"move": move, "toughness": 6, "save": 4, "wounds": 4, "objective_control": 1}},
+			"models": [
+				{"id": "m0", "alive": true, "wounds": 4, "current_wounds": 4,
+				 "base_mm": base_mm, "base_type": "circular",
+				 "position": {"x": pos_px.x, "y": pos_px.y}},
+			]},
+	}
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["phase"] = GameStateData.Phase.MOVEMENT
+	# No CP: keeps BEGIN_ADVANCE from pausing on the Command Re-roll offer.
+	for p in gs.state.get("players", {}):
+		gs.state["players"][p]["cp"] = 0
+
+func _begin(pm, action_type: String, payload: Dictionary = {}) -> Object:
+	pm.transition_to_phase(GameStateData.Phase.MOVEMENT)
+	var phase = pm.get_current_phase_instance()
+	phase.execute_action({"type": action_type, "actor_unit_id": "U_TEST", "player": 1, "payload": payload})
+	return phase
+
+func _set_skies(phase, on: bool) -> Dictionary:
+	return phase.execute_action({"type": "SET_TAKE_TO_SKIES", "actor_unit_id": "U_TEST",
+		"player": 1, "payload": {"take_to_skies": on}})
+
+func _stage(phase, dest: Vector2) -> Dictionary:
+	return phase.execute_action({"type": "STAGE_MODEL_MOVE", "actor_unit_id": "U_TEST",
+		"player": 1, "payload": {"model_id": "m0", "dest": [dest.x, dest.y]}})
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_take_to_skies_toggle (SET_TAKE_TO_SKIES mid-move) ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var pm = root.get_node_or_null("PhaseManager")
+	var tm = root.get_node_or_null("TerrainManager")
+	var meas = root.get_node_or_null("Measurement")
+	if gs == null or pm == null or tm == null or meas == null:
+		_check("autoloads reachable", false)
+		_finish(); return
+
+	var prev_state = gs.state.duplicate(true)
+	var prev_edition = GameConstants.edition
+	var prev_terrain = tm.terrain_features.duplicate(true)
+	GameConstants.edition = 11
+	tm.load_terrain_layout("take_and_hold_mirror_1")
+	var ppi: float = meas.PX_PER_INCH
+
+	# Geometry (board inches): the 5"-tall dense wall corner-ruin-balanced-left-46
+	# (vertical stroke x 26.83..27.33, y 25.38..30.38). A 75mm Deffkopta-style
+	# base starting east of it, crossing west to open ground inside the
+	# enterable trapezoid area.
+	var wall_id := "corner-ruin-balanced-left-46"
+	var start := Vector2(29.5, 28.0) * ppi
+	var across := Vector2(25.0, 28.0) * ppi   # 4.5" west, fully clear of the wall
+	# Open lane (nothing within base reach): x=30.5, y 33 -> 44
+	var lane_a := Vector2(30.5, 33.0) * ppi
+	var lane_b := Vector2(30.5, 44.0) * ppi   # 11" — legal at M12, over the flying 10" cap
+
+	print("-- T1: default-begun move is grounded — wall refusal + guidance --")
+	_seed_unit(gs, KOPTA_KW, 75, start, 12, "Deffkoptas")
+	var phase = _begin(pm, "BEGIN_NORMAL_MOVE")
+	_check("auto-begun move has took_to_skies=false",
+		phase.active_moves["U_TEST"].get("took_to_skies", true) == false)
+	var r1 = _stage(phase, across)
+	_check("grounded VEHICLE crossing the 5\" wall is refused", not r1.get("success", true), str(r1))
+	_check("refusal names the wall", str(r1.get("errors", [])).contains(wall_id), str(r1))
+	_check("refusal reads as a rules reference ('rule 13.06'), not inches",
+		str(r1.get("errors", [])).contains("rule 13.06"), str(r1))
+	_check("refusal tells FLY units about 'Take to the skies'",
+		str(r1.get("errors", [])).contains("Take to the skies"), str(r1))
+
+	print("\n-- T2: SET_TAKE_TO_SKIES true mid-move — cap -2\", crossing allowed --")
+	var r2 = _set_skies(phase, true)
+	_check("toggle accepted", r2.get("success", false), str(r2))
+	_check("took_to_skies now true", phase.active_moves["U_TEST"].get("took_to_skies", false) == true)
+	_check("move cap re-derived to 10\" (M12 - 2\")",
+		abs(phase.active_moves["U_TEST"].get("move_cap_inches", 0.0) - 10.0) < 0.01,
+		str(phase.active_moves["U_TEST"].get("move_cap_inches")))
+	_check("GameState flags.move_cap_inches follows",
+		abs(float(gs.get_unit("U_TEST").get("flags", {}).get("move_cap_inches", 0.0)) - 10.0) < 0.01)
+	var r2b = _stage(phase, across)
+	_check("same wall crossing now stages successfully", r2b.get("success", false), str(r2b))
+
+	print("\n-- T3: SET false with staged moves is refused; clean move may land --")
+	var r3 = _set_skies(phase, false)
+	_check("un-tick with a staged move is refused", not r3.get("success", true), str(r3))
+	_check("refusal says to reset first", str(r3.get("errors", [])).contains("Reset"), str(r3))
+	# RESET_UNIT_MOVE erases the active move entirely; the UI then has the
+	# player re-select the unit, which re-begins a fresh (grounded) move.
+	phase.execute_action({"type": "RESET_UNIT_MOVE", "actor_unit_id": "U_TEST", "player": 1, "payload": {}})
+	_check("reset erased the active move", not phase.active_moves.has("U_TEST"))
+	phase.execute_action({"type": "BEGIN_NORMAL_MOVE", "actor_unit_id": "U_TEST", "player": 1, "payload": {}})
+	var r3a = _set_skies(phase, true)
+	_check("fresh move: tick accepted again", r3a.get("success", false), str(r3a))
+	var r3b = _set_skies(phase, false)
+	_check("un-tick on a clean move (nothing staged) is accepted", r3b.get("success", false), str(r3b))
+	_check("cap restored to 12\"", abs(phase.active_moves["U_TEST"].get("move_cap_inches", 0.0) - 12.0) < 0.01,
+		str(phase.active_moves["U_TEST"].get("move_cap_inches")))
+
+	print("\n-- T4: SET true refused when a model already moved past the reduced cap --")
+	_seed_unit(gs, KOPTA_KW, 75, lane_a, 12, "Deffkoptas")
+	phase = _begin(pm, "BEGIN_NORMAL_MOVE")
+	var r4a = _stage(phase, lane_b)
+	_check("11\" open-ground stage is legal at M12", r4a.get("success", false), str(r4a))
+	var r4b = _set_skies(phase, true)
+	_check("tick refused — 11\" already moved > 10\" flying cap", not r4b.get("success", true), str(r4b))
+	_check("refusal explains the cap and Reset Unit", str(r4b.get("errors", [])).contains("Reset Unit"), str(r4b))
+	_check("took_to_skies unchanged after refusal",
+		phase.active_moves["U_TEST"].get("took_to_skies", true) == false)
+
+	print("\n-- T5: ADVANCE — cap tracks M-2+roll on, M+roll off --")
+	_seed_unit(gs, KOPTA_KW, 75, lane_a, 12, "Deffkoptas")
+	phase = _begin(pm, "BEGIN_ADVANCE")
+	var roll: int = phase.active_moves["U_TEST"].get("advance_roll", 0)
+	_check("advance produced a roll and an active move", roll >= 1 and roll <= 6, str(roll))
+	var base_cap: float = phase.active_moves["U_TEST"].get("move_cap_inches", 0.0)
+	_check("advance cap = 12 + roll", abs(base_cap - (12.0 + roll)) < 0.01, str(base_cap))
+	var r5 = _set_skies(phase, true)
+	_check("toggle accepted on an Advance", r5.get("success", false), str(r5))
+	_check("advance cap re-derived to 10 + roll",
+		abs(phase.active_moves["U_TEST"].get("move_cap_inches", 0.0) - (10.0 + roll)) < 0.01,
+		str(phase.active_moves["U_TEST"].get("move_cap_inches")))
+	var r5b = _set_skies(phase, false)
+	_check("un-tick (no models moved) restores 12 + roll",
+		r5b.get("success", false) and abs(phase.active_moves["U_TEST"].get("move_cap_inches", 0.0) - (12.0 + roll)) < 0.01,
+		str(phase.active_moves["U_TEST"].get("move_cap_inches")))
+
+	print("\n-- T6: HOVER — flying with no cap penalty --")
+	_seed_unit(gs, ["ORKS", "VEHICLE", "FLY", "HOVER"], 75, start, 12, "Hover Kopta")
+	phase = _begin(pm, "BEGIN_NORMAL_MOVE")
+	var r6 = _set_skies(phase, true)
+	_check("toggle accepted", r6.get("success", false), str(r6))
+	_check("HOVER keeps the full 12\" cap",
+		abs(phase.active_moves["U_TEST"].get("move_cap_inches", 0.0) - 12.0) < 0.01,
+		str(phase.active_moves["U_TEST"].get("move_cap_inches")))
+	var r6b = _stage(phase, across)
+	_check("hovering unit crosses the wall", r6b.get("success", false), str(r6b))
+
+	print("\n-- T7: guards — non-FLY refused, edition 10 inert --")
+	_seed_unit(gs, ["ORKS", "VEHICLE"], 75, start, 12, "Trukk")
+	phase = _begin(pm, "BEGIN_NORMAL_MOVE")
+	var r7 = _set_skies(phase, true)
+	_check("non-FLY unit cannot take to the skies", not r7.get("success", true), str(r7))
+	GameConstants.edition = 10
+	_seed_unit(gs, KOPTA_KW, 75, start, 12, "Deffkoptas")
+	phase = _begin(pm, "BEGIN_NORMAL_MOVE")
+	var r7b = _set_skies(phase, true)
+	_check("edition 10: action refused (11e-only rule)", not r7b.get("success", true), str(r7b))
+	GameConstants.edition = 11
+
+	gs.state = prev_state
+	GameConstants.edition = prev_edition
+	tm.terrain_features = prev_terrain
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)

--- a/40k/tests/test_take_to_skies_toggle.gd.uid
+++ b/40k/tests/test_take_to_skies_toggle.gd.uid
@@ -1,0 +1,1 @@
+uid://bj7j1l2i2yiw7


### PR DESCRIPTION
## Problem

Reported with Deffkoptas (VEHICLE + FLY, M12) blocked from crossing a catwalk. Selecting a FLY unit auto-begins a payload-less `BEGIN_NORMAL_MOVE` **before** the "Take to the skies (-2" move)" checkbox is even shown, and the checkbox was only ever read by the "Confirm Movement Mode" button — which the default drag flow never presses. So ticking the box after selection did nothing:

- the 13.06 dense-terrain gate kept refusing the path, and
- the -2" fly cap was never applied (panel still showed the full Move).

The terrain block itself was rules-correct (catwalks are 3" dense features; grounded non-INFANTRY can't cross terrain over 2" tall) — but the player's declared bypass never took effect. A secondary confusion: the error read `(13.06): ["catwalk-58"]`, where `catwalk-58` is a terrain **piece ID** (its height is 3"), not a distance — but the raw string read like inches.

## Fix

- **New `SET_TAKE_TO_SKIES` movement action** — flips `took_to_skies` on the in-progress move (NORMAL / ADVANCE / FALL_BACK) and re-derives the cap (M−2", 0 with HOVER, advance roll preserved, turbo unaffected). Read by the 13.06 dense gate and the model-crossing checks.
  - Enabling is refused if a model already moved past the reduced cap (asks to Reset Unit first).
  - Disabling is refused while moves are staged (flying paths may be illegal on the ground) — both with actionable messages.
- **MovementController** — checkbox toggles now dispatch the action; the pressed state re-syncs from the phase (a rejected toggle snaps back and a toast explains); the Move/Left readout updates immediately; and selecting a unit syncs the box to that unit's actual declaration instead of leaking the previous unit's tick.
- **Clearer refusal** — `(rule 13.06)` instead of `(13.06)`, blockers joined readably, and FLY units get `— tick 'Take to the skies' to fly over it`. Charge-phase message aligned.
- Named the Undo / Reset / Confirm movement-action buttons so windowed scenarios can target them.

## Validation

- **New headless suite** `tests/test_take_to_skies_toggle.gd` — 30/30 (grounded block, toggle on/off, cap re-derivation on Normal/Advance/HOVER, cap-guard, non-FLY and edition-10 guards).
- **New windowed scenario** `tests/scenarios/sp/take_to_skies_mid_move_11e.json` — 35/35: real click-select → refused drag across the 5" wall → real checkbox click (cap drops to 10", log entry) → staged crossing → confirmed landing. Screenshots captured; debug log clean of errors. Re-run after rebasing onto latest `main` (which renamed the confirm button and touched the same file) — still 35/35.
- **Regressions green**: solid-terrain 27/27, kustom shokk box 8/8, `vehicle_wall_block_11e` 28/28, `iss040_movement_11e` 52/52.

Changelog entry added (v0.58.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhckWWjGZS9hpPnCGkb2WL

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhckWWjGZS9hpPnCGkb2WL)_