### PR TITLE
Fix controller navigation for the drawn secondary missions dialog

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -1662,6 +1662,14 @@ func _shooting_controller_in_shooting_phase() -> Node:
 	return sc
 
 
+# Public seam: recompute the hint bar for the current board context. A
+# native-nav modal (e.g. SecondaryMissionReviewDialog) that overrode the hint
+# bar while it owned the pad calls this on close, since this router's _input
+# stands down — and stops driving the hints — while such a modal is open.
+func refresh_hints() -> void:
+	_update_hints()
+
+
 func _update_hints() -> void:
 	var hints := HINTS_BOARD
 	if carry_active:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.84.2",
+			"date": "2026-07-22",
+			"summary": "Controller fix: the 'New Secondary Missions' pop-up (shown when you draw secondaries in the Command phase) can now be used with a controller. Previously the D-pad never highlighted anything in that window, so a pad player could neither read the drawn missions nor spend 1 CP to replace one — the only way past it was the mouse. Now the D-pad moves a visible selector through each 'Replace this mission (1 CP)' button and the Continue button, the highlighted control scrolls into view, A activates it, and the controller hint bar shows Navigate / Select / Close.",
+			"changes": [
+				"The drawn-secondary-missions review pop-up is now fully controller-navigable: D-pad ▲/▼ steps through each Replace button and the Continue button (wrapping around), and the selector is always scrolled into view so you can read every mission.",
+				"Press A on a Replace button to spend 1 CP and swap that mission (it returns to your deck); press A on Continue to accept and close — no mouse required.",
+				"Opening the pop-up now puts the controller selector on the first Replace button (or Continue if you can't replace) instead of an off-screen button, and the on-screen hint bar switches to 'Navigate / Select / Close' while it's open, then back to the normal board hints when it closes.",
+				"Fixed the A button firing a stray click instead of pressing the highlighted button when the virtual cursor happened to be active as the pop-up opened."
+			]
+		},
+		{
 			"version": "0.84.1",
 			"date": "2026-07-22",
 			"summary": "Fixed Deep Strike / Strategic Reserves formation placement. Dropping a unit in Tight (or Spread) formation from reinforcements at a spot that is perfectly legal — on the board and more than 9\" from every enemy — was wrongly rejected with 'Formation would place models outside deployment zone or overlapping'. Formations arriving from reserves are now validated against the reinforcement rules (the whole battlefield, >9\" from enemies) instead of your deployment zone, so they place wherever a single-model reinforcement already could.",

--- a/40k/dialogs/SecondaryMissionReviewDialog.gd
+++ b/40k/dialogs/SecondaryMissionReviewDialog.gd
@@ -17,6 +17,23 @@ var _replacement_used: bool = false
 var _scroll_vbox: VBoxContainer = null
 var _replace_info_label: Label = null
 
+# Controller (pad) navigation state.
+var _outer_scroll: ScrollContainer = null
+var _done_button: Button = null
+# Interactive controls in top-to-bottom order — the D-pad focus chain (each
+# Replace button, then Continue). Rebuilt whenever the mission cards are.
+var _replace_buttons: Array = []
+
+# PadRouter checks this group and keeps its board-oriented handlers (bumper
+# unit-cycling, panel-focus entry, the ItemList focus-release) off a dialog
+# that drives itself with Godot's native ui_* focus navigation. Without it the
+# D-pad never lands in this window and the player cannot review or replace a
+# drawn mission with a controller.
+const PAD_MODAL_GROUP := "pad_native_nav_modal"
+# Hint chips shown while this dialog owns the pad (PadRouter stands down, so it
+# no longer drives the hint bar and would otherwise leave the board hints up).
+const PAD_HINTS := [["dpad", "Navigate"], ["a", "Select"], ["b", "Close"]]
+
 func setup(player: int, drawn_missions: Array, player_cp: int, deck_size: int) -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
 	_player = player
@@ -35,6 +52,15 @@ func setup(player: int, drawn_missions: Array, player_cp: int, deck_size: int) -
 	# Prevent closing via X button without completing
 	close_requested.connect(_on_done_pressed)
 
+	# Controller support: join the native-nav modal group so PadRouter stands
+	# down, and (re)build the pad focus chain whenever we become visible or the
+	# player picks up the pad while the dialog is open.
+	add_to_group(PAD_MODAL_GROUP)
+	if not visibility_changed.is_connected(_on_visibility_changed_pad):
+		visibility_changed.connect(_on_visibility_changed_pad)
+	if InputDeviceManager and not InputDeviceManager.device_changed.is_connected(_on_device_changed_pad):
+		InputDeviceManager.device_changed.connect(_on_device_changed_pad)
+
 	_build_ui()
 
 func _build_ui() -> void:
@@ -46,6 +72,7 @@ func _build_ui() -> void:
 	outer_scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	outer_scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	outer_scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	_outer_scroll = outer_scroll
 
 	var main_container = VBoxContainer.new()
 	main_container.name = "MainContainer"
@@ -80,6 +107,7 @@ func _build_ui() -> void:
 	main_container.add_child(_scroll_vbox)
 
 	# Show each drawn mission
+	_replace_buttons.clear()
 	for i in range(_drawn_missions.size()):
 		var mission = _drawn_missions[i]
 		_add_mission_card(_scroll_vbox, mission, i)
@@ -119,6 +147,7 @@ func _build_ui() -> void:
 	done_btn.pressed.connect(_on_done_pressed)
 	WhiteDwarfTheme.apply_primary_button(done_btn)
 	button_container.add_child(done_btn)
+	_done_button = done_btn
 
 	outer_scroll.add_child(main_container)
 	add_child(outer_scroll)
@@ -232,6 +261,8 @@ func _add_mission_card(parent: VBoxContainer, mission: Dictionary, index: int) -
 		replace_btn.pressed.connect(_on_replace_pressed.bind(mission_id))
 		WhiteDwarfTheme.apply_secondary_button(replace_btn)
 		card_vbox.add_child(replace_btn)
+		# Register in the top-to-bottom controller focus chain.
+		_replace_buttons.append(replace_btn)
 
 func _add_dialog_gold_separator(parent: Control) -> void:
 	var sep = ColorRect.new()
@@ -270,7 +301,10 @@ func update_after_replacement(new_missions: Array) -> void:
 	for child in _scroll_vbox.get_children():
 		child.queue_free()
 
-	# Rebuild mission cards (no replace buttons since replacement was used)
+	# Rebuild mission cards (no replace buttons since replacement was used).
+	# The old Replace buttons are being freed, so drop their (now stale)
+	# references from the focus chain before rebuilding.
+	_replace_buttons.clear()
 	for i in range(_drawn_missions.size()):
 		var mission = _drawn_missions[i]
 		_add_mission_card(_scroll_vbox, mission, i)
@@ -279,8 +313,121 @@ func update_after_replacement(new_missions: Array) -> void:
 	_replace_info_label.text = "Mission replaced! Review your new mission above."
 	_replace_info_label.add_theme_color_override("font_color", Color(0.4, 0.9, 0.4))
 
+	# Controller: only the Continue button remains interactive now — re-point the
+	# focus chain at it so the pad isn't left focused on a freed Replace button.
+	if InputDeviceManager and InputDeviceManager.is_pad_active():
+		_setup_pad_focus.call_deferred()
+
 func _on_done_pressed() -> void:
 	print("SecondaryMissionReviewDialog: Player %d accepted drawn missions" % _player)
 	emit_signal("review_completed")
+	_restore_board_hints()
 	hide()
 	queue_free()
+
+# ============================================================================
+# CONTROLLER (PAD) NAVIGATION
+# ============================================================================
+# Reported bug: with a controller the D-pad never highlighted this window, so
+# the player could neither read the drawn missions nor replace one. Root cause:
+# initial focus landed on the Continue button (scrolled off-screen at the
+# bottom) and Godot's geometric focus search — with the Replace buttons nested
+# one-per-card — skipped the second Replace button and dead-ended. Fix: join the
+# native-nav modal group (PadRouter stands down), wire an explicit top-to-bottom
+# focus chain, seed focus on the first VISIBLE control, and keep the focused
+# control scrolled into view.
+
+func _on_visibility_changed_pad() -> void:
+	if not visible or not _pad_active():
+		return
+	_apply_pad_hints()
+	_setup_pad_focus.call_deferred()
+
+
+func _on_device_changed_pad(mode: int) -> void:
+	# The player picked up the pad while the dialog was already open (it may have
+	# popped in mouse/keyboard mode). Set up native navigation now.
+	if not is_instance_valid(self) or not visible:
+		return
+	if mode != InputDeviceManager.InputMode.PAD:
+		return
+	_apply_pad_hints()
+	_setup_pad_focus.call_deferred()
+
+
+func _setup_pad_focus() -> void:
+	# Let the InputDeviceManager watchdog's initial confirm-button grab land
+	# first, then move focus to the TOP of the dialog so the selector is visible
+	# from the start. Two frames also clears any layout settling from popup().
+	await get_tree().process_frame
+	await get_tree().process_frame
+	if not is_inside_tree() or not visible or not _pad_active():
+		return
+	# Park the virtual cursor so A presses the focused button instead of firing a
+	# synthetic left-click at the cursor position (VirtualCursor consumes A while
+	# the cursor is live). The InputDeviceManager watchdog does the same when a
+	# dialog pops while the pad is already active; do it here too so the pick-up-
+	# the-pad-mid-dialog path is covered.
+	if VirtualCursor and VirtualCursor.has_method("park"):
+		VirtualCursor.park()
+	_wire_pad_focus_neighbors()
+	var first := _first_focus_target()
+	if first != null and is_instance_valid(first):
+		first.grab_focus()
+		_scroll_to_focused(first)
+
+
+# Build the wrap-around focus chain (each Replace button, then Continue) so
+# D-pad ▲ ▼ steps through every interactive control deterministically instead of
+# relying on Godot's geometric neighbour search.
+func _wire_pad_focus_neighbors() -> void:
+	var seq: Array = []
+	for b in _replace_buttons:
+		if is_instance_valid(b):
+			seq.append(b)
+	if is_instance_valid(_done_button):
+		seq.append(_done_button)
+	var n := seq.size()
+	if n == 0:
+		return
+	for i in range(n):
+		var ctrl: Control = seq[i]
+		ctrl.focus_mode = Control.FOCUS_ALL
+		var prev: Control = seq[(i - 1 + n) % n]
+		var next: Control = seq[(i + 1) % n]
+		ctrl.focus_neighbor_top = ctrl.get_path_to(prev)
+		ctrl.focus_previous = ctrl.get_path_to(prev)
+		ctrl.focus_neighbor_bottom = ctrl.get_path_to(next)
+		ctrl.focus_next = ctrl.get_path_to(next)
+		if not ctrl.focus_entered.is_connected(_scroll_to_focused.bind(ctrl)):
+			ctrl.focus_entered.connect(_scroll_to_focused.bind(ctrl))
+
+
+func _first_focus_target() -> Control:
+	for b in _replace_buttons:
+		if is_instance_valid(b):
+			return b
+	return _done_button if is_instance_valid(_done_button) else null
+
+
+func _scroll_to_focused(ctrl: Control) -> void:
+	# Keep the focused control on-screen so the controller "selector" is always
+	# visible — the dialog content is taller than the scroll region.
+	if is_instance_valid(_outer_scroll) and is_instance_valid(ctrl):
+		_outer_scroll.ensure_control_visible(ctrl)
+
+
+func _apply_pad_hints() -> void:
+	if PadHintBar and PadHintBar.has_method("set_hints"):
+		PadHintBar.set_hints(PAD_HINTS)
+
+
+func _restore_board_hints() -> void:
+	# Hand the hint bar back to PadRouter so it recomputes the board context
+	# (we overrode it with navigate/select chips while the dialog owned the pad).
+	if _pad_active() and PadRouter and PadRouter.has_method("refresh_hints"):
+		PadRouter.refresh_hints()
+
+
+func _pad_active() -> bool:
+	return InputDeviceManager != null and InputDeviceManager.is_pad_active()

--- a/40k/tests/scenarios/sp/pad_secondary_review_nav.json
+++ b/40k/tests/scenarios/sp/pad_secondary_review_nav.json
@@ -1,0 +1,55 @@
+{
+  "id": "pad_secondary_review_nav",
+  "covers": [
+    "controller.secondary_review.dpad_nav",
+    "controller.secondary_review.replace",
+    "controller.secondary_review.close"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "description": "Controller support for the Secondary Mission Review dialog (drawn missions). Reported bug: the D-pad never highlighted this window, so a pad player could neither read the drawn missions nor replace one. The dialog must join the native-nav modal group, seed focus on the first Replace button, let D-pad ▼ cycle Replace_0 → Replace_1 → Continue → wrap, activate a Replace with A (spends 1 CP, re-focuses Continue), and close with A on Continue.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "expect_node_visible", "node": "/root/SecondaryMissionReviewDialog", "timeout_s": 3.0 },
+    { "act": "execute_script", "script": "GameState.get_active_player()", "equals": 2 },
+    { "act": "expect_cp", "player": 2, "equals": 4 },
+
+    { "act": "simulate_joy_axis", "axis": 0, "value": 0.9 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_axis", "axis": 0, "value": 0.0 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nvar f=d.gui_get_focus_owner()\nreturn \"NULL\" if f==null else str(f.name)", "multiline": true, "equals": "ReplaceButton_0" },
+    { "act": "screenshot", "label": "01_initial_focus_first_replace" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nvar f=d.gui_get_focus_owner()\nreturn \"NULL\" if f==null else str(f.name)", "multiline": true, "equals": "ReplaceButton_1" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nvar f=d.gui_get_focus_owner()\nreturn \"NULL\" if f==null else str(f.name)", "multiline": true, "equals": "DoneButton" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nvar f=d.gui_get_focus_owner()\nreturn \"NULL\" if f==null else str(f.name)", "multiline": true, "equals": "ReplaceButton_0" },
+    { "act": "screenshot", "label": "02_wrapped_to_first_replace" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.7 },
+    { "act": "expect_cp", "player": 2, "equals": 3 },
+    { "act": "expect_node_visible", "node": "/root/SecondaryMissionReviewDialog", "timeout_s": 1.0 },
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nvar f=d.gui_get_focus_owner()\nreturn \"NULL\" if f==null else str(f.name)", "multiline": true, "equals": "DoneButton" },
+    { "act": "screenshot", "label": "03_after_replace_continue_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.7 },
+    { "act": "execute_script", "script": "var d=tree.root.get_node_or_null(\"SecondaryMissionReviewDialog\")\nreturn d==null or not d.visible", "multiline": true, "equals": true },
+    { "act": "screenshot", "label": "04_dialog_closed" }
+  ]
+}


### PR DESCRIPTION
## Problem

When secondary missions are drawn in the Command phase, the **"New Secondary Missions"** review dialog could not be used with a controller. The D-pad never highlighted anything in the window, so a pad player could neither read the drawn missions nor spend 1 CP to replace one — the only way past it was the mouse.

## Root cause

Reproduced live in the running game (windowed, via the MCP bridge). The dialog was not registered as a native-nav modal, so:
- `PadRouter` kept running its board handlers instead of standing down.
- Initial focus (from the `InputDeviceManager` watchdog) landed on the **Continue** button, which was scrolled **off-screen** at the bottom of the dialog — an invisible selector.
- Godot's geometric focus search, with the Replace buttons nested one-per-card, **skipped the second Replace button and dead-ended**.
- The virtual cursor consumed **A** as a stray click when it happened to be active as the dialog opened.
- The hint bar still showed board controls, so nothing signalled the dialog was interactive.

## Fix

`SecondaryMissionReviewDialog` now behaves like the project's existing pad-navigable dialog (`SaveLoadDialog`):
- Joins the `pad_native_nav_modal` group so `PadRouter` stands down.
- Wires an explicit **wrap-around focus chain** (each Replace button → Continue) so D-pad ▲/▼ steps through every control deterministically.
- Seeds focus on the first **visible** control and keeps the focused control scrolled into view (`ensure_control_visible`).
- Parks the virtual cursor when taking pad focus so **A** presses the focused button instead of firing a synthetic click.
- Shows **Navigate / Select / Close** hint chips while open, and hands the hint bar back to `PadRouter` on close (new additive `PadRouter.refresh_hints()` seam).
- Re-points the focus chain at Continue after a replacement rebuilds the cards.

Mouse/keyboard behavior is unchanged — all new code is gated on the pad being the active device.

## Validation

New windowed scenario **`pad_secondary_review_nav`** (32 assertions, passing) drives the full pad flow against the real UI:
- Pad focuses the first Replace button (visible, highlighted).
- D-pad ▼ cycles Replace_0 → Replace_1 → Continue → wraps.
- **A** on a Replace button replaces the mission (CP 4→3, logged) and re-focuses Continue.
- **A** on Continue closes the dialog and restores the board hints.

Existing pad dialog scenarios still pass (rolloff watchdog, save/load focus, secondary deck draw, mission discard). The two unrelated failures in the full pad suite (`pad_m3_carry_deploy`, `pad_move_dpad_menu_no_panel_trap`) were verified to fail identically on baseline with these changes stashed — pre-existing flakiness, not caused by this change.

## Follow-up

The closely related `MissionDiscardDialog` (discard-a-card-for-1CP flow) is structurally similar and likely has the same controller gap; it was left out of scope here and can be fixed next with its own validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dzWoCnuQ4DRzhD55jmVqp

---
_Generated by [Claude Code](https://claude.ai/code/session_013dzWoCnuQ4DRzhD55jmVqp)_