### PR TITLE
Add D-pad navigation to the 11e Allocate Attacks window

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.84.4",
+			"date": "2026-07-22",
+			"summary": "Controller fix: you can now reach the Allocate Attacks window with the D-pad. After you shoot and wound, the window that shows the save rolls and destroyed models (with its Done button) had never been wired for controller navigation, so a pad player was stuck — the D-pad walked the panels behind it and could never land on Done. Now the window grabs the D-pad focus (the gold ring) onto its live button at every step — Roll Saves, Keep Rolls, Auto-pick, and Done — so you can drive the whole allocation and dismiss the results with A.",
+			"changes": [
+				"The 11th-edition Allocate Attacks window (save allocation) now supports D-pad navigation on a controller. Previously its buttons — including the final Done button on the results screen — could not be focused with the D-pad, so a controller player could not close the window without the mouse/virtual cursor.",
+				"On a controller the window now traps focus inside itself (the D-pad can no longer wander onto the HUD/board behind it) and lands the gold focus ring on the current step's main button, updating as the flow moves through ordering, the Command Re-roll offer, casualty picking, and the final results — press A to activate it.",
+				"Casualty models are still picked on the board with the left-stick cursor; the D-pad now additionally reaches the Auto-pick / Confirm buttons of that step.",
+				"Keyboard and mouse behaviour is unchanged — the focus handling only engages while a controller is the active input device, and normal board navigation is restored the moment the window closes."
+			]
+		},
+		{
 			"version": "0.84.3",
 			"date": "2026-07-22",
 			"summary": "Controller deep-strike fix: placing a unit arriving from reserves no longer shows 'Move / Advance / Stay Still' instead of a way to confirm. Previously, if you had another unit selected and then picked a reserves unit to deep strike, pressing A or the D-pad mid-placement popped the movement menu of the PREVIOUSLY selected unit — options that make no sense for a unit that just arrived, and a stray A could even silently commit that other unit to Stay Still or an Advance. Now the placement flow owns the controller: A jumps the cursor to the board to place models, the D-pad reaches the Confirm button, Start confirms the arrival — and a freshly arrived unit is never offered movement options.",

--- a/40k/scripts/AllocationGroupOverlay.gd
+++ b/40k/scripts/AllocationGroupOverlay.gd
@@ -124,6 +124,24 @@ var auto_pick_button: Button = null
 var precision_picker: OptionButton = null
 var _precision_eligible: Array = []
 
+# ── Controller (D-pad) focus support ──────────────────────────────────
+# This overlay is a plain Control (not a Window), so — exactly like the
+# Save/Load dialog — Godot does NOT confine keyboard/pad focus to it. Without
+# help the D-pad (= ui_*) walks the HUD / board controls drawn BEHIND the
+# overlay, and a controller player can never reach the ordering rows, the save
+# dice, the casualty buttons, or the final Done button. Mirroring
+# SaveLoadDialog we (1) join the "pad_native_nav_modal" group so PadRouter keeps
+# its board handlers (bumper cycling, panel-focus entry) OFF us and lets native
+# ui_* navigation drive the D-pad, (2) confine focus to our own subtree while a
+# pad is active (external focusables demoted to FOCUS_NONE, restored on exit),
+# and (3) grab focus onto the current step's primary button whenever the step
+# changes (order → reroll → pick → results) or the player picks up the pad.
+# Every focus GRAB is gated on the pad being the active device: keyboard/mouse
+# behaviour is deliberately untouched.
+const PAD_MODAL_GROUP := "pad_native_nav_modal"
+var _pad_focus_confined: bool = false
+var _pad_confined_controls: Array = []
+
 func setup(p_save_data: Dictionary, p_defender_player: int) -> void:
 	save_data = p_save_data
 	defender_player = p_defender_player
@@ -134,11 +152,17 @@ func setup(p_save_data: Dictionary, p_defender_player: int) -> void:
 	auto_mode = _compute_auto_mode()
 	_build_ui()
 	_rebuild_group_list()
+	# Controller: follow device switches so picking up the pad mid-window lands
+	# focus on the live step's button (see _on_pad_device_changed).
+	var idm := _idm()
+	if idm != null and idm.has_signal("device_changed") and not idm.device_changed.is_connected(_on_pad_device_changed):
+		idm.device_changed.connect(_on_pad_device_changed)
 	print("AllocationGroupOverlay: setup — %d group(s), %d wound(s) to save vs %s (auto_mode=%s)" % [
 		groups.size(), int(save_data.get("wounds_to_save", 0)), target_unit_id, str(auto_mode)])
 	if auto_mode:
 		# Legacy fast path: the computer orders, rolls and allocates in one
-		# step (AI defender, or the auto-allocate setting in local play).
+		# step (AI defender, or the auto-allocate setting in local play). The
+		# results step (with Done) still needs pad focus — _show_results grabs it.
 		print("AllocationGroupOverlay: auto_mode — resolving without defender interaction")
 		_on_confirm_pressed()
 		return
@@ -150,6 +174,9 @@ func setup(p_save_data: Dictionary, p_defender_player: int) -> void:
 	# and the combined target unit (gold) and link them with an attack arrow,
 	# so WHO is attacking WHOM stays visible on the battlefield itself.
 	_setup_attack_context_visual()
+	# Controller: land the D-pad on the order-step primary button (Confirm /
+	# Roll Saves) so a pad player can act without a mouse.
+	_refresh_pad_focus()
 
 
 # Auto (no-interaction) mode applies when the defender cannot interact:
@@ -241,6 +268,10 @@ func _setup_attack_context_visual() -> void:
 
 func _build_ui() -> void:
 	name = "AllocationGroupOverlay"
+	# Controller: tell PadRouter to keep its board-oriented D-pad handlers off
+	# this window so native ui_* focus navigation can drive it (see the
+	# PAD_MODAL_GROUP block above and the guard in PadRouter._input).
+	add_to_group(PAD_MODAL_GROUP)
 	# Parent is Main (a CanvasLayer): anchors AND offsets must be applied
 	# for the rect to fill the viewport (set_anchors_preset alone leaves
 	# the size at 0x0).
@@ -725,6 +756,9 @@ func _show_reroll_step() -> void:
 			chip.tooltip_text = "Passed save (rolled %d)" % v
 		dice_chips.add_child(chip)
 	reroll_panel.visible = true
+	# Controller: land the D-pad on Keep Rolls (safe default); the player can
+	# navigate to a failed die to spend the re-roll.
+	_refresh_pad_focus()
 	print("AllocationGroupOverlay: Command Re-roll offered — failed dice at raw indices %s" % str(failed))
 
 
@@ -846,6 +880,11 @@ func _enter_pick_or_finalize() -> void:
 	_setup_pick_highlights()
 	_update_pick_counter()
 	set_process_input(true)
+	# Controller: land the D-pad on the pick-step buttons (Auto-pick is always
+	# enabled) so a pad player has a reachable action. Model selection on the
+	# board is done with the left-stick virtual cursor (stick → cursor mode,
+	# D-pad → button focus — the two never fight, see VirtualCursor).
+	_refresh_pad_focus()
 	print("AllocationGroupOverlay: PICK step — %d casualty pick(s) required across %d group(s)" % [
 		total_required, _pick_required.size()])
 
@@ -1091,6 +1130,9 @@ func _show_results() -> void:
 		if d.get("context", "") == "devastating_wounds_11e":
 			result_label.append_text("\nDevastating wounds: %d crit(s) applied as mortal wounds (max one model each)" % d.get("crits", 0))
 	result_panel.visible = true
+	# Controller: land the D-pad on the Done button so a pad player can dismiss
+	# the results — the reported bug (Done unreachable on the D-pad).
+	_refresh_pad_focus()
 	# Keep a plain-text debug line (icons don't survive to the log).
 	print("AllocationGroupOverlay: resolved — save_rolls(lowest first)=%s, %d saved, %d failed, %d damage, %d destroyed%s" % [
 		str(rolls), batch_result.get("saves_passed", 0), batch_result.get("saves_failed", 0),
@@ -1136,3 +1178,104 @@ func _exit_tree() -> void:
 	if attack_context_visual != null and is_instance_valid(attack_context_visual):
 		attack_context_visual.queue_free()
 		attack_context_visual = null
+	# Controller: restore the focus modes we demoted and drop our device-change
+	# hook so the pad returns to normal board navigation once the window closes.
+	_release_pad_focus_confinement()
+	var idm := _idm()
+	if idm != null and idm.has_signal("device_changed") and idm.device_changed.is_connected(_on_pad_device_changed):
+		idm.device_changed.disconnect(_on_pad_device_changed)
+
+
+# ============================================================================
+# Controller (D-pad) focus support — see the PAD_MODAL_GROUP block near the top.
+# ============================================================================
+
+func _idm() -> Node:
+	# Lazy autoload lookup (autoload ids are not compile-time resolvable in the
+	# bare headless harness runs this overlay must keep compiling under).
+	return get_node_or_null("/root/InputDeviceManager")
+
+
+func _pad_active() -> bool:
+	var idm := _idm()
+	return idm != null and idm.has_method("is_pad_active") and idm.is_pad_active()
+
+
+func _on_pad_device_changed(_mode: int) -> void:
+	# Player changed input device while the window is open. On the pad, re-confine
+	# and land focus on the live step's button; back on KBM, release confinement
+	# so keyboard focus is not trapped. _refresh_pad_focus self-gates on the pad.
+	if _pad_active():
+		_refresh_pad_focus()
+	else:
+		_release_pad_focus_confinement()
+
+
+# The single button the D-pad should start on for whichever step is showing.
+func _current_primary_button() -> Button:
+	if result_panel != null and result_panel.visible and done_button != null and done_button.visible:
+		return done_button
+	if pick_panel != null and pick_panel.visible:
+		if confirm_removal_button != null and confirm_removal_button.visible and not confirm_removal_button.disabled:
+			return confirm_removal_button
+		if auto_pick_button != null and auto_pick_button.visible:
+			return auto_pick_button
+	if reroll_panel != null and reroll_panel.visible and keep_rolls_button != null and keep_rolls_button.visible:
+		return keep_rolls_button
+	if confirm_button != null and confirm_button.visible and not confirm_button.disabled:
+		return confirm_button
+	return null
+
+
+func _refresh_pad_focus() -> void:
+	# Deferred: a step change sets its panels' visible-flags on the same frame
+	# this is called from, so read them a frame later to pick the right button.
+	call_deferred("_refresh_pad_focus_now")
+
+
+func _refresh_pad_focus_now() -> void:
+	if not is_inside_tree() or not _pad_active():
+		return
+	# Trap directional focus in the overlay before grabbing, so a D-pad press
+	# off our primary button can't walk to a HUD/board control behind us.
+	if not _pad_focus_confined:
+		_confine_pad_focus()
+	var btn := _current_primary_button()
+	if btn != null and btn.is_visible_in_tree() and not btn.disabled:
+		btn.grab_focus()
+		print("AllocationGroupOverlay: pad focus → %s" % btn.name)
+
+
+# Trap directional focus inside this overlay: demote every focusable Control
+# OUTSIDE our subtree to FOCUS_NONE (remembered for verbatim restore on exit).
+# Idempotent — guarded by _pad_focus_confined. Board tokens are Node2D, not
+# focusable Controls, so casualty-picking with the virtual cursor is unaffected.
+func _confine_pad_focus() -> void:
+	if _pad_focus_confined:
+		return
+	var scene := get_tree().current_scene
+	if scene == null:
+		return
+	_pad_confined_controls.clear()
+	var queue: Array = [scene]
+	while not queue.is_empty():
+		var n: Node = queue.pop_front()
+		if n == self:
+			continue  # skip our own subtree — its controls must stay focusable
+		if n is Control and n.focus_mode == Control.FOCUS_ALL:
+			_pad_confined_controls.append(n)
+			n.focus_mode = Control.FOCUS_NONE
+		for child in n.get_children():
+			queue.append(child)
+	_pad_focus_confined = true
+	print("AllocationGroupOverlay: pad focus confined (%d external controls demoted)" % _pad_confined_controls.size())
+
+
+func _release_pad_focus_confinement() -> void:
+	if not _pad_focus_confined:
+		return
+	for c in _pad_confined_controls:
+		if is_instance_valid(c):
+			c.focus_mode = Control.FOCUS_ALL
+	_pad_confined_controls.clear()
+	_pad_focus_confined = false

--- a/40k/tests/scenarios/sp/pad_allocate_attacks_done_11e.json
+++ b/40k/tests/scenarios/sp/pad_allocate_attacks_done_11e.json
@@ -1,0 +1,57 @@
+{
+  "id": "pad_allocate_attacks_done_11e",
+  "covers": [
+    "controller.allocate_attacks.done_reachable",
+    "controller.allocate_attacks.native_nav_modal",
+    "controller.allocate_attacks.results_focus",
+    "scripts.AllocationGroupOverlay.pad_focus"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Steam Deck / controller: the 11e Allocate Attacks window (AllocationGroupOverlay) was not wired for D-pad navigation, so a pad player could never reach its Done button — the reported bug. This reproduces the exact reported case: auto-allocate wounds ON (the computer/opponent does the ordering + picking), so the window jumps straight to the results step showing the save rolls and casualties, leaving only Done. With a controller active the window must (a) join the 'pad_native_nav_modal' group so PadRouter stands down and native ui_* navigation drives it, and (b) grab focus onto the Done button so the D-pad ring lands on it and A dismisses it. Drives the real save-resolution entry point (ShootingController._on_saves_required) at edition 11 with a 3-wound AP-3 attack vs Boyz F (Sv5+ -> auto-fail).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script", "script": "GameState.set_edition(11)", "equals": 11 },
+    { "act": "execute_script", "script": "SettingsService.set_auto_allocate_wounds(true)" },
+    { "act": "execute_script", "script": "SettingsService.auto_allocate_wounds", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "InputDeviceManager.claim_pad()\nreturn InputDeviceManager.is_pad_active()", "equals": true },
+
+    { "act": "execute_script", "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))", "equals": 20 },
+
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(3, \"U_BOYZ_F\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Pad Alloc Test Cannon\", \"ap\": -3, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/ResultPanel", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.current_scene.get_node_or_null(\"AllocationGroupOverlay\")\nreturn o != null and o.is_in_group(\"pad_native_nav_modal\")", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "return PadRouter._native_nav_modal_open()", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "DoneButton" },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.current_scene.get_node(\"AllocationGroupOverlay\")\nreturn o._pad_focus_confined and o._pad_confined_controls.size() > 0", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.current_scene.get_node(\"AllocationGroupOverlay\")\nvar c = o._pad_confined_controls[0]\nGameState.set_meta(\"_test_demoted_ctrl\", c)\nreturn is_instance_valid(c) and c.focus_mode == Control.FOCUS_NONE", "equals": true },
+
+    { "act": "screenshot", "label": "01_results_done_pad_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script", "script": "main.get_node_or_null(\"AllocationGroupOverlay\") == null", "equals": true },
+
+    { "act": "execute_script", "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))", "equals": 17 },
+
+    { "act": "execute_script", "multiline": true, "script": "var c = GameState.get_meta(\"_test_demoted_ctrl\")\nvar ok = is_instance_valid(c) and c.focus_mode == Control.FOCUS_ALL\nGameState.remove_meta(\"_test_demoted_ctrl\")\nreturn ok", "equals": true },
+
+    { "act": "screenshot", "label": "02_done_pressed_overlay_closed_focus_restored" },
+
+    { "act": "execute_script", "script": "SettingsService.set_auto_allocate_wounds(false)" },
+    { "act": "execute_script", "script": "GameState.set_edition(10)", "equals": 10 }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_allocate_attacks_interactive_11e.json
+++ b/40k/tests/scenarios/sp/pad_allocate_attacks_interactive_11e.json
@@ -1,0 +1,62 @@
+{
+  "id": "pad_allocate_attacks_interactive_11e",
+  "covers": [
+    "controller.allocate_attacks.order_focus",
+    "controller.allocate_attacks.pick_focus",
+    "controller.allocate_attacks.done_reachable",
+    "scripts.AllocationGroupOverlay.pad_focus_steps"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Steam Deck / controller: the full interactive 11e Allocate Attacks flow must be D-pad navigable at every step, not just the Done button. Defender-controlled (auto-allocate OFF), single Boyz group, 3-wound AP-3 attack (Sv5+ -> auto-fail, 3 of 20 die so the casualty PickPanel appears). Command Re-roll is removed by zeroing CP so the flow is deterministic order -> pick -> results. At each step the D-pad focus (and gold ring) must land on that step's primary button — Roll Saves, then Auto-pick, then Done — and A must advance it. Drives the real ShootingController._on_saves_required entry point.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script", "script": "GameState.set_edition(11)", "equals": 11 },
+    { "act": "execute_script", "script": "SettingsService.set_auto_allocate_wounds(false)" },
+
+    { "act": "execute_script", "multiline": true, "script": "var pl = GameState.state.get(\"players\", {})\nfor k in pl.keys():\n\tpl[k][\"cp\"] = 0\nreturn true", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "InputDeviceManager.claim_pad()\nreturn InputDeviceManager.is_pad_active()", "equals": true },
+
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(3, \"U_BOYZ_F\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Pad Interactive Cannon\", \"ap\": -3, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/ConfirmButton", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "return PadRouter._native_nav_modal_open()", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "ConfirmButton" },
+
+    { "act": "screenshot", "label": "01_order_confirm_pad_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/PickPanel", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "AutoPickButton" },
+
+    { "act": "screenshot", "label": "02_pick_autopick_pad_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/ResultPanel", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "DoneButton" },
+
+    { "act": "screenshot", "label": "03_results_done_pad_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "execute_script", "script": "main.get_node_or_null(\"AllocationGroupOverlay\") == null", "equals": true },
+    { "act": "execute_script", "script": "RulesEngine.count_alive_models(GameState.get_unit(\"U_BOYZ_F\"))", "equals": 17 },
+
+    { "act": "execute_script", "script": "GameState.set_edition(10)", "equals": 10 }
+  ]
+}


### PR DESCRIPTION
## Problem

The **Allocate Attacks** window that pops up after shooting/fighting and wounding (the 11th-edition `AllocationGroupOverlay`, showing the save rolls, destroyed models, and a **Done** button) was never wired for controller navigation. Because it is a plain `Control` — not a `Window` — Godot does not confine keyboard/pad focus to it, so a controller player's D-pad walked the HUD/board controls drawn *behind* it and could never land on the window's own buttons, **including the final Done button**. The player was stuck and had to fall back to the mouse/virtual cursor.

## Fix

Mirror the established `SaveLoadDialog` controller pattern in `AllocationGroupOverlay`:

- **Join the `pad_native_nav_modal` group** so `PadRouter` keeps its board handlers (bumper cycling, panel-focus entry) off the window and lets native `ui_*` focus navigation drive the D-pad.
- **Confine focus to the overlay's own subtree** while a pad is active (external focusables demoted to `FOCUS_NONE`, restored verbatim on close) so the D-pad can't wander onto the HUD/board behind it.
- **Grab the gold focus ring onto the current step's primary button** whenever the step changes (order → reroll → pick → results) or the player picks up the pad — Roll Saves / Keep Rolls / Auto-pick / Done — so **A** activates it.

All focus handling is gated on the pad being the active device, so keyboard/mouse behaviour is unchanged. Board casualty-picking still uses the left-stick virtual cursor (orthogonal to focus). The same overlay class is used by both the shooting and fight phases, so both are fixed.

## Validation

Two new windowed scenarios drive the real `ShootingController._on_saves_required` entry point at edition 11 against the running UI:

- **`pad_allocate_attacks_done_11e`** — the reported case (auto-allocate on → straight to results): Done gets pad focus and A dismisses it.
- **`pad_allocate_attacks_interactive_11e`** — the full order → pick → results flow, each step's button focused and advanced with A.

Both pass; screenshots show the gold focus ring on the correct button at each step. Existing allocation scenarios (`iss045_allocation_groups`, `defender_control_saves_11e`, `auto_allocate_wounds`) and a sample of pad scenarios still pass; no `SCRIPT ERROR`s fired.

## Changes

- `40k/scripts/AllocationGroupOverlay.gd` — controller focus support (group membership, focus confinement, per-step focus grab, device-change hook, cleanup on exit).
- `40k/tests/scenarios/sp/pad_allocate_attacks_done_11e.json` — new windowed scenario.
- `40k/tests/scenarios/sp/pad_allocate_attacks_interactive_11e.json` — new windowed scenario.
- `40k/data/version_history.json` — version `0.84.1` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tUbdJGVAhW6EF15iX7Fa6

---
_Generated by [Claude Code](https://claude.ai/code/session_013tUbdJGVAhW6EF15iX7Fa6)_