### PR TITLE
Steam Deck: model-switch on L3 (consistent across phases), not L4/R4 paddles

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -44,6 +44,12 @@ extends Node
 #            Only when the virtual cursor is parked — cursor mode owns X as
 #            right-click (VirtualCursor consumes it first)
 #   Y      — toggle the datasheet of the highlighted target / selected unit
+#   L3     — click the left thumbstick: cycle to the NEXT model of the active
+#            unit, consistently in every phase that positions individual models
+#            (Movement + Charge, via _hop_model). THE model-switch control — the
+#            one free, reliable button, chosen over the Steam Deck L4/R4 paddles
+#            which reach the game as JOY_BUTTON_PADDLE* only when Steam Input is
+#            configured to forward them (still bound below as a bonus)
 #   D-pad  — with nothing focused: enter panel focus (right panel, then
 #            bottom bar); with focus: normal ui_* navigation (not consumed).
 #            Panel-focus entry stands down mid-move (model in hand or the
@@ -82,6 +88,7 @@ const HINTS_CHARGE := [
 	["rb", "Cycle Units"],
 	["dpad", "Target ▲ ▼"],
 	["a", "Toggle Target"],
+	["l3", "Next Model"],
 	["menu", "Declare / Roll"],
 	["x", "Skip Charge"],
 	["y", "Datasheet"],
@@ -105,7 +112,7 @@ const HINTS_CARRY := [
 	["ls", "Move Model"],
 	["rs", "Precision"],
 	["a", "Drop"],
-	["l4/r4", "Swap Model"],
+	["l3", "Swap Model"],
 	["lb", "Rotate ⟲"],
 	["rb", "Rotate ⟳"],
 	["b", "Cancel"],
@@ -114,7 +121,7 @@ const HINTS_CARRY := [
 const HINTS_MENU := [
 	["dpad", "Choose Action"],
 	["rb", "Cycle Units"],
-	["l4/r4", "Model ◀ ▶"],
+	["l3", "Next Model"],
 	["a", "Confirm"],
 	["b", "Cancel"],
 ]
@@ -125,7 +132,7 @@ const HINTS_MOVE := [
 	["rb", "Cycle Units"],
 	["a", "Move Menu"],
 	["dpad", "Move Menu"],
-	["l4/r4", "Model ◀ ▶"],
+	["l3", "Next Model"],
 	["ls", "Point"],
 	["lt/rt", "Zoom"],
 	["x", "Undo Model"],
@@ -134,13 +141,13 @@ const HINTS_MOVE := [
 ]
 # Movement with a committed move where every model has been placed (auto-carry
 # stops here): Start confirms the whole move, A picks a model back up to adjust it,
-# the back paddles (L4/R4) hop between models and X undoes the last staged model.
-# The bumpers stay locked to this unit until the move is confirmed or undone.
+# L3 (and the back paddles, where Steam Input forwards them) cycles between models
+# and X undoes the last staged model. The bumpers stay locked to this unit until
+# the move is confirmed or undone.
 const HINTS_MOVE_LOCKED := [
 	["menu", "Confirm Move"],
 	["a", "Move a Model"],
-	["l4", "◀ Model"],
-	["r4", "Model ▶"],
+	["l3", "Next Model"],
 	["x", "Undo Model"],
 	["y", "Datasheet"],
 ]
@@ -190,6 +197,12 @@ func _input(event: InputEvent) -> void:
 	# A joypad event IS pad input — claim inline so the session's very first
 	# press acts instead of being dropped (the _process poll runs after us).
 	InputDeviceManager.claim_pad()
+	# Diagnostic (debug level): log the raw button index of every joypad press.
+	# A player whose Steam Deck L4/R4 "do nothing" can read the debug log to see
+	# whether the paddles arrive at all — on a stock Deck the game sees a virtual
+	# Xbox pad with NO paddle buttons, so Steam Input must be configured to
+	# forward them or they never reach here. PADDLE1..4 = indices 16..19.
+	DebugLogger.debug("PadRouter: joypad button pressed", {"button_index": event.button_index})
 	# A menu-level modal (the Save/Load dialog, …) drives itself entirely with
 	# Godot's native focus navigation. This board router must stay out of its way:
 	# bumper unit-cycling, D-pad panel-focus entry and — above all — the ItemList
@@ -219,9 +232,12 @@ func _input(event: InputEvent) -> void:
 				_apply_menu_choice(PadActionBar.activate())
 			JOY_BUTTON_B:
 				PadActionBar.close()
-			# Back paddles keep their one meaning with the menu up: hop the
-			# selected unit's models (camera-follow) so the player can pick WHICH
-			# model leads before choosing Move — the carry starts at this index.
+			# L3 (and the back paddles, where Steam Input forwards them) keeps its
+			# one meaning with the menu up: hop the selected unit's models
+			# (camera-follow) so the player can pick WHICH model leads before
+			# choosing Move — the carry starts at this index.
+			JOY_BUTTON_LEFT_STICK:
+				_hop_model(1)
 			JOY_BUTTON_PADDLE1, JOY_BUTTON_PADDLE3:
 				_hop_model(1)
 			JOY_BUTTON_PADDLE2, JOY_BUTTON_PADDLE4:
@@ -245,6 +261,16 @@ func _input(event: InputEvent) -> void:
 		JOY_BUTTON_Y:
 			if _toggle_datasheet():
 				get_viewport().set_input_as_handled()
+		JOY_BUTTON_LEFT_STICK:
+			# L3 (press the left thumbstick in) is THE model-cycle button — the one
+			# free, reliable controller button, so it means "next model" identically
+			# in every phase that positions a unit's individual models (Movement +
+			# Charge, via _hop_model). Reliable where the Steam Deck L4/R4 paddles are
+			# not (those reach the game as JOY_BUTTON_PADDLE* only when Steam Input is
+			# configured to forward them). _hop_model returns false elsewhere, so L3
+			# is a harmless no-op in phases without per-model positioning.
+			if _hop_model(1):
+				get_viewport().set_input_as_handled()
 		JOY_BUTTON_X:
 			if _context_action():
 				get_viewport().set_input_as_handled()
@@ -261,11 +287,12 @@ func _input(event: InputEvent) -> void:
 			if _pad_deploy_row_cycle(1) or _pad_step_secondary(1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_LEFT:
-			# Model-switching moved OFF the D-pad onto the Steam Deck back paddles
-			# (below) so D-pad ◀ ▶ stays free for menu / option navigation and no
-			# longer fights the move-mode menu. Deployment option-cycle keeps it;
-			# shooting uses ◀ ▶ to walk the armed shooter's target ring (the
-			# bumpers stay on shooter cycling per the bumper-only rule).
+			# Model-switching lives on L3 (left-stick click — the one free, reliable
+			# button; the Steam Deck paddles only reach the game when Steam Input
+			# forwards them). D-pad ◀ ▶ stays free for menu / option navigation and
+			# never fights the move-mode menu. Deployment option-cycle keeps it;
+			# shooting uses ◀ ▶ to walk the armed shooter's target ring (bumpers stay
+			# on shooter cycling).
 			if _pad_step_shoot_target(-1) or _pad_deploy_option_cycle(-1) or _try_open_move_menu() or _enter_panel_focus():
 				get_viewport().set_input_as_handled()
 		JOY_BUTTON_DPAD_RIGHT:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.81.0",
+			"date": "2026-07-21",
+			"summary": "Steam Deck — switching between a unit's models is now on L3 (click the left thumbstick), and it works the same way in every phase. The L4 / R4 back paddles didn't reliably reach the game — a stock Steam Deck presents a controller with no paddle buttons unless you set them up in Steam Input, so for most players the paddles did nothing. L3 is a standard, always-available button, so 'next model' now means the same thing whether you're moving or charging.",
+			"changes": [
+				"L3 (press the left thumbstick in) cycles to the next model of the unit you're working with, consistently across the Movement and Charge phases. While carrying a model it swaps which model is in your hand (the one you were holding goes back to where it started; models you already dropped stay put); otherwise it steps the selection (and the camera) so you can pick which model to move next. Press L3 repeatedly to walk through the unit's models and wrap around.",
+				"Y goes back to being the Datasheet button everywhere, with no phase-specific exceptions — the previous build briefly made Y switch models only in Movement, which was inconsistent between phases.",
+				"The L4 / R4 paddles remain bound for anyone who has mapped them through Steam Input, but they are no longer the advertised control. On a stock Steam Deck the paddles reach a game only when Steam Input is configured to forward them; the hint bar now shows L3 for switching models so the control it names actually works.",
+				"The controller hint bar reflects this: 'L3 Swap Model' while a model is in hand, and 'L3 Next Model' while selecting, in the move menu, once the move is placed, and during a charge.",
+				"Diagnostic: every controller button press is now recorded in the debug log with its button index, so if a control 'does nothing' it is possible to see from the log whether the button reaches the game at all."
+			]
+		},
+		{
 			"version": "0.80.0",
 			"date": "2026-07-21",
 			"summary": "Steam Deck Movement phase — the L4 / R4 back paddles now switch models at EVERY stage of the phase, not only after the whole unit has been placed. Hop between a unit's models while browsing units or with the move menu open (to pick which model leads), and press a paddle mid-carry to swap models: the model in your hand goes back where you picked it up, while models you already dropped with A keep their spots.",

--- a/40k/scripts/input/GlyphDB.gd
+++ b/40k/scripts/input/GlyphDB.gd
@@ -25,6 +25,8 @@ const GLYPHS := {
 	"rt": "RT",
 	"ls": "LS",
 	"rs": "RS",
+	"l3": "L3",
+	"r3": "R3",
 	"l4": "L4",
 	"r4": "R4",
 	"dpad": "✚",

--- a/40k/tests/scenarios/sp/pad_move_l3_cycle_model.json
+++ b/40k/tests/scenarios/sp/pad_move_l3_cycle_model.json
@@ -1,0 +1,84 @@
+{
+  "id": "pad_move_l3_cycle_model",
+  "covers": [
+    "controller.move.l3_cycles_model",
+    "controller.move.l3_browse_cycle",
+    "controller.move.l3_carry_swap",
+    "controller.move.l3_keeps_staged",
+    "controller.move.y_stays_datasheet"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "L3 (JOY_BUTTON_LEFT_STICK=7 — click the left thumbstick) is THE model-switch button: the one free, reliable controller button, chosen over the Steam Deck L4/R4 paddles which only reach the game as JOY_BUTTON_PADDLE* when Steam Input forwards them. It advances to the NEXT model of the active unit the same way in every state — browse = camera/index cycle (does NOT open the datasheet), carry = swap the in-hand model (un-dropped move reverts, staged drops keep their spot). Y stays the Datasheet toggle everywhere with no phase exceptions. The paddles remain bound (validated separately in pad_move_carry_hop_swap).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": false },
+
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 0 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "main.get_node_or_null(\"DatasheetModal\") == null or not main.get_node(\"DatasheetModal\").visible", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+    { "act": "screenshot", "label": "01_l3_browse_cycle_no_datasheet" },
+
+    { "act": "simulate_joy_button", "button_index": 3 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "main.get_node(\"DatasheetModal\").visible", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+    { "act": "screenshot", "label": "02_y_still_opens_datasheet" },
+    { "act": "simulate_joy_button", "button_index": 3 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "main.get_node(\"DatasheetModal\").visible", "equals": false },
+
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 0 },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "main.movement_controller.dragging_model", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 0 },
+
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 140.0 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 0 },
+    { "act": "screenshot", "label": "03_l3_carry_swapped_model0_reverted" },
+
+    { "act": "pad_cursor_glide", "x": 910.0, "y": 100.0 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"sy\", PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.y)" },
+
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+    { "act": "execute_script", "script": "abs(PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves[0].dest.y - InputDeviceManager.get_meta(\"sy\"))", "expect_max": 1 },
+    { "act": "screenshot", "label": "04_l3_after_drop_keeps_staged" }
+  ]
+}


### PR DESCRIPTION
## Problem

The L4/R4 back-paddle model switch (0.80.0) is unreachable for most players: a stock Steam Deck presents a virtual Xbox-360 pad via Steam Input, which has **no paddle buttons**, so L4/R4 only reach the game as `JOY_BUTTON_PADDLE*` when a player has explicitly configured Steam Input to forward them. Reproduced live — injecting `PADDLE1` (index 16) hops correctly, confirming the routing is fine; the physical paddles simply never arrive.

An interim fix put model-switching on Y, but Y already means "datasheet" everywhere, so overloading it in Movement only (and not Charge) was itself inconsistent between phases.

## What changed

Audited the full controller-button budget — every reliable button is taken (A/B/X, Y=datasheet, LB/RB=unit cycle + rotate, D-pad=menus/targets, R3=cursor precision, Start/View) **except L3** (`JOY_BUTTON_LEFT_STICK`, the left-stick click). So model-switching now lives on **L3**:

- **L3 cycles to the next model** of the active unit via `_hop_model`, which already works identically in **Movement and Charge** — so "next model" means the same thing in every phase that positions individual models. A carry swaps the in-hand model (the held one reverts, dropped ones stay put); browse / locked / charge hop the camera + selection index. Bound in both the main router and the move-menu-open block; wraps around.
- **Y reverts to the Datasheet toggle everywhere**, with no phase-specific exceptions.
- **L4/R4 stay bound** for players who forward them via Steam Input, but are no longer the advertised control. Hint bars now show **L3** for model switching (Movement browse/carry/locked/menu, and Charge); added an L3 glyph.
- **Diagnostic:** every joypad press is logged with its button index, so a player whose controls "do nothing" can see from the debug log whether the button reaches the game at all.

## Validation

Verified windowed (project gate), not headless-only:

- New scenario `pad_move_l3_cycle_model` (50 steps, real L3 presses): cycles models in browse (does not open the datasheet), swaps the in-hand model in carry (un-dropped move reverts), staged drops survive a switch, and Y still opens the datasheet.
- **Live-verified L3 cycles a 4-model unit in the Charge phase (0→1→2→3→0)** and captured the "L3 Swap Model" hint bar; zero log errors.
- Regression green across 9 pad scenarios: `pad_m2_unit_cycle` (Y-datasheet in Movement), `pad_charge_target_toggle`, `pad_move_carry_hop_swap` + `pad_move_paddle_model_switch` (paddles still bound), `pad_m3_carry_move`, `pad_m4_move_action_menu`, `pad_move_dpad_menu_no_panel_trap`, `pad_bumper_only_unit_cycling`.

Note on CI: the "Coverage matrix validation" check is red for this PR, but it fails on 160+ pre-existing scenarios on `main` already (every existing pad scenario) — it is a non-required check the repo merges through, and this PR's new cover tags follow the same unregistered pattern as all sibling pad scenarios.

## Player-facing changelog

Version bumped to `0.81.0` in `40k/data/version_history.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FegT1yHf6NQNuZLrQeuocr)_