### PR TITLE
Fix itch.io (web) out-of-memory crashes: bound all game-long accumulators

### DIFF
--- a/40k/addons/godot_mcp/mcp_server.gd
+++ b/40k/addons/godot_mcp/mcp_server.gd
@@ -26,6 +26,14 @@ var _enabled := true
 
 
 func _ready() -> void:
+	# MEM-13: browsers have no TCP listener support — on web exports the server
+	# could never work, but the autoload still allocated and polled. Disable it
+	# outright there.
+	if OS.has_feature("web"):
+		_enabled = false
+		set_process(false)
+		print("[GodotMCP] Disabled on web export (no TCP support)")
+		return
 	if OS.has_feature("editor") == false and OS.get_environment("GODOT_MCP_DISABLED") == "1":
 		_enabled = false
 		print("[GodotMCP] Disabled via GODOT_MCP_DISABLED=1")

--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -22,6 +22,17 @@ var _processing_turn: bool = false  # Guard against re-entrant calls
 var _action_log: Array = []  # Log of AI actions for summary display
 var _turn_history: Array = []  # T7-56: Per-turn action history [{round, player, phase_range, actions}]
 var _turn_start_log_index: int = 0  # T7-56: Index into _action_log where current thinking sequence started
+# MEM-4: bounds for the whole-game AI logs (oldest entries drop first).
+var _max_action_log_entries: int = 300 if OS.has_feature("web") else 2000
+var _max_turn_history_entries: int = 30 if OS.has_feature("web") else 200
+
+# MEM-4: bounded append for _action_log; keeps _turn_start_log_index pointing
+# at the same logical entry when the front is trimmed.
+func _append_action_log(entry: Dictionary) -> void:
+	_action_log.push_back(entry)
+	while _action_log.size() > _max_action_log_entries:
+		_action_log.pop_front()
+		_turn_start_log_index = max(0, _turn_start_log_index - 1)
 var _current_phase_actions: int = 0  # Safety counter per phase
 const MAX_ACTIONS_PER_PHASE: int = 200  # Safety limit to prevent infinite loops
 var _failed_deploy_unit_ids: Array = []  # Units that failed both deployment and reserves — skip to avoid infinite loop
@@ -220,10 +231,11 @@ func _end_ai_thinking() -> void:
 		_ai_thinking = false
 		_step_by_step_paused = false  # T7-36: Clear step-by-step pause when thinking ends
 		var active_player = GameState.get_active_player()
-		var actions_snapshot = _action_log.duplicate()
-		emit_signal("ai_turn_ended", active_player, actions_snapshot)
-		# T7-56: Store only this turn's actions (slice from start index to end)
+		# T7-56/MEM-4: emit only this thinking sequence's actions. Duplicating the
+		# whole-game _action_log here (every phase change) was O(n^2) churn over a
+		# game, and made the "turn summary" panel tally the entire game.
 		var turn_actions = _action_log.slice(_turn_start_log_index)
+		emit_signal("ai_turn_ended", active_player, turn_actions.duplicate())
 		_store_turn_history(active_player, turn_actions)
 		print("AIPlayer: AI thinking ended for player %d" % active_player)
 
@@ -237,6 +249,10 @@ func configure(player_types: Dictionary, difficulty_levels: Dictionary = {}) -> 
 	ai_difficulty.clear()
 	_action_log.clear()
 	_turn_history.clear()  # T7-56: Reset turn history on reconfigure
+	_all_decision_records.clear()  # MEM-4: was never cleared — leaked across games
+	_decision_records_dropped = 0
+	_decision_batches_total = 0
+	_turn_start_log_index = 0
 	_current_phase_actions = 0
 	# P2-92: Reset all transient runtime state on reconfigure
 	_failed_deploy_unit_ids.clear()
@@ -683,7 +699,7 @@ func request_suggestion() -> Dictionary:
 		if sel > 0:
 			player = sel
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var available = phase_manager.get_available_actions()
 	if available.is_empty():
 		_log_ai_thinking(player, "No actions available to suggest right now.")
@@ -734,6 +750,10 @@ func _store_turn_history(player: int, actions: Array) -> void:
 		"actions": actions.duplicate(true),
 	}
 	_turn_history.append(entry)
+	# MEM-4: bounded — turn history rides inside every save file (SAVE-7), so an
+	# unbounded array inflated each autosave serialization as the game went on.
+	while _turn_history.size() > _max_turn_history_entries:
+		_turn_history.pop_front()
 	emit_signal("turn_history_updated")
 	print("AIPlayer: T7-56 Stored turn history entry #%d (round %d, player %d, %d actions)" % [
 		_turn_history.size(), entry.battle_round, player, actions.size()])
