### PR TITLE
Controller multi-step model movement: A-drop keeps focus, X finishes model

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -39,10 +39,18 @@ extends Node
 #   A      — in TARGET_SELECT: assign the highlighted target to the current
 #            weapon (cursor mode and focused controls keep their own A)
 #   B      — release panel focus back to the board; with an active shooter,
-#            deselect (the shoot_cancel_target semantic)
+#            deselect (the shoot_cancel_target semantic). Movement: a clean B
+#            (nothing to release/park) undoes the last staged model — the
+#            mouse "Undo Last Model" button (X used to hold this job).
 #   X      — context action: skip the active shooter (shoot_skip_unit).
-#            Only when the virtual cursor is parked — cursor mode owns X as
-#            right-click (VirtualCursor consumes it first)
+#            Movement: "this model is finished" — mid-carry it drops the held
+#            model AND hands over the unit's next un-placed model; after an
+#            A-drop it does the same from the parked state. This is the
+#            multi-step seam: A taps waypoints (drop, re-pick, drop — the
+#            model keeps focus and its staged budget accumulates), X seals
+#            the model and advances. Otherwise only when the virtual cursor
+#            is parked — cursor mode owns X as right-click (VirtualCursor
+#            consumes it first, except mid-carry where the router owns X)
 #   Y      — toggle the datasheet of the highlighted target / selected unit
 #   D-pad  — with nothing focused: enter panel focus (right panel, then
 #            bottom bar); with focus: normal ui_* navigation (not consumed).
@@ -111,6 +119,21 @@ const HINTS_CARRY := [
 	["b", "Cancel"],
 	["menu", "Confirm / End"],
 ]
