### PR TITLE
Controller: show the Menu (☰) glyph on the End-Phase button so ending a phase is discoverable on a pad

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.83.2",
+			"date": "2026-07-21",
+			"summary": "End a phase from the controller without hunting for the touchscreen. The top-right 'End … Phase' button now shows the controller's Menu (☰) button when you're playing with a controller, instead of the keyboard [Enter] you can't press on a Steam Deck. So the button you'd naturally reach for reads e.g. '☰ End Movement Phase', matching the '☰ End Phase' hint in the controller bar — press Menu (Start) and confirm to end the phase. It switches back to '[Enter]' the instant you use the mouse or keyboard.",
+			"changes": [
+				"The top-right phase-action button now adapts its shortcut hint to the input device in use: '[☰] End Movement Phase' on a controller, '[Enter] End Movement Phase' on keyboard/mouse. (Pressing the Menu/Start button already ended the phase behind a quick confirm — previously there was just no cue for it on the button itself.)",
+				"The hint updates live: pick up the controller and the button switches to the ☰ glyph; touch the mouse or a key and it switches back to [Enter].",
+				"Applies to every phase's action button — End Movement / Shooting / Charge / Fight / Command Phase, End Turn, Confirm Formations, Roll the dice, and the Fight-phase step labels — and the controller's confirm dialog always names the real action (e.g. 'End Movement Phase?')."
+			]
+		},
+		{
 			"version": "0.83.1",
 			"date": "2026-07-21",
 			"summary": "Shooting phase controller fix: LB/RB were dead at the start of the phase. The bumpers now cycle through EVERY unit that can still shoot — same as the Movement phase — not just the few the panel's 'has a target' filter shows, and the camera jumps to each unit as you cycle, including the shooter that's auto-selected when the phase begins.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6,6 +6,12 @@ const AIDifficultyConfigData = preload("res://scripts/AIDifficultyConfig.gd")
 const GameLogPanelScript = preload("res://scripts/GameLogPanel.gd")
 const GameLogEntryScript = preload("res://scripts/GameLogEntry.gd")
 const UnitStatsCardPopupScript = preload("res://scripts/UnitStatsCardPopup.gd")
+# Controller glyphs for inline button labels (PRP §"inline button labels"): the
+# phase-action button advertises the keyboard [Enter] OR the pad Menu (☰) button
+# depending on the active device, so a Steam Deck player sees which controller
+# button ends the phase instead of a key they don't have.
+const GlyphDB = preload("res://scripts/input/GlyphDB.gd")
+const _PHASE_ACTION_KBM_PREFIX := "[Enter] "
 
 # UI z_index layering constants — ensure panels always render above all board elements
 const UI_PANEL_Z: int = 500      # HUD panels (left, right, bottom, stats, logs)
@@ -275,6 +281,14 @@ func _ready() -> void:
 	# Design-guidelines overlays / panels (T01-T45). Factored into a helper
 	# so this _ready stays scannable.
 	_install_design_guidelines_overlays()
+
+	# Keep the phase-action button's shortcut hint in sync with the active input
+	# device: pad → "[☰] End Phase" (the Menu button bound to pad_phase_action),
+	# KBM → "[Enter] End Phase". Without this a Steam Deck player only ever saw
+	# "[Enter]" on the button they'd naturally reach for and had no cue that the
+	# controller could end the phase at all.
+	if InputDeviceManager and not InputDeviceManager.device_changed.is_connected(_on_input_device_changed):
+		InputDeviceManager.device_changed.connect(_on_input_device_changed)
 
 	# Clear stale game event log entries from previous sessions
 	# GameEventLog is an autoload that persists across scene reloads
@@ -5434,7 +5448,7 @@ func _show_pad_phase_confirm() -> void:
 		_pad_phase_confirm.title = "Confirm"
 		_pad_phase_confirm.confirmed.connect(_on_pad_phase_confirmed)
 		add_child(_pad_phase_confirm)
-	_pad_phase_confirm.dialog_text = phase_action_button.text.replace("[Enter] ", "").strip_edges() + "?"
+	_pad_phase_confirm.dialog_text = _phase_action_bare_label().strip_edges() + "?"
 	DialogUtils.popup_at_bottom(_pad_phase_confirm)
 
 func _on_pad_phase_confirmed() -> void:
@@ -8367,7 +8381,7 @@ func _on_roll_off_result(p1: int, p2: int, winner: int, tied: bool) -> void:
 	# Keep the top-bar button consistent on both peers (it may still read
 	# "[Enter] Roll the dice" on the peer that didn't submit).
 	if phase_action_button:
-		phase_action_button.text = "[Enter] Continue"
+		phase_action_button.text = _phase_action_prefix() + "Continue"
 
 func _on_roll_off_acknowledged() -> void:
 	# The human dismissed a result that needed no choice from them.
@@ -9944,25 +9958,70 @@ func _get_phase_tooltip_text(phase: GameStateData.Phase) -> String:
 		_:
 			return "Current phase. Press ? for keyboard shortcuts."
 
-func _get_phase_button_text(phase: GameStateData.Phase) -> String:
-	match phase:
-		GameStateData.Phase.FORMATIONS: return "[Enter] Confirm Formations"
-		GameStateData.Phase.DEPLOYMENT: return "[Enter] End Deployment"
-		GameStateData.Phase.REDEPLOYMENT: return "[Enter] End Redeployment"
-		GameStateData.Phase.SCOUT: return "[Enter] End Scout Moves"
-		GameStateData.Phase.SCOUT_MOVES: return "[Enter] End Scout Moves"
-		GameStateData.Phase.ROLL_OFF: return "[Enter] Roll the dice"
-		GameStateData.Phase.FIRST_TURN_ROLLOFF: return "[Enter] Roll the dice"
-		GameStateData.Phase.COMMAND: return "[Enter] End Command Phase"
-		GameStateData.Phase.MOVEMENT: return "[Enter] End Movement Phase"
-		GameStateData.Phase.SHOOTING: return "[Enter] End Shooting Phase"
-		GameStateData.Phase.CHARGE: return "[Enter] End Charge Phase"
-		GameStateData.Phase.FIGHT: return _get_fight_phase_button_text()
-		GameStateData.Phase.SCORING: return "[Enter] End Turn"
-		GameStateData.Phase.MORALE: return "[Enter] End Morale Phase"
-		_: return "[Enter] End Phase"
+# The pad glyph prefix for the phase-action button, e.g. "[☰] ". Mirrors the
+# keyboard "[Enter] " prefix so the Steam Deck's Menu (☰) button — the one bound
+# to pad_phase_action / End Phase — is named on the button itself. Uses GlyphDB
+# so the glyph stays a single source of truth with the hint bar.
+func _phase_action_pad_prefix() -> String:
+	return "[%s] " % GlyphDB.glyph_text("menu")
 
-func _get_fight_phase_button_text() -> String:
+# The shortcut prefix for the current input device: pad → "[☰] ", KBM → "[Enter] ".
+func _phase_action_prefix() -> String:
+	if InputDeviceManager and InputDeviceManager.is_pad_active():
+		return _phase_action_pad_prefix()
+	return _PHASE_ACTION_KBM_PREFIX
+
+# The phase-action button label with any known shortcut prefix stripped, so the
+# pad confirm dialog reads the true action ("End Movement Phase?") regardless of
+# which glyph currently leads the button (or a special state like "Continue").
+func _phase_action_bare_label() -> String:
+	if not phase_action_button or not is_instance_valid(phase_action_button):
+		return ""
+	var t: String = phase_action_button.text
+	for p in [_PHASE_ACTION_KBM_PREFIX, _phase_action_pad_prefix()]:
+		if t.begins_with(p):
+			return t.substr(p.length())
+	return t
+
+# Re-stamp the button's shortcut prefix for the active device without touching
+# the label — so switching KBM ⇄ pad live swaps "[Enter] " ⇄ "[☰] " and leaves
+# any custom label (Continue, the Fight-phase step labels) intact.
+func _sync_phase_action_glyph() -> void:
+	if not phase_action_button or not is_instance_valid(phase_action_button):
+		return
+	var t: String = phase_action_button.text
+	for p in [_PHASE_ACTION_KBM_PREFIX, _phase_action_pad_prefix()]:
+		if t.begins_with(p):
+			phase_action_button.text = _phase_action_prefix() + t.substr(p.length())
+			return
+	# No recognized shortcut prefix — leave the text untouched.
+
+func _on_input_device_changed(_mode: int) -> void:
+	_sync_phase_action_glyph()
+
+func _get_phase_button_text(phase: GameStateData.Phase) -> String:
+	return _phase_action_prefix() + _get_phase_action_label(phase)
+
+# The bare action label (no shortcut prefix) for the phase-action button.
+func _get_phase_action_label(phase: GameStateData.Phase) -> String:
+	match phase:
+		GameStateData.Phase.FORMATIONS: return "Confirm Formations"
+		GameStateData.Phase.DEPLOYMENT: return "End Deployment"
+		GameStateData.Phase.REDEPLOYMENT: return "End Redeployment"
+		GameStateData.Phase.SCOUT: return "End Scout Moves"
+		GameStateData.Phase.SCOUT_MOVES: return "End Scout Moves"
+		GameStateData.Phase.ROLL_OFF: return "Roll the dice"
+		GameStateData.Phase.FIRST_TURN_ROLLOFF: return "Roll the dice"
+		GameStateData.Phase.COMMAND: return "End Command Phase"
+		GameStateData.Phase.MOVEMENT: return "End Movement Phase"
+		GameStateData.Phase.SHOOTING: return "End Shooting Phase"
+		GameStateData.Phase.CHARGE: return "End Charge Phase"
+		GameStateData.Phase.FIGHT: return _get_fight_phase_action_label()
+		GameStateData.Phase.SCORING: return "End Turn"
+		GameStateData.Phase.MORALE: return "End Morale Phase"
+		_: return "End Phase"
+
+func _get_fight_phase_action_label() -> String:
 	# The Fight phase runs three internal steps (11e): the global Pile In step
 	# (12.02) the phase opens with, the alternating Fight step (12.04), and the
 	# global Consolidate step (12.07). The action button ends whichever step is
@@ -9972,9 +10031,9 @@ func _get_fight_phase_button_text() -> String:
 	var fp = PhaseManager.get_current_phase_instance()
 	if fp and fp.has_method("get_fight_step_11e"):
 		match fp.get_fight_step_11e():
-			"PILE_IN": return "[Enter] Finish Pile Ins"
-			"CONSOLIDATE": return "[Enter] Finish Consolidations"
-	return "[Enter] End Fight Phase"
+			"PILE_IN": return "Finish Pile Ins"
+			"CONSOLIDATE": return "Finish Consolidations"
+	return "End Fight Phase"
 
 func _get_phase_button_tooltip(phase: GameStateData.Phase) -> String:
 	match phase:
@@ -9989,7 +10048,7 @@ func _get_phase_button_tooltip(phase: GameStateData.Phase) -> String:
 		_: return "Advance to the next phase"
 
 func _get_fight_phase_button_tooltip() -> String:
-	# Mirrors _get_fight_phase_button_text: describe the CURRENT Fight-phase
+	# Mirrors _get_fight_phase_action_label: describe the CURRENT Fight-phase
 	# step, since only the Fight step actually ends the phase.
 	var fp = PhaseManager.get_current_phase_instance()
 	if fp and fp.has_method("get_fight_step_11e"):

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -2996,6 +2996,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "ui.phase_action_button.device_glyph",
+      "description": "The top-right phase-action button advertises the active input device's shortcut for ending a phase: the keyboard '[Enter] End Movement Phase' when KBM is active, and the pad Menu glyph '[☰] End Movement Phase' when a controller is active. The prefix comes from GlyphDB (single source of truth with the hint bar), re-stamps live on InputDeviceManager.device_changed without disturbing custom labels (roll-off Continue, Fight-phase step labels), and the pad confirm dialog reads the prefix-stripped action ('End Movement Phase?').",
+      "scenarios": [
+        "715_controller_end_phase_glyph"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "controller.end_phase.discoverability",
+      "description": "A controller player can discover how to end a phase without the touchscreen: the button they reach for names the Menu (☰) button bound to pad_phase_action, matching the '☰ End Phase' hint-bar chip, and pressing Menu (Start) pops the confirm dialog whose OK ends the phase.",
+      "scenarios": [
+        "715_controller_end_phase_glyph"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/715_controller_end_phase_glyph.json
+++ b/40k/tests/scenarios/sp/715_controller_end_phase_glyph.json
@@ -1,0 +1,36 @@
+{
+  "id": "715_controller_end_phase_glyph",
+  "covers": [
+    "ui.phase_action_button.device_glyph",
+    "controller.end_phase.discoverability"
+  ],
+  "fixture": "New Game",
+  "description": "Controller end-phase UX: the top-right phase-action button (the one a player reaches for to end a phase) must advertise the pad Menu (☰) button when a controller is active, instead of the keyboard [Enter] a Steam Deck player cannot press. This reuses the existing pad_phase_action (JOY_BUTTON_START) -> confirm flow; the test proves the inline glyph label AND the confirm dialog text both adapt to the active input device. Assertions are self-contained (each sets the device + phase synchronously) so they are immune to AI phase drift.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.input_mode = InputDeviceManager.InputMode.KBM\nreturn node._get_phase_button_text(GameStateData.Phase.MOVEMENT)",
+      "equals": "[Enter] End Movement Phase" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.claim_pad()\nreturn node._get_phase_button_text(GameStateData.Phase.MOVEMENT)",
+      "equals": "[☰] End Movement Phase" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.claim_pad()\nnode.current_phase = GameStateData.Phase.MOVEMENT\nnode.update_ui_for_phase()\nreturn node.phase_action_button.text",
+      "equals": "[☰] End Movement Phase" },
+
+    { "act": "screenshot", "label": "01_pad_end_movement_button_glyph" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.claim_pad()\nnode.current_phase = GameStateData.Phase.MOVEMENT\nnode.update_ui_for_phase()\nnode._show_pad_phase_confirm()\nreturn node._pad_phase_confirm.dialog_text",
+      "equals": "End Movement Phase?" },
+
+    { "act": "screenshot", "label": "02_pad_end_movement_confirm" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.input_mode = InputDeviceManager.InputMode.KBM\nnode.current_phase = GameStateData.Phase.MOVEMENT\nnode.update_ui_for_phase()\nreturn node.phase_action_button.text",
+      "equals": "[Enter] End Movement Phase" }
+  ]
+}


### PR DESCRIPTION
## Problem

Ending a phase (e.g. Movement) with a controller was effectively undiscoverable, so players fell back to the touchscreen. The mechanism already existed — the **Menu/Start** button (`JOY_BUTTON_START`) is bound to `pad_phase_action`, which pops a confirm dialog and presses the top-right phase-action button, and the hint bar carries a `☰ End Phase` chip — but the prominent button a player actually reaches for hard-coded `[Enter] End Movement Phase`, a key a Steam Deck player can't press, with no cue that a controller button does the same thing.

## Change

Make the top-right phase-action button **device-adaptive** (the "inline button labels" the controller PRP planned for `GlyphDB`):

- **Pad active** → `[☰] End Movement Phase`; **keyboard/mouse** → `[Enter] End Movement Phase`.
- Glyph comes from `GlyphDB`, keeping it a single source of truth with the hint bar.
- Re-stamps **live** on `InputDeviceManager.device_changed`, without disturbing any custom label (roll-off `Continue`, the Fight-phase step labels).
- The pad confirm dialog now derives its text from the prefix-stripped label, so it always reads the true action (`End Movement Phase?`) under either glyph.

This reinforces the existing Start → confirm → end flow rather than adding a competing path (board-`A` already means "select unit", and the PRP intentionally chose Start as the global, focus-independent end-phase action).

**No keyboard behaviour change:** `"[Enter] " + "<label>"` reproduces the old literals exactly, so this is a behaviour-preserving refactor for KBM.

## Validation

Windowed, via the `addons/godot_mcp` bridge:
- Label swaps `[Enter] ⇄ [☰]` on device change — verified on the live button and screenshotted (glyph renders cleanly, matches the `☰ End Phase` hint bar chip).
- Confirm dialog shows `End Movement Phase?`; invoking its confirm callback actually ends the phase.
- New scenario `40k/tests/scenarios/sp/715_controller_end_phase_glyph.json` — **8/8 pass**.
- Two existing `sp` scenarios regression-pass; **0 errors** in the debug log.

Bumped version to **0.83.1** with a changelog entry.

> Note: a *physical* Start-button press couldn't be driven end-to-end in the headless CI container (no joypad device is connected, so simulated joypad events don't register action state — root-caused, not assumed). Every link was validated another way: the action is bound to `JOY_BUTTON_START`, the confirm dialog it opens shows the right text, and its confirm callback ends the phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LFpc9f5trxXpbBs7DVKBf)_