### PR TITLE
Movement pad: attached leaders move with their unit by default

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -987,15 +987,17 @@ func _carry_next_unplaced_model() -> void:
 	var unit_id := str(mc.active_unit_id)
 	if unit_id != _carry_unit_id:
 		return  # unit changed under us — don't drag the camera to a new unit
-	var alive := _alive_model_count(unit_id)
+	var roster := _unit_move_roster(unit_id)
+	var alive := roster.size()
 	# Hand over the next model that has NOT been placed yet, scanning forward
 	# with wrap-around and skipping staged ones — paddle hops let models be
 	# placed out of order, and handing back a model the player already dropped
-	# would silently threaten its kept position.
+	# would silently threaten its kept position. The roster spans the bodyguard
+	# AND attached characters, so an attached leader is offered here by default.
 	var next_index := -1
 	for step in range(1, alive + 1):
 		var candidate := wrapi(carry_model_index + step, 0, alive)
-		if _staged_model_pos(unit_id, _alive_model_id(unit_id, candidate)) == null:
+		if _roster_entry_staged_pos(unit_id, roster[candidate]) == null:
 			next_index = candidate
 			break
 	if next_index == -1:
@@ -1008,26 +1010,43 @@ func _carry_next_unplaced_model() -> void:
 		_update_hints()
 
 
+# The active unit's combined move roster: its own alive models plus those of
+# every attached character, as ordered {source_unit_id, model_id} entries. An
+# attached leader forms one unit with its bodyguard and moves WITH it, so the
+# per-model pad flow (L3/paddle browse, X "Next Model", the auto-advance after a
+# drop) hands you the leader's model too — the leader is included by default, not
+# only via "Move All Together". Model ids collide between the two units, so each
+# entry keeps its source unit id; staging routes through the active unit's move
+# data with model_source_unit_id (see _staged_model_pos_for).
+func _unit_move_roster(active_unit_id: String) -> Array:
+	var roster: Array = []
+	var unit = GameState.get_unit(active_unit_id)
+	if unit.is_empty():
+		return roster
+	var unit_ids := [active_unit_id]
+	for char_id in unit.get("attachment_data", {}).get("attached_characters", []):
+		unit_ids.append(str(char_id))
+	for source_uid in unit_ids:
+		var models = GameState.get_unit(source_uid).get("models", [])
+		for i in range(models.size()):
+			var model = models[i]
+			if not model.get("alive", true):
+				continue
+			roster.append({
+				"source_unit_id": source_uid,
+				"model_id": str(model.get("id", "m%d" % (i + 1))),
+			})
+	return roster
+
+
 func _alive_model_count(unit_id: String) -> int:
-	var unit = GameState.get_unit(unit_id)
-	var n := 0
-	for model in unit.get("models", []):
-		if model.get("alive", true):
-			n += 1
-	return n
+	return _unit_move_roster(unit_id).size()
 
 
-# The id ("m1", …) of unit_id's Nth alive model, or "" when out of range.
-func _alive_model_id(unit_id: String, alive_index: int) -> String:
-	var unit = GameState.get_unit(unit_id)
-	var idx := 0
-	for model in unit.get("models", []):
-		if not model.get("alive", true):
-			continue
-		if idx == alive_index:
-			return str(model.get("id", ""))
-		idx += 1
-	return ""
+# The staged dest of a roster entry (null = not placed yet this move). Wraps
+# _staged_model_pos_for with the entry's own source unit.
+func _roster_entry_staged_pos(active_unit_id: String, entry: Dictionary):
+	return _staged_model_pos_for(active_unit_id, str(entry.get("source_unit_id", active_unit_id)), str(entry.get("model_id", "")))
 
 
 # ============================================================================
@@ -1347,28 +1366,41 @@ func _swap_carry_to_index() -> void:
 # confirm), so prefer that — hopping to / picking up a staged model must land
 # where its token visually is, not at its pre-move position.
 func _model_world_pos(unit_id: String, alive_index: int):
