### PR TITLE
Shooting pad: bumpers cycle every eligible shooter, not the filtered list

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -1567,6 +1567,16 @@ func _toggle_datasheet() -> bool:
 	return true
 
 
+# Public seam for phase controllers (shooting auto-select, …): frame the
+# camera on unit_id, but ONLY while the pad is the active device. Automatic
+# camera jumps are hostile to mouse players — they can already see what they
+# clicked — so KBM callers are a no-op.
+func follow_unit_if_pad(unit_id: String) -> void:
+	if unit_id == "" or not InputDeviceManager.is_pad_active():
+		return
+	_center_camera_on_unit(unit_id)
+
+
 # Below this zoom the board is a fit-whole-table overview (a loaded save starts
 # at ~0.3) and individual models are unreadable — cycling to a unit there must
 # zoom IN on it, not just pan the overview sideways.

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.83.1",
+			"date": "2026-07-21",
+			"summary": "Shooting phase controller fix: LB/RB were dead at the start of the phase. The bumpers now cycle through EVERY unit that can still shoot — same as the Movement phase — not just the few the panel's 'has a target' filter shows, and the camera jumps to each unit as you cycle, including the shooter that's auto-selected when the phase begins.",
+			"changes": [
+				"LB/RB in the Shooting phase now cycle through every unit that can still shoot this phase, matching how Movement cycles units that can still move. Previously the bumpers only walked the visible shooter list, which by default hides units with no eligible target — at the start of the phase that is usually most of the army, so with 0-1 rows the bumpers silently did nothing.",
+				"Cycling onto a unit with no targets in range selects it, frames the camera on it, and explains why nothing is targetable — you can still Skip it with X or start a mission action, or just keep cycling.",
+				"The unit the game auto-selects when the Shooting phase starts (or after each unit finishes shooting) is now framed by the camera when playing on a controller — the phase no longer opens pointing at an empty stretch of table with the [ACTIVE] shooter somewhere off-screen.",
+				"When there is genuinely nothing left to cycle to, the bumpers say so with a toast ('No units left to shoot — Start ends the phase' / 'No other units to cycle to') instead of doing nothing.",
+				"Keyboard Tab / Shift+Tab shooter cycling gets the same fix (it shared the filtered-list ring)."
+			]
+		},
+		{
 			"version": "0.83.0",
 			"date": "2026-07-21",
 			"summary": "Move the whole squad at once with the controller. The Movement menu gains 'Move All Together': every model of the unit is picked up as one formation riding the stick, and a single A press places them all. Mid-move, any D-pad press grabs every model you haven't placed yet. If the drop spot doesn't fit the whole squad, the models that fit are placed and the rest are handed straight back to you — and the ghost preview shows green/red per model so you can see which will land before you drop.",

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -1068,6 +1068,11 @@ func _refresh_unit_list(auto_select: bool = true) -> void:
 			if auto_idx >= 0:
 				unit_selector.select(auto_idx)
 				_on_unit_selected(auto_idx)
+				# Steam Deck: the auto-armed shooter can be anywhere on the
+				# board and a pad player has no mouse to go find it — frame it
+				# so the phase never opens (or hands over to the next shooter)
+				# pointing at empty table. No-op on keyboard/mouse.
+				PadRouter.follow_unit_if_pad(active_shooter_id)
 
 	# T5-UX3: Update shoot all remaining button when unit list refreshes
 	_update_shoot_all_remaining_button()
@@ -1089,16 +1094,11 @@ func _on_shooting_show_all_units_setting_changed(show_all: bool) -> void:
 	if show_all_units_checkbox and is_instance_valid(show_all_units_checkbox) \
 			and show_all_units_checkbox.button_pressed != show_all:
 		show_all_units_checkbox.set_pressed_no_signal(show_all)
-	var keep_id = active_shooter_id
 	# Rebuild without auto-selecting so a manual selection isn't overridden.
 	_refresh_unit_list(false)
 	# Re-highlight the active shooter's row (its assignments are untouched — we
 	# only restore the visual selection, we don't re-run _on_unit_selected).
-	if keep_id != "" and unit_selector and is_instance_valid(unit_selector):
-		for i in range(unit_selector.get_item_count()):
-			if unit_selector.get_item_metadata(i) == keep_id:
-				unit_selector.select(i)
-				break
+	_highlight_active_shooter_row()
 
 func _refresh_shooter_status() -> void:
 	if not shooter_status_label or active_shooter_id == "":
@@ -4785,49 +4785,81 @@ func _keyboard_deselect_shooter() -> void:
 
 	print("T5-UX12: Deselected shooter %s" % prev_shooter)
 
-# T5-UX12: Cycle through eligible shooter units with Tab (Shift+Tab for reverse)
+# T5-UX12: Cycle through eligible shooter units with Tab (Shift+Tab for
+# reverse) — also the LB/RB bumper path via PadRouter.
+#
+# The ring is built from PHASE eligibility (_can_unit_shoot + not shot yet),
+# NOT from the visible rows of the shooter list. The list's default filter
+# hides shooters with no eligible target right now, which at the start of the
+# phase is usually MOST of the army — cycling only the visible rows left the
+# bumpers dead on phase entry (0–1 rows: next == current, silent no-op) while
+# the hint bar promised "RB Cycle Units". Mirrors the Movement phase, where
+# bumper-cycling follows activation eligibility (pad_can_cycle_to), not
+# whatever the panel happens to render. Cycling onto a filtered-out unit goes
+# through _select_shooter_by_unit_id — the same path as clicking its token —
+# so the no-targets feedback explains why nothing is targetable, and X (Skip
+# Unit) can finish its activation.
 func _keyboard_cycle_units(reverse: bool) -> void:
-	if not unit_selector or not current_phase:
+	if not current_phase:
 		return
 
-	# Build list of eligible (un-shot) unit indices
-	var eligible_indices: Array = []
-	var units_shot = current_phase.get_units_that_shot() if current_phase.has_method("get_units_that_shot") else []
-
-	for i in range(unit_selector.get_item_count()):
-		var unit_id = unit_selector.get_item_metadata(i)
-		if unit_id and unit_id not in units_shot:
-			eligible_indices.append(i)
-
-	if eligible_indices.is_empty():
+	var ring: Array = _pad_cycle_ring()
+	if ring.is_empty():
 		if dice_log_display:
 			dice_log_display.append_text("[color=gray]No eligible units to cycle through[/color]\n")
+		# Pad players don't read the dice log — say it where they look.
+		ToastManager.show_warning("No units left to shoot — Start ends the phase")
 		return
 
-	# Find current active shooter index in the eligible list
-	var current_eligible_idx: int = -1
-	for ei in range(eligible_indices.size()):
-		var unit_id = unit_selector.get_item_metadata(eligible_indices[ei])
-		if unit_id == active_shooter_id:
-			current_eligible_idx = ei
-			break
-
-	# Calculate next index
-	var next_eligible_idx: int
+	var current_idx := ring.find(active_shooter_id)
+	var next_idx: int
 	if reverse:
-		next_eligible_idx = (current_eligible_idx - 1) if current_eligible_idx > 0 else eligible_indices.size() - 1
+		next_idx = (current_idx - 1) if current_idx > 0 else ring.size() - 1
 	else:
-		next_eligible_idx = (current_eligible_idx + 1) % eligible_indices.size()
+		next_idx = (current_idx + 1) % ring.size()
 
-	var next_list_idx = eligible_indices[next_eligible_idx]
-	var next_unit_id = unit_selector.get_item_metadata(next_list_idx)
+	var next_unit_id: String = str(ring[next_idx])
+	if next_unit_id == active_shooter_id:
+		# The armed shooter is the only eligible unit left — a silent no-op here
+		# reads as "the bumpers are broken", so say why nothing moves.
+		ToastManager.show_toast("No other units to cycle to")
+		return
 
-	if next_unit_id and next_unit_id != active_shooter_id:
-		# Select in the list UI
-		unit_selector.select(next_list_idx)
-		# Trigger the same selection flow as clicking
-		_on_unit_selected(next_list_idx)
-		print("T5-UX12: Cycled to unit %s (index %d)" % [next_unit_id, next_list_idx])
+	_select_shooter_by_unit_id(next_unit_id)
+	# The cycled-to unit may have no row (hidden by the no-targets filter) —
+	# rebuild the list (the active shooter's row is always kept) and highlight
+	# it, mirroring the show-all-checkbox refresh path.
+	_refresh_unit_list(false)
+	_highlight_active_shooter_row()
+	print("T5-UX12: Cycled to unit %s" % next_unit_id)
+
+# Every unit of the current player that can still shoot this phase, in the
+# order the (unfiltered) shooter list would show them. This is the bumper/Tab
+# cycling ring: activation eligibility, independent of the list's display
+# filter.
+func _pad_cycle_ring() -> Array:
+	var ring: Array = []
+	if not current_phase:
+		return ring
+	var units = current_phase.get_units_for_player(current_phase.get_current_player())
+	var units_shot = current_phase.get_units_that_shot() if current_phase.has_method("get_units_that_shot") else []
+	for unit_id in units:
+		if unit_id in units_shot:
+			continue
+		if current_phase._can_unit_shoot(units[unit_id]):
+			ring.append(unit_id)
+	return ring
+
+# Select + reveal the active shooter's row in the unit list without re-running
+# the selection flow (visual sync only).
+func _highlight_active_shooter_row() -> void:
+	if active_shooter_id == "" or not unit_selector or not is_instance_valid(unit_selector):
+		return
+	for i in range(unit_selector.get_item_count()):
+		if unit_selector.get_item_metadata(i) == active_shooter_id:
+			unit_selector.select(i)
+			unit_selector.ensure_current_is_visible()
+			break
 
 # T5-UX12: Skip the current active unit
 func _keyboard_skip_unit() -> void:

--- a/40k/tests/scenarios/sp/pad_m2_shooting_native.json
+++ b/40k/tests/scenarios/sp/pad_m2_shooting_native.json
@@ -5,7 +5,7 @@
   "transition_to_phase": 8,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M2 gate: a full shooting activation with ZERO virtual-cursor use. RB cycles to an eligible shooter (camera pans to it; bumpers ALWAYS cycle the acting unit per the bumper-only rule), D-pad ▶ walks the eligible-target ring (camera pans to the highlighted target), A assigns the target to the current weapon, Start confirms targets (context-dependent Menu), and the staged dice resolution is walked with A on watcher-focused dialog buttons until the shooter is marked has_shot.",
+  "description": "M2 gate: a full shooting activation with ZERO virtual-cursor use. RB cycles to an eligible shooter (camera pans to it; bumpers ALWAYS cycle the acting unit per the bumper-only rule), D-pad ▶ walks the eligible-target ring (camera pans to the highlighted target), A assigns the target to the current weapon, Start confirms targets (context-dependent Menu), and the staged dice resolution is walked with A on watcher-focused dialog buttons until the shooter is marked has_shot. Since the cycle ring follows PHASE eligibility (every unit that can still shoot — engaged vehicles and no-target units included, matching Movement), the fixed RB presses may park on a shooter whose weapons are all disabled; before the target walk, the scenario cycles on (same _keyboard_cycle_units path a bumper press drives) until the armed shooter has an assignable weapon and a target.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 8 },
@@ -23,6 +23,9 @@
     { "act": "simulate_joy_button", "button_index": 9 },
     { "act": "wait_seconds", "seconds": 0.4 },
     { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id) == InputDeviceManager.get_meta(\"shooter\")", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nfor i in range(sc._pad_cycle_ring().size()):\n\tvar ok_weapon = false\n\tif sc.weapon_tree != null and sc.weapon_tree.get_root() != null:\n\t\tvar it = sc.weapon_tree.get_root().get_first_child()\n\t\twhile it != null:\n\t\t\tif it.is_selectable(0):\n\t\t\t\tok_weapon = true\n\t\t\t\tbreak\n\t\t\tit = it.get_next()\n\tif ok_weapon and not sc.eligible_targets.is_empty():\n\t\tbreak\n\tsc._keyboard_cycle_units(false)\nInputDeviceManager.set_meta(\"shooter\", str(sc.active_shooter_id))\nreturn not sc.eligible_targets.is_empty()", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
 
     { "act": "simulate_joy_button", "button_index": 14 },
     { "act": "wait_seconds", "seconds": 0.4 },

--- a/40k/tests/scenarios/sp/pad_shoot_cycle_all_eligible.json
+++ b/40k/tests/scenarios/sp/pad_shoot_cycle_all_eligible.json
@@ -1,0 +1,44 @@
+{
+  "id": "pad_shoot_cycle_all_eligible",
+  "covers": [
+    "controller.bumper_only_unit_cycling",
+    "controller.m2.shooting_native",
+    "controller.shooting.cycle_ring_phase_eligibility",
+    "ShootingController",
+    "PadRouter"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Shooting-phase bumpers must never be dead on phase entry. The shooter list's default filter hides units with no eligible target, which at the start of the phase is most of the army — cycling only the visible rows made LB/RB silent no-ops (0-1 rows) while the hint bar promised 'RB Cycle Units'. The ring is now built from PHASE eligibility (_can_unit_shoot + not shot yet), like Movement's pad_can_cycle_to. Enters shooting the way a real player does — pad Start ends the Movement phase, A confirms the dialog — then asserts: a shooter is auto-armed AND camera-framed on entry (pad active), RB cycles to a filter-hidden eligible unit whose row appears selected in the list, and LB cycles back.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id) != \"\"", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"entry_shooter\", str(main.shooting_controller.active_shooter_id))" },
+
+    { "act": "execute_script", "script": "main.shooting_controller._pad_cycle_ring().size() > main.shooting_controller.unit_selector.get_item_count()", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar sc = m.shooting_controller\nvar u = GameState.get_unit(str(sc.active_shooter_id))\nvar pos = null\nfor model in u.get(\"models\", []):\n\tif model.get(\"alive\", true):\n\t\tpos = model.get(\"position\")\n\t\tbreak\nif pos == null:\n\treturn false\nvar screen = m.world_to_screen_position(Vector2(float(pos.x), float(pos.y)))\nvar vp = m.get_viewport().get_visible_rect().size\nreturn screen.x >= 0.0 and screen.y >= 0.0 and screen.x <= vp.x and screen.y <= vp.y", "equals": true },
+    { "act": "screenshot", "label": "01_entry_shooter_framed" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id) != str(InputDeviceManager.get_meta(\"entry_shooter\"))", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nvar sel = sc.unit_selector.get_selected_items()\nif sel.size() == 0:\n\treturn \"no_row_selected\"\nreturn str(sc.unit_selector.get_item_metadata(sel[0])) == str(sc.active_shooter_id)", "equals": true },
+    { "act": "screenshot", "label": "02_rb_cycled_to_hidden_eligible_unit" },
+
+    { "act": "simulate_joy_button", "button_index": 9 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id) == str(InputDeviceManager.get_meta(\"entry_shooter\"))", "equals": true },
+    { "act": "screenshot", "label": "03_lb_cycled_back" }
+  ]
+}


### PR DESCRIPTION
## Problem

At the start of the Shooting phase, LB/RB did nothing on the controller — the same class of bug the Movement phase had. The bumper ring was built from the **visible rows of the shooter list**, and the list's default filter hides units with no eligible target *right now*. At phase start that's usually most of the army, so the list held 0–1 rows: `next == current`, and the press was a silent no-op while the hint bar still promised "RB Cycle Units". The auto-selected shooter was also off-screen, so the phase opened pointing at empty table with nothing visibly happening.

## Fix

Bring shooting in line with the Movement phase's cycling model (bumpers follow **activation eligibility**, independent of what the panel renders):

- `ShootingController._keyboard_cycle_units` (bumpers **and** keyboard Tab) now cycles a ring of every unit of the current player that `_can_unit_shoot` and hasn't shot, in unfiltered list order. Cycling onto a filter-hidden unit routes through `_select_shooter_by_unit_id` — the same path as clicking its token — so the no-targets feedback explains the situation, X (Skip) / mission actions stay available, and the list is rebuilt with the unit revealed as the `[ACTIVE]` row.
- Empty-ring / sole-shooter presses now toast ("No units left to shoot — Start ends the phase" / "No other units to cycle to") instead of doing nothing.
- New `PadRouter.follow_unit_if_pad` seam: the shooter auto-selected on phase entry (and after each unit resolves) is camera-framed when the pad is the active device, so the phase never opens with the `[ACTIVE]` unit off-screen. No-op on keyboard/mouse.

## Validation

Driven live over the real entry path (Movement → pad Start → A on the confirm dialog → Shooting) on the `audit_baseline_postdeploy` fixture:

- Entry auto-arms the Telemon with the camera framed on it; ring = 8 while the list shows 1 row.
- RB reaches the filter-hidden Witchseekers (row revealed + camera follows), LB cycles back, wrap-around works.
- `verify_delivery` → **PASS** with 0 log errors and the feature assertions confirmed.

Tests:
- New windowed scenario `pad_shoot_cycle_all_eligible` drives the path end-to-end (21/21).
- `pad_m2_shooting_native` updated for the wider ring — its fixed RB presses can now park on the engaged Contemptor (all weapons disabled), so it cycles on via the same `_keyboard_cycle_units` path until an assignable shooter is armed (44/44).
- `pad_shoot_weapon_step`, `pad_m2_unit_cycle`, `pad_bumper_only_unit_cycling`, `pad_load_zoom_focus` re-run green.

Version bumped to 0.83.1 with a player-facing changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkaATT7n94dZXTAgFotD4N

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkaATT7n94dZXTAgFotD4N)_