@@ -966,7 +986,7 @@ func _on_reactive_stratagem_opportunity(defending_player: int, available_stratag
 		_submit_reactive_action(defending_player, decline)
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_reactive_stratagem(
 		defending_player, available_stratagems, target_unit_ids, snapshot
 	)
@@ -1051,7 +1071,7 @@ func _on_movement_fire_overwatch_opportunity(defending_player: int, eligible_uni
 		_submit_reactive_action(defending_player, decline)
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_fire_overwatch(
 		defending_player, eligible_units, enemy_unit_id, snapshot
 	)
@@ -1085,7 +1105,7 @@ func _on_movement_rapid_ingress_opportunity(defending_player: int, eligible_unit
 		_submit_reactive_action(defending_player, decline)
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_rapid_ingress(defending_player, eligible_units, snapshot)
 	_flush_reactive_thinking(defending_player, "Rapid Ingress window (end of enemy movement)")
 
@@ -1116,7 +1136,7 @@ func _execute_rapid_ingress_sequence(player: int, use_action: Dictionary, placem
 
 	# Step 1: USE_RAPID_INGRESS (select the unit and spend CP)
 	var use_description = use_action.get("_ai_description", "AI uses Rapid Ingress")
-	_action_log.append({
+	_append_action_log({
 		"phase": GameState.get_current_phase(),
 		"action_type": use_action.get("type", ""),
 		"description": use_description,
@@ -1157,7 +1177,7 @@ func _execute_rapid_ingress_sequence(player: int, use_action: Dictionary, placem
 	# Step 2: PLACE_RAPID_INGRESS_REINFORCEMENT (place the unit on the board)
 	placement_action["player"] = player
 	var place_description = placement_action.get("_ai_description", "Rapid Ingress placement")
-	_action_log.append({
+	_append_action_log({
 		"phase": GameState.get_current_phase(),
 		"action_type": placement_action.get("type", ""),
 		"description": place_description,
@@ -1281,7 +1301,7 @@ func _on_counter_offensive_opportunity(player: int, eligible_units: Array) -> vo
 		_submit_reactive_action(player, decline)
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_counter_offensive(player, eligible_units, snapshot)
 	_flush_reactive_thinking(player, "Counteroffensive window (enemy just fought)")
 
@@ -1301,7 +1321,7 @@ func _on_epic_challenge_opportunity(unit_id: String, player: int) -> void:
 		return
 
 	var unit_name = _get_unit_name(unit_id)
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_epic_challenge(player, unit_id, snapshot)
 	_flush_reactive_thinking(player, "Epic Challenge window (%s selected to fight)" % unit_name)
 	if decision.is_empty():
@@ -1366,7 +1386,7 @@ func _on_katah_stance_required(unit_id: String, player: int) -> void:
 	if ability_mgr and ability_mgr.has_method("has_master_of_the_stances"):
 		master_available = ability_mgr.has_master_of_the_stances(unit_id)
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var decision = AIDecisionMaker.evaluate_katah_stance(player, unit_id, snapshot, master_available)
 	_flush_reactive_thinking(player, "Ka'tah stance (%s activating)" % _get_unit_name(unit_id))
 	decision["player"] = player
@@ -1395,7 +1415,7 @@ func _on_command_reroll_opportunity(unit_id: String, player: int, roll_context: 
 		_submit_reactive_action(player, decline)
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var should_reroll = false
 
 	var roll_type = roll_context.get("roll_type", "")
@@ -1485,7 +1505,7 @@ func _execute_pending_advance_move(player: int, decision: Dictionary, unit_id: S
 
 	if actual_differs:
 		print("AIPlayer: Advance actual cap %.1f\" differs from estimate %.1f\" — recomputing destinations for %s" % [actual_move_cap, estimated_move, unit_id])
-		var snapshot = GameState.create_snapshot()
+		var snapshot = GameState.create_snapshot(false)
 		var enemies = _get_enemies_for_recompute(player, snapshot)
 		var objectives = snapshot.get("board", {}).get("objectives", [])
 
@@ -1583,7 +1603,7 @@ func _execute_reactive_action_deferred(player: int, decision: Dictionary) -> voi
 		return
 
 	var description = decision.get("_ai_description", str(decision.get("type", "unknown")))
-	_action_log.append({
+	_append_action_log({
 		"phase": GameState.get_current_phase(),
 		"action_type": decision.get("type", ""),
 		"description": description,
@@ -1782,7 +1802,7 @@ func _evaluate_and_act() -> void:
 
 func _execute_next_action(player: int) -> void:
 	var phase = GameState.get_current_phase()
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 
 	# Get available actions from phase
 	var phase_manager = get_node("/root/PhaseManager")
@@ -1902,13 +1922,21 @@ func _execute_next_action(player: int) -> void:
 			"thinking_steps": decision.get("_ai_thinking_steps", []),
 			"actions": [{"type": decision.get("type", ""), "description": decision.get("_ai_description", "")}],
 		})
+		_decision_batches_total += 1
+		# MEM-4: bound retained batches (oldest drop first)
+		while _all_decision_records.size() > _max_decision_record_batches:
+			_all_decision_records.pop_front()
+			_decision_records_dropped += 1
 		# Auto-save decision log every 50 decision batches for mid-game access
-		if _all_decision_records.size() % 50 == 0:
-			export_decision_log()
+		# (refreshes only the 'latest' file — no timestamped copy per export).
+		# Uses the monotonic total, not size(): once the cap pins size, a
+		# size-based check would fire on every append.
+		if _decision_batches_total % 50 == 0:
+			export_decision_log(false)
 
 	# Log for summary
 	var description = decision.get("_ai_description", str(decision.get("type", "unknown")))
-	_action_log.append({
+	_append_action_log({
 		"phase": phase,
 		"action_type": decision.get("type", ""),
 		"description": description,
@@ -2274,7 +2302,7 @@ func _execute_ai_movement(player: int, decision: Dictionary) -> void:
 		if rebegin == null or not rebegin.get("success", false):
 			break
 
-		var snapshot = GameState.create_snapshot()
+		var snapshot = GameState.create_snapshot(false)
 		var enemies = _get_enemies_for_recompute(player, snapshot)
 		var parsed_objectives = AIDecisionMaker._get_objectives(snapshot)
 		# Head toward the AI's originally chosen target (from the pre-scale
@@ -2416,7 +2444,7 @@ func _try_stage_and_confirm(player: int, unit_id: String, destinations: Dictiona
 
 	if confirm_result != null and confirm_result.get("success", false):
 		print("AIPlayer: Confirmed movement for %s (%d models staged)" % [unit_id, staged_count])
-		_action_log.append({
+		_append_action_log({
 			"phase": GameState.get_current_phase(),
 			"action_type": "CONFIRM_UNIT_MOVE",
 			"description": "%s (moved %d models)" % [description, staged_count],
@@ -2504,7 +2532,7 @@ func _execute_ai_scout_movement(player: int, decision: Dictionary) -> void:
 		if confirm_result != null and confirm_result.get("success", false):
 			print("AIPlayer: Confirmed scout movement for %s (%d/%d models staged)" % [
 				unit_id, staged_count, staged_count + failed_count])
-			_action_log.append({
+			_append_action_log({
 				"phase": GameState.get_current_phase(),
 				"action_type": "CONFIRM_SCOUT_MOVE",
 				"description": "%s (moved %d models)" % [description, staged_count],
@@ -2765,7 +2793,7 @@ func _on_secondary_requires_interaction(player: int, mission_id: String, interac
 				print("AIPlayer: Marked for Death drawn by AI P%d — HUMAN opponent P%d selects via dialog (not auto-resolving)" % [player, opponent])
 				return
 			var required_alpha = details.get("alpha_targets", 3)
-			var snapshot = GameState.create_snapshot()
+			var snapshot = GameState.create_snapshot(false)
 			var units = snapshot.get("units", {})
 			var eligible_units = []
 			for uid in units:
@@ -3171,7 +3199,7 @@ func _handle_failed_deployment(player: int, original_decision: Dictionary) -> vo
 	if unit_id == "":
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var unit = snapshot.get("units", {}).get(unit_id, {})
 	if unit.is_empty():
 		return
@@ -3259,7 +3287,7 @@ func _handle_failed_deployment(player: int, original_decision: Dictionary) -> vo
 		var result = NetworkIntegration.route_action(retry_action)
 		if result != null and result.get("success", false):
 			print("AIPlayer: Deployment retry %d succeeded for %s" % [attempt + 1, unit_name])
-			_action_log.append({
+			_append_action_log({
 				"phase": GameState.get_current_phase(),
 				"action_type": "DEPLOY_UNIT",
 				"description": "Deployed %s (retry %d)" % [unit_name, attempt + 1],
@@ -3292,7 +3320,7 @@ func _fallback_to_reserves(player: int, unit_id: String, unit_name: String) -> v
 
 	if result != null and result.get("success", false):
 		print("AIPlayer: Successfully placed %s in strategic reserves" % unit_name)
-		_action_log.append({
+		_append_action_log({
 			"phase": GameState.get_current_phase(),
 			"action_type": "PLACE_IN_RESERVES",
 			"description": "%s placed in reserves (fallback)" % unit_name,
@@ -3310,7 +3338,7 @@ func _handle_failed_reinforcement(player: int, original_decision: Dictionary) ->
 	if unit_id == "":
 		return
 
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var unit = snapshot.get("units", {}).get(unit_id, {})
 	if unit.is_empty():
 		return
@@ -3400,7 +3428,7 @@ func _handle_failed_reinforcement(player: int, original_decision: Dictionary) ->
 		var result = NetworkIntegration.route_action(retry_action)
 		if result != null and result.get("success", false):
 			print("AIPlayer: Reinforcement retry %d succeeded for %s" % [attempt + 1, unit_name])
-			_action_log.append({
+			_append_action_log({
 				"phase": GameState.get_current_phase(),
 				"action_type": "PLACE_REINFORCEMENT",
 				"description": "%s arrives (retry %d)" % [unit_name, attempt + 1],
@@ -3423,9 +3451,24 @@ func _handle_failed_reinforcement(player: int, original_decision: Dictionary) ->
 
 # Accumulated decision records from all AI decisions this game
 var _all_decision_records: Array = []  # Array of {round, phase, player, records: Array}
+# MEM-4: bound the retained decision-record batches. Each batch carries the
+# full candidate-scoring breakdown for one decision, so an unbounded array grew
+# without limit during AI-vs-AI games (and, before the configure() clear, even
+# across games). Oldest batches drop first; the export notes how many dropped.
+var _max_decision_record_batches: int = 100 if OS.has_feature("web") else 500
+var _decision_records_dropped: int = 0
+var _decision_batches_total: int = 0  # monotonic count of batches ever appended this game
 
-func export_decision_log() -> void:
-	"""Export the full AI decision log as JSON for the AI Gameplay Visualizer web app."""
+func export_decision_log(archive: bool = true) -> void:
+	"""Export the full AI decision log as JSON for the AI Gameplay Visualizer web app.
+	archive=true additionally writes a timestamped copy; the periodic mid-game
+	auto-export passes false so it only refreshes the 'latest' file (MEM-4: the
+	old behavior wrote a NEW ever-larger timestamped file every 50 decisions)."""
+	# MEM-4: on web, user:// files live in browser RAM (MEMFS + IndexedDB) and
+	# each export re-serializes the whole cumulative log — skip file exports
+	# there. The visualizer is a desktop-side tool reading files from disk.
+	if OS.has_feature("web"):
+		return
 	var timestamp = Time.get_datetime_string_from_system().replace(":", "-")
 
 	# Build game metadata
@@ -3498,25 +3541,31 @@ func export_decision_log() -> void:
 		"action_log": _action_log.duplicate(true),
 		"turn_history": _turn_history.duplicate(true),
 	}
-
-	# Write to user:// directory
-	var filename = "ai_decision_log_%s.json" % timestamp
-	var path = "user://%s" % filename
-	var file = FileAccess.open(path, FileAccess.WRITE)
-	if file == null:
-		push_error("AIPlayer: Failed to open %s for writing" % path)
-		return
+	if _decision_records_dropped > 0:
+		export_data["decision_record_batches_dropped"] = _decision_records_dropped
 
 	var json_string = JSON.stringify(export_data, "\t")
-	file.store_string(json_string)
-	file.close()
 
-	# Also write a "latest" symlink-style copy for easy access
+	# The stable "latest" copy is always refreshed.
 	var latest_path = "user://ai_decision_log.json"
 	var latest_file = FileAccess.open(latest_path, FileAccess.WRITE)
 	if latest_file:
 		latest_file.store_string(json_string)
 		latest_file.close()
+	else:
+		push_error("AIPlayer: Failed to open %s for writing" % latest_path)
+		return
+
+	# Timestamped archive only for explicit/final exports (MEM-4).
+	var path = latest_path
+	if archive:
+		path = "user://ai_decision_log_%s.json" % timestamp
+		var file = FileAccess.open(path, FileAccess.WRITE)
+		if file:
+			file.store_string(json_string)
+			file.close()
+		else:
+			push_error("AIPlayer: Failed to open %s for writing" % path)
 
 	print("AIPlayer: Exported AI decision log to %s (%d rounds, %d action log entries, %d decision record batches)" % [
 		path, rounds_data.size(), _action_log.size(), _all_decision_records.size()])

--- a/40k/autoloads/ActionLogger.gd
+++ b/40k/autoloads/ActionLogger.gd
@@ -12,7 +12,22 @@ var current_session_id: String = ""
 var action_sequence: int = 0
 var session_actions: Array = []
 var auto_save_enabled: bool = true
-var max_memory_actions: int = 1000  # Limit memory usage
+var max_memory_actions: int = 500 if OS.has_feature("web") else 1000  # Limit memory usage
+
+# MEM-8: on web, user:// is RAM-backed — skip the per-action audit file there
+# (the in-memory session_actions ring is unaffected).
+var _file_logging_allowed: bool = not OS.has_feature("web")
+# MEM-8: hard byte cap for the session audit file; once reached we stop
+# appending (logged once) rather than growing without bound.
+const MAX_SESSION_FILE_BYTES: int = 10 * 1024 * 1024
+var _session_file_bytes: int = 0
+var _session_file_cap_reported: bool = false
+
+# MEM-8: heavy per-action payloads stripped before retention. Diffs are action
+# OUTPUTS (recomputed on replay; ReplayManager keeps its own copy for replay
+# files) and the _ai_* keys are decision metadata — neither is needed for the
+# deterministic replay bundle, and both made every retained action several KB.
+const _ACTION_STRIP_KEYS := ["_replay_diffs", "_ai_thinking_steps", "_ai_decision_records", "_ai_thinking_context"]
 
 func _ready() -> void:
 	_initialize_session()
@@ -50,9 +65,10 @@ func _generate_session_id() -> String:
 # Main logging interface
 func log_action(action: Dictionary) -> void:
 	# ISS-021: capture the pre-game baseline lazily, before the first action
-	# mutates anything beyond it.
+	# mutates anything beyond it. MEM-2: gameplay snapshot — the bundle replays
+	# the action stream forward, it never reads state.history.
 	if initial_snapshot.is_empty() and GameState != null:
-		initial_snapshot = GameState.create_snapshot()
+		initial_snapshot = GameState.create_snapshot(false)
 	var enriched_action = _enrich_action(action)
 	
 	# Add to memory
@@ -89,7 +105,12 @@ func log_action_batch(actions: Array) -> void:
 	emit_signal("action_batch_logged", enriched_actions)
 
 func _enrich_action(action: Dictionary) -> Dictionary:
-	var enriched = action.duplicate(true)
+	# MEM-8: strip heavy metadata via a shallow copy first, THEN deep-copy what
+	# remains — avoids deep-duplicating multi-KB diff/AI payloads per action.
+	var slim = action.duplicate()
+	for k in _ACTION_STRIP_KEYS:
+		slim.erase(k)
+	var enriched = slim.duplicate(true)
 	
 	# Add logging metadata
 	enriched["_log_metadata"] = {
@@ -116,23 +137,36 @@ func _capture_game_context() -> Dictionary:
 	}
 
 # File operations
+# MEM-8: the old implementation opened with FileAccess.WRITE, which TRUNCATES —
+# seek_end() was a no-op at position 0, so the "append log" only ever held the
+# last action. Real append = READ_WRITE on an existing file + seek_end. Writes
+# are skipped on web (RAM-backed FS) and stop at MAX_SESSION_FILE_BYTES.
 func _append_to_file(action: Dictionary) -> void:
-	var file = FileAccess.open(log_file_path, FileAccess.WRITE)
-	if file:
-		file.seek_end()
-		var json_string = JSON.stringify(action)
-		file.store_line(json_string)
-		file.close()
-	else:
-		push_error("ActionLogger: Failed to open log file for writing: " + log_file_path)
+	_append_lines_to_file([JSON.stringify(action)])
 
 func _append_batch_to_file(actions: Array) -> void:
-	var file = FileAccess.open(log_file_path, FileAccess.WRITE)
+	var lines: Array = []
+	for action in actions:
+		lines.append(JSON.stringify(action))
+	_append_lines_to_file(lines)
+
+func _append_lines_to_file(lines: Array) -> void:
+	if not _file_logging_allowed:
+		return
+	if _session_file_bytes > MAX_SESSION_FILE_BYTES:
+		if not _session_file_cap_reported:
+			_session_file_cap_reported = true
+			print("ActionLogger: session file cap reached (%d bytes) — further actions kept in memory only" % MAX_SESSION_FILE_BYTES)
+		return
+	var file_exists = FileAccess.file_exists(log_file_path)
+	var mode = FileAccess.READ_WRITE if file_exists else FileAccess.WRITE
+	var file = FileAccess.open(log_file_path, mode)
 	if file:
-		file.seek_end()
-		for action in actions:
-			var json_string = JSON.stringify(action)
-			file.store_line(json_string)
+		if file_exists:
+			file.seek_end()
+		for line in lines:
+			file.store_line(line)
+		_session_file_bytes = file.get_length()
 		file.close()
 	else:
 		push_error("ActionLogger: Failed to open log file for writing: " + log_file_path)
@@ -256,7 +290,7 @@ func create_replay_data() -> Dictionary:
 			"session_id": current_session_id,
 			"created_at": Time.get_unix_time_from_system(),
 			"total_actions": session_actions.size(),
-			"initial_state": GameState.create_snapshot()
+			"initial_state": GameState.create_snapshot(false)
 		},
 		"actions": session_actions.duplicate()
 	}
@@ -395,4 +429,4 @@ static func replay_hash(state: Dictionary) -> int:
 func reset_session_baseline() -> void:
 	session_actions.clear()
 	action_sequence = 0
-	initial_snapshot = GameState.create_snapshot()
+	initial_snapshot = GameState.create_snapshot(false)

--- a/40k/autoloads/DebugLogger.gd
+++ b/40k/autoloads/DebugLogger.gd
@@ -23,9 +23,15 @@ enum LogLevel {
 # File management
 var log_file_path: String = ""
 var session_id: String = ""
-var max_log_size: int = 50 * 1024 * 1024  # 50 MB
+# MEM-7: on web, user:// is a RAM-backed filesystem (MEMFS synced to
+# IndexedDB) — every log byte is tab memory, and old sessions' files are
+# mounted back into RAM on the next visit. Keep the same logging calls but
+# bound the bytes: 5 MB rolling file on web, 50 MB on desktop.
+var max_log_size: int = (5 * 1024 * 1024) if OS.has_feature("web") else (50 * 1024 * 1024)
 var current_log_size: int = 0
 var _is_rotating: bool = false
+# MEM-7: how many previous sessions' debug_*.log files to keep at startup.
+var _max_old_log_files: int = 1 if OS.has_feature("web") else 3
 
 # Performance optimization
 var log_buffer: Array[String] = []
@@ -43,6 +49,11 @@ func _initialize_logger() -> void:
 	# Create logs directory
 	var logs_dir = "user://logs/"
 	DirAccess.open("user://").make_dir_recursive("logs")
+
+	# MEM-7: prune previous sessions' log files BEFORE creating this session's —
+	# they were never deleted, so on web they accumulated in IndexedDB and were
+	# mounted back into tab RAM on every later visit.
+	_prune_old_logs(logs_dir)
 
 	# Set up log file path
 	log_file_path = logs_dir + "debug_%s.log" % session_id
@@ -197,28 +208,53 @@ func _write_to_file_immediate(content: String) -> void:
 		push_error("DebugLogger: Failed to open log file: " + log_file_path)
 
 func _rotate_log() -> void:
+	# MEM-7: rotate by RENAMING the file instead of reading it back into a
+	# String. The old implementation did get_as_text() on the full log — at the
+	# 50 MB cap that was a ~200 MB transient String (4 bytes/char), enough to
+	# OOM a WASM heap on its own — and then wrote a second full copy.
 	_is_rotating = true
 	var archived_path = log_file_path.replace(".log", "_archived.log")
 
-	var file = FileAccess.open(log_file_path, FileAccess.READ)
-	if file:
-		var content = file.get_as_text()
-		file = null
-
-		var archive = FileAccess.open(archived_path, FileAccess.WRITE)
-		if archive:
-			archive.store_string(content)
-			archive = null
-
-	# Truncate the original file
-	var truncated = FileAccess.open(log_file_path, FileAccess.WRITE)
-	if truncated:
-		truncated = null
+	var dir = DirAccess.open("user://logs/")
+	if dir:
+		if dir.file_exists(archived_path.get_file()):
+			dir.remove(archived_path.get_file())
+		var err = dir.rename(log_file_path.get_file(), archived_path.get_file())
+		if err != OK:
+			# Rename failed (shouldn't happen on any supported FS) — fall back
+			# to plain truncation so the live log stays bounded regardless.
+			var truncated = FileAccess.open(log_file_path, FileAccess.WRITE)
+			if truncated:
+				truncated = null
 	current_log_size = 0
 	log_buffer.clear()
 	_is_rotating = false
 	_write_log_header()
 	print("Log rotated - Previous log archived to: %s" % archived_path)
+
+# MEM-7: delete log files from previous sessions beyond the newest N
+# (debug_*.log including *_archived.log). Never touches the file that is about
+# to be created for the current session (session_id is unique per boot).
+func _prune_old_logs(logs_dir: String) -> void:
+	var dir = DirAccess.open(logs_dir)
+	if dir == null:
+		return
+	var candidates: Array = []
+	dir.list_dir_begin()
+	var fname = dir.get_next()
+	while fname != "":
+		if not dir.current_is_dir() and fname.begins_with("debug_") and fname.ends_with(".log"):
+			candidates.append({
+				"name": fname,
+				"mtime": FileAccess.get_modified_time(logs_dir + fname)
+			})
+		fname = dir.get_next()
+	dir.list_dir_end()
+	if candidates.size() <= _max_old_log_files:
+		return
+	candidates.sort_custom(func(a, b): return a["mtime"] > b["mtime"])  # newest first
+	for i in range(_max_old_log_files, candidates.size()):
+		dir.remove(candidates[i]["name"])
 
 # Utility functions
 func get_log_file_path() -> String:

--- a/40k/autoloads/GameEventLog.gd
+++ b/40k/autoloads/GameEventLog.gd
@@ -11,6 +11,21 @@ signal entry_added(text: String, entry_type: String)
 #             "combat_header", "combat_detail", "combat_result"
 var entries: Array = []
 
+# MEM-9: bound the retained log entries. AI-vs-AI games generate thousands of
+# entries (6-14 per attack sequence plus per-decision thinking blocks with
+# board-context payloads); the array was only cleared on new game. The UI
+# (GameLogPanel) already caps itself at 300 cards — this caps the data side.
+# Oldest entries drop first; readers use the tail or iterate, so trimming the
+# front is safe.
+var _max_entries: int = 800 if OS.has_feature("web") else 3000
+
+func _push_entry(entry: Dictionary) -> void:
+	entries.append(entry)
+	if entries.size() > _max_entries:
+		# Trim in a chunk (not one-by-one) so the O(n) front-removal cost is
+		# paid once per ~100 entries instead of on every append at the cap.
+		entries = entries.slice(100)
+
 # Noisy internal actions to filter out
 const FILTERED_ACTIONS = [
 	"STAGE_MODEL_MOVE",
@@ -374,7 +389,7 @@ func _current_history_marker() -> int:
 	return -1
 
 func _add_entry(text: String, entry_type: String) -> void:
-	entries.append({"text": text, "type": entry_type, "history_index": _current_history_marker()})
+	_push_entry({"text": text, "type": entry_type, "history_index": _current_history_marker()})
 	print("[GameEventLog] %s" % text)
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, entry_type)
@@ -401,7 +416,7 @@ func add_ai_thinking_block(player: int, header: String, lines: Array, context: D
 	var text = "P%d AI: %s" % [player, header]
 	for line in lines:
 		text += "\n" + str(line)
-	entries.append({"text": text, "type": "ai_thinking_block", "context": context, "history_index": _current_history_marker()})
+	_push_entry({"text": text, "type": "ai_thinking_block", "context": context, "history_index": _current_history_marker()})
 	print("[GameEventLog] %s" % text)
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, "ai_thinking_block")
@@ -415,7 +430,7 @@ func add_ai_turn_summary(player: int, header: String, lines: Array) -> void:
 	var text = header
 	for line in lines:
 		text += "\n" + str(line)
-	entries.append({"text": text, "type": "ai_turn_summary", "history_index": _current_history_marker()})
+	_push_entry({"text": text, "type": "ai_turn_summary", "history_index": _current_history_marker()})
 	print("[GameEventLog] %s" % text)
 	DebugLogger.info("GameEventLog: %s" % text, {})
 	emit_signal("entry_added", text, "ai_turn_summary")

--- a/40k/autoloads/GameManager.gd
+++ b/40k/autoloads/GameManager.gd
@@ -6,6 +6,11 @@ signal action_logged(log_text: String)
 
 var action_history: Array = []
 
+# MEM-5: cap for action_history/undo_history (multiplayer path) — reverse diffs
+# hold deep copies of prior state values, so unbounded growth bloated long
+# multiplayer sessions. Undo is single-step, so 200 retained actions is plenty.
+const MAX_ACTION_HISTORY: int = 200
+
 # Cached reference to PhaseManager (get_node_or_null fails in web exports)
 var _phase_manager_ref: Node = null
 
@@ -68,6 +73,14 @@ func apply_action(action: Dictionary) -> Dictionary:
 		else:
 			# Store empty array to keep histories aligned
 			undo_history.append([])
+
+		# MEM-5: bound both histories (kept aligned — trim fronts together).
+		# They grew per action for the whole session in multiplayer games, and
+		# undo only ever reaches back one action at a time.
+		while action_history.size() > MAX_ACTION_HISTORY:
+			action_history.pop_front()
+			if not undo_history.is_empty():
+				undo_history.pop_front()
 
 	return result
 
@@ -505,7 +518,10 @@ func apply_result(result: Dictionary) -> void:
 			if current_phase_inst and current_phase_inst.has_method("update_local_state"):
 				var game_state_ref = get_node_or_null("/root/GameState")
 				if game_state_ref:
-					current_phase_inst.update_local_state(game_state_ref.create_snapshot())
+					# MEM-2: update_local_state is a no-op since ISS-024 (phases
+					# read live state), so the full deep-copy snapshot formerly
+					# built here per deployment action was pure waste.
+					current_phase_inst.update_local_state(game_state_ref.state)
 					print("GameManager: Refreshed phase snapshot after %s" % action_type)
 
 	# Trigger a state change signal so UI updates

--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -1246,8 +1246,23 @@ func is_at_half_strength_combined(unit_id: String) -> bool:
 		return false  # combined starting strength odd -> cannot be at half
 	return alive_models * 2 == total_models
 
+# MEM-1: keys stripped from actions before they are stored in phase_log/history.
+# _replay_diffs can be a large array of state diffs (ReplayManager keeps its own
+# copy for replays) and the _ai_* keys carry the AI's full candidate-scoring
+# payloads — none are read back from history, they only bloated every snapshot
+# and save file.
+const _PHASE_LOG_STRIP_KEYS := ["_replay_diffs", "_ai_thinking_steps", "_ai_decision_records", "_ai_thinking_context"]
+
+# MEM-1: history is write-only during a game (only serialized into saves), so it
+# can be safely bounded. Web builds get a tighter cap because the WASM heap
+# never shrinks and every byte of state is multiplied by autosave serialization.
+var _max_history_entries: int = 40 if OS.has_feature("web") else 200
+
 func add_action_to_phase_log(action: Dictionary) -> void:
-	state["phase_log"].append(action)
+	var slim = action.duplicate()  # shallow: nested payloads stay shared
+	for k in _PHASE_LOG_STRIP_KEYS:
+		slim.erase(k)
+	state["phase_log"].append(slim)
 
 func commit_phase_log_to_history() -> void:
 	if state["phase_log"].size() > 0:
@@ -1258,9 +1273,23 @@ func commit_phase_log_to_history() -> void:
 		}
 		state["history"].append(phase_entry)
 		state["phase_log"].clear()
+		# MEM-1: bound the retained history (oldest phases drop first)
+		while state["history"].size() > _max_history_entries:
+			state["history"].pop_front()
 
-# Create a deep copy of the current state
-func create_snapshot() -> Dictionary:
+# Create a deep copy of the current state.
+#
+# MEM-2: include_history=false returns a "gameplay snapshot" — everything the
+# rules/AI/replay-navigation need (units, board, players, meta, terrain, manager
+# state) but WITHOUT the ever-growing history/phase_log arrays, the AI turn
+# history, or the measuring-tape dump, and without any logging. AIPlayer calls
+# this for every single decision (hundreds per AI turn) and ReplayManager for
+# every phase transition; deep-copying the full history each time made snapshot
+# cost grow quadratically over a game and was the main driver of the itch.io
+# (WASM) out-of-memory crashes. Saves keep using the full snapshot.
+func create_snapshot(include_history: bool = true) -> Dictionary:
+	if not include_history:
+		return _create_gameplay_snapshot()
 	# Create base snapshot
 	var snapshot = _deep_copy_dict(state)
 	
@@ -1335,6 +1364,56 @@ func create_snapshot() -> Dictionary:
 	
 	return snapshot
 
+# MEM-2: the light snapshot used by AI decisions and replay phase snapshots.
+# Deep-copies the live state minus the unbounded log arrays; keeps terrain and
+# the (small) manager-state dumps so replay navigation can still restore
+# stratagem/mission/ability locks. No prints — this runs hundreds of times per
+# AI turn.
+func _create_gameplay_snapshot() -> Dictionary:
+	var snapshot = {}
+	for key in state:
+		if key == "history" or key == "phase_log":
+			snapshot[key] = []
+			continue
+		var value = state[key]
+		if value is Dictionary:
+			snapshot[key] = _deep_copy_dict(value)
+		elif value is Array:
+			snapshot[key] = _deep_copy_array(value)
+		else:
+			snapshot[key] = value
+
+	var terrain_manager = get_node_or_null("/root/TerrainManager")
+	if terrain_manager:
+		if terrain_manager.current_layout != "":
+			snapshot.board["terrain_layout"] = terrain_manager.current_layout
+		if terrain_manager.terrain_features.size() > 0:
+			snapshot.board["terrain_features"] = terrain_manager.terrain_features.duplicate(true)
+
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr:
+		var secondary_data = secondary_mgr.get_save_data()
+		if not secondary_data.is_empty():
+			snapshot["secondary_missions"] = secondary_data
+
+	var faction_ability_mgr = get_node_or_null("/root/FactionAbilityManager")
+	if faction_ability_mgr:
+		snapshot["faction_ability_manager"] = faction_ability_mgr.get_state_for_save()
+
+	var stratagem_mgr = get_node_or_null("/root/StratagemManager")
+	if stratagem_mgr and stratagem_mgr.has_method("get_state_for_save"):
+		snapshot["stratagem_manager"] = stratagem_mgr.get_state_for_save()
+
+	var mission_mgr = get_node_or_null("/root/MissionManager")
+	if mission_mgr and mission_mgr.has_method("get_state_for_save"):
+		snapshot["mission_manager"] = mission_mgr.get_state_for_save()
+
+	var unit_ability_mgr = get_node_or_null("/root/UnitAbilityManager")
+	if unit_ability_mgr and unit_ability_mgr.has_method("get_state_for_save"):
+		snapshot["unit_ability_manager"] = unit_ability_mgr.get_state_for_save()
+
+	return snapshot
+
 func _deep_copy_dict(dict: Dictionary) -> Dictionary:
 	var copy = {}
 	for key in dict:
@@ -1405,6 +1484,25 @@ func _restore_terrain_types(terrain_features: Array) -> Array:
 # Load state from a snapshot
 func load_from_snapshot(snapshot: Dictionary) -> void:
 	state = _deep_copy_dict(snapshot)
+
+	# MEM-1: saves written before the memory fixes carry history actions with
+	# their full _replay_diffs / _ai_* payloads baked in — the very bloat the
+	# slimmed phase log now prevents. Sanitize once on load so legacy saves
+	# shed it too (and the trimmed cap applies going forward).
+	if state.has("history") and state["history"] is Array:
+		for phase_entry in state["history"]:
+			if phase_entry is Dictionary and phase_entry.get("actions", null) is Array:
+				for a in phase_entry["actions"]:
+					if a is Dictionary:
+						for k in _PHASE_LOG_STRIP_KEYS:
+							a.erase(k)
+		while state["history"].size() > _max_history_entries:
+			state["history"].pop_front()
+	if state.has("phase_log") and state["phase_log"] is Array:
+		for a in state["phase_log"]:
+			if a is Dictionary:
+				for k in _PHASE_LOG_STRIP_KEYS:
+					a.erase(k)
 
 	# SAVE/LOAD FIX: Ensure formation metadata exists for backwards compatibility with old saves.
 	# If the saved phase is past FORMATIONS and formation flags are missing, infer they were completed.

--- a/40k/autoloads/PadActionBar.gd.uid
+++ b/40k/autoloads/PadActionBar.gd.uid
@@ -1,0 +1,1 @@
+uid://bnj5065yvfq6s

--- a/40k/autoloads/PhaseManager.gd
+++ b/40k/autoloads/PhaseManager.gd
@@ -184,10 +184,14 @@ func transition_to_phase(new_phase: GameStateData.Phase) -> void:
 		else:
 			print("[PhaseManager] WARNING: No action_taken signal")
 		
-		# Enter the new phase
-		var snapshot = GameState.create_snapshot()
-		print("[PhaseManager] Creating snapshot for phase ", new_phase)
-		print("[PhaseManager] Snapshot has ", snapshot.get("units", {}).size(), " units")
+		# Enter the new phase.
+		# MEM-2: phases read LIVE state (BasePhase.game_state_snapshot is a
+		# property view over GameState.state and its setter is a no-op — ISS-024),
+		# so the full deep-copy snapshot formerly built here was discarded
+		# immediately. Pass the live state reference instead.
+		var snapshot = GameState.state
+		print("[PhaseManager] Entering phase ", new_phase, " (live-state view, ISS-024)")
+		print("[PhaseManager] State has ", snapshot.get("units", {}).size(), " units")
 		if snapshot.has("units") and snapshot.units.size() > 0:
 			print("[PhaseManager] Unit IDs: ", snapshot.units.keys())
 

--- a/40k/autoloads/ReplayManager.gd
+++ b/40k/autoloads/ReplayManager.gd
@@ -88,6 +88,23 @@ const PHASE_NAMES = {
 const REPLAY_VERSION = "1.0.0"
 const REPLAY_DIR = "user://replays/"
 
+# MEM-3: bound the in-memory recording snapshots. Snapshot 0 (the initial
+# state) is always kept so any position can be rebuilt by replaying diffs;
+# later snapshots are just seek-acceleration points, so dropping the oldest
+# non-initial ones only makes deep backward seeks slower, never wrong
+# (_find_recording_snapshot_index_at_or_before falls back toward snapshot 0).
+# Web builds keep fewer because the WASM heap never shrinks.
+var _max_recording_snapshots: int = 8 if OS.has_feature("web") else 24
+
+# MEM-3: heavy per-action metadata stripped from recorded events. The diffs are
+# already stored separately on the event ("diffs"), and the _ai_* payloads
+# (candidate scorings, thinking steps) were making every AI action's event
+# several KB — they are never read back during playback.
+const _EVENT_STRIP_KEYS := ["_replay_diffs", "_ai_thinking_steps", "_ai_decision_records", "_ai_thinking_context"]
+
+# MEM-3: cap replay files kept on disk (user:// is RAM-backed on web).
+var _max_replay_files: int = 5 if OS.has_feature("web") else 10
+
 # Cached reference to PhaseManager (get_node_or_null fails in web exports)
 var _phase_manager_ref: Node = null
 
@@ -153,8 +170,9 @@ func start_recording(persist_flag: bool = false) -> void:
 	_recording_snapshots.clear()
 	_recording_event_index = 0
 
-	# Capture initial state
-	_recording_initial_state = GameState.create_snapshot()
+	# Capture initial state. MEM-2/MEM-3: gameplay snapshot (no history/phase_log)
+	# — the replay's own event list IS the history.
+	_recording_initial_state = GameState.create_snapshot(false)
 
 	# Capture metadata
 	var game_config = GameState.state.get("meta", {}).get("game_config", {})
@@ -170,10 +188,13 @@ func start_recording(persist_flag: bool = false) -> void:
 		"player2_faction": GameState.get_faction_name(2),
 	}
 
-	# Take initial snapshot at event index 0
+	# Take initial snapshot at event index 0.
+	# MEM-3: share the initial-state dict instead of duplicating it — every
+	# consumer (_restore_to_position, build_recorded_state_at, the incremental
+	# save) either deep-copies before mutating or only serializes it.
 	_recording_snapshots.append({
 		"event_index": -1,
-		"state": _recording_initial_state.duplicate(true)
+		"state": _recording_initial_state
 	})
 
 	# Build a stable file path based on game_id so per-turn saves overwrite the same file
@@ -284,12 +305,18 @@ func _record_action_event(action_type: String, action_data: Dictionary, diffs: A
 	if action_type in FILTERED_ACTIONS:
 		return
 
-	# Build the replay event
+	# Build the replay event.
+	# MEM-3: slim the stored action — the diffs live in event["diffs"] and the
+	# _ai_* metadata is never used by playback; without this every AI action was
+	# retained (and re-serialized each turn) with its full thinking payload twice.
+	var slim_action = action_data.duplicate()  # shallow; nested payloads shared with the copy below
+	for k in _EVENT_STRIP_KEYS:
+		slim_action.erase(k)
 	var event = {
 		"index": _recording_event_index,
 		"type": "action",
 		"action_type": action_type,
-		"action_data": action_data.duplicate(true),
+		"action_data": slim_action.duplicate(true),
 		"diffs": diffs.duplicate(true),
 		"timestamp": Time.get_unix_time_from_system(),
 		"phase": GameState.get_current_phase(),
@@ -335,11 +362,17 @@ func _on_phase_changed_for_recording(new_phase: GameStateData.Phase) -> void:
 
 	_recording_events.append(event)
 
-	# Take a snapshot at every phase transition for backward navigation
+	# Take a snapshot at every phase transition for backward navigation.
+	# MEM-2/MEM-3: gameplay snapshot (no history/phase_log — those grew every
+	# phase, so snapshot N used to embed all actions of phases 1..N: quadratic
+	# memory over a game, the main itch.io OOM driver).
 	_recording_snapshots.append({
 		"event_index": _recording_event_index,
-		"state": GameState.create_snapshot()
+		"state": GameState.create_snapshot(false)
 	})
+	# MEM-3: keep the initial snapshot plus the newest N-1 seek points.
+	while _recording_snapshots.size() > _max_recording_snapshots:
+		_recording_snapshots.remove_at(1)
 
 	_recording_event_index += 1
 
@@ -368,6 +401,13 @@ func save_replay_incremental() -> void:
 
 	# Human games record in memory only (no per-turn replay files on disk).
 	if not persist_to_disk:
+		return
+
+	# MEM-3: on web, user:// is a RAM-backed filesystem and JSON.stringify of the
+	# whole recording is a multi-MB transient string that grows every turn — both
+	# ratcheted the WASM heap until the browser killed the tab. Web builds write
+	# the replay once, at stop_recording (game end / return to menu).
+	if OS.has_feature("web"):
 		return
 
 	# Update metadata with current state (but keep status as in_progress)
@@ -505,12 +545,41 @@ func _save_replay_to_file() -> String:
 		file.close()
 		print("ReplayManager: Saved replay to %s" % file_path)
 		DebugLogger.info("ReplayManager: Saved replay", {"path": file_path, "events": _recording_events.size()})
+		_prune_old_replays()
 		return file_path
 	else:
 		var error = "Failed to save replay to: " + file_path
 		push_error("ReplayManager: " + error)
 		DebugLogger.error("ReplayManager: " + error, {})
 		return ""
+
+# MEM-3: replay files were never auto-pruned — on web every AI-vs-AI game left
+# a multi-MB file in the RAM-backed user:// filesystem (persisted to IndexedDB
+# and mounted back into memory on every later visit). Keep the newest N.
+func _prune_old_replays() -> void:
+	var dir = DirAccess.open(REPLAY_DIR)
+	if dir == null:
+		return
+	var files: Array = []
+	dir.list_dir_begin()
+	var fname = dir.get_next()
+	while fname != "":
+		if not dir.current_is_dir() and fname.ends_with(".json"):
+			files.append({
+				"name": fname,
+				"mtime": FileAccess.get_modified_time(REPLAY_DIR + fname)
+			})
+		fname = dir.get_next()
+	dir.list_dir_end()
+	if files.size() <= _max_replay_files:
+		return
+	files.sort_custom(func(a, b): return a["mtime"] > b["mtime"])  # newest first
+	for i in range(_max_replay_files, files.size()):
+		var doomed: String = files[i]["name"]
+		if dir.remove(doomed) == OK:
+			print("ReplayManager: Pruned old replay %s" % doomed)
+		else:
+			DebugLogger.warn("ReplayManager: Failed to prune replay", {"file": doomed})
 
 func _generate_replay_id() -> String:
 	return "%08x-%04x-%04x" % [randi(), randi() & 0xFFFF, randi() & 0xFFFF]

--- a/40k/autoloads/SaveLoadManager.gd
+++ b/40k/autoloads/SaveLoadManager.gd
@@ -333,6 +333,15 @@ func _perform_event_autosave(event_tag: String, event_metadata: Dictionary) -> b
 		print("SaveLoadManager: Autosave disabled, skipping event autosave for: %s" % event_tag)
 		return false
 
+	# MEM-6: on web these rotating autosaves targeted "cloud://autosaves/…",
+	# which FileAccess cannot open — the full snapshot + serialization ran and
+	# was then thrown away on every round end / timer tick. The phase-start
+	# named autosave (save_game → CloudStorage) already covers web crash
+	# recovery, so skip before doing any work.
+	if is_web_platform:
+		print("SaveLoadManager: Event autosave skipped on web (%s) — phase-start cloud autosave covers recovery" % event_tag)
+		return false
+
 	var battle_round = GameState.get_battle_round()
 	var active_player = GameState.get_active_player()
 	var timestamp = Time.get_datetime_string_from_system().replace(":", "-")
@@ -806,6 +815,13 @@ func set_autosave_interval(seconds: float) -> void:
 
 func perform_autosave() -> bool:
 	if not autosave_enabled:
+		return false
+
+	# MEM-6: same as _perform_event_autosave — "cloud://" paths can't be opened
+	# with FileAccess, so the timer autosave burned a full snapshot+serialize on
+	# web with nothing written. Phase-start cloud autosaves cover web recovery.
+	if is_web_platform:
+		print("SaveLoadManager: Timer autosave skipped on web — phase-start cloud autosave covers recovery")
 		return false
 
 	# SAVE-6: Skip timer-based autosave if AI is mid-action to avoid capturing incomplete state

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,20 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.65.3",
+			"date": "2026-07-19",
+			"summary": "Big memory fix for the itch.io (browser) build: long games — especially AI vs AI — no longer balloon the tab's memory until the browser kills the page. Replay recording, AI decision logs, game history and debug logs are now all bounded, and a game abandoned via 'Return to Menu' fully stops instead of simulating invisibly behind the menu.",
+			"changes": [
+				"Fixed the main crash driver: the replay recorder kept a full copy of the game state at every phase change, and each copy also contained the entire ever-growing action history — memory grew faster every round. Snapshots are now history-free and capped, and replay files are only written per-turn on desktop (web writes once at game end).",
+				"AI decision records, the AI action log, AI turn history, the game event log and the in-game action history are all bounded now; the AI decision log no longer leaks between games or writes an ever-larger new file to browser storage every 50 decisions.",
+				"Every AI decision used to deep-copy the full game state (including all history) hundreds of times per turn — decisions now use a slim gameplay snapshot, which also removes several log lines per decision.",
+				"Debug logging is web-aware: 5 MB rolling log on web (50 MB desktop), rotation no longer re-reads the whole file (which spiked ~200 MB at the cap), and old session logs are cleaned up at startup instead of piling up in browser storage forever.",
+				"Returning to the main menu (game over, settings, or mid-game) now disables the AI and finalizes the replay recording — an abandoned AI-vs-AI game no longer keeps playing and recording invisibly behind the menu.",
+				"Dice History panel no longer grows without limit (it also skips work entirely while hidden), autosaves on web no longer burn a full save's work on a file that can never be written, and a few small board-visual leaks (shooting target chips, pile-in overlays, deployment picker) are freed on phase end.",
+				"Session action log file writes actually append now (a truncate bug meant the file only ever held the last action) and are capped at 10 MB, desktop-only."
+			]
+		},
+		{
 			"version": "0.65.2",
 			"date": "2026-07-19",
 			"summary": "AI armies no longer stack models on top of each other. Reinforcements arriving from Strategic Reserves / Deep Strike (the main offender in AI vs AI games — e.g. Warbikers landing on a corner Battlewagon and on themselves) are now rejected if any base would overlap, and the AI picks a clear spot instead. Battlewagons also get their real 180mm hull footprint instead of a 32mm round base.",

--- a/40k/dialogs/GrenadeTargetDialog.gd
+++ b/40k/dialogs/GrenadeTargetDialog.gd
@@ -163,7 +163,7 @@ func _on_grenade_unit_selected(unit_id: String) -> void:
 	print("GrenadeTargetDialog: Selected grenade unit: %s" % unit_id)
 
 	# Get eligible targets within 8" of this unit
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	eligible_targets = RulesEngine.get_grenade_eligible_targets(unit_id, board)
 
 	if eligible_targets.is_empty():

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -2164,8 +2164,12 @@ func _show_mathhammer_predictions() -> void:
 		# Build mathhammer simulation config
 		# Issue #329: route through RNGService so RNGService.test_mode_seed applies for deterministic UI snapshots
 		var _mh_rng = RulesEngine.make_rng()
+		# MEM-12: fewer trials on web — this runs per declared attack, and the
+		# per-trial allocations ratchet the WASM heap. 200 trials keeps the
+		# one-line "~X wounds, Y% kill" estimate stable enough for the UI.
+		var _mh_trials = 200 if OS.has_feature("web") else 1000
 		var config = {
-			"trials": 1000,  # Reduced for real-time predictions
+			"trials": _mh_trials,  # Reduced for real-time predictions
 			"attackers": [attacker_config],
 			"defender": {"unit_id": target_id},
 			"rule_toggles": rule_toggles,

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -1222,7 +1222,7 @@ func _refresh_ui() -> void:
 func _can_unit_charge(unit: Dictionary) -> bool:
 	# Use RulesEngine to check if unit can charge
 	var unit_id = unit.get("id", "")
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	return RulesEngine.eligible_to_charge(unit_id, board)
 
 func get_displayed_charge_unit_ids() -> Array:
@@ -1244,7 +1244,7 @@ func _filter_units_with_charge_targets(unit_ids: Array) -> Array:
 	# display-only refinement; the phase's own eligibility (used by AI / phase
 	# logic) is unchanged.
 	var result: Array = []
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	for unit_id in unit_ids:
 		if not RulesEngine.charge_targets_within_12(unit_id, board).is_empty():
 			result.append(unit_id)
@@ -1346,7 +1346,7 @@ func _on_unit_selected(index: int) -> void:
 			skip_button.disabled = false  # Can always skip once a unit is selected
 		
 		# Get eligible targets for this unit
-		var board = GameState.create_snapshot()
+		var board = GameState.create_snapshot(false)
 		eligible_targets = RulesEngine.charge_targets_within_12(active_unit_id, board)
 		
 		print("Found ", eligible_targets.size(), " eligible targets for unit ", active_unit_id)

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -86,6 +86,13 @@ func _ready() -> void:
 	set_process(true)
 	set_process_unhandled_input(true)
 
+func _exit_tree() -> void:
+	# MEM-13: the model-type picker CanvasLayer is parented to /root (it must
+	# outdraw the HUD), so it survives this controller unless freed here — a
+	# picker left open when the deployment phase ended leaked past the game
+	# scene, even into the main menu.
+	_hide_model_type_picker()
+
 func set_layers(tokens: Node2D, ghosts: Node2D) -> void:
 	token_layer = tokens
 	ghost_layer = ghosts

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -162,6 +162,11 @@ func _exit_tree() -> void:
 		damage_feedback.queue_free()
 		damage_feedback = null
 
+	# MEM-13: pile-in/consolidate visuals were only freed on success/cancel —
+	# if the Fight phase ended while a pile-in drag was open they leaked under
+	# BoardView permanently.
+	_clear_pile_in_visuals()
+
 	# Right panel cleanup
 	var container = SceneRefs.hud_right_vbox()
 	if container and is_instance_valid(container):
@@ -3174,7 +3179,7 @@ func _maybe_snap_to_b2b(candidate_pos: Vector2) -> Vector2:
 	var snap_zone_px: float = Measurement.inches_to_px(PILEIN_SNAP_ZONE_INCHES)
 	var best_candidate: Vector2 = Vector2.ZERO
 	var best_excess: float = INF
-	var snapshot = GameState.create_snapshot() if GameState else {}
+	var snapshot = GameState.create_snapshot(false) if GameState else {}
 	for uid in snapshot.get("units", {}):
 		var u = snapshot.units[uid]
 		if int(u.get("owner", 0)) == owner:

--- a/40k/scripts/LoSDebugVisual.gd
+++ b/40k/scripts/LoSDebugVisual.gd
@@ -350,7 +350,7 @@ func _overview_state_signature() -> int:
 func _rebuild_overview() -> void:
 	overview_lines.clear()
 	_overview_sig = _overview_state_signature()
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	var units: Dictionary = board.get("units", {})
 
 	var sources: Array = []
@@ -469,7 +469,7 @@ func test_los_between_units(shooter_id: String, target_id: String) -> void:
 		return
 	
 	# Check and visualize
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	var result = check_and_visualize_los(shooter_pos, target_pos, board)
 	
 	print("[LoSDebugVisual] LoS from %s to %s: %s" % [
@@ -862,7 +862,7 @@ func test_enhanced_los_between_models(shooter_unit_id: String, shooter_model_id:
 		return
 	
 	# Visualize enhanced LoS
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 	visualize_enhanced_los(shooter_model, target_model, board)
 	
 	print("[LoSDebugVisual] Enhanced LoS test: %s.%s → %s.%s" % [

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -258,6 +258,8 @@ var _dice_history_panel: PanelContainer = null
 var _dice_history_label: RichTextLabel = null
 var _dice_history_scroll: ScrollContainer = null
 var _is_dice_history_visible: bool = false
+var _dice_history_line_count: int = 0  # MEM-10: lines appended to the dice-history label since last rebuild
+var _dice_history_label_stale: bool = false  # MEM-10: rolls arrived while the panel was hidden
 var _dice_history_toggle_button: Button = null
 
 # P2-40: Deployment log panel — tracks all deployments in order for multiplayer visibility
@@ -9023,11 +9025,27 @@ func _on_main_menu_requested() -> void:
 	if NetworkManager.is_networked():
 		print("Main: Disconnecting network before returning to menu")
 		NetworkManager.disconnect_network()
+	# MEM-11: stop the AI and the replay recording before leaving the game.
+	# Both live in autoloads, so without this an abandoned AI-vs-AI game kept
+	# simulating (and recording snapshots) invisibly behind the main menu,
+	# growing memory until the browser killed the tab.
+	_stop_background_game_activity()
 	# Reset PhaseManager state so it doesn't carry stale phase instances into the next game
 	var phase_manager = get_node_or_null("/root/PhaseManager")
 	if phase_manager:
 		phase_manager.reset()
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+
+# MEM-11: disable AI evaluation and finalize any in-progress replay recording.
+# Called on every route back to the main menu.
+func _stop_background_game_activity() -> void:
+	if AIPlayer and AIPlayer.enabled:
+		print("Main: Disabling AI before leaving the game scene")
+		AIPlayer.enabled = false
+		AIPlayer.ai_players = {1: false, 2: false}
+	if ReplayManager and ReplayManager.is_recording:
+		print("Main: Stopping replay recording before leaving the game scene")
+		ReplayManager.stop_recording()
 
 func _on_save_requested(save_name: String) -> void:
 	print("Main: Save requested with name: ", save_name)
@@ -9473,6 +9491,8 @@ func _on_game_over_return_to_menu() -> void:
 	if NetworkManager.is_networked():
 		print("Main: Disconnecting network before returning to menu from game over")
 		NetworkManager.disconnect_network()
+	# MEM-11: make sure AI + recording are fully stopped before the menu loads
+	_stop_background_game_activity()
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
 
 # ============================================================================
@@ -11104,8 +11124,7 @@ func _setup_dice_history_panel() -> void:
 		print("Main: Connected to DiceHistoryPanel.roll_recorded")
 
 		# Populate any entries that were added before we connected
-		for entry_item in DiceHistoryPanel.get_history():
-			_append_dice_history_entry(entry_item)
+		_rebuild_dice_history_label()
 
 	# Add toggle button to HUD_Bottom
 	var hud_bottom = get_node_or_null("HUD_Bottom/HBoxContainer")
@@ -11126,6 +11145,13 @@ func _setup_dice_history_panel() -> void:
 	print("Main: Dice Roll History panel created")
 
 func _on_dice_history_roll_recorded(entry: Dictionary) -> void:
+	# MEM-10: while the panel is hidden, don't append to (or re-layout) the
+	# RichTextLabel — AI-vs-AI games record thousands of rolls with the panel
+	# closed. The label is rebuilt from the DiceHistoryPanel autoload (which
+	# caps itself at 500 entries) when the panel is next shown.
+	if not _is_dice_history_visible:
+		_dice_history_label_stale = true
+		return
 	_append_dice_history_entry(entry)
 
 	# Auto-scroll to bottom
@@ -11138,6 +11164,22 @@ func _append_dice_history_entry(entry: Dictionary) -> void:
 		return
 	var bbcode = DiceHistoryPanel.format_entry_bbcode(entry)
 	_dice_history_label.append_text(bbcode + "\n")
+	# MEM-10: the label previously grew without bound (append per roll, cleared
+	# only by the manual Clear button). Rebuild from the autoload's capped
+	# history once we exceed its cap by a margin.
+	_dice_history_line_count += 1
+	if _dice_history_line_count > 600:
+		_rebuild_dice_history_label()
+
+func _rebuild_dice_history_label() -> void:
+	if not _dice_history_label:
+		return
+	_dice_history_label.clear()
+	_dice_history_line_count = 0
+	for entry_item in DiceHistoryPanel.get_history():
+		_dice_history_label.append_text(DiceHistoryPanel.format_entry_bbcode(entry_item) + "\n")
+		_dice_history_line_count += 1
+	_dice_history_label_stale = false
 
 func _on_dice_history_collapse_pressed() -> void:
 	_is_dice_history_visible = false
@@ -11152,12 +11194,20 @@ func _on_dice_history_toggle_pressed() -> void:
 		_dice_history_panel.visible = _is_dice_history_visible
 	if _dice_history_toggle_button:
 		_dice_history_toggle_button.text = "Hide Dice" if _is_dice_history_visible else "Dice History"
+	# MEM-10: rolls recorded while hidden weren't appended — rebuild on show.
+	if _is_dice_history_visible and _dice_history_label_stale:
+		_rebuild_dice_history_label()
+		if _dice_history_scroll:
+			await get_tree().process_frame
+			_dice_history_scroll.scroll_vertical = int(_dice_history_scroll.get_v_scroll_bar().max_value)
 
 func _on_dice_history_clear_pressed() -> void:
 	if DiceHistoryPanel:
 		DiceHistoryPanel.clear()
 	if _dice_history_label:
 		_dice_history_label.clear()
+	_dice_history_line_count = 0
+	_dice_history_label_stale = false
 
 # ============================================================================
 # History Browser — click a game-log entry to revert the board to that step

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -112,6 +112,18 @@ func _ready() -> void:
 		print("MainMenu: Cleaning up stale network state")
 		NetworkManager.disconnect_network()
 
+	# MEM-11: defensive stop for ANY route back to the menu (game over, settings,
+	# replay browser, web lobby). AIPlayer and ReplayManager are autoloads — if a
+	# game was abandoned mid-way they would otherwise keep simulating/recording
+	# invisibly behind the menu, growing memory until the tab was killed.
+	if AIPlayer and AIPlayer.enabled:
+		print("MainMenu: Disabling leftover AI from previous game")
+		AIPlayer.enabled = false
+		AIPlayer.ai_players = {1: false, 2: false}
+	if ReplayManager and ReplayManager.is_recording:
+		print("MainMenu: Finalizing leftover replay recording from previous game")
+		ReplayManager.stop_recording()
+
 	_apply_theme()
 	_base_terrain_options = terrain_options.duplicate()
 	_setup_dropdowns()

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -5424,7 +5424,7 @@ func _show_er_overlay(unit_id: String) -> void:
 		return
 	var active_unit = GameState.get_unit(unit_id)
 	var owner = int(active_unit.get("owner", 0))
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	for uid in snapshot.get("units", {}):
 		var u = snapshot.units[uid]
 		if int(u.get("owner", 0)) == owner:

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -321,6 +321,13 @@ func _exit_tree() -> void:
 		shooting_lines_container.queue_free()
 	remote_assignment_lines.clear()
 
+	# MEM-13: the target-chips container was created under BoardRoot every
+	# shooting phase but never freed here — one orphan Node2D accumulated per
+	# shooting phase (2 per battle round) for the rest of the session.
+	if target_chips_container and is_instance_valid(target_chips_container):
+		target_chips_container.queue_free()
+		target_chips_container = null
+
 	# T5-V2: Clean up animated shooting line visuals
 	_clear_shooting_line_visuals()
 	shooting_line_visuals.clear()
@@ -947,7 +954,7 @@ func resync_from_phase() -> void:
 	# The phase DOES have an active shooter — mirror it. If the controller had
 	# drifted to a different unit, snap back to the phase's shooter.
 	active_shooter_id = phase_active
-	eligible_targets = RulesEngine.get_eligible_targets(active_shooter_id, GameState.create_snapshot())
+	eligible_targets = RulesEngine.get_eligible_targets(active_shooter_id, GameState.create_snapshot(false))
 	weapon_assignments.clear()
 	var weapons_seen := {}
 	for assignment in current_phase.pending_assignments:
@@ -1998,7 +2005,7 @@ func _visualize_los_to_target(shooter_id: String, target_id: String) -> void:
 	if shooter_unit.is_empty() or target_unit.is_empty():
 		return
 
-	var board = GameState.create_snapshot()
+	var board = GameState.create_snapshot(false)
 
 	# Use enhanced LoS visualization for each model pair
 	for shooter_model in shooter_unit.get("models", []):
@@ -2183,7 +2190,7 @@ func _on_unit_selected_for_shooting(unit_id: String) -> void:
 		los_debug_visual.clear_all_debug_visuals()
 
 	# Request targets and trigger LoS visualization
-	eligible_targets = RulesEngine.get_eligible_targets(unit_id, GameState.create_snapshot())
+	eligible_targets = RulesEngine.get_eligible_targets(unit_id, GameState.create_snapshot(false))
 	_highlight_targets()
 	_refresh_shooter_status()
 	_refresh_weapon_tree()
@@ -4009,7 +4016,7 @@ func _build_auto_shoot_plan() -> Array:
 	"""Build a plan of SHOOT actions for all remaining eligible units.
 	Returns [{unit_id, unit_name, assignments, target_names, weapon_count}]."""
 	var plan = []
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var current_player = current_phase.get_current_player()
 	var units = current_phase.get_units_for_player(current_player)
 	var units_shot = current_phase.get_units_that_shot()
@@ -5033,7 +5040,7 @@ func _handle_board_click(position: Vector2) -> void:
 		else:
 			# Player clicked on an ineligible enemy unit — explain why instead of
 			# silently switching to a different unit.
-			var reason = RulesEngine.get_target_ineligibility_reason(active_shooter_id, closest_target, GameState.create_snapshot())
+			var reason = RulesEngine.get_target_ineligibility_reason(active_shooter_id, closest_target, GameState.create_snapshot(false))
 			if reason == "":
 				reason = "Target cannot be shot"
 			print("[ShootingController] Click on ineligible target %s: %s" % [closest_target, reason])
@@ -5082,7 +5089,7 @@ func _report_no_eligible_targets(unit_id: String, force: bool = false) -> void:
 	var unit = GameState.get_unit(unit_id)
 	var unit_meta = unit.get("meta", {})
 	var unit_name = unit_meta.get("display_name", unit_meta.get("name", unit_id))
-	var snapshot = GameState.create_snapshot()
+	var snapshot = GameState.create_snapshot(false)
 	var reasons: Array = []
 	var all_units = snapshot.get("units", {})
 	var my_owner = unit.get("owner", 0)

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -9,6 +9,41 @@
   ],
   "tiles": [
     {
+      "id": "autoloads.ReplayManager.memops",
+      "description": "ReplayManager's recording stays bounded during a long AI-vs-AI game: phase-transition snapshots use the history-free gameplay snapshot and are capped (oldest non-initial snapshots dropped); recorded action events carry no _replay_diffs/_ai_* payloads (diffs are stored once, separately).",
+      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "autoloads.GameState.memops",
+      "description": "GameState.state[\"history\"] stays capped during a long AI-vs-AI game, and phase_log/history actions are stored without their _replay_diffs/_ai_* payloads.",
+      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "autoloads.AIPlayer.memops",
+      "description": "AIPlayer's whole-game accumulators (_all_decision_records, _action_log) stay within their bounded caps during a long AI-vs-AI game.",
+      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "autoloads.GameEventLog.memops",
+      "description": "GameEventLog.entries stays within its bounded cap during a long AI-vs-AI game.",
+      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "autoloads.ActionLogger.memops",
+      "description": "ActionLogger.session_actions stays within its bounded cap, and retained actions carry no _replay_diffs/_ai_decision_records payloads, during a long AI-vs-AI game.",
+      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
       "id": "scripts.ChargeController.attached_character_drag",
       "description": "During a Charge move the attached CHARACTER of a charging unit (e.g. a Blade Champion leading Custodian Guard) is draggable like its squadmates. ChargeController keys all movement bookkeeping by a charge key (bare model id for the bodyguard, '<char_unit>:<model>' for character models) and hit-tests in board space against each model's real base radius, nearest-wins.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/memops_ai_vs_ai_bounded.json
+++ b/40k/tests/scenarios/sp/memops_ai_vs_ai_bounded.json
@@ -1,0 +1,51 @@
+{
+  "id": "memops_ai_vs_ai_bounded",
+  "covers": ["autoloads.ReplayManager.memops", "autoloads.GameState.memops", "autoloads.AIPlayer.memops", "autoloads.GameEventLog.memops", "autoloads.ActionLogger.memops"],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "description": "MEM (itch.io OOM fix): AI-vs-AI at fastest speed for ~75s of real play. The unbounded accumulators that crashed long browser games must stay bounded and slimmed while the game demonstrably progresses: replay phase snapshots are capped and carry no history, recorded events and phase_log/history actions carry no _replay_diffs/_ai_* payloads, decision-record batches and event-log entries respect their caps. Boundedness must not stall the AI game (forward-progress assert mirrors iss062_ai_11e).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "execute_script", "script": "AIPlayer.set_ai_speed_preset(0)" },
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"AI\", 2: \"AI\"})" },
+    { "act": "execute_script", "script": "AIPlayer.enabled", "equals": true },
+    { "act": "screenshot", "label": "01_memops_ai_vs_ai_started" },
+
+    { "act": "wait_seconds", "seconds": 75.0 },
+    { "act": "screenshot", "label": "02_memops_ai_midgame" },
+    { "act": "execute_script",
+      "script": "GameState.get_battle_round() * 100 + GameState.get_current_phase()",
+      "expect_min": 101 },
+
+    { "act": "execute_script", "script": "ReplayManager._recording_events.size()", "expect_min": 20 },
+    { "act": "execute_script", "script": "ReplayManager._recording_snapshots.size()", "expect_min": 2 },
+    { "act": "execute_script", "script": "ReplayManager._recording_snapshots.size()", "expect_max": 24 },
+    { "act": "execute_script", "script": "GameState.state[\"history\"].size()", "expect_max": 200 },
+    { "act": "execute_script", "script": "AIPlayer._all_decision_records.size()", "expect_max": 500 },
+    { "act": "execute_script", "script": "AIPlayer._action_log.size()", "expect_max": 2000 },
+    { "act": "execute_script", "script": "GameEventLog.entries.size()", "expect_max": 3000 },
+    { "act": "execute_script", "script": "ActionLogger.session_actions.size()", "expect_max": 1000 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var n = 0\nfor e in ReplayManager._recording_events:\n\tvar ad = e.get(\"action_data\", {})\n\tif ad.has(\"_replay_diffs\") or ad.has(\"_ai_decision_records\") or ad.has(\"_ai_thinking_steps\") or ad.has(\"_ai_thinking_context\"):\n\t\tn += 1\nreturn n",
+      "equals": 0 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var n = 0\nfor ph in GameState.state[\"history\"]:\n\tfor a in ph.get(\"actions\", []):\n\t\tif a.has(\"_replay_diffs\") or a.has(\"_ai_decision_records\") or a.has(\"_ai_thinking_steps\"):\n\t\t\tn += 1\nreturn n",
+      "equals": 0 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var n = 0\nfor s in ReplayManager._recording_snapshots:\n\tvar st = s.get(\"state\", {})\n\tif not st.get(\"history\", []).is_empty() or not st.get(\"phase_log\", []).is_empty():\n\t\tn += 1\nreturn n",
+      "equals": 0 },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var n = 0\nfor a in ActionLogger.session_actions:\n\tif a.has(\"_replay_diffs\") or a.has(\"_ai_decision_records\"):\n\t\tn += 1\nreturn n",
+      "equals": 0 },
+
+    { "act": "screenshot", "label": "03_memops_bounded_verified" },
+    { "act": "execute_script", "script": "AIPlayer.configure({1: \"HUMAN\", 2: \"HUMAN\"})" }
+  ]
+}


### PR DESCRIPTION
## Summary

Long games — AI-vs-AI especially — grew the browser tab's memory until itch.io reloaded the page ("using significant memory"). This closes the memory-growth audit with fixes for the root causes:

- **Full-state deep copies that grew quadratically.** Every AI decision, every replay phase-transition snapshot, and several controller call sites deep-copied the *entire* game state — including the ever-growing action history — so each copy embedded everything before it. Added `GameState.create_snapshot(include_history=false)`, a slim "gameplay snapshot" (no history/phase_log/ai_turn_history, no per-call prints) now used everywhere a full history-bearing snapshot wasn't actually needed.
- **Unbounded in-memory logs.** AI decision records, the AI action log, AI turn history, the game event log, the action logger, and the dice-history UI all grew for the life of the game (or across games, in one case) with no cap. All are now bounded (tighter caps on web), and heavy per-action metadata (`_replay_diffs`, `_ai_*` payloads) is stripped from what's retained.
- **RAM-backed `user://` file growth on web.** On the web export, `user://` is a MEMFS synced to IndexedDB — every logged/saved byte is tab memory. Replay recording, the AI decision-log auto-export, and the debug logger all wrote unboundedly there. Replay's per-turn incremental write and the AI decision-log's per-50-decisions timestamped export are now skipped on web; the debug log has a smaller cap and rotates by rename instead of reading the whole file into a String; old session log files are pruned at startup; timer/event autosaves (which targeted an unopenable `cloud://` path and did full work for nothing) are skipped on web.
- **Abandoned games kept running.** Returning to the main menu didn't stop the AI or the replay recorder — an abandoned AI-vs-AI game kept simulating and recording invisibly behind the menu. Both are now stopped on every route back to the menu.
- **A few small node leaks**: `ShootingController` target-chips container, `FightController` pile-in visuals, and `DeploymentController`'s model-type-picker `CanvasLayer` are now freed on phase/controller exit.
- **`ActionLogger` truncate bug**: the per-action "append" log opened with `FileAccess.WRITE`, which truncates — the file only ever held the last action. Now a real append with a 10 MB cap, skipped on web.

Legacy save files are sanitized on load (stripped/capped) so old saves don't reintroduce the bloat.

## Test plan

- [x] New windowed scenario `tests/scenarios/sp/memops_ai_vs_ai_bounded.json`: boots an AI-vs-AI game at fastest speed, plays ~75s into round 2, and asserts every accumulator stays bounded and stored actions carry no heavy `_replay_diffs`/`_ai_*` payloads — **23/23 passed**.
- [x] Existing AI-vs-AI gate `tests/scenarios/sp/iss062_ai_11e.json` still passes **13/13** — no regression to AI play.
- [x] Live before/after memory sampling via the MCP bridge over 5-minute AI-vs-AI runs (same fixture/seed): lower memory at matched checkpoints, and the post-fix game covered roughly twice as much play for similar memory. No new `ERROR`/`SCRIPT ERROR` lines in the debug log.
- [x] `40k/data/version_history.json` updated (0.60.1) per project convention for player-facing changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5Ed4usLxzNPevN2mBkgXm)_