-	var unit = GameState.get_unit(unit_id)
-	var idx := 0
-	for model in unit.get("models", []):
-		if not model.get("alive", true):
-			continue
-		if idx == alive_index:
-			var staged = _staged_model_pos(unit_id, str(model.get("id", "")))
-			if staged != null:
-				return staged
-			var pos = model.get("position", null)
-			if pos is Dictionary and pos.has("x"):
-				return Vector2(float(pos.x), float(pos.y))
-			elif pos is Vector2:
-				return pos
-			return null
-		idx += 1
+	var roster := _unit_move_roster(unit_id)
+	if alive_index < 0 or alive_index >= roster.size():
+		return null
+	var entry = roster[alive_index]
+	var source_uid := str(entry.get("source_unit_id", unit_id))
+	var model_id := str(entry.get("model_id", ""))
+	# A model already dropped this move sits at its STAGED dest (GameState only
+	# updates on confirm), so prefer that — hopping to / picking up a staged model
+	# must land where its token visually is, not its pre-move position.
+	var staged = _staged_model_pos_for(unit_id, source_uid, model_id)
+	if staged != null:
+		return staged
+	var model := _roster_model(source_uid, model_id)
+	var pos = model.get("position", null)
+	if pos is Dictionary and pos.has("x"):
+		return Vector2(float(pos.x), float(pos.y))
+	elif pos is Vector2:
+		return pos
 	return null
 
 
-# The staged (uncommitted) destination of unit_id's own model model_id in the
-# Movement phase, or null when it has no staged move / not in Movement.
-func _staged_model_pos(unit_id: String, model_id: String):
+# The model dict for source_uid's model_id, or {} when absent.
+func _roster_model(source_uid: String, model_id: String) -> Dictionary:
+	for model in GameState.get_unit(source_uid).get("models", []):
+		if str(model.get("id", "")) == model_id:
+			return model
+	return {}
+
+
+# The staged (uncommitted) destination of source_unit_id's model_id within the
+# ACTIVE unit's move data, in the Movement phase, or null when it has no staged
+# move / not in Movement. Attached-character models stage under the bodyguard's
+# move (actor = active_unit_id) with model_source_unit_id set, so the move data
+# is always the active unit's; source_unit_id disambiguates the colliding ids.
+func _staged_model_pos_for(active_unit_id: String, source_unit_id: String, model_id: String):
 	if model_id == "":
 		return null
 	var m := get_tree().current_scene
@@ -1377,14 +1409,12 @@ func _staged_model_pos(unit_id: String, model_id: String):
 	var phase = PhaseManager.get_current_phase_instance()
 	if phase == null or not phase.has_method("get_active_move_data"):
 		return null
-	var staged: Array = phase.get_active_move_data(unit_id).get("staged_moves", [])
-	# Match on model_source_unit_id too: bodyguard and attached character
-	# model ids can collide (both "m1"); we only hop the active unit's own models.
+	var staged: Array = phase.get_active_move_data(active_unit_id).get("staged_moves", [])
 	for i in range(staged.size() - 1, -1, -1):
 		var sm = staged[i]
 		if str(sm.get("model_id", "")) != model_id:
 			continue
-		if str(sm.get("model_source_unit_id", unit_id)) != unit_id:
+		if str(sm.get("model_source_unit_id", active_unit_id)) != source_unit_id:
 			continue
 		var dest = sm.get("dest")
 		if dest is Vector2:
@@ -1695,8 +1725,8 @@ func _movement_has_unplaced_models() -> bool:
 	if mc == null or str(mc.active_unit_id) == "":
 		return false
 	var unit_id := str(mc.active_unit_id)
