### PR TITLE
Fix Deep Strike formation placement rejected outside deployment zone

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.84.1",
+			"date": "2026-07-22",
+			"summary": "Fixed Deep Strike / Strategic Reserves formation placement. Dropping a unit in Tight (or Spread) formation from reinforcements at a spot that is perfectly legal — on the board and more than 9\" from every enemy — was wrongly rejected with 'Formation would place models outside deployment zone or overlapping'. Formations arriving from reserves are now validated against the reinforcement rules (the whole battlefield, >9\" from enemies) instead of your deployment zone, so they place wherever a single-model reinforcement already could.",
+			"changes": [
+				"Deep Strike and Strategic Reserves arrivals can now be placed in Tight or Spread formation anywhere the reinforcement rules allow (on the board, >9\" from enemy models, plus the within-6\"-of-a-board-edge rule for Strategic Reserves) — not only inside your own deployment zone. Single-model reinforcement placement already worked this way; formation placement now matches it.",
+				"The formation ghost preview turns green in every legal reinforcement spot, so you can see a Deep Strike drop is valid before committing it.",
+				"When a reinforcement formation genuinely can't be placed, the message no longer mentions your 'deployment zone' (it isn't the constraint): the specific reason still shows (e.g. 'Must be >9\" from enemy models'), followed by 'Formation placement is not legal here'."
+			]
+		},
+		{
 			"version": "0.84.0",
 			"date": "2026-07-21",
 			"summary": "Attached leaders now move with their unit on the controller by default. When a Character has joined a unit, its model is part of that unit's move everywhere: L3 (and the paddles) now cycle onto the leader as well as the bodyguard's models, so you can move it in the normal one-model-at-a-time flow — not only via 'Move All Together'. You can no longer finish a unit's move having accidentally left its leader behind.",

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -635,7 +635,14 @@ func try_place_formation_at(world_pos: Vector2) -> void:
 		var validate_rot = formation_rotations[i] if i < formation_rotations.size() else 0.0
 		if not _validate_formation_position(pos, model, zone, validate_rot):
 			all_valid = false
-			error_msg = "Formation would place models outside deployment zone or overlapping"
+			# _validate_formation_position already surfaced the specific reason
+			# (e.g. ">9\" from enemy models") via its own toast; the fallback text
+			# must not claim "deployment zone" in reinforcement/infiltrator modes
+			# where placement is not zone-constrained.
+			if is_reinforcement_mode or is_infiltrators_mode:
+				error_msg = "Formation placement is not legal here"
+			else:
+				error_msg = "Formation would place models outside deployment zone or overlapping"
 			break
 
 	if not all_valid:
@@ -2319,7 +2326,19 @@ func _update_formation_ghost_positions(mouse_pos: Vector2) -> void:
 
 func _validate_formation_position(pos: Vector2, model_data: Dictionary, zone: PackedVector2Array, model_rotation: float = 0.0) -> bool:
 	"""Validate a single position in a formation"""
-	if is_infiltrators_mode:
+	if is_reinforcement_mode:
+		# Reinforcement (Deep Strike / Strategic Reserves): reinforcements arrive
+		# across the whole battlefield, NOT the owning player's deployment zone,
+		# so validate against the reinforcement rules (>9" from enemies, on the
+		# board, Strategic-Reserves board-edge, Omni-scramblers) instead of the
+		# zone check. Mirrors the single-model path in try_place_at()/_process();
+		# without this branch a formation dropped in a legal Deep Strike spot
+		# would be falsely rejected as "outside deployment zone".
+		if not _validate_reinforcement_position(pos, model_data, model_rotation):
+			return false
+		if _overlaps_with_existing_models_shape(pos, model_data, model_rotation):
+			return false
+	elif is_infiltrators_mode:
 		# In Infiltrators mode, use Infiltrators validation instead of zone check
 		if not _validate_infiltrators_position(pos, model_data, model_rotation):
 			return false

--- a/40k/tests/scenarios/sp/deep_strike_tight_formation.json
+++ b/40k/tests/scenarios/sp/deep_strike_tight_formation.json
@@ -1,0 +1,42 @@
+{
+  "id": "deep_strike_tight_formation",
+  "covers": [
+    "controller.reinforcement.formation_placement",
+    "DeploymentController._validate_formation_position",
+    "DeploymentController.try_place_formation_at"
+  ],
+  "fixture": "ri_pretrigger",
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Deep Strike + TIGHT formation regression (GH bug): placing a formation from Deep Strike at a spot that is a LEGAL deep-strike position (on the board, >9\" from all enemies) but OUTSIDE the owning player's deployment zone was being falsely rejected with 'Formation would place models outside deployment zone or overlapping'. Root cause: _validate_formation_position only branched on is_infiltrators_mode, so reinforcement placements fell through to the deployment-zone check. This drives the real reinforcement UI path (select reserves unit -> TIGHT formation -> try_place_formation_at) at board-centre no-man's-land (880,1200) and asserts the 5-model formation actually places. Negative case: the next TIGHT group dropped 5.5\" from the enemy Witchseekers is still rejected, proving the >9\" reinforcement gate stays enforced.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_state", "path": "units.U_BOYZ_F.status", "equals": 7 },
+
+    { "act": "execute_script", "multiline": true, "script": "GameState.state.units.U_BOYZ_F.reserve_type = \"deep_strike\"\nreturn GameState.state.units.U_BOYZ_F.reserve_type", "equals": "deep_strike" },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar list = m.unit_list\nfor i in range(list.item_count):\n\tif str(list.get_item_metadata(i)) == \"U_BOYZ_F\":\n\t\tlist.select(i)\n\t\tlist.item_selected.emit(i)\n\t\treturn true\nreturn false", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "script": "main.deployment_controller.is_placing()", "equals": true },
+    { "act": "execute_script", "script": "main.deployment_controller.is_reinforcement_mode", "equals": true },
+    { "act": "execute_script", "script": "main.deployment_controller.reinforcement_placement_type", "equals": "deep_strike" },
+
+    { "act": "execute_script", "script": "main.deployment_controller.set_formation_mode(\"TIGHT\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.deployment_controller.formation_mode", "equals": "TIGHT" },
+    { "act": "screenshot", "label": "01_deep_strike_tight_formation_armed" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(880, 1200))\nreturn dc.get_placed_count()", "equals": 5 },
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\nvar p = dc.temp_positions[0]\nreturn p != null and p.y > 560.0 and p.y < 1840.0", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "02_formation_placed_in_no_mans_land" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(880, 270))\nreturn dc.get_placed_count()", "equals": 5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "03_near_enemy_group_still_rejected" }
+  ]
+}


