### PR TITLE
Bumper-only unit cycling on the pad; D-pad/stick up-down drive the phase sub-menu

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -3,22 +3,32 @@ extends Node
 # M2 pad router (PRPs/steam_deck_controller_support.md §4.1/§5.1, milestone
 # M2): the native-controls layer on top of the M1 virtual cursor.
 #
-#   LB/RB  — cycle the "current list": eligible shooters / eligible targets
+#   LB/RB  — THE unit-cycling control, and the only one (BUMPER-ONLY rule):
+#            cycle the "current list": eligible shooters / eligible targets
 #            (shooting, reusing the shipped shoot_* semantics) or the
 #            right-panel unit list (other phases; same entry point a mouse
 #            row-click uses). Deployment: cycling switches which unit is being
 #            deployed, but locks once any model of the current unit is placed
-#            (undo them all to unlock — mirrors the mouse rule)
+#            (undo them all to unlock — mirrors the mouse rule). Works while
+#            the action bar is open too — the menu follows the new unit.
 #   D-pad ◀ ▶ — placement (deployment / reinforcement / scout reserves):
 #            cycle the value of the highlighted selector row — model type
 #            (multi-profile units) or formation (Single / Spread / Tight);
 #            otherwise panel focus entry
-#   D-pad ▲ ▼ — placement with a model-type picker: move the ▶ highlight
+#   D-pad ▲ ▼ — the SELECTED unit's phase sub-menu, never the unit list:
+#            placement with a model-type picker: move the ▶ highlight
 #            between the Select Model Type and Deploy Formation rows.
 #            Charge: step the ELIGIBLE TARGETS rows (A toggles the stepped
 #            row in/out of the declaration — pad Click / Ctrl+Click).
 #            Shooting with an armed shooter: step the weapon rows so each
-#            gun can get its own target. Otherwise panel focus entry.
+#            gun can get its own target. Movement with an open move-mode
+#            decision: open the action bar (Move / Advance / Fall Back /
+#            Stay Still) and step its options. Otherwise panel focus entry —
+#            which lands on buttons only: unit lists are demoted to
+#            FOCUS_CLICK while the pad is active (see
+#            _apply_list_focus_policy) so neither the D-pad nor the left
+#            stick's ui_up/ui_down can ever walk the unit list. Cycling
+#            units is the bumpers' job alone.
 #   A      — in TARGET_SELECT: assign the highlighted target to the current
 #            weapon (cursor mode and focused controls keep their own A)
 #   B      — release panel focus back to the board; with an active shooter,
@@ -86,8 +96,21 @@ const HINTS_CARRY := [
 ]
 const HINTS_MENU := [
 	["dpad", "Choose Action"],
+	["rb", "Cycle Units"],
 	["a", "Confirm"],
 	["b", "Cancel"],
+]
+# Movement with a selected unit whose move-mode decision is still open: ▲ ▼
+# opens the same action bar A does, so the D-pad browses the unit's phase
+# options instead of the unit list.
+const HINTS_MOVE := [
+	["ls", "Cursor"],
+	["rb", "Cycle Units"],
+	["dpad", "Move Menu"],
+	["a", "Menu / Pick Up"],
+	["x", "Undo Model"],
+	["y", "Datasheet"],
+	["menu", "End Phase"],
 ]
 
 # The target currently highlighted by LB/RB in shooting TARGET_SELECT mode
@@ -109,7 +132,14 @@ func is_carrying() -> bool:
 
 
 func _ready() -> void:
-	InputDeviceManager.device_changed.connect(func(_m): _update_hints())
+	InputDeviceManager.device_changed.connect(_on_device_changed)
+
+
+func _on_device_changed(mode: int) -> void:
+	# BUMPER-ONLY rule: while the pad drives, unit lists leave the focus
+	# chain (and give up any focus they already hold); on KBM they restore.
+	_apply_list_focus_policy(mode == InputDeviceManager.InputMode.PAD)
+	_update_hints()
 
 
 func _input(event: InputEvent) -> void:
@@ -118,15 +148,23 @@ func _input(event: InputEvent) -> void:
 	# A joypad event IS pad input — claim inline so the session's very first
 	# press acts instead of being dropped (the _process poll runs after us).
 	InputDeviceManager.claim_pad()
