### PR TITLE
Add "Auto Pile In" / "Auto Consolidate" — move the whole unit toward the closest opponents automatically

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.62.0",
+			"date": "2026-07-18",
+			"summary": "New \"Auto Pile In\" button in the Fight phase. During the Pile In step you can now let the computer move every model toward the closest enemy for you — up to 3\", legally — instead of dragging each model by hand. It fills the move in as a preview so you can review it and then Confirm, or Reset and position them yourself.",
+			"changes": [
+				"Pile In dialog now has an \"Auto Pile In\" button that moves all of a unit's models (and any attached characters) toward the closest enemy automatically, up to 3\".",
+				"The automatic move follows the same legal pile-in rules the AI uses: each model ends closer to its nearest enemy, models already in base contact stay put, and overlaps are avoided.",
+				"The computed move is shown as a preview with the usual arrows — review it, then Confirm to commit, or Reset to clear it and drag models yourself."
+			]
+		},
+		{
 			"version": "0.61.1",
 			"date": "2026-07-18",
 			"summary": "Swept out several 10th-edition rules that were still being applied in the 11th-edition game. The headline: models on non-round bases (Battlewagons, Squiggoths, Gorkanauts and the like) no longer pay 2\" of movement to turn — pivoting is free in 11th edition. Also fixed cover wrongly boosting saves on Overwatch/auto-resolved shots and an over-strict charge distance.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.63.0",
+			"date": "2026-07-18",
+			"summary": "The \"Auto\" helper now covers the Consolidate step too. Just like Auto Pile In, the Consolidate dialog has an \"Auto Consolidate\" button that moves every model toward the closest enemy (or objective, following the mandatory consolidate mode) for you — up to 3\", legally — instead of dragging each model by hand. It fills the move in as a preview to review and Confirm, or Reset.",
+			"changes": [
+				"Consolidate dialog now has an \"Auto Consolidate\" button that moves all of a unit's models (and any attached characters) toward the closest enemy — or the closest objective when no enemy is in reach — automatically, up to 3\".",
+				"Follows the same legal consolidate rules the AI uses (correct 12.08 mode, each model ends closer, models already in base contact stay put, overlaps avoided).",
+				"Shown as a preview with the usual arrows — review it, then Confirm to commit, or Reset to drag models yourself."
+			]
+		},
+		{
 			"version": "0.62.0",
 			"date": "2026-07-18",
 			"summary": "New \"Auto Pile In\" button in the Fight phase. During the Pile In step you can now let the computer move every model toward the closest enemy for you — up to 3\", legally — instead of dragging each model by hand. It fills the move in as a preview so you can review it and then Confirm, or Reset and position them yourself.",

--- a/40k/dialogs/ConsolidateDialog.gd
+++ b/40k/dialogs/ConsolidateDialog.gd
@@ -71,6 +71,18 @@ func _build_ui() -> void:
 	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
 	button_container.add_theme_constant_override("separation", 10)
 
+	# Auto consolidate button — let the computer move every model toward the
+	# closest enemy (or objective, per the 12.08 mode) up to 3", legally, so the
+	# player doesn't have to drag each one. Fills in a preview; the player still
+	# reviews it and hits Confirm.
+	var auto_button = Button.new()
+	auto_button.name = "AutoButton"
+	auto_button.text = "Auto Consolidate"
+	auto_button.tooltip_text = "Move every model toward the closest enemy (or objective) automatically (up to 3\"). Review the preview, then Confirm."
+	auto_button.custom_minimum_size = Vector2(0, 36)
+	auto_button.pressed.connect(_on_auto_consolidate_pressed)
+	button_container.add_child(auto_button)
+
 	# Reset button
 	reset_button = Button.new()
 	reset_button.name = "ResetButton"
@@ -177,6 +189,27 @@ func _validate_movements() -> Dictionary:
 		return phase_reference._validate_consolidate(action)
 
 	return {"valid": true, "errors": []}
+
+func _on_auto_consolidate_pressed() -> void:
+	"""Have the computer consolidate every model toward the closest enemy (or
+	objective), then let the player review and Confirm (or Reset). Reuses the AI
+	consolidate solver via the FightController so the move is always legal."""
+	print("[ConsolidateDialog] Auto Consolidate pressed")
+	if not controller_reference or not controller_reference.has_method("auto_consolidate_movements"):
+		print("[ConsolidateDialog] No controller / auto_consolidate_movements — cannot auto consolidate")
+		return
+
+	model_movements = controller_reference.auto_consolidate_movements()
+	print("[ConsolidateDialog] Auto consolidate produced movements: ", model_movements)
+
+	if not status_label:
+		return
+	if model_movements.is_empty():
+		status_label.text = "Auto consolidate: no legal move (no enemy or objective in reach, or already in base contact)"
+		status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
+	else:
+		# _update_status() re-validates via FightPhase and shows the ✓/✗ result
+		_update_status()
 
 func _on_reset_pressed() -> void:
 	"""Reset all model positions to original"""

--- a/40k/dialogs/PileInDialog.gd
+++ b/40k/dialogs/PileInDialog.gd
@@ -46,7 +46,7 @@ func _build_ui() -> void:
 	# Heading — gold, to match the gold section headers used across the menus.
 	var instruction = Label.new()
 	instruction.name = "Instruction"
-	instruction.text = "Drag models on the battlefield to pile in\nUp to %.1f\" toward the closest enemy" % max_distance
+	instruction.text = "Drag models to pile in — or hit \"Auto Pile In\"\nUp to %.1f\" toward the closest enemy" % max_distance
 	instruction.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	instruction.add_theme_font_size_override("font_size", 15)
 	instruction.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
@@ -68,6 +68,17 @@ func _build_ui() -> void:
 	button_container.name = "Buttons"
 	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
 	button_container.add_theme_constant_override("separation", 10)
+
+	# Auto pile-in button — let the computer move every model toward the closest
+	# enemy (up to 3", legally) so the player doesn't have to drag each one. Fills
+	# in the move as a preview; the player still reviews it and hits Confirm.
+	var auto_button = Button.new()
+	auto_button.name = "AutoButton"
+	auto_button.text = "Auto Pile In"
+	auto_button.tooltip_text = "Move every model toward the closest enemy automatically (up to 3\"). Review the preview, then Confirm."
+	auto_button.custom_minimum_size = Vector2(0, 36)
+	auto_button.pressed.connect(_on_auto_pile_in_pressed)
+	button_container.add_child(auto_button)
 
 	# Reset button
 	reset_button = Button.new()
@@ -173,6 +184,27 @@ func _validate_movements() -> Dictionary:
 		return phase_reference._validate_pile_in(action)
 
 	return {"valid": true, "errors": []}
+
+func _on_auto_pile_in_pressed() -> void:
+	"""Have the computer pile every model in toward the closest enemy, then let
+	the player review and Confirm (or Reset). Reuses the AI pile-in solver via the
+	FightController so the move follows the same legal rules."""
+	print("[PileInDialog] Auto Pile In pressed")
+	if not controller_reference or not controller_reference.has_method("auto_pile_in_movements"):
+		print("[PileInDialog] No controller / auto_pile_in_movements — cannot auto pile in")
+		return
+
+	model_movements = controller_reference.auto_pile_in_movements()
+	print("[PileInDialog] Auto pile-in produced movements: ", model_movements)
+
+	if not status_label:
+		return
+	if model_movements.is_empty():
+		status_label.text = "Auto pile-in: no legal move (models already in base contact or no enemy in reach)"
+		status_label.add_theme_color_override("font_color", _NEUTRAL_STATUS)
+	else:
+		# _update_status() re-validates via FightPhase and shows the ✓/✗ result
+		_update_status()
 
 func _on_reset_pressed() -> void:
 	"""Reset all model positions to original"""

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -3068,10 +3068,39 @@ func auto_pile_in_movements() -> Dictionary:
 	var snapshot = GameState.create_snapshot()
 	var ai_movements = AIDecisionMaker._compute_pile_in_movements(snapshot, pile_in_unit_id, unit, owner)
 	ai_movements = AIDecisionMaker._merge_attached_char_fight_movements(snapshot, pile_in_unit_id, owner, ai_movements, "pile_in")
+	return _load_ai_fight_movements_into_preview(ai_movements, "pile-in")
 
-	# Convert the index keys into this controller's model-id tracking keys and
-	# load them into current_model_positions. Skip models locked in base contact
-	# (they must not move — the solver already holds them, this is belt-and-braces).
+func auto_consolidate_movements() -> Dictionary:
+	"""Let the computer consolidate the whole unit for the player — the mirror of
+	auto_pile_in_movements() for the 12.07 Consolidate step.
+
+	Reuses AIDecisionMaker._compute_consolidate_action, which picks the mandatory
+	12.08 mode (Ongoing/Engaging toward the closest enemy, or Objective toward the
+	nearest objective marker) the SAME way FightPhase._validate_consolidate_11e
+	judges it, folds in attached characters (19.03), and returns per-model
+	destinations up to 3". The result is loaded into the interactive preview;
+	nothing is submitted here — the player reviews it and clicks Confirm (or
+	Reset). Returns the movements dict in this controller's tracking-key form."""
+	if pile_in_unit_id == "" or not current_phase:
+		return {}
+	var unit = current_phase.get_unit(pile_in_unit_id)
+	if unit.is_empty():
+		return {}
+	var owner = int(unit.get("owner", GameState.get_active_player()))
+
+	# _compute_consolidate_action selects ENGAGEMENT/OBJECTIVE/NONE mode and merges
+	# attached characters, returning the same index-keyed movement shape as pile-in.
+	var snapshot = GameState.create_snapshot()
+	var action = AIDecisionMaker._compute_consolidate_action(snapshot, pile_in_unit_id, owner)
+	var ai_movements = action.get("movements", {})
+	return _load_ai_fight_movements_into_preview(ai_movements, "consolidate")
+
+func _load_ai_fight_movements_into_preview(ai_movements: Dictionary, label: String) -> Dictionary:
+	"""Shared by the auto pile-in / consolidate buttons: convert the AI solver's
+	index-keyed destinations ("0", "<char_unit>:0") into this controller's model-id
+	tracking keys, load them into current_model_positions (skipping models locked
+	in base contact — they must not move), and refresh the board tokens + arrow /
+	coherency visuals. Returns get_pile_in_movements() for the dialog to display."""
 	var applied := 0
 	for ai_key in ai_movements:
 		var route = _pile_in_split_key(str(ai_key))
@@ -3089,11 +3118,11 @@ func auto_pile_in_movements() -> Dictionary:
 		if key in locked_base_contact_models:
 			continue
 		if not current_model_positions.has(key):
-			continue  # not part of the seeded pile-in group (shouldn't happen)
+			continue  # not part of the seeded move group (shouldn't happen)
 		current_model_positions[key] = ai_movements[ai_key]
 		applied += 1
 
-	print("[FightController] Auto pile-in computed %d model destination(s) for %s" % [applied, pile_in_unit_id])
+	print("[FightController] Auto %s computed %d model destination(s) for %s" % [label, applied, pile_in_unit_id])
 
 	# Reflect the computed destinations on the board tokens + arrow/coherency visuals
 	_apply_model_positions_to_scene()

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -3044,6 +3044,63 @@ func reset_pile_in_movements() -> void:
 
 	print("[FightController] Pile-in movements reset")
 
+func auto_pile_in_movements() -> Dictionary:
+	"""Let the computer pile the whole unit in for the player.
+
+	Reuses the SAME solver the AI uses (AIDecisionMaker._compute_pile_in_movements)
+	so a human piling in can send every model toward the closest enemy — up to 3",
+	ending closer, avoiding overlaps, holding models already in base contact —
+	instead of dragging each one by hand. 19.03: attached characters' models pile
+	in as part of the same move. The result is loaded into the interactive preview
+	(tokens + arrows update); nothing is submitted here — the player reviews it and
+	clicks Confirm (or Reset). Returns the movements dict in this controller's
+	tracking-key form for the dialog to display."""
+	if pile_in_unit_id == "" or not current_phase:
+		return {}
+	var unit = current_phase.get_unit(pile_in_unit_id)
+	if unit.is_empty():
+		return {}
+	var owner = int(unit.get("owner", GameState.get_active_player()))
+
+	# The AI solver returns per-model destinations keyed by the model's ARRAY
+	# INDEX as a string ("0", "1", …) for pile_in_unit_id's own models, and
+	# "<char_unit_id>:<index>" for attached characters (19.03).
+	var snapshot = GameState.create_snapshot()
+	var ai_movements = AIDecisionMaker._compute_pile_in_movements(snapshot, pile_in_unit_id, unit, owner)
+	ai_movements = AIDecisionMaker._merge_attached_char_fight_movements(snapshot, pile_in_unit_id, owner, ai_movements, "pile_in")
+
+	# Convert the index keys into this controller's model-id tracking keys and
+	# load them into current_model_positions. Skip models locked in base contact
+	# (they must not move — the solver already holds them, this is belt-and-braces).
+	var applied := 0
+	for ai_key in ai_movements:
+		var route = _pile_in_split_key(str(ai_key))
+		var route_unit_id = route.unit_id
+		var idx_str = str(route.model_id)
+		if not idx_str.is_valid_int():
+			continue
+		var route_unit = current_phase.get_unit(route_unit_id)
+		var models = route_unit.get("models", [])
+		var idx = int(idx_str)
+		if idx < 0 or idx >= models.size():
+			continue
+		var model_id = models[idx].get("id", "m%d" % (idx + 1))
+		var key = _pile_in_model_key(route_unit_id, model_id)
+		if key in locked_base_contact_models:
+			continue
+		if not current_model_positions.has(key):
+			continue  # not part of the seeded pile-in group (shouldn't happen)
+		current_model_positions[key] = ai_movements[ai_key]
+		applied += 1
+
+	print("[FightController] Auto pile-in computed %d model destination(s) for %s" % [applied, pile_in_unit_id])
+
+	# Reflect the computed destinations on the board tokens + arrow/coherency visuals
+	_apply_model_positions_to_scene()
+	_update_pile_in_visuals()
+
+	return get_pile_in_movements()
+
 func _apply_model_positions_to_scene() -> void:
 	"""Apply current_model_positions (and rotations) to the actual tokens in the scene"""
 	if pile_in_unit_id == "":

--- a/40k/tests/scenarios/sp/auto_consolidate_closest_opponents.json
+++ b/40k/tests/scenarios/sp/auto_consolidate_closest_opponents.json
@@ -1,0 +1,59 @@
+{
+  "id": "auto_consolidate_closest_opponents",
+  "covers": [
+    "scripts.FightController.auto_consolidate_movements",
+    "scripts.FightController._load_ai_fight_movements_into_preview",
+    "dialogs.ConsolidateDialog.AutoButton",
+    "phases.FightPhase.consolidate_11e",
+    "scripts.AIDecisionMaker._compute_consolidate_action"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "New feature (consolidate half): the Consolidate dialog has an 'Auto Consolidate' button that moves every model toward the closest enemy for the player (reusing the AI's consolidate solver), instead of dragging each model. Setup walks the fight phase to the global Consolidate step (12.07) via END_PILE_IN/END_FIGHT, then places the Contemptor Dreadnought (the only consolidate-eligible unit for P1) and one Ork Boy in open space with a ~0.8\" gap (engaged, ongoing-mode, but not yet in base contact). Player path: click the Dreadnought's Consolidate step entry to open the ConsolidateDialog, then click 'Auto Consolidate'. The Dreadnought is moved toward the Boy automatically (get_pile_in_movements() becomes non-empty). Confirm submits ONE legal CONSOLIDATE that moves it closer (y increases toward the Boy) and records the unit as consolidated — all with no manual dragging.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "execute_script", "script": "GameState.state.players[\"1\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "GameState.state.players[\"2\"].merge({\"cp\": 0}, true)" },
+    { "act": "execute_script", "script": "SettingsService.set(\"auto_allocate_wounds\", true)" },
+
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "END_FIGHT", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "END_FIGHT", "player": 2 } },
+
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/ConsolidationStepPanel", "timeout_s": 5.0 },
+    { "act": "expect_phase_property", "property": "consolidation_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "consolidating_player_11e", "equals": 1 },
+
+    { "act": "execute_script", "multiline": true, "script": "var st = GameState.state\nst.units[\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\"].models[0].position = {\"x\": 400.0, \"y\": 400.0}\nvar k = st.units[\"U_BOYZ_K\"]\nfor i in range(k.models.size()):\n\tk.models[i].position = {\"x\": 1500.0 + (i % 5) * 40.0, \"y\": 2100.0 + (i / 5) * 40.0}\nk.models[0].position = {\"x\": 400.0, \"y\": 504.0}\nreturn \"repositioned\"" },
+    { "act": "execute_script", "script": "main._sync_all_token_positions()" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "RulesEngine.is_unit_engaged(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\", GameState.state)", "equals": true },
+    { "act": "screenshot", "label": "01_consolidate_step_dread_engaged_with_a_gap" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/ConsolidationStepPanel/UnitList/Consolidate_U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/ConsolidateDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.fight_controller.consolidate_active", "equals": true },
+    { "act": "expect_node_property", "node": "/root/ConsolidateDialog/Content/Buttons/AutoButton", "property": "text", "equals": "Auto Consolidate" },
+    { "act": "screenshot", "label": "02_consolidate_dialog_open_with_auto_button" },
+
+    { "act": "click_node", "node": "/root/ConsolidateDialog/Content/Buttons/AutoButton", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script", "script": "main.fight_controller.get_pile_in_movements().size() > 0", "equals": true },
+    { "act": "screenshot", "label": "03_auto_consolidate_filled_the_move" },
+
+    { "act": "click_node", "node": "/root/ConsolidateDialog/Content/Buttons/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().units_that_consolidated_11e.has(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\")", "equals": true },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\"].models[0].position.y > 410.0", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.is_unit_engaged(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\", GameState.state)", "equals": true },
+    { "act": "screenshot", "label": "04_auto_consolidate_committed" }
+  ]
+}

--- a/40k/tests/scenarios/sp/auto_pile_in_closest_opponents.json
+++ b/40k/tests/scenarios/sp/auto_pile_in_closest_opponents.json
@@ -1,0 +1,50 @@
+{
+  "id": "auto_pile_in_closest_opponents",
+  "covers": [
+    "scripts.FightController.auto_pile_in_movements",
+    "dialogs.PileInDialog.AutoButton",
+    "phases.FightPhase.pile_in_11e",
+    "scripts.AIDecisionMaker._compute_pile_in_movements"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "New feature: the Pile In dialog has an 'Auto Pile In' button that moves every model toward the closest enemy for the player (reusing the AI's pile-in solver) instead of dragging each model by hand. Setup: the Contemptor Dreadnought (the only unit eligible to pile in for P1) and one Ork Boy are placed in open space with a ~0.8\" gap between them (engaged, but not yet in base contact). Player path: open the Fight phase (global Pile In step, P1 active), click the Dreadnought's step entry to open the PileInDialog, then click 'Auto Pile In'. The Dreadnought is moved toward the Boy automatically (get_pile_in_movements() becomes non-empty). Confirm then submits ONE legal PILE_IN that moves the Dreadnought into base contact (ending closer, y increases toward the Boy) and advances the step to P2 — all with no manual dragging.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "expect_node_visible", "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/PileInStepPanel", "timeout_s": 5.0 },
+    { "act": "expect_phase_property", "property": "pile_in_step_11e", "equals": 1 },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 1 },
+
+    { "act": "execute_script", "multiline": true, "script": "var st = GameState.state\nst.units[\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\"].models[0].position = {\"x\": 400.0, \"y\": 400.0}\nvar k = st.units[\"U_BOYZ_K\"]\nfor i in range(k.models.size()):\n\tk.models[i].position = {\"x\": 1500.0 + (i % 5) * 40.0, \"y\": 2100.0 + (i / 5) * 40.0}\nk.models[0].position = {\"x\": 400.0, \"y\": 504.0}\nreturn \"repositioned\"" },
+    { "act": "execute_script", "script": "main._sync_all_token_positions()" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "RulesEngine.is_unit_engaged(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\", GameState.state)", "equals": true },
+    { "act": "screenshot", "label": "01_dread_engaged_with_a_gap_before_pile_in" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/PileInStepPanel/UnitList/PileIn_U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_node_visible", "node": "/root/PileInDialog", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_active", "equals": true },
+    { "act": "expect_node_property", "node": "/root/PileInDialog/Content/Buttons/AutoButton", "property": "text", "equals": "Auto Pile In" },
+    { "act": "screenshot", "label": "02_pile_in_dialog_open_with_auto_button" },
+
+    { "act": "click_node", "node": "/root/PileInDialog/Content/Buttons/AutoButton", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 6 },
+
+    { "act": "execute_script", "script": "main.fight_controller.get_pile_in_movements().size() > 0", "equals": true },
+    { "act": "screenshot", "label": "03_auto_pile_in_filled_the_move" },
+
+    { "act": "click_node", "node": "/root/PileInDialog/Content/Buttons/ConfirmButton", "emit_pressed": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script", "script": "PhaseManager.get_current_phase_instance().units_that_piled_in.has(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\")", "equals": true },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\"].models[0].position.y > 410.0", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.is_unit_engaged(\"U_CONTEMPTOR-ACHILLUS_DREADNOUGHT_H\", GameState.state)", "equals": true },
+    { "act": "expect_phase_property", "property": "piling_in_player_11e", "equals": 2 },
+    { "act": "screenshot", "label": "04_auto_pile_in_committed_step_advanced" }
+  ]
+}


### PR DESCRIPTION
## What & why

During the Fight phase, piling in and consolidating means dragging every model toward the enemy by hand. The AI already solves this exact problem for its own units, so this reuses that solver to give **human players** a one-click option to do it too.

Two mirrored buttons, both optional and non-destructive:

- **Auto Pile In** (Pile In dialog, step 12.02)
- **Auto Consolidate** (Consolidate dialog, step 12.07)

Each moves every model of the unit — and any attached characters (19.03) — toward the closest enemy (consolidate also handles the Objective mode when no enemy is in reach), up to 3", legally. The move is loaded in as a **preview** (tokens + the usual arrows update); nothing is submitted until the player clicks **Confirm**, so they can review it or **Reset** and position models themselves.

## How it works

- `FightController.auto_pile_in_movements()` → `AIDecisionMaker._compute_pile_in_movements` (+ attached-character merge).
- `FightController.auto_consolidate_movements()` → `AIDecisionMaker._compute_consolidate_action`, which picks the mandatory 12.08 mode (Ongoing/Engaging/Objective) the same way `FightPhase._validate_consolidate_11e` judges it.
- Shared `_load_ai_fight_movements_into_preview()` converts the solver's index keys to the controller's model-id tracking keys, loads them into the interactive preview (skipping base-contact-locked models), and refreshes the visuals.
- Because the result goes through the existing **Confirm** path, the phase validates and commits it exactly as a manual drag would — the move is always legal (ends closer, no overlaps, coherency maintained).

## Rules followed

Each moved model ends closer to its nearest enemy, models already in base contact hold, overlaps are avoided, and unit coherency is preserved — the same constraints the AI's own pile-in/consolidate are held to.

## Validation

Driven end-to-end against the running game (windowed scenarios via the `addons/godot_mcp` bridge):

- **`auto_pile_in_closest_opponents`** (27/27): open the Pile In dialog → Auto Pile In → Confirm; unit moves closer, a legal `PILE_IN` is accepted and the step advances.
- **`auto_consolidate_closest_opponents`** (33/33): walk to the Consolidate step → open dialog → Auto Consolidate → Confirm; unit moves closer, a legal `CONSOLIDATE` is recorded.
- Regression: existing pile-in scenarios (`attached_char_pile_in_step_11e`, `pile_in_button_label_bv8yue`, `iss066_pile_in_consolidate_11e`) and consolidate scenarios (`global_consolidation_step_11e`, `consolidate_menu_visibility`, `consolidate_onto_terrain_objective_11e`) all pass; AI pile-in (29/29) and AI consolidation (40/40) unit tests pass.

Version bumped to 0.60.0 (0.59.0 = pile-in, 0.60.0 = consolidate) with changelog entries.

## Notes

In tightly-packed geometry (a model fully boxed in by its own squad and the enemy), the solver may legally hold that model — same as the AI behaves — and the button reports "no legal move"; the player can still drag manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAVcTYR7b211xh89aetKgf

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAVcTYR7b211xh89aetKgf)_