### PR TITLE
Steam Deck P1 controls: Controller settings tab, range-ring prominence, cycling-first hints

### DIFF
--- a/40k/autoloads/InputDeviceManager.gd
+++ b/40k/autoloads/InputDeviceManager.gd
@@ -182,6 +182,54 @@ func _register_button_action(action: String, button: JoyButton) -> void:
 
 
 # ============================================================================
+# P1 stick-swap rebind: re-point the cursor/camera stick actions. Consumers read
+# them by NAME (VirtualCursor: pad_cursor_*, Main: pad_camera_*), so swapping the
+# underlying physical axis is transparent to them — no consumer changes. Default:
+# cursor = LEFT stick, camera = RIGHT stick. Driven by SettingsService.pad_swap_sticks.
+# ============================================================================
+
+func apply_stick_swap(swapped: bool) -> void:
+	var cursor_x := JOY_AXIS_RIGHT_X if swapped else JOY_AXIS_LEFT_X
+	var cursor_y := JOY_AXIS_RIGHT_Y if swapped else JOY_AXIS_LEFT_Y
+	var camera_x := JOY_AXIS_LEFT_X if swapped else JOY_AXIS_RIGHT_X
+	var camera_y := JOY_AXIS_LEFT_Y if swapped else JOY_AXIS_RIGHT_Y
+	_rebind_axis("pad_cursor_left", cursor_x, -1.0)
+	_rebind_axis("pad_cursor_right", cursor_x, 1.0)
+	_rebind_axis("pad_cursor_up", cursor_y, -1.0)
+	_rebind_axis("pad_cursor_down", cursor_y, 1.0)
+	_rebind_axis("pad_camera_left", camera_x, -1.0)
+	_rebind_axis("pad_camera_right", camera_x, 1.0)
+	_rebind_axis("pad_camera_up", camera_y, -1.0)
+	_rebind_axis("pad_camera_down", camera_y, 1.0)
+
+
+# Scenario/verify seam: the physical axis currently bound to the cursor's
+# horizontal action — JOY_AXIS_LEFT_X (0) by default, JOY_AXIS_RIGHT_X (2) when
+# the sticks are swapped. Windowed scenarios assert the swap took effect.
+func cursor_stick_axis_x() -> int:
+	for ev in InputMap.action_get_events("pad_cursor_left"):
+		if ev is InputEventJoypadMotion:
+			return ev.axis
+	return -1
+
+
+func _rebind_axis(action: String, axis: JoyAxis, direction: float) -> void:
+	if not InputMap.has_action(action):
+		return
+	# Strip only the joypad-motion events (keep the action + its deadzone), then
+	# bind the chosen axis/direction. The registration helpers early-return on an
+	# existing action, so a live rebind must mutate events in place like this.
+	for ev in InputMap.action_get_events(action):
+		if ev is InputEventJoypadMotion:
+			InputMap.action_erase_event(action, ev)
+	var e := InputEventJoypadMotion.new()
+	e.device = -1
+	e.axis = axis
+	e.axis_value = direction
+	InputMap.action_add_event(action, e)
+
+
+# ============================================================================
 # Active-device tracking
 # ============================================================================
 

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -46,9 +46,9 @@ extends Node
 # active. Everything here acts on what falls through.
 
 const HINTS_BOARD := [
-	["ls", "Cursor"],
 	["rb", "Cycle Units"],
-	["a", "Select / Click"],
+	["a", "Select"],
+	["ls", "Point"],
 	["y", "Datasheet"],
 	["dpad", "Focus Panels"],
 	["menu", "End Phase"],
@@ -105,10 +105,10 @@ const HINTS_MENU := [
 # opens the same action bar A does, so the D-pad browses the unit's phase
 # options instead of the unit list.
 const HINTS_MOVE := [
-	["ls", "Cursor"],
 	["rb", "Cycle Units"],
-	["dpad", "Move Menu"],
 	["a", "Menu / Pick Up"],
+	["dpad", "Move Menu"],
+	["ls", "Point"],
 	["x", "Undo Model"],
 	["y", "Datasheet"],
 	["menu", "End Phase"],

--- a/40k/autoloads/SettingsService.gd
+++ b/40k/autoloads/SettingsService.gd
@@ -54,6 +54,15 @@ var animation_speed: float = 1.0 # 0.25 to 3.0
 var controller_text_boost: bool = true
 const PAD_UI_SCALE_BOOST: float = 1.2
 
+# P1 Steam Deck controller options (Settings › Controls › Controller). All are
+# pad-only; mouse/keyboard is unaffected. Consumed by Main._process (camera pan),
+# VirtualCursor (cursor speed + magnetism) and InputDeviceManager (stick swap).
+var pad_invert_camera_y: bool = false
+var pad_swap_sticks: bool = false          # cursor on the RIGHT stick, camera on the LEFT
+var pad_camera_sensitivity: float = 1.0    # 0.3 to 2.0 — right-stick camera pan speed
+var pad_cursor_sensitivity: float = 1.0    # 0.3 to 2.0 — virtual-cursor speed
+var pad_cursor_magnetism: bool = true      # ease the cursor toward nearby tokens (P0 magnetism)
+
 # Menu / panel scroll speed — fraction of Godot's default mouse-wheel / trackpad
 # scroll distance applied to ScrollContainers and other scroll surfaces. 1.0 ==
 # stock engine speed; lower == slower. Consumed by ScrollSpeedController.
@@ -365,6 +374,7 @@ func _connect_device_boost() -> void:
 	if not idm.device_changed.is_connected(_on_input_device_changed):
 		idm.device_changed.connect(_on_input_device_changed)
 	_apply_ui_scale()  # the active device may already be PAD by the time this fires
+	_apply_pad_stick_swap()  # re-point the sticks per the saved preference
 
 func _on_input_device_changed(_mode: int) -> void:
 	# P0: KBM↔pad switch → re-apply so the controller text boost engages/clears.
@@ -375,6 +385,35 @@ func set_controller_text_boost(enabled: bool) -> void:
 	_apply_ui_scale()
 	_save_settings()
 	print("[SettingsService] Controller text boost: %s" % ("on" if enabled else "off"))
+
+# --- P1 pad controller options ---------------------------------------------
+func set_pad_invert_camera_y(enabled: bool) -> void:
+	pad_invert_camera_y = enabled
+	_save_settings()
+
+func set_pad_camera_sensitivity(value: float) -> void:
+	pad_camera_sensitivity = clampf(value, 0.3, 2.0)
+	_save_settings()
+
+func set_pad_cursor_sensitivity(value: float) -> void:
+	pad_cursor_sensitivity = clampf(value, 0.3, 2.0)
+	_save_settings()
+
+func set_pad_cursor_magnetism(enabled: bool) -> void:
+	pad_cursor_magnetism = enabled
+	_save_settings()
+
+func set_pad_swap_sticks(enabled: bool) -> void:
+	pad_swap_sticks = enabled
+	_apply_pad_stick_swap()
+	_save_settings()
+
+func _apply_pad_stick_swap() -> void:
+	# Consumers read the cursor/camera stick actions by NAME, so re-pointing which
+	# physical stick each is bound to (InputDeviceManager) is transparent to them.
+	var idm = get_node_or_null("/root/InputDeviceManager")
+	if idm != null and idm.has_method("apply_stick_swap"):
+		idm.apply_stick_swap(pad_swap_sticks)
 
 func set_animation_speed(value: float) -> void:
 	animation_speed = clampf(value, 0.25, 3.0)
@@ -555,6 +594,11 @@ func _save_settings() -> void:
 	# Controls
 	config.set_value("controls", "menu_scroll_speed", menu_scroll_speed)
 	config.set_value("controls", "controller_text_boost", controller_text_boost)
+	config.set_value("controls", "pad_invert_camera_y", pad_invert_camera_y)
+	config.set_value("controls", "pad_swap_sticks", pad_swap_sticks)
+	config.set_value("controls", "pad_camera_sensitivity", pad_camera_sensitivity)
+	config.set_value("controls", "pad_cursor_sensitivity", pad_cursor_sensitivity)
+	config.set_value("controls", "pad_cursor_magnetism", pad_cursor_magnetism)
 
 	var err = config.save(SETTINGS_FILE_PATH)
 	if err != OK:
@@ -615,5 +659,10 @@ func _load_settings() -> void:
 	# Controls
 	menu_scroll_speed = clampf(config.get_value("controls", "menu_scroll_speed", 0.4), 0.1, 1.0)
 	controller_text_boost = bool(config.get_value("controls", "controller_text_boost", true))
+	pad_invert_camera_y = bool(config.get_value("controls", "pad_invert_camera_y", false))
+	pad_swap_sticks = bool(config.get_value("controls", "pad_swap_sticks", false))
+	pad_camera_sensitivity = clampf(config.get_value("controls", "pad_camera_sensitivity", 1.0), 0.3, 2.0)
+	pad_cursor_sensitivity = clampf(config.get_value("controls", "pad_cursor_sensitivity", 1.0), 0.3, 2.0)
+	pad_cursor_magnetism = bool(config.get_value("controls", "pad_cursor_magnetism", true))
 
 	print("[SettingsService] Settings loaded from %s" % SETTINGS_FILE_PATH)

--- a/40k/autoloads/VirtualCursor.gd
+++ b/40k/autoloads/VirtualCursor.gd
@@ -97,13 +97,15 @@ func _process(delta: float) -> void:
 		# Precision modifier (R3 held): scale the whole step down for fine
 		# placement / target picking (P0; Gears Tactics "Precision Mode").
 		var precision := PRECISION_FACTOR if _precision_held() else 1.0
+		# P1 controller option: cursor sensitivity (Settings › Controls).
+		var sens: float = SettingsService.pad_cursor_sensitivity if SettingsService != null else 1.0
 		if PadRouter.is_carrying():
 			# Carrying a model: linear response with a lower ceiling — inch
 			# budgets are small and precision beats travel speed.
-			_move_cursor(vec * CARRY_SPEED * delta * precision)
+			_move_cursor(vec * CARRY_SPEED * delta * precision * sens)
 		else:
 			# Quadratic response: gentle deflection = precision, full = speed.
-			var rel := vec.normalized() * BASE_SPEED * vec.length() * vec.length() * delta * precision
+			var rel := vec.normalized() * BASE_SPEED * vec.length() * vec.length() * delta * precision * sens
 			# Magnetism (P0): ease toward the nearest selectable token while
 			# fine-tuning near it so grabbing a unit doesn't need pixel-hunting.
 			rel += _snap_assist(vec.length())
@@ -124,6 +126,9 @@ func _precision_held() -> bool:
 # intended empty-board click during fast travel.
 func _snap_assist(deflection: float) -> Vector2:
 	if PadRouter.is_carrying():
+		return Vector2.ZERO
+	# P1 controller option: players can turn magnetism off (Settings › Controls).
+	if SettingsService != null and not SettingsService.pad_cursor_magnetism:
 		return Vector2.ZERO
 	var assist := clampf(1.0 - deflection, 0.0, 1.0)
 	if assist <= 0.0:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.75.0",
+			"date": "2026-07-20",
+			"summary": "Steam Deck controls — customisation pass. A new Controller section in Settings › Controls lets you invert the camera Y axis, swap which stick moves the cursor vs the camera, tune camera and cursor sensitivity, and turn the cursor magnetism on or off — plus a full on-screen reference of the pad control scheme. The controller hint bar now leads with 'Cycle Units' (the bumpers are how you pick units), and the movement-range ring is bolder while you carry a model on a controller so the edge you slide to is unmistakable.",
+			"changes": [
+				"New Controller settings (Settings › Controls): Invert camera Y, Swap sticks (cursor on the right stick, camera on the left), Camera Sensitivity, Cursor Sensitivity, and a Cursor Magnetism on/off toggle. All pad-only — mouse & keyboard are unaffected — and saved between sessions.",
+				"Controller Reference: the Controls tab now shows the full pad scheme (what every button and stick does) using the same button glyphs as the in-game hint bar.",
+				"Controller hint bar now leads with 'RB Cycle Units' on the board and in the Movement phase (the bumpers are the primary way to pick units), and the left-stick pointer is labelled 'Point' so it reads as the secondary aim.",
+				"The movement-range circle is drawn brighter, thicker and above other tokens while you carry a model with a controller, so the boundary your model clamps to is easy to see."
+			]
+		},
+		{
 			"version": "0.74.0",
 			"date": "2026-07-20",
 			"summary": "Steam Deck controls — the first 'smoothness' pass. Moving a model with the stick now stops it exactly on the edge of its movement range instead of rejecting the move and snapping it back. A new precision mode (hold the right stick, R3) slows the cursor for fine placement and target picking, and the cursor now gently eases onto the nearest model when you hover near one, so selecting a unit no longer needs pixel-perfect aim. On-screen text is also enlarged while a controller is in use so it stays readable on the Deck's screen (toggle in Settings › Controls).",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6051,8 +6051,11 @@ func _process(delta: float) -> void:
 	# The pad_* actions are registered at runtime by InputDeviceManager.
 	if not _text_focused and InputMap.has_action("pad_camera_left"):
 		var pad_pan = Input.get_vector("pad_camera_left", "pad_camera_right", "pad_camera_up", "pad_camera_down")
+		# P1 controller options: optional Y invert + camera sensitivity (Settings › Controls).
+		if SettingsService.pad_invert_camera_y:
+			pad_pan.y = -pad_pan.y
 		if pad_pan != Vector2.ZERO:
-			view_offset += pad_pan.rotated(-view_rotation) * pan_speed
+			view_offset += pad_pan.rotated(-view_rotation) * pan_speed * SettingsService.pad_camera_sensitivity
 			view_changed = true
 		var pad_zoom = Input.get_action_strength("pad_zoom_in") - Input.get_action_strength("pad_zoom_out")
 		if pad_zoom != 0.0:

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -5370,6 +5370,17 @@ func _draw_dashed_range_circle(center: Vector2, radius_px: float, label_text: St
 	# Shared by the per-model movement-reach overlays.
 	if not is_instance_valid(move_range_visual) or radius_px <= 0.0:
 		return
+	# P1 (Steam Deck): on the pad the carried model CLAMPS exactly onto this ring
+	# (MovementController._clamp_move_to_budget), so the boundary is a hard edge the
+	# player slides to — draw it brighter, thicker, and lifted above board tokens so
+	# it can't read as a faint suggestion or be occluded. Mouse keeps the softer
+	# dashed guide, since a mouse drag can cross the ring into an invalid preview.
+	var pad_carry := InputDeviceManager.is_pad_active()
+	var col: Color = MOVE_RANGE_OVERLAY_COLOR
+	var width: float = MOVE_RANGE_OVERLAY_WIDTH
+	if pad_carry:
+		col = Color(col.r, col.g, col.b, 0.9)
+		width = MOVE_RANGE_OVERLAY_WIDTH * 1.4
 	var total_arcs: int = 8
 	var arc_length: float = TAU / float(total_arcs)
 	var dash_fraction: float = 0.75
@@ -5378,10 +5389,12 @@ func _draw_dashed_range_circle(center: Vector2, radius_px: float, label_text: St
 		var arc_dash_end: float = arc_start + arc_length * dash_fraction
 		var dash := Line2D.new()
 		dash.name = "MoveRangeDash_%d_%d_%d" % [int(center.x), int(center.y), arc_idx]
-		dash.width = MOVE_RANGE_OVERLAY_WIDTH
-		dash.default_color = MOVE_RANGE_OVERLAY_COLOR
+		dash.width = width
+		dash.default_color = col
 		dash.begin_cap_mode = Line2D.LINE_CAP_ROUND
 		dash.end_cap_mode = Line2D.LINE_CAP_ROUND
+		if pad_carry:
+			dash.z_index = 50  # above board tokens (z 0); below the label's 55
 		var pts: int = 8
 		for i in range(pts + 1):
 			var theta: float = arc_start + (arc_dash_end - arc_start) * float(i) / float(pts)
@@ -5392,7 +5405,7 @@ func _draw_dashed_range_circle(center: Vector2, radius_px: float, label_text: St
 		var range_label := Label.new()
 		range_label.text = label_text
 		range_label.add_theme_font_size_override("font_size", 36)
-		range_label.add_theme_color_override("font_color", MOVE_RANGE_OVERLAY_COLOR)
+		range_label.add_theme_color_override("font_color", col)
 		range_label.position = center + Vector2(-20, -(radius_px + 40))
 		range_label.z_index = 55
 		move_range_visual.add_child(range_label)

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -38,6 +38,14 @@ var _terrain_cover_checkbox: CheckBox
 var _auto_allocate_checkbox: CheckBox
 var _autosave_phase_start_checkbox: CheckBox
 var _controller_text_boost_checkbox: CheckBox
+var _pad_invert_y_checkbox: CheckBox
+var _pad_swap_sticks_checkbox: CheckBox
+var _pad_magnetism_checkbox: CheckBox
+var _pad_camera_sens_slider: HSlider
+var _pad_camera_sens_label: Label
+var _pad_cursor_sens_slider: HSlider
+var _pad_cursor_sens_label: Label
+const GlyphDB = preload("res://scripts/input/GlyphDB.gd")
 
 var _close_button: Button
 var _return_to_menu_button: Button
@@ -329,6 +337,19 @@ func _build_controls_tab(parent: VBoxContainer) -> void:
 	boost_help.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
 	parent.add_child(boost_help)
 
+	# P1 controller options — pad only; mouse & keyboard are unaffected.
+	_pad_invert_y_checkbox = _add_checkbox_row(parent, "Invert camera Y (right stick up / down)", "_on_pad_invert_y_toggled")
+	_pad_swap_sticks_checkbox = _add_checkbox_row(parent, "Swap sticks (cursor on right stick, camera on left)", "_on_pad_swap_sticks_toggled")
+	_pad_magnetism_checkbox = _add_checkbox_row(parent, "Cursor magnetism (cursor eases onto nearby models)", "_on_pad_magnetism_toggled")
+	_pad_camera_sens_slider = _add_slider_row(parent, "Camera Sensitivity:", 0.3, 2.0, 0.1, "_on_pad_camera_sens_changed")
+	_pad_camera_sens_label = _get_last_value_label()
+	_pad_cursor_sens_slider = _add_slider_row(parent, "Cursor Sensitivity:", 0.3, 2.0, 0.1, "_on_pad_cursor_sens_changed")
+	_pad_cursor_sens_label = _get_last_value_label()
+
+	# Read-only reference of the whole pad scheme, drawn with the in-game glyph chips.
+	_add_section_header(parent, "Controller Reference")
+	_add_controller_reference(parent)
+
 	# Reset All Defaults button
 	var spacer = Control.new()
 	spacer.custom_minimum_size = Vector2(0, 10)
@@ -578,6 +599,20 @@ func _load_current_settings() -> void:
 		_update_scroll_speed_label(_menu_scroll_speed_label, SettingsService.menu_scroll_speed)
 	if _controller_text_boost_checkbox:
 		_controller_text_boost_checkbox.button_pressed = SettingsService.controller_text_boost
+	if _pad_invert_y_checkbox:
+		_pad_invert_y_checkbox.button_pressed = SettingsService.pad_invert_camera_y
+	if _pad_swap_sticks_checkbox:
+		_pad_swap_sticks_checkbox.button_pressed = SettingsService.pad_swap_sticks
+	if _pad_magnetism_checkbox:
+		_pad_magnetism_checkbox.button_pressed = SettingsService.pad_cursor_magnetism
+	if _pad_camera_sens_slider:
+		_pad_camera_sens_slider.value = SettingsService.pad_camera_sensitivity
+		if _pad_camera_sens_label:
+			_pad_camera_sens_label.text = "%.1fx" % SettingsService.pad_camera_sensitivity
+	if _pad_cursor_sens_slider:
+		_pad_cursor_sens_slider.value = SettingsService.pad_cursor_sensitivity
+		if _pad_cursor_sens_label:
+			_pad_cursor_sens_label.text = "%.1fx" % SettingsService.pad_cursor_sensitivity
 
 func _connect_signals() -> void:
 	# Update in-game-only button visibility
@@ -662,6 +697,48 @@ func _on_menu_scroll_speed_changed(value: float) -> void:
 
 func _on_controller_text_boost_toggled(pressed: bool) -> void:
 	SettingsService.set_controller_text_boost(pressed)
+
+func _on_pad_invert_y_toggled(pressed: bool) -> void:
+	SettingsService.set_pad_invert_camera_y(pressed)
+
+func _on_pad_swap_sticks_toggled(pressed: bool) -> void:
+	SettingsService.set_pad_swap_sticks(pressed)
+
+func _on_pad_magnetism_toggled(pressed: bool) -> void:
+	SettingsService.set_pad_cursor_magnetism(pressed)
+
+func _on_pad_camera_sens_changed(value: float) -> void:
+	SettingsService.set_pad_camera_sensitivity(value)
+	if _pad_camera_sens_label:
+		_pad_camera_sens_label.text = "%.1fx" % value
+
+func _on_pad_cursor_sens_changed(value: float) -> void:
+	SettingsService.set_pad_cursor_sensitivity(value)
+	if _pad_cursor_sens_label:
+		_pad_cursor_sens_label.text = "%.1fx" % value
+
+func _add_controller_reference(parent: VBoxContainer) -> void:
+	# A compact, accurate map of the whole pad scheme, rendered with the same glyph
+	# chips the in-game hint bar uses (GlyphDB). Read-only — the face-button routing
+	# is context-dependent, so this documents rather than rebinds it.
+	var rows := [
+		["ls", "Move the on-screen cursor / point at the board"],
+		["rs", "Move the camera  ·  click (R3) = precision (slow) mode"],
+		["lb", "Cycle to the previous unit / target"],
+		["rb", "Cycle to the next unit / target"],
+		["a", "Select  ·  confirm  ·  pick up a model"],
+		["b", "Cancel  ·  back to the board"],
+		["x", "Skip  ·  undo the last model"],
+		["y", "Show the unit's datasheet"],
+		["dpad", "Menus, movement options & weapon / target rows"],
+		["lt", "Zoom out"],
+		["rt", "Zoom in"],
+		["menu", "End phase / confirm  (Start)"],
+		["view", "Pause menu  (View / Select)"],
+	]
+	for r in rows:
+		var chip: Control = GlyphDB.make_chip(str(r[0]), str(r[1]))
+		parent.add_child(chip)
 
 func _on_colorblind_changed(index: int) -> void:
 	var modes = ["none", "protanopia", "deuteranopia", "tritanopia"]

--- a/40k/tests/scenarios/sp/pad_controller_settings.json
+++ b/40k/tests/scenarios/sp/pad_controller_settings.json
@@ -1,0 +1,41 @@
+{
+  "id": "pad_controller_settings",
+  "covers": ["controller.p1.settings", "controller.p1.swap_sticks", "controller.p1.magnetism_toggle", "controller.p1.reference_tab"],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "P1 Controller settings (Settings › Controls › Controller). Swap-sticks re-points the cursor stick to the RIGHT stick (JOY_AXIS_RIGHT_X=2) and back to the LEFT stick (0). Cursor sensitivity clamps to its 0.3-2.0 range. Cursor magnetism can be toggled off so the snap-assist produces zero pull near a token. The Controls tab builds the new controller option controls (invert-Y / swap / magnetism / camera & cursor sensitivity) alongside the read-only glyph reference of the pad scheme.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "InputDeviceManager.cursor_stick_axis_x()", "equals": 0 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_swap_sticks(true)" },
+    { "act": "execute_script", "script": "InputDeviceManager.cursor_stick_axis_x()", "equals": 2 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_swap_sticks(false)" },
+    { "act": "execute_script", "script": "InputDeviceManager.cursor_stick_axis_x()", "equals": 0 },
+
+    { "act": "execute_script", "script": "SettingsService.set_pad_cursor_sensitivity(99.0)" },
+    { "act": "execute_script", "script": "SettingsService.pad_cursor_sensitivity", "expect_max": 2.0 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_cursor_sensitivity(1.0)" },
+
+    { "act": "execute_script", "script": "InputDeviceManager.claim_pad()" },
+    { "act": "execute_script", "script": "VirtualCursor.warp_to(main.world_to_screen_position(Vector2(850.0, 50.0)) + Vector2(25.0, 0.0))" },
+    { "act": "wait_seconds", "seconds": 0.15 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_cursor_magnetism(true)" },
+    { "act": "execute_script", "script": "VirtualCursor._snap_assist(0.2).length()", "expect_min": 0.2 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_cursor_magnetism(false)" },
+    { "act": "execute_script", "script": "VirtualCursor._snap_assist(0.2).length()", "expect_max": 0.001 },
+    { "act": "execute_script", "script": "SettingsService.set_pad_cursor_magnetism(true)" },
+
+    { "act": "execute_script", "script": "main._open_settings_menu()" },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "main._settings_menu._on_tab_pressed(3)" },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "main._settings_menu._pad_invert_y_checkbox != null and main._settings_menu._pad_swap_sticks_checkbox != null and main._settings_menu._pad_magnetism_checkbox != null and main._settings_menu._pad_camera_sens_slider != null and main._settings_menu._pad_cursor_sens_slider != null", "equals": true },
+    { "act": "execute_script", "script": "main._settings_menu._tab_containers[3].set(\"scroll_vertical\", 900)" },
+    { "act": "screenshot", "label": "01_controller_settings_tab" },
+    { "act": "execute_script", "script": "main._settings_menu._on_close_pressed()" }
+  ]
+}


### PR DESCRIPTION
P1 controller polish, building on the P0 pass (v0.75.0). Mouse & keyboard behaviour is unchanged throughout.

## What changed

**Controller settings tab** — a new Controller section in **Settings › Controls** with pad-only, persisted options:
- **Invert camera Y**, **Swap sticks** (cursor on the right stick / camera on the left), **Camera Sensitivity**, **Cursor Sensitivity**, and a **Cursor Magnetism** on/off toggle (opt out of the P0 magnetism).
- A **read-only glyph reference** of the full pad scheme (13 rows), rendered with the same button glyphs as the in-game hint bar.

Swap-sticks re-points the `pad_cursor_*` / `pad_camera_*` InputMap axes in `InputDeviceManager`; every consumer reads them by name, so the swap is transparent (no phase-controller changes). Literal face-button remapping is deliberately left out — per the scoping research it's the **M4-scale `KeybindingManager` migration** (~59 call sites, breaks pin tests, and still can't cleanly rebind the context-dependent face buttons). The reference tab documents that scheme instead.

**Range ring** — while carrying a model on the pad (where the ghost now CLAMPS onto the ring), the movement-reach circle is drawn brighter, thicker, and above board tokens so the boundary is unmistakable. Mouse keeps the softer dashed guide it always had.

**Hints** — the board and movement hint bars now lead with **`[RB] Cycle Units`** (bumper-only cycling from #702 is the primary unit selection) and relabel the left-stick pointer **`[LS] Point`**, so the free cursor reads as the secondary aim.

Changelog bumped to **0.75.0**. On-screen keyboard was intentionally skipped (the Steam Deck's own OSK covers text entry).

## Validation

Driven live against the running game via the in-game MCP bridge (**0 errors / 0 warnings**):

| Check | Evidence |
|---|---|
| Swap-sticks (real axis rebind) | cursor `LEFT_X(0) → RIGHT_X(2) → LEFT_X(0)`, camera `RIGHT_X → LEFT_X` |
| Sensitivity clamp | set 99 → clamped to **2.0** |
| Magnetism opt-out | near a token: ON pull **1.165** → OFF pull **0.000** |
| Controls tab builds | all five option controls wired + **13 glyph reference chips** rendered |

Clean compile (0 parse errors / 0 autoload failures). `KeybindingManager` is untouched, so `keybindings_menu.json` stays green. A windowed scenario `pad_controller_settings.json` is added for CI regression (it hits the same llvmpipe shader-compile wall in the dev container as the other battle-scene scenarios, so it was validated live via the bridge here; it runs normally on GPU/CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsZoCgzJ8dCZY4XMXV9b8R

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsZoCgzJ8dCZY4XMXV9b8R)_