### PR TITLE
Movement pad: switch models with Steam Deck back paddles, not the D-pad

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -114,11 +114,12 @@ const HINTS_MOVE := [
 	["menu", "End Phase"],
 ]
 # Movement with a committed move (mode locked or a model staged): the bumpers are
-# locked to this unit, A picks the model back up, D-pad hops between models, X
-# undoes the last staged model and Start confirms the whole unit's move.
+# locked to this unit, A picks the model back up, the back paddles (L4/R4) hop
+# between models, X undoes the last staged model and Start confirms the whole move.
 const HINTS_MOVE_LOCKED := [
 	["a", "Pick Up Model"],
-	["dpad", "Switch Model"],
+	["l4", "◀ Model"],
+	["r4", "Model ▶"],
 	["x", "Undo Model"],
 	["menu", "Confirm Move"],
 	["y", "Datasheet"],
@@ -215,10 +216,23 @@ func _input(event: InputEvent) -> void:
 			if _pad_deploy_row_cycle(1) or _pad_step_secondary(1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_LEFT:
-			if _hop_model(-1) or _pad_deploy_option_cycle(-1) or _enter_panel_focus():
+			# Model-switching moved OFF the D-pad onto the Steam Deck back paddles
+			# (below) so D-pad ◀ ▶ stays free for menu / option navigation and no
+			# longer fights the move-mode menu. Deployment option-cycle keeps it.
+			if _pad_deploy_option_cycle(-1) or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_RIGHT:
-			if _hop_model(1) or _pad_deploy_option_cycle(1) or _enter_panel_focus():
+			if _pad_deploy_option_cycle(1) or _enter_panel_focus():
+				get_viewport().set_input_as_handled()
+		# Steam Deck back paddles hop between the selected unit's models (Movement
+		# / Charge) — the job D-pad ◀ ▶ used to do. Both back pairs are bound so
+		# whichever the player's config exposes works: right paddles (commonly
+		# R4/R5 → PADDLE1/3) = next model, left paddles (L4/L5 → PADDLE2/4) = prev.
+		JOY_BUTTON_PADDLE1, JOY_BUTTON_PADDLE3:
+			if _hop_model(1):
+				get_viewport().set_input_as_handled()
+		JOY_BUTTON_PADDLE2, JOY_BUTTON_PADDLE4:
+			if _hop_model(-1):
 				get_viewport().set_input_as_handled()
 	# A handler above may have re-focused a list (e.g. a phase's selection
 	# refresh); take it back so a following stick deflection can't walk it.

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.76.1",
+			"date": "2026-07-21",
+			"summary": "Steam Deck controls — switching between models in a unit moved off the D-pad and onto the back paddles (L4 = previous model, R4 = next model), so the D-pad ◀ ▶ is free for the move-mode menu (Normal Move / Advance / Fall Back / Remain Stationary) and no longer double-duties as model-switching.",
+			"changes": [
+				"Movement / Charge on a controller: hop between the models of the selected unit with the Steam Deck back paddles — L4 = previous model, R4 = next model (both back-button pairs are bound, so whichever your controller config exposes will work). The D-pad no longer switches models.",
+				"D-pad ◀ ▶ is now dedicated to menu / option navigation (e.g. stepping the move-mode menu), matching the D-pad ▲ ▼ that opens it — no more accidental model-switching while choosing a move type.",
+				"The controller hint bar and the Controller Reference (Settings › Controls) now show L4 ◀ Model / R4 Model ▶ for model-switching.",
+				"Note: the back paddles must be passed through to the game as gamepad paddle buttons. Running the native build directly, this works via SDL; under Steam's controller layer you may need to map L4/R4 to the paddle buttons in the Steam controller settings."
+			]
+		},
+		{
 			"version": "0.76.0",
 			"date": "2026-07-21",
 			"summary": "Steam Deck controls — Movement phase carry fix. On a controller, trying to drop a model somewhere it can't go (into a wall, past its move, or on top of another model) now KEEPS the model in your hand so you can just steer somewhere legal, instead of dropping it and leaving you unable to grab the unit again. Once you've moved a model the bumpers lock to that unit until you confirm (Start) or reset the move, so a stray bump can't strand a half-moved unit, and Start now confirms the selected unit's move.",

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -731,6 +731,8 @@ func _add_controller_reference(parent: VBoxContainer) -> void:
 		["x", "Skip  ·  undo the last model"],
 		["y", "Show the unit's datasheet"],
 		["dpad", "Menus, movement options & weapon / target rows"],
+		["l4", "Previous model in the unit while moving (Steam Deck back paddle)"],
+		["r4", "Next model in the unit while moving (Steam Deck back paddle)"],
 		["lt", "Zoom out"],
 		["rt", "Zoom in"],
 		["menu", "End phase / confirm  (Start)"],

--- a/40k/scripts/input/GlyphDB.gd
+++ b/40k/scripts/input/GlyphDB.gd
@@ -25,6 +25,8 @@ const GLYPHS := {
 	"rt": "RT",
 	"ls": "LS",
 	"rs": "RS",
+	"l4": "L4",
+	"r4": "R4",
 	"dpad": "✚",
 	"menu": "☰",
 	"view": "⧉",

--- a/40k/tests/scenarios/sp/pad_m3_carry_move.json
+++ b/40k/tests/scenarios/sp/pad_m3_carry_move.json
@@ -9,7 +9,7 @@
   "transition_to_phase": 7,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M3 model carry in the Movement phase: A (cursor parked) opens the M4 move-mode action bar; A again ('Move') begins the carry — the active model rides the cursor with a held synthetic LMB (the real drag pipeline runs), the stick drives it within the move cap and unit coherency, A drops (staged_moves grows), D-pad right hops to the next model for a second carry, X undoes the last staged model, Confirm Move lands only the kept move in GameState; then the oval-based jetbike is carried, rotated with LB (rebindable rotate_left synthesized), and the carry cancelled with B.",
+  "description": "M3 model carry in the Movement phase: A (cursor parked) opens the M4 move-mode action bar; A again ('Move') begins the carry — the active model rides the cursor with a held synthetic LMB (the real drag pipeline runs), the stick drives it within the move cap and unit coherency, A drops (staged_moves grows), the R4 back paddle (PADDLE1) hops to the next model for a second carry, X undoes the last staged model, Confirm Move lands only the kept move in GameState; then the oval-based jetbike is carried, rotated with LB (rebindable rotate_left synthesized), and the carry cancelled with B.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -122,7 +122,7 @@
     },
     {
       "act": "simulate_joy_button",
-      "button_index": 14
+      "button_index": 16
     },
     {
       "act": "wait_seconds",

--- a/40k/tests/scenarios/sp/pad_move_paddle_model_switch.json
+++ b/40k/tests/scenarios/sp/pad_move_paddle_model_switch.json
@@ -1,0 +1,47 @@
+{
+  "id": "pad_move_paddle_model_switch",
+  "covers": [
+    "controller.move.paddle_model_switch",
+    "controller.move.dpad_no_longer_hops"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Model-switching moved off the D-pad onto the Steam Deck back paddles so D-pad ◀ ▶ stays free for the move-mode menu. Selects a 4-model unit; the R4 paddle (PADDLE1=16) steps carry_model_index forward and the L4 paddle (PADDLE2=17) steps it back, while D-pad LEFT/RIGHT (13/14) no longer change it. NOTE: this proves the in-engine routing (button_index → _hop_model); whether a physical Deck's L4/R4 reach the game as PADDLE buttons is Steam Input / SDL dependent and is not asserted here.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "simulate_joy_button", "button_index": 16 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "screenshot", "label": "01_paddle_next_model_1" },
+
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+
+    { "act": "simulate_joy_button", "button_index": 13 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+
+    { "act": "simulate_joy_button", "button_index": 16 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+
+    { "act": "simulate_joy_button", "button_index": 17 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "screenshot", "label": "02_paddle_prev_model_1" }
+  ]
+}


### PR DESCRIPTION
## Summary

The D-pad ◀ ▶ was double-duty in the Movement/Charge phases: it stepped the move-mode menu (Normal Move / Advance / Fall Back / Remain Stationary) **and** hopped between the selected unit's models, which fought each other. Model-switching now lives on the **Steam Deck back paddles**, freeing the D-pad for menu / option navigation.

## Changes

- **`PadRouter._input`:** `JOY_BUTTON_PADDLE1/3` → next model, `PADDLE2/4` → previous model (both back-button pairs bound so whichever the controller config exposes works). Removed `_hop_model` from `JOY_BUTTON_DPAD_LEFT/RIGHT` — those now only drive deployment option-cycling / panel focus. The move-mode menu (which owns the D-pad while open) is unchanged.
- **Hints / reference:** `HINTS_MOVE_LOCKED`, `GlyphDB`, and the Controller Reference (Settings › Controls) now show `L4 ◀ Model` / `R4 Model ▶` instead of the D-pad.
- **`pad_m3_carry_move` scenario** updated to hop via the paddle (button 16).

## Validation

- New windowed scenario `tests/scenarios/sp/pad_move_paddle_model_switch.json` proves the paddles step `carry_model_index` forward/back and **D-pad LEFT/RIGHT no longer do** (27/27).
- Regression (all pass): `pad_m3_carry_move`, `pad_m4_move_action_menu` (D-pad menu nav intact), `pad_move_illegal_drop_keeps_model`, and the deployment D-pad scenarios (`pad_deploy_model_type_rows`, `pad_reinforcement_formation_row`, `pad_deploy_unit_cycling`).
- Screenshot confirms the `L4 ◀ Model` / `R4 Model ▶` hint chips render.

## Caveat (not verified in-engine)

Whether a **physical Deck's L4/R4 reach the game as PADDLE buttons is Steam Input / SDL dependent** — running the native build directly this works via SDL; under Steam's controller layer the paddles may need mapping to the paddle buttons. The in-engine routing (`button_index → _hop_model`) is proven; hardware pass-through is not. If it doesn't register on hardware, a reliable fallback (LB/RB switch models while the unit is locked mid-move) can be added.

Changelog bumped to `0.76.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsRzz5Qjz1DvDmmYa8AH1Y)_