### PR DESCRIPTION
## Summary

Placing a unit in **Tight** or **Spread** formation from **Deep Strike / Strategic Reserves** at a spot that is a perfectly legal reinforcement position — on the board and more than 9" from every enemy — was wrongly rejected with:

> Formation would place models outside deployment zone or overlapping

### Root cause

`DeploymentController._validate_formation_position()` only branched on `is_infiltrators_mode`, so reinforcement formations fell through to the **deployment-zone** check (`_circle/_shape_wholly_in_polygon` against the owning player's zone). Reinforcements arrive across the whole battlefield, not the deployment zone, so any legal Deep Strike drop outside that zone was rejected. The single-model path (`try_place_at` / `_process`) already handled `is_reinforcement_mode` correctly — only *formation* placement was missing it, which is why single-model Deep Strike worked but formations didn't.

### Fix

- Add an `is_reinforcement_mode` branch to `_validate_formation_position` that validates via `_validate_reinforcement_position` (>9" from enemies, on the board, Strategic-Reserves board-edge, Omni-scramblers) plus the existing model-overlap check — mirroring the single-model path. This also fixes the formation **ghost preview** validity colouring in reinforcement mode.
- Make the fallback error message in `try_place_formation_at` mode-aware, so it no longer claims "deployment zone" for reinforcement/infiltrator drops (the specific reason, e.g. `Must be >9" from enemy models`, still shows).

## Validation

Added windowed scenario `deep_strike_tight_formation.json` that drives the real reinforcement UI (select reserves unit → TIGHT → place a formation at no-man's-land centre, outside the deployment zone but >9" from enemies) and asserts the 5-model formation places.

- **Pre-fix code:** `0/20` models placed (rejected — bug reproduced)
- **Post-fix code:** `5/20` models placed (formation drops successfully)
- **Negative case still enforced:** a drop 7.6" from enemy models is correctly rejected

Regression-checked `deploy_formation_ghost_sprite` (normal-zone branch), `iss068_infiltrators_8in_11e` (infiltrator branch) and `pad_reinforcement_formation_row` (reinforcement formation row) — all still pass. No `SCRIPT ERROR` / `ERROR:` in the debug log during the runs.

## Changelog

Version bumped to `0.84.1` in `40k/data/version_history.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au)_