-	for i in range(_alive_model_count(unit_id)):
-		if _staged_model_pos(unit_id, _alive_model_id(unit_id, i)) == null:
+	for entry in _unit_move_roster(unit_id):
+		if _roster_entry_staged_pos(unit_id, entry) == null:
 			return true
 	return false
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.84.0",
+			"date": "2026-07-21",
+			"summary": "Attached leaders now move with their unit on the controller by default. When a Character has joined a unit, its model is part of that unit's move everywhere: L3 (and the paddles) now cycle onto the leader as well as the bodyguard's models, so you can move it in the normal one-model-at-a-time flow — not only via 'Move All Together'. You can no longer finish a unit's move having accidentally left its leader behind.",
+			"changes": [
+				"The controller's per-model move now includes an attached Character's model in the unit's roster: L3 / the back paddles cycle through the bodyguard's models AND the leader, and the automatic 'next model' after finishing one (X) hands you the leader too.",
+				"This means a joined leader is included in the unit's move by default — you no longer have to use 'Move All Together' to bring it along, and the move isn't treated as finished while the leader still hasn't been placed.",
+				"'Move All Together' and the mouse bulk-select already moved the leader with the group; this extends the same 'the leader moves with its unit' rule to the normal one-at-a-time move flow.",
+				"Picking up, dropping and confirming the leader's model routes its move under the parent unit correctly (the leader's own token ends up where you placed it)."
+			]
+		},
+		{
 			"version": "0.83.2",
 			"date": "2026-07-21",
 			"summary": "End a phase from the controller without hunting for the touchscreen. The top-right 'End … Phase' button now shows the controller's Menu (☰) button when you're playing with a controller, instead of the keyboard [Enter] you can't press on a Steam Deck. So the button you'd naturally reach for reads e.g. '☰ End Movement Phase', matching the '☰ End Phase' hint in the controller bar — press Menu (Start) and confirm to end the phase. It switches back to '[Enter]' the instant you use the mouse or keyboard.",
@@ -20,8 +31,7 @@
 				"Cycling onto a unit with no targets in range selects it, frames the camera on it, and explains why nothing is targetable — you can still Skip it with X or start a mission action, or just keep cycling.",
 				"The unit the game auto-selects when the Shooting phase starts (or after each unit finishes shooting) is now framed by the camera when playing on a controller — the phase no longer opens pointing at an empty stretch of table with the [ACTIVE] shooter somewhere off-screen.",
 				"When there is genuinely nothing left to cycle to, the bumpers say so with a toast ('No units left to shoot — Start ends the phase' / 'No other units to cycle to') instead of doing nothing.",
-				"Keyboard Tab / Shift+Tab shooter cycling gets the same fix (it shared the filtered-list ring)."
-			]
+				"Keyboard Tab / Shift+Tab shooter cycling gets the same fix (it shared the filtered-list ring)."			]
 		},
 		{
 			"version": "0.83.0",

--- a/40k/tests/scenarios/sp/pad_move_attached_leader.json
+++ b/40k/tests/scenarios/sp/pad_move_attached_leader.json
@@ -1,0 +1,65 @@
+{
+  "id": "pad_move_attached_leader",
+  "covers": [
+    "controller.move.attached_leader_in_roster",
+    "controller.move.attached_leader_l3_reachable",
+    "controller.move.attached_leader_picks_up",
+    "controller.move.attached_leader_moves_permodel"
+  ],
+  "fixture": "attached_char_advance_overlap",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "An attached character (Blade Champion joined to the Custodian Guard) is included in the unit's move BY DEFAULT — not only via 'Move All Together'. The pad's per-model move roster spans the bodyguard's models AND the attached leader's, so L3 (JOY_BUTTON_LEFT_STICK=7) browsing reaches the leader, it picks up as a single model, and dropping + confirming actually moves it. Drives a plain Normal Move (not the group carry): select the bodyguard, open the move menu, choose Move, L3 past the three bodyguard models onto the leader, carry it ~2.5\" down, drop, and confirm — the leader's own position changes in GameState.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "PadRouter._alive_model_count(\"U_CUSTODIAN_GUARD_B\")", "equals": 4 },
+    { "act": "execute_script", "script": "str(PadRouter._unit_move_roster(\"U_CUSTODIAN_GUARD_B\")[3].source_unit_id)", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"ly0\", GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y)" },
+
+    { "act": "execute_script", "script": "main.movement_controller._select_unit_in_list_by_id(\"U_CUSTODIAN_GUARD_B\")", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_CUSTODIAN_GUARD_B" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "execute_script", "script": "PadActionBar.highlighted_id()", "equals": "NORMAL" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.9 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.group_carry_active", "equals": false },
+    { "act": "screenshot", "label": "01_single_carry_started" },
+
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 2 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 3 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.selected_model.get(\"unit_id\", \"\"))", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "screenshot", "label": "02_leader_in_hand" },
+
+    { "act": "pad_cursor_glide", "x": 600.0, "y": 900.0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.movement_controller.selected_model.get(\"unit_id\", \"\"))", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PadRouter._staged_model_pos_for(\"U_CUSTODIAN_GUARD_B\", \"U_BLADE_CHAMPION_A\", \"m1\") != null", "equals": true },
+    { "act": "screenshot", "label": "03_leader_staged" },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "execute_script", "script": "abs(GameState.state.units[\"U_BLADE_CHAMPION_A\"].models[0].position.y - InputDeviceManager.get_meta(\"ly0\")) > 40", "equals": true },
+    { "act": "screenshot", "label": "04_leader_moved_permodel" }
+  ]
+}


### PR DESCRIPTION
## Summary

When a Character has joined a unit, its model is now included in that unit's move **by default** on the controller — in the normal one-model-at-a-time flow, not only via "Move All Together". You can no longer finish a unit's move having accidentally left its leader behind.

### Before
- The **bulk** paths ("Move All Together", D-pad Grab-All, mouse Ctrl+A) already picked up and moved an attached leader.
- The **normal per-model move** (plain "Move" → carry one model, browse with L3/paddles, X-to-finish) only ever walked the **bodyguard's own** models. The leader was never handed to the player, so a unit's move could be "finished" with the leader still sitting behind.

### After
- The pad's per-model move roster spans the bodyguard **plus** every attached character. L3 / the back paddles cycle onto the leader too, and #713's X "next model" auto-advance hands you the leader; the move isn't treated as finished while the leader is still unplaced.

## Implementation
- `PadRouter.gd`:
  - `_unit_move_roster(active_unit_id)` — the unit's move roster as ordered `{source_unit_id, model_id}` entries spanning the bodyguard + attached characters (alive only).
  - `_alive_model_count`, `_model_world_pos`, `_carry_next_unplaced_model`, `_movement_has_unplaced_models` now drive off the roster.
  - `_staged_model_pos` → `_staged_model_pos_for(active_unit_id, source_unit_id, model_id)`: staged-position lookups are source-unit aware, since model ids collide between the two units and attached-character models stage under the parent unit's move with `model_source_unit_id`.
- No `MovementController` change needed: it already supports dragging/staging attached-character models (`_is_model_in_active_unit_group`, `model_source_unit_id` in `_end_model_drag`) and excludes them from click-to-switch-unit (`_try_click_select_unit`). The change is confined to *which* models the pad offers.
- For attachment-free units the roster reduces to the old bodyguard-only set, so existing behavior is unchanged.

## Testing
- New windowed scenario `pad_move_attached_leader.json` (43/43) drives a plain Normal Move on Custodian Guard + attached Blade Champion: asserts the roster count includes the leader, L3-browses onto the leader (roster index 3), carries it, drops + confirms, and the leader's own position changes in GameState.
- Live MCP validation: leader reachable via L3, picks up as a single model (`held unit = U_BLADE_CHAMPION_A`), drop is legal, stages under the parent unit (`model_source_unit_id`), and moves on confirm (y 800→900).
- Regression (post-rebase onto #715/#716): `pad_group_move_all`, `pad_move_l3_cycle_model`, `pad_move_carry_hop_swap`, `pad_m3_carry_move` all still pass.

> CI note: the pre-existing `Coverage matrix validation` and `Multi-peer integration (GUT)` failures belong to the `Windowed Scenario Suite` workflow, which is red on every recent merge (its windowed-scenario job is skipped in CI) and unrelated to this diff. Every check that is green on `main` (Headless audit, GUT, Code Quality) is green here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLuVumJMFExY5Kb7LUPAco

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLuVumJMFExY5Kb7LUPAco)_