### PR TITLE
Steam Deck Movement: L4/R4 model switching at every stage, incl. mid-carry

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -105,6 +105,7 @@ const HINTS_CARRY := [
 	["ls", "Move Model"],
 	["rs", "Precision"],
 	["a", "Drop"],
+	["l4/r4", "Swap Model"],
 	["lb", "Rotate ⟲"],
 	["rb", "Rotate ⟳"],
 	["b", "Cancel"],
@@ -113,6 +114,7 @@ const HINTS_CARRY := [
 const HINTS_MENU := [
 	["dpad", "Choose Action"],
 	["rb", "Cycle Units"],
+	["l4/r4", "Model ◀ ▶"],
 	["a", "Confirm"],
 	["b", "Cancel"],
 ]
@@ -123,6 +125,7 @@ const HINTS_MOVE := [
 	["rb", "Cycle Units"],
 	["a", "Move Menu"],
 	["dpad", "Move Menu"],
+	["l4/r4", "Model ◀ ▶"],
 	["ls", "Point"],
 	["lt/rt", "Zoom"],
 	["x", "Undo Model"],
@@ -216,6 +219,13 @@ func _input(event: InputEvent) -> void:
 				_apply_menu_choice(PadActionBar.activate())
 			JOY_BUTTON_B:
 				PadActionBar.close()
+			# Back paddles keep their one meaning with the menu up: hop the
+			# selected unit's models (camera-follow) so the player can pick WHICH
+			# model leads before choosing Move — the carry starts at this index.
+			JOY_BUTTON_PADDLE1, JOY_BUTTON_PADDLE3:
+				_hop_model(1)
+			JOY_BUTTON_PADDLE2, JOY_BUTTON_PADDLE4:
+				_hop_model(-1)
 		get_viewport().set_input_as_handled()
 		_update_hints()
 		return
@@ -267,7 +277,10 @@ func _input(event: InputEvent) -> void:
 			if _pad_step_shoot_target(1) or _pad_deploy_option_cycle(1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		# Steam Deck back paddles hop between the selected unit's models (Movement
-		# / Charge) — the job D-pad ◀ ▶ used to do. Both back pairs are bound so
+		# / Charge) — the job D-pad ◀ ▶ used to do. Works at every stage of the
+		# Movement phase: browsing/menu = camera hop to pick the lead model;
+		# mid-carry = revert the un-dropped model in hand and take the prev/next
+		# one (staged drops keep their spot). Both back pairs are bound so
 		# whichever the player's config exposes works: right paddles (commonly
 		# R4/R5 → PADDLE1/3) = next model, left paddles (L4/L5 → PADDLE2/4) = prev.
 		JOY_BUTTON_PADDLE1, JOY_BUTTON_PADDLE3:
@@ -822,8 +835,18 @@ func _auto_carry_next_model() -> void:
 	if unit_id != _carry_unit_id:
 		return  # unit changed under us — don't drag the camera to a new unit
 	var alive := _alive_model_count(unit_id)
-	var next_index := carry_model_index + 1
-	if next_index >= alive:
+	# Hand over the next model that has NOT been placed yet, scanning forward
+	# with wrap-around and skipping staged ones — paddle hops let models be
+	# placed out of order, and auto-handing back a model the player already
+	# dropped would silently threaten its kept position. None un-placed →
+	# leave the player in the locked state to Confirm.
+	var next_index := -1
+	for step in range(1, alive + 1):
+		var candidate := wrapi(carry_model_index + step, 0, alive)
+		if _staged_model_pos(unit_id, _alive_model_id(unit_id, candidate)) == null:
+			next_index = candidate
+			break
+	if next_index == -1:
 		return  # whole unit placed — leave the player in the locked state to Confirm
 	carry_model_index = next_index
 	if _try_begin_carry():
@@ -837,6 +860,19 @@ func _alive_model_count(unit_id: String) -> int:
 		if model.get("alive", true):
 			n += 1
 	return n
+
+
+# The id ("m1", …) of unit_id's Nth alive model, or "" when out of range.
+func _alive_model_id(unit_id: String, alive_index: int) -> String:
+	var unit = GameState.get_unit(unit_id)
+	var idx := 0
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		if idx == alive_index:
+			return str(model.get("id", ""))
+		idx += 1
+	return ""
 
 
 # Public seam for Main's Start (End-Phase / Confirm) handler: when Start is
@@ -874,7 +910,22 @@ func _cancel_carry() -> void:
 	# release (there is no dedicated drag-cancel in the mouse flow either).
 	var unit_id := _carry_unit_id
 	var staged_before := _movement_staged_count(unit_id)
-	VirtualCursor.warp_to(_carry_pickup_screen)
+	# Warp target: re-project the drag's authoritative world origin rather than
+	# trusting the remembered screen point — edge-panning during the carry makes
+	# that stale, and a release at a stale point stages a WRONG-position move.
+	# For an unstaged model the count-check undo below would still rescue it,
+	# but for a re-picked staged model the release REPLACES its stage in place
+	# (count unchanged → no undo), silently corrupting the kept position.
+	# Center the camera on the origin first so the projection is on-screen —
+	# the cursor warp clamps to the viewport.
+	var back_screen := _carry_pickup_screen
+	var m := get_tree().current_scene
+	var mc := _movement_controller()
+	if mc != null and ("dragging_model" in mc) and mc.dragging_model \
+			and ("drag_start_pos" in mc) and m != null and m.has_method("world_to_screen_position"):
+		_center_camera_on_world(mc.drag_start_pos)
+		back_screen = m.world_to_screen_position(mc.drag_start_pos)
+	VirtualCursor.warp_to(back_screen)
 	VirtualCursor.set_left_button(false)
 	carry_active = false
 	# Park (warp_to above re-activated the cursor) so the next A re-arms through
@@ -920,8 +971,6 @@ func _movement_staged_count(unit_id: String) -> int:
 
 
 func _hop_model(dir: int) -> bool:
-	if carry_active:
-		return false
 	var m := get_tree().current_scene
 	if m == null or not ("current_phase" in m):
 		return false
@@ -930,14 +979,24 @@ func _hop_model(dir: int) -> bool:
 	var ctrl = m.movement_controller if m.current_phase == GameStateData.Phase.MOVEMENT else m.charge_controller
 	if ctrl == null or not is_instance_valid(ctrl) or str(ctrl.active_unit_id) == "":
 		return false
+	if carry_active:
+		# Mid-carry hop (Movement only): put the in-hand model back where it was
+		# picked up — an un-dropped move reverts; a model already dropped with A
+		# keeps its staged spot (the cancel's count-check leaves prior stages
+		# alone) — then hand the player the prev/next model. Charge keeps its
+		# one-model-at-a-time flow.
+		if _movement_controller() == null:
+			return false
+		var alive_c := _alive_model_count(_carry_unit_id)
+		if alive_c <= 1:
+			return true  # nothing to swap to — consume without a pointless regrab
+		carry_model_index = wrapi(carry_model_index + dir, 0, alive_c)
+		_swap_carry_to_index()
+		return true
 	if str(ctrl.active_unit_id) != _carry_unit_id:
 		_carry_unit_id = str(ctrl.active_unit_id)
 		carry_model_index = 0
-	var unit = GameState.get_unit(str(ctrl.active_unit_id))
-	var alive := 0
-	for model in unit.get("models", []):
-		if model.get("alive", true):
-			alive += 1
+	var alive := _alive_model_count(str(ctrl.active_unit_id))
 	if alive == 0:
 		return false
 	carry_model_index = wrapi(carry_model_index + dir, 0, alive)
@@ -947,8 +1006,38 @@ func _hop_model(dir: int) -> bool:
 	return true
 
 
+# Mid-carry paddle hop: cancel the live carry (reverting an un-staged model to
+# its pickup spot), wait for the synthetic release + junk-stage undo to settle,
+# then pick up the model now at carry_model_index. 3 frames: _cancel_carry's
+# undo coroutine runs at frame 2, so frame 3 is safely after it — re-arming
+# earlier would make that coroutine bail on its carry_active guard and leave
+# the junk 0" stage in place.
+func _swap_carry_to_index() -> void:
+	_cancel_carry()
+	await get_tree().process_frame
+	await get_tree().process_frame
+	await get_tree().process_frame
+	if carry_active or PadActionBar.is_open():
+		return  # something else re-claimed the pad mid-swap
+	if get_viewport().gui_get_focus_owner() != null:
+		return
+	var mc := _movement_controller()
+	if mc == null or str(mc.active_unit_id) == "" or str(mc.active_unit_id) != _carry_unit_id:
+		return
+	# The player is often still deflecting the stick when the paddle clicks,
+	# which re-activates the parked cursor and would make _try_begin_carry bail.
+	# The paddle press claimed this hop — park again and take the model.
+	if VirtualCursor.is_cursor_active():
+		VirtualCursor.park()
+	if _try_begin_carry():
+		_update_hints()
+
+
 # Returns the world-space position (Vector2) of the unit's Nth alive model,
-# or null when out of range.
+# or null when out of range. In the Movement phase a model that has already
+# been dropped this move sits at its STAGED dest (GameState only updates on
+# confirm), so prefer that — hopping to / picking up a staged model must land
+# where its token visually is, not at its pre-move position.
 func _model_world_pos(unit_id: String, alive_index: int):
 	var unit = GameState.get_unit(unit_id)
 	var idx := 0
@@ -956,6 +1045,9 @@ func _model_world_pos(unit_id: String, alive_index: int):
 		if not model.get("alive", true):
 			continue
 		if idx == alive_index:
+			var staged = _staged_model_pos(unit_id, str(model.get("id", "")))
+			if staged != null:
+				return staged
 			var pos = model.get("position", null)
 			if pos is Dictionary and pos.has("x"):
 				return Vector2(float(pos.x), float(pos.y))
@@ -963,6 +1055,35 @@ func _model_world_pos(unit_id: String, alive_index: int):
 				return pos
 			return null
 		idx += 1
+	return null
+
+
+# The staged (uncommitted) destination of unit_id's own model model_id in the
+# Movement phase, or null when it has no staged move / not in Movement.
+func _staged_model_pos(unit_id: String, model_id: String):
+	if model_id == "":
+		return null
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m) or m.current_phase != GameStateData.Phase.MOVEMENT:
+		return null
+	var phase = PhaseManager.get_current_phase_instance()
+	if phase == null or not phase.has_method("get_active_move_data"):
+		return null
+	var staged: Array = phase.get_active_move_data(unit_id).get("staged_moves", [])
+	# Match on model_source_unit_id too: bodyguard and attached character
+	# model ids can collide (both "m1"); we only hop the active unit's own models.
+	for i in range(staged.size() - 1, -1, -1):
+		var sm = staged[i]
+		if str(sm.get("model_id", "")) != model_id:
+			continue
+		if str(sm.get("model_source_unit_id", unit_id)) != unit_id:
+			continue
+		var dest = sm.get("dest")
+		if dest is Vector2:
+			return dest
+		if dest is Array and dest.size() >= 2:
+			return Vector2(float(dest[0]), float(dest[1]))
+		return null
 	return null
 
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.80.0",
+			"date": "2026-07-21",
+			"summary": "Steam Deck Movement phase — the L4 / R4 back paddles now switch models at EVERY stage of the phase, not only after the whole unit has been placed. Hop between a unit's models while browsing units or with the move menu open (to pick which model leads), and press a paddle mid-carry to swap models: the model in your hand goes back where you picked it up, while models you already dropped with A keep their spots.",
+			"changes": [
+				"L4 / R4 model switching now works while a model is in hand: the un-dropped model in your hand returns to where it was picked up and the previous/next model is handed to you instead. Models you already dropped with A stay exactly where you put them.",
+				"Hopping onto a model you already dropped picks it up from its dropped position (so you can adjust it), and putting it back down or cancelling keeps that position — nothing you confirmed is ever lost by switching models.",
+				"The paddles also hop between models while the move-mode menu is open and while a unit is merely selected (the camera follows), so you can choose which model to lead with before choosing Move.",
+				"After you drop a model, the automatic hand-off now skips models you already placed and hands you the next un-moved one — placing models out of order no longer hands you an already-placed model back.",
+				"The hint bar now shows the paddles wherever they work: 'L4/R4 Model ◀ ▶' with a unit selected or the move menu open, and 'L4/R4 Swap Model' while carrying — not just in the all-models-placed state."
+			]
+		},
+		{
 			"version": "0.79.0",
 			"date": "2026-07-21",
 			"summary": "Steam Deck Save/Load — the controller now actually works in the Save & Load window. Opening it used to leave the D-pad stuck on the main-menu buttons drawn behind it, so you could never pick a saved game to load. Now focus jumps straight into the window and lands on your list of saves: the D-pad walks the saved games (and every button), A loads the highlighted one, and B closes the window and returns you to where you were.",

--- a/40k/tests/scenarios/sp/pad_move_carry_hop_swap.json
+++ b/40k/tests/scenarios/sp/pad_move_carry_hop_swap.json
@@ -1,0 +1,94 @@
+{
+  "id": "pad_move_carry_hop_swap",
+  "covers": [
+    "controller.move.paddle_swap_mid_carry",
+    "controller.move.paddle_revert_unstaged",
+    "controller.move.paddle_keeps_staged",
+    "controller.move.paddle_menu_hop"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "L4/R4 back-paddle model switching works at EVERY stage of the Movement phase, not only the all-models-placed locked state. With the move-mode menu open the paddles hop between the unit's models (choosing which model the carry starts with) without closing the menu. Mid-carry, a paddle press puts the un-dropped model in hand back where it was picked up (its move reverts, no stage left behind) and hands over the prev/next model; a model already dropped with A keeps its staged position — hopping back to it picks it up AT that staged spot, and a later cancel returns it there. Confirming lands only the staged model's move in GameState.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w0y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y)" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w1y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y)" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w2y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[2].position.y)" },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 16 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 17 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 0 },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "main.movement_controller.dragging_model", "equals": true },
+    { "act": "screenshot", "label": "01_model0_in_hand" },
+
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 140.0 },
+    { "act": "simulate_joy_button", "button_index": 16 },
+    { "act": "wait_seconds", "seconds": 0.7 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 0 },
+    { "act": "screenshot", "label": "02_swapped_to_model1_model0_reverted" },
+
+    { "act": "pad_cursor_glide", "x": 910.0, "y": 100.0 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"d1x\", PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.x)" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"d1y\", PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.y)" },
+
+    { "act": "simulate_joy_button", "button_index": 16 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+
+    { "act": "pad_cursor_glide", "x": 970.0, "y": 140.0 },
+    { "act": "simulate_joy_button", "button_index": 17 },
+    { "act": "wait_seconds", "seconds": 0.7 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "main.movement_controller.drag_start_pos.distance_to(PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest)", "expect_max": 8 },
+    { "act": "screenshot", "label": "03_staged_model_repicked_at_staged_spot" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "abs(PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.x - InputDeviceManager.get_meta(\"d1x\"))", "expect_max": 8 },
+    { "act": "execute_script", "script": "abs(PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.y - InputDeviceManager.get_meta(\"d1y\"))", "expect_max": 8 },
+
+    { "act": "pad_cursor_glide", "button_text": "End This Unit's Move" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y - InputDeviceManager.get_meta(\"w1y\"))", "expect_min": 35 },
+    { "act": "execute_script", "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y - InputDeviceManager.get_meta(\"w0y\"))", "expect_max": 1 },
+    { "act": "execute_script", "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[2].position.y - InputDeviceManager.get_meta(\"w2y\"))", "expect_max": 1 },
+    { "act": "screenshot", "label": "04_confirm_only_staged_model_moved" }
+  ]
+}