+	# Re-assert the bumper-only rule before routing: lists spawned since the
+	# last press get demoted, and any list that grabbed focus lets go.
+	_apply_list_focus_policy(true)
 	# While the action bar is open it owns the pad exclusively (a lightweight
-	# modal): D-pad / bumpers move the highlight, A confirms, B cancels, and
-	# everything else is swallowed so Start can't end the phase mid-decision.
+	# modal): D-pad moves the highlight, A confirms, B cancels, and everything
+	# else is swallowed so Start can't end the phase mid-decision. The bumpers
+	# keep their one global meaning — switch units — and the menu follows.
 	if PadActionBar.is_open():
 		match event.button_index:
-			JOY_BUTTON_DPAD_LEFT, JOY_BUTTON_LEFT_SHOULDER:
+			JOY_BUTTON_DPAD_LEFT, JOY_BUTTON_DPAD_UP:
 				PadActionBar.move_highlight(-1)
-			JOY_BUTTON_DPAD_RIGHT, JOY_BUTTON_RIGHT_SHOULDER:
+			JOY_BUTTON_DPAD_RIGHT, JOY_BUTTON_DPAD_DOWN:
 				PadActionBar.move_highlight(1)
+			JOY_BUTTON_LEFT_SHOULDER:
+				_menu_cycle_unit(-1)
+			JOY_BUTTON_RIGHT_SHOULDER:
+				_menu_cycle_unit(1)
 			JOY_BUTTON_A:
 				_apply_menu_choice(PadActionBar.activate())
 			JOY_BUTTON_B:
@@ -160,10 +198,10 @@ func _input(event: InputEvent) -> void:
 			if _handle_back():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_UP:
-			if _pad_deploy_row_cycle(-1) or _pad_step_secondary(-1) or _enter_panel_focus():
+			if _pad_deploy_row_cycle(-1) or _pad_step_secondary(-1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_DOWN:
-			if _pad_deploy_row_cycle(1) or _pad_step_secondary(1) or _enter_panel_focus():
+			if _pad_deploy_row_cycle(1) or _pad_step_secondary(1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_LEFT:
 			if _hop_model(-1) or _pad_deploy_option_cycle(-1) or _enter_panel_focus():
@@ -171,6 +209,11 @@ func _input(event: InputEvent) -> void:
 		JOY_BUTTON_DPAD_RIGHT:
 			if _hop_model(1) or _pad_deploy_option_cycle(1) or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
+	# A handler above may have re-focused a list (e.g. a phase's selection
+	# refresh); take it back so a following stick deflection can't walk it.
+	var f := get_viewport().gui_get_focus_owner()
+	if f is ItemList:
+		f.release_focus()
 	_update_hints()
 
 
@@ -234,6 +277,23 @@ func _apply_menu_choice(choice_id: String) -> void:
 
 func _auto_carry_after_menu() -> void:
 	if not carry_active and _try_begin_carry():
+		_update_hints()
+
+
+# Bumper press while the action bar is open: the bumpers still mean "switch
+# unit" (their one global meaning), so close the menu, cycle, and reopen it
+# for the new unit — the sub-menu follows the selection. The reopen is
+# deferred so the list-selection handlers (radio updates etc.) settle first.
+func _menu_cycle_unit(dir: int) -> void:
+	PadActionBar.close()
+	_cycle(dir)
+	call_deferred("_reopen_move_menu")
+
+
+func _reopen_move_menu() -> void:
+	if carry_active or PadActionBar.is_open():
+		return
+	if _try_open_move_menu():
 		_update_hints()
 
 
@@ -742,12 +802,47 @@ func _find_first_focusable(root: Node) -> Control:
 	var queue: Array = [root]
 	while not queue.is_empty():
 		var n: Node = queue.pop_front()
-		if n is Control and n.focus_mode == Control.FOCUS_ALL and n.is_visible_in_tree() \
-				and not (n is BaseButton and n.disabled):
+		# ItemLists never take pad focus: lists are driven by their dedicated
+		# affordances (LB/RB unit cycling, ▲ ▼ steppers) — focusing one would
+		# turn ui_up/ui_down into unit cycling, the exact bug the bumper-only
+		# rule exists to prevent.
+		if n is Control and not (n is ItemList) and n.focus_mode == Control.FOCUS_ALL \
+				and n.is_visible_in_tree() and not (n is BaseButton and n.disabled):
 			return n
 		for child in n.get_children(true):
 			queue.append(child)
 	return null
+
+
+# BUMPER-ONLY unit cycling: while the pad is the active device every ItemList
+# in the side panels is demoted to FOCUS_CLICK (mouse clicks are unaffected)
+# so directional focus navigation — D-pad OR left-stick ui_up/ui_down — can
+# neither land in a list nor walk through it, and a list that already holds
+# focus (e.g. mouse-clicked before switching to pad) releases it. Restored to
+# the saved focus mode when the keyboard/mouse takes over.
+func _apply_list_focus_policy(pad: bool) -> void:
+	var m := get_tree().current_scene
+	if m == null:
+		return
+	for root_path in ["HUD_Right", "HUD_Bottom"]:
+		var root := m.get_node_or_null(root_path)
+		if root == null:
+			continue
+		var queue: Array = [root]
+		while not queue.is_empty():
+			var n: Node = queue.pop_front()
+			if n is ItemList:
+				if pad:
+					if n.focus_mode == Control.FOCUS_ALL:
+						n.set_meta("pad_saved_focus_mode", n.focus_mode)
+						n.focus_mode = Control.FOCUS_CLICK
+					if n.has_focus():
+						n.release_focus()
+				elif n.has_meta("pad_saved_focus_mode"):
+					n.focus_mode = n.get_meta("pad_saved_focus_mode")
+					n.remove_meta("pad_saved_focus_mode")
+			for child in n.get_children(true):
+				queue.append(child)
 
 
 # ============================================================================
@@ -832,7 +927,21 @@ func _update_hints() -> void:
 			var cc = _charge_controller_selecting()
 			if cc != null:
 				hints = HINTS_CHARGE
+			elif _movement_menu_available():
+				hints = HINTS_MOVE
 	PadHintBar.set_hints(hints)
+
+
+# Movement phase with a selected unit whose move-mode decision is still open
+# (the state where ▲ ▼ / A open the action bar).
+func _movement_menu_available() -> bool:
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m) or m.current_phase != GameStateData.Phase.MOVEMENT:
+		return false
+	var mc = m.movement_controller if ("movement_controller" in m) else null
+	if mc == null or not is_instance_valid(mc) or not mc.has_method("pad_menu_options"):
+		return false
+	return not mc.pad_menu_options().is_empty()
 
 
 # The ChargeController while the charge phase is live with a unit selected

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.72.0",
+			"date": "2026-07-20",
+			"summary": "Controller: LB/RB are now the ONLY way to cycle units. D-pad and left-stick up/down no longer switch units — they navigate the selected unit's phase options instead. In the Movement phase, D-pad up/down opens the move action menu (Move / Advance / Fall Back / Stay Still) and steps through it, and pressing a bumper while the menu is open switches units with the menu following the new unit.",
+			"changes": [
+				"Unit cycling is bumper-only: pressing up/down on the D-pad or left analog stick never changes the selected unit in any phase (previously the unit list could grab focus and up/down walked it).",
+				"Movement phase: D-pad up/down with a unit selected opens the same action menu as A (Move / Advance / Fall Back / Stay Still / special actions) and moves its highlight; left/right still work too.",
+				"LB/RB pressed while the action menu is open switch to the previous/next unit and reopen the menu for that unit, so you can browse units without leaving the menu.",
+				"Deployment/reinforcements/scout reserves keep their up/down row navigation (Select Model Type / Deploy Formation); single-row units now land panel focus on the card's buttons instead of the unit list.",
+				"The unit list can still be clicked with the mouse as before; pad button hints updated ('Move Menu', 'RB Cycle Units' in the menu bar)."
+			]
+		},
+		{
 			"version": "0.71.0",
 			"date": "2026-07-20",
 			"summary": "Controller pass across every phase: all option lists the game displays are now selectable with the pad, following the deployment-phase pattern. Charge: D-pad up/down walks the ELIGIBLE TARGETS list and A toggles each target in/out (pad Ctrl+Click for multi-charges), Start declares then rolls, X skips. Shooting: D-pad up/down steps the weapon rows so each gun can get its own target. Reinforcement and scout-reserves placement get the full deployment pad kit (formation row, X undo, Start confirm, A cursor-warp). Also fixes reserves units being unselectable in loaded saves.",

--- a/40k/tests/scenarios/sp/pad_bumper_only_unit_cycling.json
+++ b/40k/tests/scenarios/sp/pad_bumper_only_unit_cycling.json
@@ -1,0 +1,66 @@
+{
+  "id": "pad_bumper_only_unit_cycling",
+  "covers": [
+    "controller.bumper_only_unit_cycling",
+    "controller.m4.action_bar",
+    "controller.m2.unit_cycling",
+    "PadRouter",
+    "PadActionBar"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "BUMPER-ONLY unit cycling (Steam Deck): LB/RB are the only controls that switch units. In the Movement phase D-pad ▼ opens the selected unit's move action menu (Move / Advance / Stay Still) instead of touching the unit list, ▼/▲ step the menu highlight, and pressing RB/LB while the menu is open switches units WITH the menu following the new selection (close → cycle → reopen). B closes the menu without losing the selection, and holding the left stick up/down never changes the selected unit because the unit list is demoted to FOCUS_CLICK while the pad is the active device.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != \"\"", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"ua\", str(main.movement_controller.active_unit_id))" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "NORMAL" },
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "ADVANCE" },
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "NORMAL" },
+    { "act": "screenshot", "label": "01_dpad_opens_menu_unit_unchanged" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"ub\", str(main.movement_controller.active_unit_id))" },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "screenshot", "label": "02_rb_in_menu_cycles_unit_menu_follows" },
+
+    { "act": "simulate_joy_button", "button_index": 9 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": false },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+
+    { "act": "simulate_joy_axis", "axis": 1, "value": 1.0, "hold_s": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": false },
+    { "act": "simulate_joy_axis", "axis": 1, "value": -1.0, "hold_s": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var queue = [tree.current_scene.get_node(\"HUD_Right\")]\nwhile not queue.is_empty():\n\tvar n = queue.pop_front()\n\tif n is ItemList and n.is_visible_in_tree() and n.item_count > 0:\n\t\treturn int(n.focus_mode)\n\tfor c in n.get_children(true):\n\t\tqueue.append(c)\nreturn -1", "equals": 1 },
+    { "act": "screenshot", "label": "03_stick_updown_never_cycles" }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_deploy_unit_cycling.json
+++ b/40k/tests/scenarios/sp/pad_deploy_unit_cycling.json
@@ -3,6 +3,7 @@
   "covers": [
     "controller.deploy.unit_cycling",
     "controller.deploy.formation_dpad",
+    "controller.bumper_only_unit_cycling",
     "deployment.unit_list_stays_visible",
     "deployment.switch_locked_after_placement",
     "PadRouter",
@@ -12,7 +13,7 @@
   "fixture": "New Game",
   "transition_to_phase": 1,
   "disable_ai": true,
-  "description": "DEPLOY-CYCLE: during deployment the right-panel unit list stays visible while placing, RB/LB cycle which unit is being deployed (the highlighted row follows, old unit returns to UNDEPLOYED, new one becomes DEPLOYING), D-pad left/right steps the formation mode Single/Spread/Tight, and once a model is placed switching is locked for BOTH pad bumpers and mouse row-clicks until every placed model is undone (pad X = undo last model with the cursor parked). Also proves the mouse row-click switch path works when nothing is placed.",
+  "description": "DEPLOY-CYCLE: during deployment the right-panel unit list stays visible while placing, RB/LB cycle which unit is being deployed (the highlighted row follows, old unit returns to UNDEPLOYED, new one becomes DEPLOYING) and are the ONLY unit-switching control: D-pad ▲ ▼ and left-stick up/down never change which unit is being deployed (the unit list is FOCUS_CLICK while the pad drives, so directional focus can't walk it). D-pad left/right steps the formation mode Single/Spread/Tight, and once a model is placed switching is locked for BOTH pad bumpers and mouse row-clicks until every placed model is undone (pad X = undo last model with the cursor parked). Also proves the mouse row-click switch path works when nothing is placed.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.2 },
     { "act": "expect_state", "path": "meta.phase", "equals": 1 },
@@ -40,6 +41,21 @@
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "execute_script", "script": "str(main.deployment_controller.unit_id) == str(InputDeviceManager.get_meta(\"u1\"))", "equals": true },
     { "act": "execute_script", "script": "int(GameState.get_unit(str(InputDeviceManager.get_meta(\"u2\"))).status)", "equals": 0 },
+
+    { "act": "execute_script", "script": "int(main.unit_list.focus_mode)", "equals": 1 },
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.deployment_controller.unit_id) == str(InputDeviceManager.get_meta(\"u1\"))", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.deployment_controller.unit_id) == str(InputDeviceManager.get_meta(\"u1\"))", "equals": true },
+    { "act": "simulate_joy_axis", "axis": 1, "value": 1.0, "hold_s": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.deployment_controller.unit_id) == str(InputDeviceManager.get_meta(\"u1\"))", "equals": true },
+    { "act": "execute_script", "script": "main.unit_list.get_selected_items().size() > 0 and str(main.unit_list.get_item_metadata(main.unit_list.get_selected_items()[0])) == str(InputDeviceManager.get_meta(\"u1\"))", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
 
     { "act": "simulate_joy_button", "button_index": 14 },
     { "act": "wait_seconds", "seconds": 0.3 },

--- a/40k/tests/scenarios/sp/pad_m2_unit_cycle.json
+++ b/40k/tests/scenarios/sp/pad_m2_unit_cycle.json
@@ -1,11 +1,11 @@
 {
   "id": "pad_m2_unit_cycle",
-  "covers": ["controller.m2.unit_cycling", "controller.m2.panel_focus", "controller.m2.datasheet"],
+  "covers": ["controller.m2.unit_cycling", "controller.m2.panel_focus", "controller.m2.datasheet", "controller.bumper_only_unit_cycling"],
   "fixture": "audit_baseline_postdeploy",
   "transition_to_phase": 7,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M2 native controls in the Movement phase: RB/LB cycles the unit list (same selection entry point as clicking a row), Y toggles the selected unit's datasheet, a D-pad press with nothing focused enters panel focus (unit list grabs focus), and B releases focus back to the board.",
+  "description": "M2 native controls in the Movement phase: RB/LB cycles the unit list (same selection entry point as clicking a row) and is the ONLY unit-cycling control. Y toggles the selected unit's datasheet. A D-pad ▼ press with a unit selected opens the move action menu (the unit's phase sub-menu) WITHOUT switching units and WITHOUT focusing the unit list; ▼/▲ step the menu highlight and B closes it. Left-stick up/down never changes the selected unit either — while the pad is active the unit list is demoted to FOCUS_CLICK so ui_up/ui_down cannot land in or walk it.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
@@ -19,6 +19,7 @@
     { "act": "simulate_joy_button", "button_index": 10 },
     { "act": "wait_seconds", "seconds": 0.4 },
     { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != str(InputDeviceManager.get_meta(\"first\"))", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"second\", str(main.movement_controller.active_unit_id))" },
     { "act": "screenshot", "label": "02_second_unit_cycled" },
 
     { "act": "simulate_joy_button", "button_index": 3 },
@@ -31,12 +32,33 @@
 
     { "act": "simulate_joy_button", "button_index": 12 },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() != null", "equals": true },
-    { "act": "screenshot", "label": "04_panel_focus_entered" },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"second\"))", "equals": true },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "NORMAL" },
+    { "act": "screenshot", "label": "04_dpad_opens_move_menu_not_unit_list" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "ADVANCE" },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"second\"))", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "NORMAL" },
 
     { "act": "simulate_joy_button", "button_index": 1 },
     { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": false },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"second\"))", "equals": true },
+
+    { "act": "simulate_joy_axis", "axis": 1, "value": 1.0, "hold_s": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"second\"))", "equals": true },
+    { "act": "simulate_joy_axis", "axis": 1, "value": -1.0, "hold_s": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"second\"))", "equals": true },
     { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
-    { "act": "screenshot", "label": "05_focus_released" }
+    { "act": "execute_script", "multiline": true, "script": "var queue = [tree.current_scene.get_node(\"HUD_Right\")]\nwhile not queue.is_empty():\n\tvar n = queue.pop_front()\n\tif n is ItemList and n.is_visible_in_tree() and n.item_count > 0:\n\t\treturn int(n.focus_mode)\n\tfor c in n.get_children(true):\n\t\tqueue.append(c)\nreturn -1", "equals": 1 },
+    { "act": "screenshot", "label": "05_stick_never_cycles_units" }
   ]
 }

--- a/40k/tests/scenarios/sp/pad_m4_move_action_menu.json
+++ b/40k/tests/scenarios/sp/pad_m4_move_action_menu.json
@@ -8,7 +8,7 @@
   "transition_to_phase": 7,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M4 move-mode action menu: pressing A on a bumper-cycled unit opens the PadActionBar (Move / Advance / Stay Still) instead of silently starting a Normal Move. D-pad moves the highlight, B cancels, A confirms. Choosing Stay Still resolves the unit (remained_stationary flag set, selection cleared); choosing Move flows straight into the model carry; cancelling the carry before any drop reopens the menu so the mode can still be changed.",
+  "description": "M4 move-mode action menu: pressing A on a bumper-cycled unit opens the PadActionBar (Move / Advance / Stay Still) instead of silently starting a Normal Move. D-pad ◀ ▶ AND ▲ ▼ move the highlight, B cancels, A confirms. Choosing Stay Still resolves the unit (remained_stationary flag set, selection cleared); choosing Move flows straight into the model carry; cancelling the carry before any drop reopens the menu so the mode can still be changed.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
@@ -26,6 +26,13 @@
     { "act": "screenshot", "label": "01_menu_open" },
 
     { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "ADVANCE" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "REMAIN_STATIONARY" },
+    { "act": "simulate_joy_button", "button_index": 11 },
     { "act": "wait_seconds", "seconds": 0.2 },
     { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "ADVANCE" },
 


### PR DESCRIPTION
## Summary

On the Steam Deck, pressing **up/down** on the D-pad or left analog stick could switch the selected unit, which collided with up/down's real job — navigating the selected unit's phase options. This PR makes **LB/RB the only unit-cycling control** and repurposes up/down to drive the selected unit's phase sub-menu.

### Root cause

The D-pad's panel-focus entry landed focus on the right-panel unit-list `ItemList`, and from there `ui_up`/`ui_down` (which Godot binds to **both** the D-pad and the left stick) walked the list rows — each row change re-selecting a unit.

### Changes (`40k/autoloads/PadRouter.gd`)

- **LB/RB are now the only unit-cycling control.** While the pad is active, every `ItemList` under `HUD_Right`/`HUD_Bottom` is demoted to `FOCUS_CLICK` (mouse clicks unaffected; restored on KBM), and pad panel-focus entry skips `ItemList`s entirely — so neither the D-pad nor the left stick can ever cycle units again.
- **Movement phase sub-menu:** with a unit selected, D-pad ▼/▲ opens the action menu (Move / Advance / Fall Back / Stay Still / special actions) — the movement equivalent of deployment's formation / model-type rows — and steps its highlight. New `HINTS_MOVE` hint set advertises it.
- **Bumpers keep meaning inside the open menu:** LB/RB close it, cycle the unit, and reopen the menu for the new unit, so you can browse units without leaving the menu.
- **Deployment selector-row navigation** (model type / formation) is unchanged and keeps priority; shooting's weapon stepping and charge's target stepping are untouched.

## Validation

Per the project's windowed-scenario gate:

- **New scenario** `pad_bumper_only_unit_cycling` plus updated `pad_m2_unit_cycle`, `pad_m4_move_action_menu`, and `pad_deploy_unit_cycling` all pass — including explicit "hold the left stick up/down and assert the unit didn't change" and `FOCUS_CLICK` assertions.
- Full pad scenario suite passes **except** `pad_m3_carry_deploy`, which fails identically on unmodified `main` (pre-existing embark-dialog step, unrelated to this change).
- **Live MCP-bridge run** driving the real UI: `verify_delivery: PASS`, zero errors in the debug log.

Screenshots from the live run: D-pad ▼ opens the move menu for the selected unit, and RB while the menu is open switches to the next unit with the menu following (hint bar reads "RB Cycle Units").

## Player-facing

Version bumped to **0.72.0** in `40k/data/version_history.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Xq1Ci3nj6vQb4zbpJd9gL)_