### PR TITLE
Fix controller deployment cursor offset on Steam Deck / non-100% UI Scale

### DIFF
--- a/40k/autoloads/VirtualCursor.gd
+++ b/40k/autoloads/VirtualCursor.gd
@@ -108,7 +108,19 @@ func _move_cursor(rel: Vector2) -> void:
 	if overshoot != Vector2.ZERO:
 		_edge_pan(overshoot.limit_length(30.0))
 	InputDeviceManager.note_synthetic_mouse()
-	Input.warp_mouse(_pos)
+	# Input.warp_mouse() takes WINDOW pixels, but _pos (like the ring and the
+	# synthetic motion below) is in viewport / base-resolution space. When the
+	# window's content scale is not 1 — the Steam Deck renders the 1920x1080 base
+	# onto a 1280x800 panel, and the UI Scale slider also sets content_scale_factor
+	# — warping to the raw _pos lands the OS pointer at the wrong physical spot.
+	# Everything that reads event.position (e.g. MovementController's drag) stays
+	# correct because it uses _pos directly, but everything that POLLS
+	# get_viewport().get_mouse_position() (the deployment/shooting placement ghosts)
+	# then follows the mis-warped pointer and drifts off the visible cursor by the
+	# content-scale factor. Convert through the viewport's screen transform so the
+	# polled mouse position resolves back to _pos. At content scale 1.0 (desktop)
+	# get_screen_transform() is the identity, so this is a no-op there.
+	Input.warp_mouse(get_viewport().get_screen_transform() * _pos)
 	var motion := InputEventMouseMotion.new()
 	motion.position = _pos
 	motion.global_position = _pos

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.69.1",
+			"date": "2026-07-20",
+			"summary": "Fixed controller deployment on the Steam Deck (and any time the UI Scale is not 100%): the model you were placing appeared offset from the cursor instead of centred on it. The gamepad cursor now warps the pointer using the window's content scale, so the deployment and shooting placement previews line up exactly with the on-screen cursor again.",
+			"changes": [
+				"Deployment: the model preview is now centred on the controller cursor on the Steam Deck / at non-100% UI Scale (previously it drifted off by the content-scale factor).",
+				"Root cause: the virtual cursor warped the OS pointer in base-resolution coordinates, so anything reading the live pointer position (deployment and shooting placement ghosts) followed a mis-scaled point while drag-based tools stayed correct. The warp now goes through the viewport's screen transform. No change at 100% UI Scale on desktop."
+			]
+		},
+		{
 			"version": "0.69.0",
 			"date": "2026-07-20",
 			"summary": "Controller players can now open the pause menu without a keyboard. Pressing the View/Select button (the small ⧉ button — 'Back' on Xbox pads / the Deck's ☰ View button) opens the in-game menu, where you can Save/Load, change settings, or Return to Main Menu to exit the game. Previously the pad's only menu button (Start) ended the phase, leaving no controller way to reach the pause menu or quit.",


### PR DESCRIPTION
## Problem

On the Steam Deck, the model being deployed appeared **offset from the cursor** instead of centred on it (reported symptom: a single model lands off-cursor).

## Root cause

On a controller the pointer is the gamepad-driven `VirtualCursor`, which every frame calls `Input.warp_mouse(_pos)` **and** synthesizes an `InputEventMouseMotion` with `position = _pos`. The catch: `warp_mouse()` takes **window pixels**, but `_pos` (and the visible cursor ring, and the synthetic event) are in **viewport / base-resolution** space. Under a non‑1 content scale — the Deck renders the 1920×1080 base onto its 1280×800 panel, and the UI Scale slider also sets `content_scale_factor` — the warped OS pointer lands at the wrong physical spot.

- **MovementController** reads `event.position` (= `_pos`) → tracked the cursor correctly. That's why dragging worked.
- **DeploymentController** (and shooting placement) **polls** `get_viewport().get_mouse_position()` → followed the mis‑warped pointer and drifted off the visible cursor ring by the content‑scale factor.

## Fix

One line in `VirtualCursor._move_cursor`: warp through the viewport's screen transform so the polled mouse position resolves back to `_pos`.

```gdscript
Input.warp_mouse(get_viewport().get_screen_transform() * _pos)
```

At content scale 1.0 (desktop) `get_screen_transform()` is the identity, so this is a **no‑op** there. Because it's the root cause, it also fixes the shooting placement ghost on the Deck (same polling pattern).

## Validation (windowed, live game)

- **Before**, content scale 1.5: deployment ghost ↔ cursor‑ring divergence **(−200, −200)** base‑px.
- **After**, content scale 1.5: divergence **(0, 0)** — screenshot shows the model base dead‑centre in the cursor ring; `get_viewport().get_mouse_position()` now returns `_pos`.
- **Desktop** scale 1.0: warp target and `get_mouse_position()` unchanged → verified no‑op, divergence (0, 0).
- Windowed pad scenarios `pad_m1_cursor_basics` and `pad_deploy_unit_cycling` pass on the rebased branch; no errors in the debug log.

## Scope

- `40k/autoloads/VirtualCursor.gd` — one‑line warp fix + explanatory comment.
- `40k/data/version_history.json` — new `0.69.1` entry.

_Note: `pad_m3_carry_deploy` currently fails at the "Deploy Without Embarking" step, but it fails identically on `main` without this change (stale expectation left by the deployment‑picking rework) — pre‑existing and out of scope for this PR._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8KN9dRzq2j2PhCdgCWH1E)_