### PR TITLE
Movement pad: illegal drop keeps model in hand; lock session + Start confirms

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -113,6 +113,16 @@ const HINTS_MOVE := [
 	["y", "Datasheet"],
 	["menu", "End Phase"],
 ]
+# Movement with a committed move (mode locked or a model staged): the bumpers are
+# locked to this unit, A picks the model back up, D-pad hops between models, X
+# undoes the last staged model and Start confirms the whole unit's move.
+const HINTS_MOVE_LOCKED := [
+	["a", "Pick Up Model"],
+	["dpad", "Switch Model"],
+	["x", "Undo Model"],
+	["menu", "Confirm Move"],
+	["y", "Datasheet"],
+]
 
 # The target currently highlighted by LB/RB in shooting TARGET_SELECT mode
 # (empty when none). Windowed scenarios assert this.
@@ -322,6 +332,13 @@ func _cycle(dir: int) -> void:
 	var dc = _deployment_controller_placing()
 	if dc != null and dc.get_placed_count() > 0:
 		ToastManager.show_warning("Undo the placed models before switching units")
+		return
+	# Movement: a unit committed to its move (mode locked or a model staged) can't
+	# be bumped away until it's confirmed (Start) or reset (undo) — mirrors the
+	# deployment lock above so a mis-cycle can't strand a half-moved unit.
+	var mc := _movement_controller()
+	if mc != null and mc.has_method("pad_is_move_session_locked") and mc.pad_is_move_session_locked():
+		ToastManager.show_warning("Confirm or reset this unit's move before switching")
 		return
 	_cycle_unit_list(dir)
 
@@ -648,8 +665,22 @@ func _try_begin_carry() -> bool:
 
 
 func _drop_carry() -> void:
+	# Movement phase: consult the controller BEFORE releasing. An illegal drop
+	# (over a wall, past the move cap, overlapping) keeps the model in hand — the
+	# "you can't put the piece on an illegal square" rule — instead of snapping it
+	# back and stranding the still-active cursor, which used to swallow the next A
+	# press as a raw board click and silently switch the selected unit.
+	var mc := _movement_controller()
+	if mc != null and mc.has_method("pad_carry_drop_rejection"):
+		var reason := str(mc.pad_carry_drop_rejection(VirtualCursor.get_cursor_pos()))
+		if reason != "":
+			ToastManager.show_warning(reason)
+			return  # still carrying: A re-checks, the stick keeps steering
 	VirtualCursor.set_left_button(false)
 	carry_active = false
+	# Park so the cursor can't consume the next A as a stray click; with it
+	# parked, A routes back through the router (pick the model up again / confirm).
+	VirtualCursor.park()
 
 
 func _cancel_carry() -> void:
@@ -660,6 +691,9 @@ func _cancel_carry() -> void:
 	VirtualCursor.warp_to(_carry_pickup_screen)
 	VirtualCursor.set_left_button(false)
 	carry_active = false
+	# Park (warp_to above re-activated the cursor) so the next A re-arms through
+	# the router instead of firing as a stray click at the pickup point.
+	VirtualCursor.park()
 	# Releasing at the pickup point still STAGES a zero-distance move (the
 	# drag pipeline stages every drop) — which would mark the unit as
 	# mid-move: the M4 action menu won't reopen and a junk 0" stage would be
@@ -930,7 +964,31 @@ func _update_hints() -> void:
 				hints = HINTS_CHARGE
 			elif _movement_menu_available():
 				hints = HINTS_MOVE
+			elif _movement_session_locked():
+				hints = HINTS_MOVE_LOCKED
 	PadHintBar.set_hints(hints)
