### PR TITLE
Remove 10th-edition rules still applied in the 11th-edition game

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -5333,6 +5333,15 @@ static func _calculate_save_needed(base_save: int, ap: int, has_cover: bool, inv
 	var ap_magnitude = abs(ap)
 	var armour_save = base_save + ap_magnitude  # AP makes saves worse (higher number needed)
 
+	# 11e (13.08): Benefit of Cover worsens the attacking model's BS by 1 — it does
+	# NOT modify the save. Cover-improves-save is a 10e-only rule. The 11e resolution
+	# paths handle cover hit-side (ModifierStack) and the 11e allocation path never
+	# calls this function; the two legacy callers that still reach it (overwatch
+	# saves, AI/auto-allocate saves) must therefore ignore cover for saves at e11,
+	# otherwise cover is double-counted (BS worsened AND save improved).
+	if GameConstants.edition >= 11:
+		has_cover = false
+
 	# 10e Benefit of Cover cap: a unit with a Save characteristic of 3+ or better cannot
 	# have its Save improved by Cover against an attack with AP 0. The cap matters only
 	# when AP is 0 — at AP -1+ the modified (post-AP) save is already 4+ or worse, so
@@ -9771,16 +9780,19 @@ static func validate_base_to_base_possible_rules(unit_id: String, per_model_path
 	if target_models.is_empty():
 		return {"valid": true, "errors": []}
 
-	# 11.04 WHILE MOVING (11e): each model that CAN end within 1" of one or more
-	# charge targets MUST do so — a PER-MODEL obligation. The old 10e reading was
-	# wrongly satisfied by a SINGLE model reaching base contact; here every model
-	# is judged. Base-to-base (0") is the UI snap assist and over-satisfies the band.
+	# 11.04 WHILE MOVING (11e): each model that CAN end ENGAGED (within Engagement
+	# Range) with one or more charge targets MUST do so — a PER-MODEL obligation.
+	# The old 10e reading was wrongly satisfied by a SINGLE model reaching base
+	# contact; here every model is judged. Base-to-base (0") over-satisfies the band.
 	if rolled_distance <= 0:
 		return {"valid": true, "errors": []}
 
-	# Distance band a model must close into if it can (11e "within 1 inch").
-	# Named so a stricter "must base up" (0") house rule is a one-line change.
-	var close_inches: float = 1.0
+	# Distance band a model must close into if it can. 11e: a charge ends with the
+	# unit ENGAGED — Engagement Range is 2" horizontally (03.04). 10e used 1". This
+	# reads from GameConstants so the edition switch applies; a hardcoded 1" here
+	# was a 10e engagement-range leak that over-constrained 11e charges (a model
+	# legitimately ending engaged at ~1.1"-2.0" was wrongly told to close to 1").
+	var close_inches: float = GameConstants.engagement_range_inches()
 	var band_tol: float = 0.05  # fp / snap-noise slack on the band
 
 	for model_id in final_models:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.61.1",
+			"date": "2026-07-18",
+			"summary": "Swept out several 10th-edition rules that were still being applied in the 11th-edition game. The headline: models on non-round bases (Battlewagons, Squiggoths, Gorkanauts and the like) no longer pay 2\" of movement to turn — pivoting is free in 11th edition. Also fixed cover wrongly boosting saves on Overwatch/auto-resolved shots and an over-strict charge distance.",
+			"changes": [
+				"Pivoting is now free: models on rectangular/oval bases (and vehicles on flying stems) no longer lose 2\" of their Move when they turn. The 2\" pivot cost was a 10th-edition rule and is gone.",
+				"Cover no longer improves armour saves during Fire Overwatch or when wounds are auto-allocated (for example against the AI). In 11th edition cover worsens the shooter's aim, which was already applied — the extra +1 to the save was a leftover 10th-edition rule that double-counted cover.",
+				"Charging models now only need to finish within Engagement Range (2\") of a target, not the old 1\". Charges that legitimately end 1–2\" away are no longer rejected.",
+				"Units arriving with the Rapid Ingress stratagem now set up more than 8\" from enemies, matching every other 11th-edition reserve arrival (it was still using the 10th-edition 9\").",
+				"Fixed an internal 1\" engagement-range value so the 'consolidate into combat' option is offered at the correct 2\" range."
+			]
+		},
+		{
 			"version": "0.61.0",
 			"date": "2026-07-18",
 			"summary": "Melee hit and wound rolls now resolve in the right-hand panel, exactly like shooting — no more pop-up window covering the battle. The fight phase gets the same staged resolution dock the shooting phase uses: one button in a fixed spot steps through 'Roll to Wound' and 'Continue to Saving Throws', clickable Command Re-roll dice chips, a Fast Roll button, and the same 'Pauses' setting — so both phases feel identical to play.",

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -749,7 +749,7 @@ func _can_unit_reach_engagement_range(unit: Dictionary, consol_dist: float = 3.0
 	"""Check if it's POSSIBLE for unit to reach engagement range within consolidation distance.
 	This means: is ANY enemy model within (consol_dist + 1") of ANY friendly model?
 	(consolidation movement + 1" engagement range)"""
-	var max_reach = consol_dist + 1.0  # consolidation distance + engagement range
+	var max_reach = consol_dist + GameConstants.engagement_range_inches()  # consolidation distance + engagement range (2" at 11e, 1" at 10e)
 	var models = unit.get("models", [])
 	var all_units = game_state_snapshot.get("units", {})
 	var unit_owner = unit.get("owner", 0)
@@ -3581,11 +3581,11 @@ func _is_unit_in_combat(unit: Dictionary) -> bool:
 ## accounting for barricade terrain (2" instead of 1" if barricade is between them).
 func _get_effective_engagement_range(pos1: Vector2, pos2: Vector2) -> float:
 	if not is_inside_tree():
-		return 1.0
+		return GameConstants.engagement_range_inches()
 	var terrain_manager = get_node_or_null("/root/TerrainManager")
 	if terrain_manager and terrain_manager.has_method("get_engagement_range_for_positions"):
 		return terrain_manager.get_engagement_range_for_positions(pos1, pos2)
-	return 1.0
+	return GameConstants.engagement_range_inches()
 
 func _units_in_engagement_range(unit1: Dictionary, unit2: Dictionary) -> bool:
 	# Check if any model from unit1 is within 1" of any model from unit2

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -149,13 +149,24 @@ var _grot_oiler_bearer_id: String = ""              # The unit with Grot Oiler w
 var _grot_oiler_targets: Array = []                 # Eligible healing targets
 var _grot_oiler_pending_changes: Array = []         # Pending changes from END_MOVEMENT cleanup
 
-# Calculate pivot value for a unit based on base type and keywords (10e Core Rules + Pariah Nexus)
-# Per Pariah Nexus Companion & Q3 2024 Balance Update:
+# Calculate pivot value for a unit based on base type and keywords.
+#
+# 11e (the player edition): pivoting/rotating a model is FREE — the core rules
+# state "rotating a model does not count towards the distance it has moved",
+# with no exception for non-circular bases, Vehicles or Monsters. So every unit
+# has a 0" pivot value at edition >= 11 and no movement is deducted for turning.
+#
+# The 2" pivot cost below is a 10e-only rule (Pariah Nexus Companion & Q3 2024
+# Balance Update) — retained solely for the edition==10 regression baseline:
 # - All non-round base models: 2" (Pariah Nexus expanded this from just Vehicle/Monster)
 # - Vehicle round base >32mm with flying stem/hover stand: 2" (August 2024 FAQ)
 # - Aircraft: 0"
 # - All other (standard round base): 0"
 func get_pivot_value_for_unit(unit_id: String) -> float:
+	# 11e: no pivot cost for any base type — rotating is free.
+	if GameConstants.edition >= 11:
+		return 0.0
+
 	var unit = get_unit(unit_id)
 	if unit.is_empty():
 		return 0.0
@@ -2773,6 +2784,10 @@ func _validate_place_kunnin_infiltrator(action: Dictionary) -> Dictionary:
 			var dist_inches = dist_px / px_per_inch
 			# Edge-to-edge distance: center distance minus both radii
 			var edge_dist = dist_inches - model_radius_inches - enemy_radius_inches
+			# NOTE: Kunnin' Infiltrator's printed text says >9"; whether 11e Orks
+			# rebased it to the core 8" reserves distance is unconfirmed (faction
+			# rules unavailable), so this deliberately stays 9" — do not "fix" to
+			# 8" without the current Ork datasheet. (Core reserves ARE 8" at e11.)
 			if edge_dist < 9.0:
 				errors.append("Model %d: must be >9\" from enemy models (currently %.1f\")" % [i, edge_dist])
 				break
@@ -3764,6 +3779,8 @@ func _validate_place_rapid_ingress_reinforcement(action: Dictionary) -> Dictiona
 
 			# For Rapid Ingress, "enemies" are the active player's models
 			# get_enemy_model_positions(player) returns models NOT belonging to player
+			# 11e (20.04 Ingress): set up >8" from enemies (vs 10e's >9").
+			var min_enemy_sep = GameConstants.reinforcement_min_enemy_distance_inches()
 			var enemy_positions = GameState.get_enemy_model_positions(player)
 			for enemy in enemy_positions:
 				var enemy_pos_px = Vector2(enemy.x, enemy.y)
@@ -3771,8 +3788,8 @@ func _validate_place_rapid_ingress_reinforcement(action: Dictionary) -> Dictiona
 				var dist_px = pos.distance_to(enemy_pos_px)
 				var dist_inches = dist_px / px_per_inch
 				var edge_dist = dist_inches - model_radius_inches - enemy_radius_inches
-				if edge_dist < 9.0:
-					errors.append("Model %d: must be >9\" from enemy models (currently %.1f\")" % [i, edge_dist])
+				if edge_dist < min_enemy_sep:
+					errors.append("Model %d: must be >%.0f\" from enemy models (currently %.1f\")" % [i, min_enemy_sep, edge_dist])
 					break
 
 			# Strategic Reserves: must be within 6" of a battlefield edge

--- a/40k/scripts/rules/GameConstants.gd
+++ b/40k/scripts/rules/GameConstants.gd
@@ -40,6 +40,15 @@ static func barricade_engagement_range_inches() -> float:
 	return 2.0
 
 
+# ── Reinforcements / Reserves ───────────────────────────────────────
+## Minimum distance a unit set up from Reserves — Deep Strike, Strategic
+## Reserves, Rapid Ingress — or via an infiltrate-style redeploy must be
+## placed from all enemy models (edge-to-edge, "more than").
+## 10e: >9". 11e (20.04 Ingress Move): >8".
+static func reinforcement_min_enemy_distance_inches() -> float:
+	return 8.0 if edition >= 11 else 9.0
+
+
 # ── Unit coherency ──────────────────────────────────────────────────
 ## Horizontal distance to count as "in coherency" with another model
 ## (both editions: 2").

--- a/docs/rules/11th_edition_doc_change_audit.md
+++ b/docs/rules/11th_edition_doc_change_audit.md
@@ -79,7 +79,7 @@ after abilities). Command-abilities-after-battleshock ordering ✅ in `CommandPh
 | Move **through** enemy ER (end outside) | ✅ | `MovementPhase` staging allows transit, checks end-position. |
 | Set-Up outside ER; **Engaged** as a term | ✅ | Deploy/ingress validators enforce. |
 | Move templates (Max/Set-Up dist, Before/While/After) | ✅ | `movetypes/*`. |
-| **Free pivots** / straight-line+pivot | 🟡 | Pivot cost gated off at e11; not a fully modelled multi-segment pivot geometry. |
+| **Free pivots** / straight-line+pivot | ✅ | Pivoting is FREE at e11 — `get_pivot_value_for_unit` returns 0" for every base type. (Correction 2026-07-18: this row previously claimed the cost was "gated off at e11", but the 10e 2" non-round-base pivot cost was actually applied **un-gated** and hit players; now edition-gated to 0" at e11.) Multi-segment pivot geometry still not modelled. |
 | **FLY "Take to the Skies"** (−2", ignore vertical, through all) | ✅ | Movement-panel toggle validated live (12→10"). |
 | Move through gaps by base | ✅ | Pre-existing. |
 | M/V through non-M/V enemies | ✅ | Gated at e11. |


### PR DESCRIPTION
## Summary
- The 2" pivot cost for non-round bases was applied unconditionally with no edition gate, so it hit players even though 11th edition makes pivoting free ("rotating a model does not count towards the distance it has moved"). `get_pivot_value_for_unit` now returns 0" at edition >= 11; the 10e cost stays behind the edition flag for the pinned regression baseline.
- Auditing the rest of the ruleset for the same pattern (a 10e value applied with no `GameConstants.edition` check) turned up four more leaks, now edition-gated:
  - **Cover no longer improves armour saves at e11** (`RulesEngine._calculate_save_needed`). In 11e cover worsens the shooter's BS (already applied elsewhere); the +1 save was a 10e leftover that double-counted cover on Fire Overwatch and auto-allocated saves (e.g. vs the AI).
  - **Charge "must end engaged" band now uses Engagement Range** (2" at e11) instead of a hardcoded 1" (`RulesEngine.validate_base_to_base_possible_rules`), so charges that legitimately finish 1–2" from the target are no longer rejected (11.04 + 03.04).
  - **Rapid Ingress reserves now set up >8" from enemies** at e11, matching every other 11e reinforcement, instead of the 10e 9".
  - **Fight-phase engagement-range heuristic/fallbacks** now use `GameConstants.engagement_range_inches()` (2" at e11) instead of a hardcoded 1".
- Every fix reduces to the original 10e constant at edition 10, so the pinned regression suite is unaffected.

## Left unchanged (flagged for follow-up, not fixed here)
- **Kunnin' Infiltrator's 9"** (Orks faction ability) — its printed description text says 9", and the current 11e Ork rules aren't available to confirm whether it was rebased to the core 8" reserves distance. Left as-is rather than guessed.
- **Charge-path terrain climb / "difficult ground" +2" penalty** — un-gated and inconsistent with the movement path, but 11e does count vertical climb, so this needs a rules-intent decision on how to model climbing on the 2D board rather than a blind removal.
- **`[BLAST]`'s minimum-3-attacks clause** — resembles an older-edition rule but I could not source authoritative 11e `[BLAST]` text to confirm it should be removed.

## Test plan
- [x] Re-imported the project after each change; clean compile, no parse/script errors.
- [x] Ran the game live (xvfb + `addons/godot_mcp` bridge) at edition 11 and edition 10, driving each changed function directly and asserting both editions:
  - Pivot value: rectangular/oval bases → 0" at e11, 2" at e10.
  - Cover save: armour stays at base (4) at e11 with cover present, improves to 3 at e10.
  - Charge close band: a model ending ~1.5" from target is valid at e11 (engaged within 2"), invalid at e10 (outside the 1" band).
  - Reserve distance: `GameConstants.reinforcement_min_enemy_distance_inches()` → 8" at e11, 9" at e10.
- [x] `read_debug_log` / `verify_delivery` showed 0 errors across all live checks.
- [x] Ran the standalone `tests/test_b2b_rules_standalone_check.gd` script (exercises the changed charge validator) — 12/12 passed at the harness's pinned edition 10.
- [x] Updated `40k/data/version_history.json` (0.61.1) and corrected a stale claim in `docs/rules/11th_edition_doc_change_audit.md` that the pivot cost was already "gated off at e11" (it wasn't).


---
_Generated by [Claude Code](https://claude.ai/code/session_016VJLUjXG3upxQy3HsMykc1)_