### PR DESCRIPTION
## Problem

The L4/R4 back-paddle model switch was dead exactly where it mattered. `PadRouter._hop_model` bailed out whenever a model was in hand — and since the moving-by-default flow keeps a model in your hand for the whole move, the paddles effectively only worked (and their hint chip only appeared) once **every** model in the unit had already been placed, by which point switching models is pointless.

## What changed

Model switching now works at **every stage** of the Movement phase, matching the requested behaviour:

- **Mid-carry swap** — pressing L4/R4 while holding a model puts it back where it was picked up (its un-dropped move fully reverts, no stray 0" stage left behind) and hands you the previous/next model. Models you already dropped with **A keep their spots** — hopping back onto one picks it up *at* its dropped position so you can nudge it, and putting it down or cancelling leaves it there. Confirming (Start) lands only the models you actually placed.
- **Browsing / menu** — paddles also hop between a unit's models while you're cycling units with LB/RB (camera follows) and while the move-mode menu is open, so you can choose which model leads before picking "Move". The carry then starts on that model.
- **Order-independent auto hand-off** — after a drop, the next model handed to you skips ones you already placed, so out-of-order placement (now reachable via hops) never hands back an already-placed model.
- **Hint bar** advertises the paddles wherever they work: `L4/R4 Model ◀ ▶` with a unit selected or the menu open, and `L4/R4 Swap Model` while carrying.

Two latent bugs fixed along the way:
- Picking up an already-placed model used to warp the cursor to its *pre-move* position (empty board) — `_model_world_pos` now prefers a model's staged dest over its GameState position.
- Cancelling a carry after the camera edge-panned could silently re-stage a picked-up staged model at the wrong spot — `_cancel_carry` now re-projects the drag's authoritative world origin instead of the stale remembered screen point.

Charge phase deliberately keeps its one-model-at-a-time carry; paddles still hop there when not carrying.

## Validation

Verified windowed (project gate), not headless-only:

- New scenario `pad_move_carry_hop_swap` (67/67 steps) exercises the full swap / revert / keep-staged / skip-staged / confirm path.
- Regression suite green: `pad_m3_carry_move`, `pad_move_paddle_model_switch`, `pad_p0_move_clamp`, `pad_move_illegal_drop_keeps_model`, `pad_m4_move_action_menu`, `pad_bumper_only_unit_cycling`, `pad_charge_target_toggle`.
- After rebasing onto the concurrently-merged #709 (D-pad panel-trap) and #711 (Save/Load focus), re-validated the integration windowed: my scenario plus `pad_move_dpad_menu_no_panel_trap`, `pad_saveload_ingame_focus`, and `pad_saveload_menu_focus` all pass — the auto-merged `PadRouter.gd` is behaviorally sound.
- Live MCP-bridge drive of the running windowed game confirmed the semantics end-to-end: staged-model pickup at distance `0.0`, staged position surviving a pass-through, skip-staged auto hand-off, and final confirm moving only the placed models — with `verify_delivery` verdict **PASS** and zero log errors. Screenshots captured the carry with the new hint chips rendered.

Note: `pad_m3_carry_deploy` fails identically on the base commit (missing "Deploy Without Embarking" button) — pre-existing and unrelated to this change. The "Coverage matrix validation" CI check is red for this PR, but it fails on **160 scenarios on `main` already** (every existing pad scenario, including #709's own just-merged one); it is a non-required check the repo merges through. This PR's 4 new cover tags follow the same unregistered pattern as all sibling pad scenarios.

## Player-facing changelog

Version bumped to `0.80.0` in `40k/data/version_history.json` (was authored as `0.79.0`, renumbered to `0.80.0` after #711 took `0.79.0` on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)