+
+
+# The MovementController while the Movement phase is live, else null. Used by the
+# bumper lock, the drop-rejection check and the locked-session hint so each reads
+# the same authoritative move state.
+func _movement_controller() -> Node:
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m) or m.current_phase != GameStateData.Phase.MOVEMENT:
+		return null
+	if not ("movement_controller" in m):
+		return null
+	var mc = m.movement_controller
+	if mc == null or not is_instance_valid(mc):
+		return null
+	return mc
+
+
+# True while the active unit has a committed move (mode locked or a model staged)
+# — the state where the bumpers are locked and the locked-session hints apply.
+func _movement_session_locked() -> bool:
+	var mc := _movement_controller()
+	return mc != null and mc.has_method("pad_is_move_session_locked") and mc.pad_is_move_session_locked()
 
 
 # Movement phase with a selected unit whose move-mode decision is still open

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.76.0",
+			"date": "2026-07-21",
+			"summary": "Steam Deck controls — Movement phase carry fix. On a controller, trying to drop a model somewhere it can't go (into a wall, past its move, or on top of another model) now KEEPS the model in your hand so you can just steer somewhere legal, instead of dropping it and leaving you unable to grab the unit again. Once you've moved a model the bumpers lock to that unit until you confirm (Start) or reset the move, so a stray bump can't strand a half-moved unit, and Start now confirms the selected unit's move.",
+			"changes": [
+				"Controller movement: an illegal drop (into a wall this unit can't cross, beyond its Move, or overlapping another model) now keeps the model on the cursor so you can slide to a legal spot and drop again — it no longer snaps back and leaves you unable to pick the unit up. Fixes the 'the A button seems to point at something else and I can't move the vehicle again' bug.",
+				"Controller movement: after any drop the cursor is parked, so the next A always picks the model back up (or confirms) instead of registering as a stray board click that silently switched to another unit.",
+				"Controller movement: once a unit has a mode locked or a model staged, the bumpers stay locked to that unit (you're told to confirm or reset first) — the same lock deployment already uses — so a mis-cycle can't abandon a half-finished move.",
+				"Controller movement: Start now confirms the selected unit's move when one is in progress (matching how Start confirms targets in Shooting and a unit in Deployment); the hint bar shows the locked-unit controls (Pick Up Model / Switch Model / Undo Model / Confirm Move).",
+				"Mouse & keyboard movement is unchanged."
+			]
+		},
+		{
 			"version": "0.75.0",
 			"date": "2026-07-20",
 			"summary": "Steam Deck controls — customisation pass. A new Controller section in Settings › Controls lets you invert the camera Y axis, swap which stick moves the cursor vs the camera, tune camera and cursor sensitivity, and turn the cursor magnetism on or off — plus a full on-screen reference of the pad control scheme. The controller hint bar now leads with 'Cycle Units' (the bumpers are how you pick units), and the movement-range ring is bolder while you carry a model on a controller so the edge you slide to is unmistakable.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -5468,6 +5468,14 @@ func _input(event: InputEvent) -> void:
 			# targets selected, Roll 2D6 once declared. Falls through to the
 			# End-Phase confirm when neither applies.
 			pass
+		elif current_phase == GameStateData.Phase.MOVEMENT and movement_controller \
+				and is_instance_valid(movement_controller) \
+				and movement_controller.has_method("pad_confirm_move") \
+				and movement_controller.pad_confirm_move():
+			# Movement: Start confirms the active unit's in-progress move (staged
+			# models) — the same context-dependent Menu shooting/deployment use.
+			# Falls through to the End-Phase confirm when no move is pending.
+			pass
 		elif phase_action_button and phase_action_button.visible and not phase_action_button.disabled:
 			_show_pad_phase_confirm()
 		get_viewport().set_input_as_handled()

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -2242,10 +2242,34 @@ func _update_model_drag(mouse_pos: Vector2) -> void:
 	# P3-116: Update coherency preview lines during drag
 	_update_coherency_preview(world_pos)
 
+func _compute_move_rejection(world_pos: Vector2) -> String:
+	"""Single source of truth for why staging the active model at world_pos is
+	illegal ("" = legal): over the move cap, off the board, or overlapping a
+	wall/model. Shared by _end_model_drag (mouse + pad drop) and the pad carry's
+	pad_carry_drop_rejection() so a controller drop is judged identically to a
+	mouse drop."""
+	var terrain_penalty = _get_terrain_penalty_for_move(drag_start_pos, world_pos)
+	var distance_inches = Measurement.distance_polyline_inches([drag_start_pos, world_pos]) + terrain_penalty
+	var total_distance = _get_accumulated_distance() + distance_inches
+	var effective_cap = _get_effective_move_cap()
+	if total_distance > effective_cap + MOVEMENT_CAP_EPSILON:
+		return "Movement exceeds %.1f\" cap (would be %.1f\")" % [effective_cap, total_distance]
+	if current_phase and selected_model and _is_position_outside_board(world_pos, selected_model):
+		return "Cannot place model beyond the board edge"
+	if current_phase and _check_position_would_overlap(world_pos):
+		# Distinguish wall overlap from model overlap so the player knows whether
+		# to find a different lane or just nudge sideways.
+		var test_model = selected_model.duplicate()
+		test_model["position"] = world_pos
+		if Measurement.model_overlaps_any_wall(test_model, _get_active_unit_keywords()):
+			return "Cannot place model overlapping a wall this unit can't cross"
+		return "Cannot place model overlapping another model"
+	return ""
+
 func _end_model_drag(mouse_pos: Vector2) -> void:
 	if not dragging_model:
 		return
-	
+
 	print("Ending model drag")
 	
 	# Get the board transform from Main
@@ -2268,35 +2292,18 @@ func _end_model_drag(mouse_pos: Vector2) -> void:
 	if InputDeviceManager.is_pad_active():
 		world_pos = _clamp_move_to_budget(world_pos)
 
-	# Calculate distance
-	var distance_inches = Measurement.distance_polyline_inches([drag_start_pos, world_pos])
-
-	# Add terrain penalty (elevation changes for non-FLY units)
+	# Distance is recomputed here only for the debug log; the legality decision
+	# lives in _compute_move_rejection so the pad carry can consult the exact
+	# same rules BEFORE it releases a model (see pad_carry_drop_rejection).
 	var terrain_penalty = _get_terrain_penalty_for_move(drag_start_pos, world_pos)
-	distance_inches += terrain_penalty
+	var distance_inches = Measurement.distance_polyline_inches([drag_start_pos, world_pos]) + terrain_penalty
+	var total_distance = _get_accumulated_distance() + distance_inches
 	print("Distance moved: ", distance_inches, " inches (terrain penalty: ", terrain_penalty, ")")
 
-	# Get accumulated distance to check against cap (accounting for pivot cost)
-	var accumulated = _get_accumulated_distance()
-	var total_distance = accumulated + distance_inches
-	var effective_cap = _get_effective_move_cap()
-
-	# Build a single rejection-reason string for the toast so silent reverts
-	# don't leave the player guessing why the model snapped back.
-	var rejection_reason: String = ""
-	if total_distance > effective_cap + MOVEMENT_CAP_EPSILON:
-		rejection_reason = "Movement exceeds %.1f\" cap (would be %.1f\")" % [effective_cap, total_distance]
-	elif current_phase and selected_model and _is_position_outside_board(world_pos, selected_model):
-		rejection_reason = "Cannot place model beyond the board edge"
-	elif current_phase and _check_position_would_overlap(world_pos):
-		# Distinguish wall overlap from model overlap so the player knows
-		# whether to find a different lane or just nudge sideways.
-		var test_model = selected_model.duplicate()
-		test_model["position"] = world_pos
-		if Measurement.model_overlaps_any_wall(test_model, _get_active_unit_keywords()):
-			rejection_reason = "Cannot place model overlapping a wall this unit can't cross"
-		else:
-			rejection_reason = "Cannot place model overlapping another model"
+	# Single rejection-reason string (empty = legal) so silent reverts don't
+	# leave the player guessing why the model snapped back — and so the pad
+	# carry refuses an illegal drop with the identical rule set.
+	var rejection_reason: String = _compute_move_rejection(world_pos)
 
 	if rejection_reason == "":
 		print("Move is valid, sending STAGE_MODEL_MOVE action")
@@ -5198,6 +5205,56 @@ func pad_can_cycle_to(unit_id: String) -> bool:
 	"""Bumper cycling skips units whose activation is spent (PRP §2.6: cycling
 	follows eligibility, not raw list order). Mouse row-clicks are unaffected."""
 	return _get_unit_movement_status(unit_id) != "completed"
+
+
+func pad_carry_drop_rejection(screen_pos: Vector2) -> String:
+	"""Pad carry seam: would dropping the carried model at screen_pos be
+	rejected? Returns the toast reason ("" = legal), computed at the EXACT world
+	position _end_model_drag would stage (same board transform, grid snap and
+	over-range budget clamp). PadRouter consults this BEFORE releasing the
+	synthetic button so an illegal drop keeps the model in hand instead of
+	snapping it back and stranding the cursor."""
+	if not dragging_model:
+		return ""
+	var board_root = SceneRefs.board_root()
+	var world_pos: Vector2 = board_root.transform.affine_inverse() * screen_pos if board_root else get_global_mouse_position()
+	if _should_snap_to_grid():
+		world_pos = _snap_to_grid(world_pos)
+	if InputDeviceManager.is_pad_active():
+		world_pos = _clamp_move_to_budget(world_pos)
+	return _compute_move_rejection(world_pos)
+
+
+func pad_is_move_session_locked() -> bool:
+	"""True once the active unit has committed to its move — mode locked (Advance
+	rolled, Fall Back, confirmed) OR at least one model staged/committed. While
+	locked, the pad bumpers refuse to switch units (deployment-style lock) so a
+	mis-cycle can't strand a half-moved unit. Choosing a mode but not yet touching
+	a model does NOT lock, so the player can still freely change their mind."""
+	if active_unit_id == "":
+		return false
+	if not current_phase or not current_phase.has_method("get_active_move_data"):
+		return false
+	var move_data = current_phase.get_active_move_data(active_unit_id)
+	if move_data.is_empty() or move_data.get("completed", false):
+		return false
+	if move_data.get("mode_locked", false):
+		return true
+	return not move_data.get("staged_moves", []).is_empty() \
+		or not move_data.get("model_moves", []).is_empty()
+
+
+func pad_confirm_move() -> bool:
+	"""Start-button context action in the Movement phase: confirm the active
+	unit's in-progress move (the same CONFIRM_UNIT_MOVE the "Confirm Move" button
+	sends). Returns true only when there is a pending move to confirm, so Start
+	falls through to the End-Phase confirm when nothing is staged."""
+	if active_unit_id == "":
+		return false
+	if not _has_pending_unconfirmed_move(active_unit_id):
+		return false
+	_on_confirm_move_pressed()
+	return true
 
 
 func pad_menu_options() -> Array:

--- a/40k/tests/scenarios/sp/pad_move_illegal_drop_keeps_model.json
+++ b/40k/tests/scenarios/sp/pad_move_illegal_drop_keeps_model.json
@@ -1,0 +1,72 @@
+{
+  "id": "pad_move_illegal_drop_keeps_model",
+  "covers": [
+    "controller.move.illegal_drop_keeps_model",
+    "controller.move.drop_parks_cursor",
+    "controller.move.session_lock",
+    "controller.move.start_confirms"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Movement pad-carry regression (the Battle Wagon bug): a single-model vehicle-analog (Blade Champion, Move 6\") is picked up via the move action menu. Dropping A onto another in-range model (Shield Captain) is REJECTED and the model STAYS IN HAND (is_carrying true, nothing staged) instead of snapping back and stranding the cursor. A legal drop then stages the move AND parks the cursor, so the very next A re-arms as pick-up (the old bug swallowed that A as a stray board click that silently switched the selected unit). While a model is staged the bumpers refuse to switch units (session lock), and Start confirms the whole unit's move.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"bc_y0\", GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y)" },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_BLADE_CHAMPION_A" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_BLADE_CHAMPION_A" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "screenshot", "label": "01_champion_carried" },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_SHIELD_CAPTAIN_A" },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "main.movement_controller.dragging_model", "equals": true },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves.get(\"U_BLADE_CHAMPION_A\", {}).get(\"staged_moves\", []).size()", "equals": 0 },
+    { "act": "screenshot", "label": "02_illegal_drop_still_in_hand" },
+
+    { "act": "pad_cursor_glide", "x": 120.0, "y": 300.0 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_BLADE_CHAMPION_A\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": false },
+    { "act": "screenshot", "label": "03_legal_drop_staged_and_parked" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_BLADE_CHAMPION_A" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "screenshot", "label": "04_A_rearmed_repickup" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_BLADE_CHAMPION_A\"].staged_moves.size()", "equals": 1 },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_BLADE_CHAMPION_A\"].get(\"completed\", false)", "equals": true },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y - InputDeviceManager.get_meta(\"bc_y0\")", "expect_min": 150 },
+    { "act": "screenshot", "label": "05_start_confirmed_move" }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes the controller Movement-phase bug where, after a rejected drag-drop (e.g. dropping a Battle Wagon into a wall), the model snapped back and the player could no longer pick the unit up — the **A button had silently become a raw board click** that switched the selected unit.

**Root cause:** `PadRouter._drop_carry` always released the synthetic left-mouse button but left the virtual cursor **active**. With the cursor active, `VirtualCursor` consumes A as a mouse click *before* `PadRouter` sees it (input runs Main → VirtualCursor → PadRouter). So the next A press landed as a board click near the wall, and because the rejected drop had staged nothing, `_try_click_select_unit` switched the active unit with no confirm dialog to guard it.

## Changes

- **MovementController:** factor the drop-legality checks out of `_end_model_drag` into a single `_compute_move_rejection` (one source of truth for mouse + pad). Add `pad_carry_drop_rejection()` so the pad can test a drop at the exact position `_end_model_drag` would stage (same board transform, grid snap, over-range budget clamp).
- **PadRouter `_drop_carry`:** consult `pad_carry_drop_rejection` first — an illegal drop (wall / over-cap / overlap) keeps the model in hand (toast + stay carrying) instead of snapping back. After a legal drop, **park the cursor** so the next A always re-arms through the router (pick up / confirm) rather than firing as a stray click.
- **PadRouter `_cancel_carry`:** park the cursor too (`warp_to` had re-activated it).
- **PadRouter `_cycle`:** while a unit has a mode locked or a model staged, the **bumpers refuse to switch units** (deployment-style lock) so a mis-cycle can't strand a half-moved unit. Choosing a mode but not yet moving does **not** lock — the player can still change their mind.
- **Main pad Start handler + `MovementController.pad_confirm_move`:** Start now **confirms the selected unit's in-progress move** (context-dependent Menu, matching how Start confirms targets in Shooting and a unit in Deployment).
- New `HINTS_MOVE_LOCKED` hint state for the locked session (`Pick Up Model / Switch Model / Undo Model / Confirm Move`).

Mouse & keyboard movement is unchanged — the rejection logic is byte-identical, just relocated.

## Validation

- New windowed scenario `tests/scenarios/sp/pad_move_illegal_drop_keeps_model.json` drives the full player path on a single-model unit (Blade Champion — a Battle Wagon analog): pick up via the action menu, illegal drop onto an in-range model **stays in hand** (nothing staged), legal drop **stages + parks the cursor**, bumper is **locked**, A **re-arms** as pick-up, Start **confirms** the move. **48/48 asserts pass.**
- Regression: `pad_m3_carry_move`, `pad_m4_move_action_menu`, `pad_p0_move_clamp`, `pad_bumper_only_unit_cycling` and five mouse-movement scenarios (`movement_auto_confirm`, `click_select_unit_movement`, `horde_movement`, `move_range_per_model_circle`, `iss040_movement_11e`) all still pass.
- Zero `SCRIPT ERROR` / `Parse Error` in the debug log during the run.

## Notes / follow-ups

- Model-switch stays on the **D-pad**, not the bumpers — bumpers keep rotation for vehicles (pivot).
- Chain-carry auto-advance intentionally **not** added (would break the existing D-pad model-hop index expectation).
- Minor cosmetic: right after Start confirms, the hint bar keeps the locked hints until the next pad input (Main handles Start without refreshing PadRouter's hints — same pre-existing pattern Shooting's Start-confirm has). Self-heals on next input.
- Attached-character models still aren't reachable by pad hop/carry (only the active unit's own models) — deferred to limit blast radius; single-model vehicles are unaffected.

Changelog bumped to `0.76.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsRzz5Qjz1DvDmmYa8AH1Y)_