+# Movement carry: same as HINTS_CARRY plus the multi-step contract — A drops a
+# waypoint (the model KEEPS focus; A again picks it back up to keep going with
+# whatever movement it has left), X drops AND seals the model, advancing to the
+# unit's next un-placed model. Charge keeps the plain HINTS_CARRY.
+const HINTS_CARRY_MOVE := [
+	["ls", "Move Model"],
+	["rs", "Precision"],
+	["a", "Drop"],
+	["x", "Finish Model"],
+	["l4/r4", "Swap Model"],
+	["lb", "Rotate ⟲"],
+	["rb", "Rotate ⟳"],
+	["b", "Cancel"],
+	["menu", "Confirm / End"],
+]
 const HINTS_MENU := [
 	["dpad", "Choose Action"],
 	["rb", "Cycle Units"],
@@ -120,7 +143,8 @@ const HINTS_MENU := [
 ]
 # Movement with a selected unit whose move-mode decision is still open: ▲ ▼
 # opens the same action bar A does, so the D-pad browses the unit's phase
-# options instead of the unit list.
+# options instead of the unit list. (No X/undo chip: nothing can be staged
+# while the mode decision is still open.)
 const HINTS_MOVE := [
 	["rb", "Cycle Units"],
 	["a", "Move Menu"],
@@ -128,20 +152,33 @@ const HINTS_MOVE := [
 	["l4/r4", "Model ◀ ▶"],
 	["ls", "Point"],
 	["lt/rt", "Zoom"],
-	["x", "Undo Model"],
 	["y", "Datasheet"],
 	["menu", "End Phase"],
 ]
-# Movement with a committed move where every model has been placed (auto-carry
-# stops here): Start confirms the whole move, A picks a model back up to adjust it,
-# the back paddles (L4/R4) hop between models and X undoes the last staged model.
-# The bumpers stay locked to this unit until the move is confirmed or undone.
+# Movement mid-move with a model just dropped and models still un-placed (the
+# multi-step state): the dropped model KEEPS focus — A picks it back up to keep
+# spending its remaining move, X seals it and hands over the next un-placed
+# model, B undoes the last staged model, paddles browse freely. The bumpers
+# stay locked to this unit until the move is confirmed or undone.
+const HINTS_MOVE_STAGED := [
+	["a", "Move Model"],
+	["x", "Next Model"],
+	["l4/r4", "Model ◀ ▶"],
+	["b", "Undo Model"],
+	["y", "Datasheet"],
+	["menu", "Confirm Move"],
+]
+# Movement with a committed move where every model has been placed (X's
+# finish-model advance lands here after the last model): Start confirms the
+# whole move, A picks a model back up to adjust it, the back paddles (L4/R4)
+# hop between models and B undoes the last staged model. The bumpers stay
+# locked to this unit until the move is confirmed or undone.
 const HINTS_MOVE_LOCKED := [
 	["menu", "Confirm Move"],
 	["a", "Move a Model"],
 	["l4", "◀ Model"],
 	["r4", "Model ▶"],
-	["x", "Undo Model"],
+	["b", "Undo Model"],
 	["y", "Datasheet"],
 ]
 
@@ -660,7 +697,16 @@ func _assign_highlighted_target() -> bool:
 
 
 func _context_action() -> bool:
-	if VirtualCursor.is_cursor_active() and not carry_active:
+	# Mid-carry X (the cursor is live but VirtualCursor stands down — see its
+	# carry guard): Movement = "finish this model" — drop it here and hand
+	# over the unit's next un-placed model. Any other carry (charge) consumes
+	# the press inert so a stray X can't fire the skip-charge action or a
+	# synthetic right-click underneath a held model.
+	if carry_active:
+		if _movement_controller() != null:
+			return _finish_model_and_advance()
+		return true
+	if VirtualCursor.is_cursor_active():
 		return false  # cursor mode owns X (right-click); VC consumed it anyway
 	var sc = _shooting_controller_in_shooting_phase()
 	if sc != null and str(sc.active_shooter_id) != "":
@@ -684,15 +730,10 @@ func _context_action() -> bool:
 			and mc_scene.charge_controller.has_method("pad_skip") \
 			and mc_scene.charge_controller.pad_skip():
 		return true
-	# Movement: X = undo last staged model (plan §4.2 context action).
-	var m := get_tree().current_scene
-	if m != null and ("current_phase" in m) and m.current_phase == GameStateData.Phase.MOVEMENT \
-			and not carry_active and m.movement_controller != null and is_instance_valid(m.movement_controller) \
-			and str(m.movement_controller.active_unit_id) != "" \
-			and m.movement_controller.has_method("_on_undo_model_pressed"):
-		m.movement_controller._on_undo_model_pressed()
-		return true
-	return false
+	# Movement, parked after an A-drop (the multi-step state): X = "this model
+	# is finished" — advance to the unit's next un-placed model. The undo that
+	# used to live here moved to B (_handle_back).
+	return _finish_model_and_advance()
 
 
 func _handle_back() -> bool:
@@ -716,6 +757,16 @@ func _handle_back() -> bool:
 	if sc != null and str(sc.active_shooter_id) != "":
 		sc._keyboard_deselect_shooter()
 		target_highlight_id = ""
+		return true
+	# Movement: a clean B (no focus to release, cursor already parked) backs the
+	# move out one model — the mouse "Undo Last Model" button. X used to hold
+	# this job; it now seals models in the multi-step flow, and B is the natural
+	# back-out. Only with something actually staged, so B stays inert otherwise.
+	var mc := _movement_controller()
+	if mc != null and str(mc.active_unit_id) != "" \
+			and _movement_staged_count(str(mc.active_unit_id)) > 0 \
+			and mc.has_method("_on_undo_model_pressed"):
+		mc._on_undo_model_pressed()
 		return true
 	return false
 
@@ -769,7 +820,7 @@ func _try_begin_carry() -> bool:
 	return false
 
 
-func _drop_carry(advance := true) -> bool:
+func _drop_carry() -> bool:
 	# Movement phase: consult the controller BEFORE releasing. An illegal drop
 	# (over a wall, past the move cap, overlapping) keeps the model in hand — the
 	# "you can't put the piece on an illegal square" rule — instead of snapping it
@@ -787,36 +838,55 @@ func _drop_carry(advance := true) -> bool:
 	# Park so the cursor can't consume the next A as a stray click; with it
 	# parked, A routes back through the router (pick the model up again / confirm).
 	VirtualCursor.park()
-	# Moving-by-default: once a model is placed, hand the stick the NEXT un-moved
-	# model of the same unit automatically so the player never presses "A to pick
-	# up" between the models of a unit — the stick just keeps moving models. Stops
-	# after the last model, dropping the player into the locked state to Confirm
-	# (Start). Movement phase only; charge keeps its one-model-at-a-time flow.
-	# advance=false when Start places the held model to end the whole move, so the
-	# player isn't handed another model at the very moment they asked to confirm.
-	if advance and _movement_controller() != null and not _in_windowed_scenario():
-		call_deferred("_auto_carry_next_model")
+	# The dropped model KEEPS the focus (carry_model_index untouched): a drop is
+	# a waypoint, not a hand-off. A picks the same model back up to spend its
+	# remaining move in another leg (multi-step around terrain, mouse parity with
+	# release-and-re-drag); X seals the model and advances to the next un-placed
+	# one; L4/R4 browse freely. Nothing is auto-grabbed on the player's behalf.
+	# The hint bar is refreshed once the queued release has actually staged —
+	# the _input-tail refresh runs too early and would advertise the pre-drop set.
+	call_deferred("_refresh_hints_settled")
 	return true
 
 
-func _in_windowed_scenario() -> bool:
-	# Auto-carry-after-drop is a real-play smoothness affordance. The committed
-	# carry scenarios (pad_m3_carry_move, pad_p0_move_clamp, …) assert the manual
-	# contract — a drop parks the cursor (is_carrying == false) and the R4 paddle
-	# then hops to the next model — so suppress the auto-hand-off under the scenario
-	# runner, exactly as SettingsService suppresses the pad text-boost for the same
-	# reason. The feature is validated live via the MCP bridge, not the runner.
-	for a in OS.get_cmdline_args() + OS.get_cmdline_user_args():
-		if typeof(a) == TYPE_STRING and a.begins_with("--scenario-file="):
-			return true
-	return false
+func _refresh_hints_settled() -> void:
+	# A drop's synthetic release travels the input queue and its
+	# STAGE_MODEL_MOVE lands a frame or two later; refresh the hint bar after
+	# that so the multi-step affordances (A Move Model / X Next Model / B Undo
+	# Model) appear right at the drop instead of only on the next press.
+	await get_tree().process_frame
+	await get_tree().process_frame
+	_update_hints()
 
 
-func _auto_carry_next_model() -> void:
-	# Runs a couple frames after a drop so the STAGE_MODEL_MOVE from the released
+# X in the Movement phase: "this model is finished". Mid-carry it first drops
+# the held model (same legality gate as A — an illegal spot keeps it in hand);
+# from the parked multi-step state it advances directly. Either way the unit's
+# next un-placed model is then handed to the stick. Returns true when the press
+# was consumed (movement context existed), false to let X fall through.
+func _finish_model_and_advance() -> bool:
+	var mc := _movement_controller()
+	if mc == null or str(mc.active_unit_id) == "":
+		return false
+	if carry_active:
+		if not _drop_carry():
+			return true  # illegal spot: toast shown, model stays in hand
+	elif not _movement_session_locked():
+		return false  # no move in progress — nothing to finish
+	# Browsing with the pad after mouse-staged moves (or a unit switch) can leave
+	# the carry bookkeeping on another unit; re-anchor before the deferred scan.
+	if str(mc.active_unit_id) != _carry_unit_id:
+		_carry_unit_id = str(mc.active_unit_id)
+		carry_model_index = 0
+	call_deferred("_carry_next_unplaced_model")
+	return true
+
+
+func _carry_next_unplaced_model() -> void:
+	# Runs a couple frames after X so the STAGE_MODEL_MOVE from a just-released
 	# model lands first (and so a Start/B pressed in the same frame wins). Advances
-	# in alive-model order within the SAME unit; stops once the last model has been
-	# placed so the player sits in the locked state and Start confirms the move.
+	# in alive-model order within the SAME unit; with every model placed it leaves
+	# the player in the locked state where Start confirms the move.
 	await get_tree().process_frame
 	await get_tree().process_frame
 	if carry_active:
@@ -837,9 +907,8 @@ func _auto_carry_next_model() -> void:
 	var alive := _alive_model_count(unit_id)
 	# Hand over the next model that has NOT been placed yet, scanning forward
 	# with wrap-around and skipping staged ones — paddle hops let models be
-	# placed out of order, and auto-handing back a model the player already
-	# dropped would silently threaten its kept position. None un-placed →
-	# leave the player in the locked state to Confirm.
+	# placed out of order, and handing back a model the player already dropped
+	# would silently threaten its kept position.
 	var next_index := -1
 	for step in range(1, alive + 1):
 		var candidate := wrapi(carry_model_index + step, 0, alive)
@@ -847,7 +916,10 @@ func _auto_carry_next_model() -> void:
 			next_index = candidate
 			break
 	if next_index == -1:
-		return  # whole unit placed — leave the player in the locked state to Confirm
+		# Whole unit placed — tell the player what X can't do any more and where
+		# the flow goes next, then leave them in the locked state to Confirm.
+		ToastManager.show_toast("All models placed — Start confirms the move")
+		return
 	carry_model_index = next_index
 	if _try_begin_carry():
 		_update_hints()
@@ -884,7 +956,7 @@ func _alive_model_id(unit_id: String, alive_index: int) -> String:
 func confirm_from_carry() -> bool:
 	if not carry_active:
 		return false
-	if _drop_carry(false):
+	if _drop_carry():
 		call_deferred("_confirm_move_after_drop")
 	# Even if the drop was illegal (still carrying) we've handled the press — the
 	# player gets the "can't place here" toast rather than a stray phase confirm.
@@ -1317,7 +1389,9 @@ func _shooting_controller_in_shooting_phase() -> Node:
 func _update_hints() -> void:
 	var hints := HINTS_BOARD
 	if carry_active:
-		hints = HINTS_CARRY
+		# Movement carries advertise the multi-step X (Finish Model); charge
+		# carries keep the plain set — charge has no per-model advance.
+		hints = HINTS_CARRY_MOVE if _movement_controller() != null else HINTS_CARRY
 	elif PadActionBar.is_open():
 		hints = HINTS_MENU
 	elif get_viewport().gui_get_focus_owner() != null:
@@ -1335,7 +1409,10 @@ func _update_hints() -> void:
 			elif _movement_menu_available():
 				hints = HINTS_MOVE
 			elif _movement_session_locked():
-				hints = HINTS_MOVE_LOCKED
+				# Mid-move with models still to place = the multi-step state
+				# (A re-picks the dropped model, X advances); all placed = the
+				# locked state waiting on Start.
+				hints = HINTS_MOVE_STAGED if _movement_has_unplaced_models() else HINTS_MOVE_LOCKED
 	PadHintBar.set_hints(hints)
 
 
@@ -1359,6 +1436,20 @@ func _movement_controller() -> Node:
 func _movement_session_locked() -> bool:
 	var mc := _movement_controller()
 	return mc != null and mc.has_method("pad_is_move_session_locked") and mc.pad_is_move_session_locked()
+
+
+# True while the active movement unit still has at least one alive model with
+# no staged destination — the multi-step state where X ("Next Model") has
+# somewhere to advance to.
+func _movement_has_unplaced_models() -> bool:
+	var mc := _movement_controller()
+	if mc == null or str(mc.active_unit_id) == "":
+		return false
+	var unit_id := str(mc.active_unit_id)
+	for i in range(_alive_model_count(unit_id)):
+		if _staged_model_pos(unit_id, _alive_model_id(unit_id, i)) == null:
+			return true
+	return false
 
 
 # Movement phase with a selected unit whose move-mode decision is still open

--- a/40k/autoloads/VirtualCursor.gd
+++ b/40k/autoloads/VirtualCursor.gd
@@ -252,6 +252,12 @@ func _input(event: InputEvent) -> void:
 				_emit_button(MOUSE_BUTTON_LEFT, event.pressed)
 				get_viewport().set_input_as_handled()
 			JOY_BUTTON_X:
+				# Mid-carry the router owns X too (Movement "Finish Model" —
+				# drop + advance to the next un-placed model). A synthetic RMB
+				# under a held model was never useful anyway: rotation is on
+				# LB/RB, and a same-spot RMB tap rotates nothing.
+				if PadRouter.is_carrying():
+					return
 				_emit_button(MOUSE_BUTTON_RIGHT, event.pressed)
 				get_viewport().set_input_as_handled()
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.81.0",
+			"date": "2026-07-21",
+			"summary": "Controller multi-step model movement — moving a model in several legs (around terrain, through a gap) now works on the pad like it does with the mouse. Dropping a model with A keeps it in focus: press A again to pick it back up and keep spending its remaining movement. When the model is where you want it, X finishes it and hands you the unit's next un-moved model. B undoes the last placed model.",
+			"changes": [
+				"A drops the carried model as a waypoint and KEEPS it selected — it no longer auto-jumps you to the next model. Press A again to pick the same model back up from where it stands and continue its move; the inches already used carry over, exactly like releasing and re-dragging with the mouse.",
+				"X is the new 'this model is finished' button: mid-carry it drops the model AND hands you the unit's next un-moved model in one press; after a drop it does the same from the parked state. On a one-model unit a single X seals the move.",
+				"When every model has been placed, X tells you so with a toast ('All models placed — Start confirms the move') and Start confirms as before.",
+				"Undo moved from X to B: a plain B press (nothing held, nothing focused) takes back the last placed model. B while carrying still cancels the pickup, and the L4/R4 paddles still hop between models at any time.",
+				"The hint bar teaches the flow as you go: while carrying it shows 'A Drop · X Finish Model', after a drop 'A Move Model · X Next Model · B Undo Model · Start Confirm Move', and once every model is placed the locked set with 'B Undo Model'."
+			]
+		},
+		{
 			"version": "0.80.0",
 			"date": "2026-07-21",
 			"summary": "Steam Deck Movement phase — the L4 / R4 back paddles now switch models at EVERY stage of the phase, not only after the whole unit has been placed. Hop between a unit's models while browsing units or with the move menu open (to pick which model leads), and press a paddle mid-carry to swap models: the model in your hand goes back where you picked it up, while models you already dropped with A keep their spots.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -5450,9 +5450,9 @@ func _input(event: InputEvent) -> void:
 	if event.is_action_pressed("pad_phase_action"):
 		if current_phase == GameStateData.Phase.MOVEMENT and PadRouter \
 				and PadRouter.has_method("confirm_from_carry") and PadRouter.confirm_from_carry():
-			# A model is in hand (the moving-by-default carry): place it and confirm
-			# the unit's move via PadRouter, instead of confirming underneath the live
-			# carry and stranding the still-held cursor. State-checked here (not just
+			# A model is in hand (mid-carry): place it and confirm the unit's move
+			# via PadRouter, instead of confirming underneath the live carry and
+			# stranding the still-held cursor. State-checked here (not just
 			# consumed in PadRouter._input) so it works regardless of _input order.
 			get_viewport().set_input_as_handled()
 			return

--- a/40k/tests/scenarios/sp/pad_m3_carry_move.json
+++ b/40k/tests/scenarios/sp/pad_m3_carry_move.json
@@ -9,7 +9,7 @@
   "transition_to_phase": 7,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M3 model carry in the Movement phase: A (cursor parked) opens the M4 move-mode action bar; A again ('Move') begins the carry — the active model rides the cursor with a held synthetic LMB (the real drag pipeline runs), the stick drives it within the move cap and unit coherency, A drops (staged_moves grows), the R4 back paddle (PADDLE1) hops to the next model for a second carry, X undoes the last staged model, Confirm Move lands only the kept move in GameState; then the oval-based jetbike is carried, rotated with LB (rebindable rotate_left synthesized), and the carry cancelled with B.",
+  "description": "M3 model carry in the Movement phase: A (cursor parked) opens the M4 move-mode action bar; A again ('Move') begins the carry — the active model rides the cursor with a held synthetic LMB (the real drag pipeline runs), the stick drives it within the move cap and unit coherency, A drops (staged_moves grows; the dropped model KEEPS focus — multi-step contract), the R4 back paddle (PADDLE1) hops to the next model for a second carry, B (clean press) undoes the last staged model (X now means Finish Model), Confirm Move lands only the kept move in GameState; then the oval-based jetbike is carried, rotated with LB (rebindable rotate_left synthesized), and the carry cancelled with B.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -169,16 +169,13 @@
       "label": "03_second_model_dropped"
     },
     {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 1
+    },
+    {
       "act": "simulate_joy_button",
       "button_index": 1
-    },
-    {
-      "act": "wait_seconds",
-      "seconds": 0.2
-    },
-    {
-      "act": "simulate_joy_button",
-      "button_index": 2
     },
     {
       "act": "wait_seconds",

--- a/40k/tests/scenarios/sp/pad_move_multistep_model.json
+++ b/40k/tests/scenarios/sp/pad_move_multistep_model.json
@@ -1,0 +1,300 @@
+{
+  "id": "pad_move_multistep_model",
+  "covers": [
+    "controller.multistep.drop_keeps_focus",
+    "controller.multistep.repick_accumulates",
+    "controller.multistep.x_finish_advances",
+    "controller.multistep.b_undo_staged"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Multi-step controller model movement (mouse release-and-re-drag parity): A drops the carried Witchseeker at a waypoint and the model KEEPS focus (no auto-advance) — A again picks the SAME model back up at its STAGED spot and the second leg accumulates path distance (|A→B| + |B→C|, not straight-line). X mid-carry seals the model (drop + hand over the unit's next un-placed model, auto-carried); a plain A-drop on that second model again keeps focus; a clean B undoes the last staged model; X from the parked multi-step state advances to the next un-placed model; B mid-carry still cancels the leg. Start then confirms the whole unit: only the sealed multi-leg model moved in GameState.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 7
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"w0x\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.x)"
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"w0y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y)"
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"w1y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y)"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_WITCHSEEKERS_C"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_WITCHSEEKERS_C"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadActionBar.is_open()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 0
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 850.0,
+      "y": 150.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 0
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].model_distances[\"U_WITCHSEEKERS_C:m1\"]",
+      "expect_min": 2.2,
+      "expect_max": 2.8
+    },
+    {
+      "act": "screenshot",
+      "label": "01_waypoint_dropped_focus_kept"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.movement_controller.drag_start_pos.distance_to(Vector2(850.0, 150.0))",
+      "expect_max": 8
+    },
+    {
+      "act": "execute_script",
+      "script": "main.movement_controller._get_accumulated_distance()",
+      "expect_min": 2.2,
+      "expect_max": 2.8
+    },
+    {
+      "act": "screenshot",
+      "label": "02_same_model_repicked_at_waypoint"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 910.0,
+      "y": 170.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 2
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].model_distances[\"U_WITCHSEEKERS_C:m1\"]",
+      "expect_min": 3.85,
+      "expect_max": 4.6
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "03_x_sealed_model_and_advanced"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 970.0,
+      "y": 130.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "04_b_undid_second_model_stage"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 2
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.carry_model_index",
+      "equals": 2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 6
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].get(\"completed\", false)",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.x - 910.0) + abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y - 170.0)",
+      "expect_max": 12
+    },
+    {
+      "act": "execute_script",
+      "script": "abs(GameState.state.units[\"U_WITCHSEEKERS_C\"].models[1].position.y - InputDeviceManager.get_meta(\"w1y\"))",
+      "expect_max": 2
+    },
+    {
+      "act": "screenshot",
+      "label": "05_confirmed_multistep_only_sealed_model_moved"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_move_multistep_single_model.json
+++ b/40k/tests/scenarios/sp/pad_move_multistep_single_model.json
@@ -1,0 +1,132 @@
+{
+  "id": "pad_move_multistep_single_model",
+  "covers": [
+    "controller.multistep.x_finish_single_model",
+    "controller.multistep.all_placed_toast"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Multi-step controller movement on a single-model unit (the everyday character/vehicle case): the Blade Champion is picked up via the move menu and X mid-carry seals him in one press — the drop stages, no next model exists, so the advance stops with the 'All models placed — Start confirms the move' toast and the player sits in the locked state (A could still re-pick; the model keeps focus). Start then confirms the move in GameState.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 7
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.set_meta(\"bc_y0\", GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y)"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_BLADE_CHAMPION_A"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_BLADE_CHAMPION_A"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "PadActionBar.is_open()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": true
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 120.0,
+      "y": 300.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 2
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.is_carrying()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_BLADE_CHAMPION_A\"].staged_moves.size()",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "ToastManager.active_toasts.size()",
+      "expect_min": 1
+    },
+    {
+      "act": "screenshot",
+      "label": "01_x_sealed_single_model_toast_shown"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 6
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.current_phase_instance.active_moves[\"U_BLADE_CHAMPION_A\"].get(\"completed\", false)",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y - InputDeviceManager.get_meta(\"bc_y0\")",
+      "expect_min": 150
+    },
+    {
+      "act": "screenshot",
+      "label": "02_start_confirmed_single_model_move"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Mouse players could always move a model in several legs — drag, release, pick it back up, drag again — to thread a model around terrain or through a gap. The controller had no parallel: dropping a model with **A** auto-handed the stick the *next* model, stealing focus from the one just placed, so a pad player could never continue moving the same model.

This adds the multi-step contract to the Movement phase on the pad, keeping the model in focus after a drop until the player themselves moves on.

## New Movement-phase pad contract

| Button | While carrying | After a drop (models remaining) | All models placed |
|---|---|---|---|
| **A** | Drop at waypoint — **model keeps focus** | Pick the *same* model back up and keep moving it (budget carries over) | Pick a model up to adjust |
| **X** | Drop here **and** finish this model → next un-moved model | Finish → next un-moved model | Toast: "All models placed — Start confirms the move" |
| **B** | Cancel the pickup (unchanged) | **Undo last placed model** (was on X) | Undo last placed model |
| **L4/R4** | Swap model (unchanged) | Browse models freely | Browse models |
| **Start** | Place held model + confirm unit | Confirm unit's move | Confirm unit's move |

- **A** drops the carried model as a waypoint and keeps it focused (`carry_model_index` untouched, no auto-advance). A again re-picks it at its staged spot; the drag pipeline already accumulates path distance (`|A→B| + |B→C|`, not straight-line) so the remaining move budget carries across legs.
- **X** is the explicit "this model is finished" hand-off: mid-carry it drops (same legality gate as A — an illegal spot keeps the model in hand) and hands over the unit's next un-placed model; from the parked state it advances directly. With every model placed it toasts and leaves the player in the locked state where Start confirms.
- **Undo** moved from X to **B**: a clean B press (nothing to release/park) undoes the last staged model. B mid-carry still cancels the pickup.
- The hint bar teaches each state — `A Drop · X Finish Model` while carrying, `A Move Model · X Next Model · B Undo Model · Start Confirm Move` between drops, and the locked set once all models are placed. Drops now refresh hints after the queued release stages so the new affordances appear immediately.
- `VirtualCursor` routes X to the router mid-carry instead of synthesizing a right-click (which did nothing useful under a held model). The old `_in_windowed_scenario` auto-advance suppression is gone — drops never auto-advance anywhere, so scenarios and real play agree.

## Validation (windowed, per project gate)

Driven end-to-end against the running UI via the `addons/godot_mcp` bridge:

- **New** `pad_move_multistep_model` (63/63 PASS): waypoint drop keeps focus, re-pick at the staged spot with accumulated inches (2.5" → 4.1" across two legs, proving path-sum not endpoint distance), X seal+advance, plain drop on the second model keeps focus, B undo, X advance from parked, B cancel, Start confirm — only the sealed model moved in GameState.
- **New** `pad_move_multistep_single_model` (27/27 PASS): one-press X seal on a character, all-placed toast rendered, Start confirm.
- **Updated** `pad_m3_carry_move` (68/68 PASS): remapped to B-undoes, added focus-kept assertion.
- Regression sweep: all other movement / charge / deploy / bumper / cursor pad scenarios PASS. `pad_m2_shooting_native` and `pad_m3_carry_deploy` fail identically on the unmodified base (pre-existing, unrelated — confirmed via `git stash`).
- Screenshots confirm the new hint bars, in-hand budget readout, and the all-placed toast; debug logs show 0 ERROR lines.

## Files

- `40k/autoloads/PadRouter.gd` — drop keeps focus, `_finish_model_and_advance` (X), B-undo, hint sets, deferred hint refresh
- `40k/autoloads/VirtualCursor.gd` — X routes to router mid-carry
- `40k/scripts/Main.gd` — comment update for the renamed drop flow
- `40k/data/version_history.json` — v0.81.0 entry
- `40k/tests/scenarios/sp/pad_move_multistep_model.json`, `pad_move_multistep_single_model.json` (new), `pad_m3_carry_move.json` (updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2rn3L8BVuyREeVBEzDow2

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2rn3L8BVuyREeVBEzDow2)_