### PR TITLE
Add controller pause-menu button (View/Select = Escape)

### DIFF
--- a/40k/autoloads/InputDeviceManager.gd
+++ b/40k/autoloads/InputDeviceManager.gd
@@ -116,6 +116,13 @@ func _register_pad_bindings() -> void:
 	# Menu (Start) = phase action with confirm (consumed in Main._input). M1.
 	_register_button_action("pad_phase_action", JOY_BUTTON_START)
 
+	# View/Select = the pad's "Escape": opens the in-game pause/settings menu
+	# (Save/Load, Return to Main Menu, quit path), consumed in Main._input.
+	# Start is already End-Phase, so the pause menu needs its own button — the
+	# View/Select button is the standard console convention for it, and there
+	# was previously NO pad way to reach the pause menu or exit a game.
+	_register_button_action("pad_menu_action", JOY_BUTTON_BACK)
+
 	# Probe action for propagation-proof device detection: bound to EVERY
 	# joypad button. Input action states update when an event is parsed,
 	# regardless of who consumes it (scene _input runs BEFORE autoloads and

--- a/40k/autoloads/PadHintBar.gd
+++ b/40k/autoloads/PadHintBar.gd
@@ -20,6 +20,7 @@ const M0_HINTS := [
 	["lt", "Zoom Out"],
 	["rt", "Zoom In"],
 	["menu", "End Phase"],
+	["view", "Pause Menu"],
 ]
 
 var _panel: PanelContainer

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -34,6 +34,7 @@ const HINTS_BOARD := [
 	["y", "Datasheet"],
 	["dpad", "Focus Panels"],
 	["menu", "End Phase"],
+	["view", "Pause Menu"],
 ]
 const HINTS_TARGETS := [
 	["rb", "Cycle Targets"],

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.69.0",
+			"date": "2026-07-20",
+			"summary": "Controller players can now open the pause menu without a keyboard. Pressing the View/Select button (the small ⧉ button — 'Back' on Xbox pads / the Deck's ☰ View button) opens the in-game menu, where you can Save/Load, change settings, or Return to Main Menu to exit the game. Previously the pad's only menu button (Start) ended the phase, leaving no controller way to reach the pause menu or quit.",
+			"changes": [
+				"New controller binding: the View/Select button opens (and closes) the in-game pause/settings menu — the pad equivalent of the Escape key.",
+				"The controller hint bar now lists the View button as 'Pause Menu' so the affordance is discoverable.",
+				"From the pause menu you can Save/Load, adjust settings, or Return to Main Menu (and quit) — all reachable pad-only now."
+			]
+		},
+		{
 			"version": "0.68.0",
 			"date": "2026-07-20",
 			"summary": "Deployment picking reworked for controller AND mouse: the unit list in the top-right panel now stays visible while you place models, so you can always see who is up to deploy and change your mind. Controller: LB/RB cycle the unit to deploy, D-pad left/right switches the placement formation (Single / Spread / Tight), X undoes the last placed model.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -5307,44 +5307,26 @@ func _input(event: InputEvent) -> void:
 		get_viewport().set_input_as_handled()
 		return
 
+	# Pad View/Select button (pad_menu_action): the controller's "Escape". Start
+	# is already End-Phase, so without this the pad had NO way to reach the
+	# pause/settings menu — where Save/Load and Return to Main Menu (the exit-the-
+	# game path) live. Opens that menu, or closes the top open overlay, mirroring
+	# the ESC cascade below (minus the shooting defer, which is Shooting/keyboard-
+	# specific). B/ui_cancel still closes the menu once open; this button toggles it.
+	if event.is_action_pressed("pad_menu_action"):
+		_run_pause_menu_cascade(false)
+		get_viewport().set_input_as_handled()
+		return
+
 	# ESC key handling — highest priority: opens settings menu (or closes overlays first)
 	# Use direct keycode check for reliability (is_action_pressed can miss with physical_keycode-only mappings)
 	if event is InputEventKey and event.pressed and not event.echo and event.keycode == KEY_ESCAPE:
 		print("Main: Escape key pressed")
-		# History browser: ESC returns to the live game before anything else.
-		if _history_view_active:
-			_exit_history_view()
+		# Shared with the pad View/Select button — see _run_pause_menu_cascade.
+		# Returns false only for the shooting defer (leave the event for
+		# ShootingController); every other branch handles and consumes it.
+		if _run_pause_menu_cascade(true):
 			get_viewport().set_input_as_handled()
-			return
-		# T7-56: Close replay panel on ESC if open
-		if _ai_turn_replay_panel and _ai_turn_replay_panel.visible:
-			_ai_turn_replay_panel.hide_panel()
-			get_viewport().set_input_as_handled()
-			return
-		# Measuring tape: ESC cancels the in-progress line, or exits the tool.
-		if MeasuringTapeManager and MeasuringTapeManager.measure_mode_active:
-			MeasuringTapeManager.cancel_or_exit()
-			_update_measure_mode_hint()
-			get_viewport().set_input_as_handled()
-			return
-		if shooting_controller and shooting_controller.active_shooter_id != "":
-			# Let ShootingController handle ESC for deselect/cancel
-			return
-		# Close save/load dialog if open
-		if save_load_dialog and save_load_dialog.visible:
-			save_load_dialog.hide()
-			get_viewport().set_input_as_handled()
-			return
-		# Close settings menu if open, otherwise open it
-		if _settings_menu and is_instance_valid(_settings_menu):
-			_settings_menu.queue_free()
-			_settings_menu = null
-			print("Main: Settings menu closed via Escape")
-			get_viewport().set_input_as_handled()
-			return
-		# Open settings menu
-		_open_settings_menu()
-		get_viewport().set_input_as_handled()
 		return
 
 	# History browser: while viewing a past step, none of Main's own game-input
@@ -13848,6 +13830,48 @@ func _scout_clear_highlights() -> void:
 # purpose — they must pre-empt GUI focus and modal dialogs. Controllers
 # handle their phase input in _unhandled_input unless they need to bypass a
 # modal dialog (see ShootingController/FightController/ChargeController).
+
+func _run_pause_menu_cascade(is_keyboard_escape: bool) -> bool:
+	# The single "pause / open settings" cascade, shared by the Escape key AND
+	# the pad View/Select button (pad_menu_action). Closes the highest-priority
+	# open overlay; if nothing is open, toggles the in-game settings menu — the
+	# screen with Save/Load and Return to Main Menu (the exit-the-game path).
+	#
+	# Returns true when the caller should mark the event handled. Returns false
+	# only for the keyboard-Escape shooting defer: ShootingController owns ESC
+	# while a shooter is active, so we leave the event for it. The pad's View
+	# button has no such downstream handler, so it passes is_keyboard_escape =
+	# false and falls straight through to the settings toggle instead.
+
+	# History browser: return to the live game before anything else.
+	if _history_view_active:
+		_exit_history_view()
+		return true
+	# T7-56: Close replay panel if open.
+	if _ai_turn_replay_panel and _ai_turn_replay_panel.visible:
+		_ai_turn_replay_panel.hide_panel()
+		return true
+	# Measuring tape: cancel the in-progress line, or exit the tool.
+	if MeasuringTapeManager and MeasuringTapeManager.measure_mode_active:
+		MeasuringTapeManager.cancel_or_exit()
+		_update_measure_mode_hint()
+		return true
+	if is_keyboard_escape and shooting_controller and shooting_controller.active_shooter_id != "":
+		# Let ShootingController handle ESC for deselect/cancel.
+		return false
+	# Close save/load dialog if open.
+	if save_load_dialog and save_load_dialog.visible:
+		save_load_dialog.hide()
+		return true
+	# Close settings menu if open, otherwise open it.
+	if _settings_menu and is_instance_valid(_settings_menu):
+		_settings_menu.queue_free()
+		_settings_menu = null
+		print("Main: Settings menu closed")
+		return true
+	# Open settings menu.
+	_open_settings_menu()
+	return true
 
 func _open_settings_menu() -> void:
 	# Shared entry point for opening the in-game settings menu (used by the

--- a/40k/tests/scenarios/sp/pad_menu_button.json
+++ b/40k/tests/scenarios/sp/pad_menu_button.json
@@ -1,0 +1,35 @@
+{
+  "id": "pad_menu_button",
+  "covers": ["controller.pause_menu.view_button"],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Controller pause-menu access: the View/Select button (JoyButton 4 = BACK) opens the in-game settings/pause menu — the pad equivalent of the Escape key, where Save/Load, settings and Return to Main Menu (the exit-the-game path) live. Pressing it again closes the menu. Regression guard for the fix: previously Start (End Phase) was the pad's only menu button, so a controller player had no way to reach the pause menu or quit.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "execute_script", "script": "InputDeviceManager.registered_actions.has(\"pad_menu_action\")", "equals": true },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": false },
+    { "act": "screenshot", "label": "01_board_no_menu" },
+
+    { "act": "simulate_joy_button", "button_index": 4 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": true },
+    { "act": "execute_script", "script": "main.get_node_or_null(\"SettingsMenu\") != null", "equals": true },
+    { "act": "execute_script", "script": "main._settings_menu._return_to_menu_button.visible", "equals": true },
+    { "act": "execute_script", "script": "str(main._settings_menu._return_to_menu_button.text)", "equals": "Return to Main Menu" },
+    { "act": "screenshot", "label": "02_pause_menu_open_via_view" },
+
+    { "act": "simulate_joy_button", "button_index": 4 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": false },
+    { "act": "screenshot", "label": "03_pause_menu_closed_via_view" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadHintBar.get_node(\"PadHintPanel\").visible", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var found = false\nfor chip in PadHintBar.get_node(\"PadHintPanel\").get_child(0).get_children():\n\tfor sub in chip.get_children():\n\t\tif sub is Label and str(sub.text) == \"Pause Menu\":\n\t\t\tfound = true\nreturn found", "equals": true },
+    { "act": "screenshot", "label": "04_board_hint_bar_shows_pause_menu" }
+  ]
+}


### PR DESCRIPTION
## Problem

When playing with a controller there was no way to reach the in-game pause menu or exit a game. The pad's only menu button (Start) is bound to **End Phase**, and the pause/settings menu — which holds **Save/Load**, settings, and **Return to Main Menu** — could only be opened with the keyboard's Escape key. A pad-only player was effectively stuck.

## Change

Bind the **View/Select button** (`JOY_BUTTON_BACK`, glyph ⧉ — "Back" on Xbox pads / the ☰ View button on a Steam Deck) to open and close that menu, which is the standard console convention for a pause menu.

- **`InputDeviceManager`** registers a new `pad_menu_action` on `JOY_BUTTON_BACK`.
- **`Main._input`** handles it via a new shared `_run_pause_menu_cascade()`, refactored out of the existing Escape handler so both paths stay in sync. The Escape key keeps its exact behavior (including the ShootingController deselect defer, which is keyboard-only); the pad button skips that defer and falls through to the settings toggle. `B`/`ui_cancel` still closes the menu once open — this button toggles it.
- The controller hint bar now advertises **⧉ Pause Menu** (`PadHintBar` and `PadRouter` board hints) so the affordance is discoverable.

## Validation

New windowed scenario `40k/tests/scenarios/sp/pad_menu_button.json` (21 assertions, all pass), driven against the running UI via the `godot_mcp` bridge:

- The View button opens the pause menu showing the **Return to Main Menu** / **Save / Load** / **Close** buttons (screenshot-verified).
- A second press closes it and returns to the board.
- The board hint bar renders the **⧉ Pause Menu** chip.

Regression-checked the keyboard Escape path and pad behavior — all pass:

- `game_log_switch_step_no_escape` (Escape → exit history) — 47 passed
- `swift_onslaught_reroll_dismiss` (Escape → dismiss) — 22 passed
- `auto_allocate_wounds_settings_ui` (settings menu open) — 15 passed
- `pad_m1_full_turn_cursor` (full pad turn incl. Start = End Phase) — 73 passed

## Player-facing

Version bumped to **0.68.0** with a `version_history.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUET1PnPbSdxakggoLp1Tr

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUET1PnPbSdxakggoLp1Tr)_