### PR TITLE
Controller targeting: visible reticle + pad-operable split fire (Shooting, Charge, Fight)

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -290,6 +290,17 @@ func _on_device_changed(mode: int) -> void:
 	# only the HUD panel subtrees release.
 	if pad:
 		_release_panel_focus()
+	# Shooting: the gold target reticle exists for the pad only — arm it the
+	# moment the pad takes over mid-phase, drop it (and the highlight) when the
+	# mouse does; sync_shoot_target_highlight branches on the active device.
+	sync_shoot_target_highlight()
+	# Charge: same contract for the ▲ ▼ target-row cursor and its reticle.
+	var m := get_tree().current_scene
+	if m != null and ("current_phase" in m) and m.current_phase == GameStateData.Phase.CHARGE \
+			and ("charge_controller" in m) and m.charge_controller != null \
+			and is_instance_valid(m.charge_controller) \
+			and m.charge_controller.has_method("pad_sync_target_cursor"):
+		m.charge_controller.pad_sync_target_cursor()
 	_update_hints()
 
 
@@ -597,7 +608,11 @@ func _cycle(dir: int) -> void:
 		# Targets are the armed shooter's sub-menu now: D-pad ◀ ▶, next to the
 		# weapon rows on ▲ ▼ (mirrors charge's target stepping).
 		sc._keyboard_cycle_units(dir < 0)  # reuses the Tab / Shift+Tab path
-		target_highlight_id = ""
+		# The selection flow above already re-armed the highlight for the NEW
+		# shooter (sync_shoot_target_highlight runs at the arming tail) — the
+		# old blanket reset here wiped it and left ◀ ▶ / A subject-less until
+		# the first D-pad press. Re-sync instead of blanking.
+		sync_shoot_target_highlight()
 		if str(sc.active_shooter_id) != "":
 			_center_camera_on_unit(str(sc.active_shooter_id))
 		return
@@ -631,6 +646,8 @@ func _cycle_target(sc: Node, dir: int) -> void:
 	ring.sort()
 	if ring.is_empty():
 		target_highlight_id = ""
+		if sc.has_method("pad_clear_target_reticle"):
+			sc.pad_clear_target_reticle()
 		return
 	# Entering TARGET_SELECT claims the pad: release any panel focus (the
 	# shooter-cycling path focuses the unit list) so A means "assign", not
@@ -641,7 +658,39 @@ func _cycle_target(sc: Node, dir: int) -> void:
 	var idx := ring.find(target_highlight_id)
 	idx = wrapi(idx + dir, 0, ring.size()) if idx != -1 else (0 if dir > 0 else ring.size() - 1)
 	target_highlight_id = str(ring[idx])
+	# Gold reticle brackets + "TARGET n/m" banner on the board — the camera pan
+	# alone was invisible whenever the targets sat close together, which read
+	# as "◀ ▶ does nothing" (the 2026-07 controller-targeting report).
+	if sc.has_method("pad_show_target_reticle"):
+		sc.pad_show_target_reticle(target_highlight_id)
 	_center_camera_on_unit(target_highlight_id)
+
+
+# (Re)arm the shooting target highlight for the pad: keeps a still-valid
+# highlight, otherwise lands on the first entry of the sorted target ring, and
+# draws the gold reticle either way. Called by ShootingController at every
+# shooter-arming tail (select / cycle / resync) and on device switch, so a pad
+# player ALWAYS has a bracketed subject for ◀ ▶ / A the moment a shooter is
+# armed. KBM players never get the reticle (mouse hover/click needs no cursor);
+# their highlight id is blanked so a later A can't fire at a stale target.
+func sync_shoot_target_highlight() -> void:
+	var sc = _shooting_controller_in_shooting_phase()
+	if sc == null or str(sc.active_shooter_id) == "" or sc.eligible_targets.is_empty():
+		target_highlight_id = ""
+		if sc != null and sc.has_method("pad_clear_target_reticle"):
+			sc.pad_clear_target_reticle()
+		return
+	if not InputDeviceManager.is_pad_active():
+		target_highlight_id = ""
+		if sc.has_method("pad_clear_target_reticle"):
+			sc.pad_clear_target_reticle()
+		return
+	if not sc.eligible_targets.has(target_highlight_id):
+		var ring: Array = sc.eligible_targets.keys()
+		ring.sort()
+		target_highlight_id = str(ring[0])
+	if sc.has_method("pad_show_target_reticle"):
+		sc.pad_show_target_reticle(target_highlight_id)
 
 
 func _cycle_unit_list(dir: int) -> void:
@@ -736,7 +785,14 @@ func _pad_step_secondary(dir: int) -> bool:
 		GameStateData.Phase.CHARGE:
 			var cc = m.charge_controller if ("charge_controller" in m) else null
 			if cc != null and is_instance_valid(cc) and cc.has_method("pad_step_target"):
-				return cc.pad_step_target(dir)
+				if cc.pad_step_target(dir):
+					# Camera-follow the stepped row's unit, mirroring the
+					# shooting phase's ◀ ▶ target walk — a charge target can
+					# sit off-screen and an invisible bracket teaches nothing.
+					if cc.has_method("pad_current_target_id") and str(cc.pad_current_target_id()) != "":
+						_center_camera_on_unit(str(cc.pad_current_target_id()))
+					return true
+				return false
 		GameStateData.Phase.SHOOTING:
 			var sc = _shooting_controller_in_shooting_phase()
 			if sc != null and sc.has_method("pad_step_weapon"):
@@ -880,12 +936,24 @@ func _assign_highlighted_target() -> bool:
 			"type": "SELECT_SHOOTER",
 			"actor_unit_id": str(sc.active_shooter_id)
 		})
-	# The click path requires a selected weapon row; select the first one if
-	# the player hasn't focused any (same default the mouse flow nudges you to).
+	# The click path requires a selected weapon row; select the first USABLE one
+	# if the player hasn't focused any (same default the mouse flow nudges you
+	# to). Disabled rows — engaged non-pistols, post-advance non-assault, an 11e
+	# shooting type's weapon_allowed — are unselectable, and TreeItem.select()
+	# on one silently does nothing, which used to make A a silent no-op.
 	if sc.weapon_tree != null and sc.weapon_tree.get_selected() == null:
 		var root: TreeItem = sc.weapon_tree.get_root()
-		if root != null and root.get_first_child() != null:
-			root.get_first_child().select(0)
+		if root != null:
+			var child: TreeItem = root.get_first_child()
+			while child != null and not child.is_selectable(0):
+				child = child.get_next()
+			if child != null:
+				child.select(0)
+	if sc.weapon_tree != null and sc.weapon_tree.get_selected() == null:
+		# Every weapon row is disabled (e.g. engaged with no pistols): consume
+		# the press WITH feedback — a silent A reads as "the pad is broken".
+		ToastManager.show_warning("No usable weapon for this target — X skips the unit")
+		return true
 	sc._select_target_for_current_weapon(target_highlight_id)
 	return true
 

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -234,6 +234,22 @@ const HINTS_MOVE_LOCKED := [
 	["b", "Undo Model"],
 	["y", "Datasheet"],
 ]
+# Fight phase, board context (fighter selection + the global Pile In /
+# Consolidate steps): the bumpers cycle the panel's action buttons (fighter /
+# unit picks + End), D-pad enters/navigates that panel, A commits the focused
+# button. The interactive pile-in / consolidate model moves use the virtual
+# cursor (left stick + A), same as any board drag. The attack-assignment dialog
+# carries its own on-dialog hint row (▲▼ Weapon · ◀▶ Target · Ⓐ Assign · ☰
+# Fight!), so no separate board set is needed while it is open.
+const HINTS_FIGHT := [
+	["rb", "Cycle Units"],
+	["dpad", "Navigate Panel"],
+	["a", "Select"],
+	["ls", "Move Models"],
+	["y", "Datasheet"],
+	["menu", "End Phase"],
+	["view", "Pause Menu"],
+]
 
 # The target currently highlighted by LB/RB in shooting TARGET_SELECT mode
 # (empty when none). Windowed scenarios assert this.
@@ -591,6 +607,19 @@ func _reopen_move_menu() -> void:
 # ============================================================================
 
 func _cycle(dir: int) -> void:
+	# Fight phase: the bumpers cycle keyboard focus among the ACTION BUTTONS of
+	# the visible fight-panel section (fighter picks, pile-in / consolidate unit
+	# picks + their End button) and A commits the focused one — the "pick a
+	# unit" bumper meaning, adapted to the fight phase's button-based selection.
+	# Crucially this does NOT drive the informational FIGHT SEQUENCE ItemList,
+	# whose generic bumper-cycle used to misfire SELECT_FIGHTER on the wrong
+	# unit. Handled before the panel-focus release below so a second press
+	# advances from the currently-focused button instead of restarting at 0.
+	var fc := _fight_controller()
+	if fc != null:
+		if fc.has_method("pad_cycle_fight_buttons"):
+			fc.pad_cycle_fight_buttons(dir)
+		return
 	# Bumpers are a BOARD action: cycling while a side-panel control holds
 	# focus (mouse-click residue, or deliberate D-pad panel work) releases
 	# that focus first, so the pad lands back in the unit flow. Without this,
@@ -1916,6 +1945,40 @@ func _center_camera_on_world(world_pos: Vector2) -> void:
 	m.update_view_transform()
 
 
+# Frame `world_pos` at a chosen vertical screen fraction (0 = top, 0.5 = center)
+# instead of dead-center. The fight attack reticle uses this to lift the
+# bracketed target into the clear top strip above the bottom-anchored
+# AttackAssignmentDialog, which otherwise occludes a centered target.
+func _center_camera_on_world_biased(world_pos: Vector2, frac_y: float) -> void:
+	var m := get_tree().current_scene
+	if m == null or not ("view_offset" in m) or not m.has_method("update_view_transform"):
+		return
+	var vp: Vector2 = m.get_viewport().get_visible_rect().size
+	var zoom: float = m.view_zoom if "view_zoom" in m else 1.0
+	m.view_offset = world_pos - Vector2(vp.x * 0.5, vp.y * frac_y) / zoom
+	m.update_view_transform()
+
+
+# Frame `unit_id` in the UPPER portion of the viewport (pad-only), so a
+# bottom-anchored dialog can't hide it. Used by the fight attack reticle.
+func frame_unit_upper_if_pad(unit_id: String) -> void:
+	if unit_id == "" or not InputDeviceManager.is_pad_active():
+		return
+	var unit = GameState.get_unit(unit_id)
+	if unit.is_empty():
+		return
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var pos = model.get("position", null)
+		if pos is Dictionary and pos.has("x"):
+			_center_camera_on_world_biased(Vector2(float(pos.x), float(pos.y)), 0.22)
+			return
+		elif pos is Vector2:
+			_center_camera_on_world_biased(pos, 0.22)
+			return
+
+
 func _shooting_controller_in_shooting_phase() -> Node:
 	var m := get_tree().current_scene
 	if m == null or not ("current_phase" in m) or not ("shooting_controller" in m):
@@ -1934,6 +1997,20 @@ func _shooting_controller_in_shooting_phase() -> Node:
 # stands down — and stops driving the hints — while such a modal is open.
 func refresh_hints() -> void:
 	_update_hints()
+
+
+# The FightController while the Fight phase is live, else null. Used by the
+# bumper button-cycle and the fight hint sets so each reads the same authority.
+func _fight_controller() -> Node:
+	var m := get_tree().current_scene
+	if m == null or not ("current_phase" in m) or not ("fight_controller" in m):
+		return null
+	if m.current_phase != GameStateData.Phase.FIGHT:
+		return null
+	var fc = m.fight_controller
+	if fc == null or not is_instance_valid(fc):
+		return null
+	return fc
 
 
 func _update_hints() -> void:
@@ -1977,6 +2054,12 @@ func _update_hints() -> void:
 				# (A re-picks the dropped model, X advances); all placed = the
 				# locked state waiting on Start.
 				hints = HINTS_MOVE_STAGED if _movement_has_unplaced_models() else HINTS_MOVE_LOCKED
+			elif _fight_controller() != null:
+				# Fight board context (fighter selection / pile-in / consolidate).
+				# The attack dialog carries its own on-dialog hint row while open;
+				# its focus lives in the modal's own viewport, so the main-viewport
+				# focus check above stays false and this set still shows behind it.
+				hints = HINTS_FIGHT
 	PadHintBar.set_hints(hints)
 
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,21 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.88.0",
+			"date": "2026-07-22",
+			"summary": "You can now SEE which enemy you're targeting on a controller — and split fire without a mouse. In the Shooting phase the current target wears gold reticle brackets with a 'TARGET 2/3: <name>' banner: it appears on the first target automatically when a shooter is armed, D-pad ◀ ▶ visibly walks it between targets (the damage forecast follows), and A assigns it to the highlighted weapon. Aim each weapon at a different enemy with ▲ ▼ + ◀ ▶ + A, and when you fire one weapon's bearers at a second enemy, the split-fire dialog is now fully controller-operable: ◀ ▶ picks how many models switch, A confirms, B cancels. The Charge phase speaks the same language — the target row your D-pad steps to is bracketed on the board too, with the camera following.",
+			"changes": [
+				"Shooting: the controller's current target is marked on the board with pulsing gold corner brackets on every model of the unit, plus a '▶ TARGET n/m: <name>' banner. Previously the only feedback for D-pad ◀ ▶ was a camera pan — with two targets close together it looked like the buttons did nothing.",
+				"Arming a shooter with the controller auto-brackets the first target, so A always has a visible subject and ◀ ▶'s first press visibly moves the bracket.",
+				"The FORECAST damage preview now follows the controller: it always shows the selected weapon against the bracketed target, both when cycling targets (◀ ▶) and when stepping weapons (▲ ▼).",
+				"Split fire per weapon on a controller: ▲ ▼ steps the weapon rows (now skipping disabled weapons), ◀ ▶ picks the target, A assigns — each gun can aim at a different enemy, with a toast confirming every assignment ('✓ Big shoota → Witchseekers', plus 'all weapons assigned — Start confirms' when done).",
+				"Split fire per model on a controller: assigning the same weapon at a second target opens the split-fire picker as with the mouse, and the picker is now pad-operable — D-pad ◀ ▶ (or ▲ ▼) steps the 'how many models' counter, A confirms, B cancels, with the hints shown in the dialog.",
+				"A no longer dies silently when every weapon is disabled (e.g. engaged with no pistols): a toast explains and points at X (skip unit).",
+				"Charge: the ELIGIBLE TARGETS row your D-pad ▲ ▼ steps to is bracketed on the board with the same gold reticle and TARGET n/m banner, the camera follows the stepped target (it can be off-screen at combat zoom), and the first row is auto-bracketed when you arm a unit. The reticle clears when the charge is declared.",
+				"The reticle is controller-only: it never appears while playing with mouse and keyboard, and it disappears the moment the mouse takes over."
+			]
+		},
+		{
 			"version": "0.87.2",
 			"date": "2026-07-22",
 			"summary": "Fixed walls not blocking line of sight (or movement) after loading a save or in a networked game. Terrain walls are stored as exact coordinates, but once terrain had round-tripped through a save file or a network sync those coordinates came back in a form the geometry check couldn't read — so the check errored out and quietly treated the wall as if it wasn't there. Units could see and shoot through walls they shouldn't, and the same walls stopped blocking movement. Now handled in both formats.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,19 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.89.0",
+			"date": "2026-07-22",
+			"summary": "The controller target-picking treatment now reaches the Fight phase. The Assign Attacks dialog is fully controller-operable — the melee twin of the shooting fix: D-pad ▲▼ steps the weapon, ◀▶ steps the target (the enemy you're about to hit wears the same gold reticle brackets + 'TARGET n/m' banner, auto-armed and lifted into the clear strip above the dialog so it's never hidden), Ⓐ adds the assignment, and ☰ resolves the fight. Picking which unit fights, and the pile-in / consolidate unit picks, are reachable with the bumpers + D-pad too — the bumpers no longer misfire on the fight-order list.",
+			"changes": [
+				"Fight — Assign Attacks dialog is now fully controller-drivable: D-pad ▲▼ steps the melee weapon list, ◀▶ steps the target list, Ⓐ adds the assignment (with a confirming toast), ☰ (Menu) presses Fight! to resolve, and Ⓑ ends the fight when the dialog offers it. An on-dialog hint row spells this out, shown only on a controller.",
+				"The melee target you're about to assign wears the same gold reticle brackets + '▶ TARGET n/m: NAME' banner as the shooting and charge phases — auto-shown on the first target when the dialog opens, and following your ◀▶ steps.",
+				"Because the Assign Attacks dialog sits along the bottom of the screen, the bracketed target is framed into the clear strip above it, so it's never hidden behind the dialog.",
+				"Fight — the bumpers (LB/RB) now cycle the fighter-selection buttons (and the pile-in / consolidate unit picks + their End button) instead of the informational Fight Sequence list, which previously misfired and could select the wrong unit. The D-pad also enters and navigates those panel buttons, and Ⓐ commits the highlighted one.",
+				"Added a Fight-phase controller hint bar (bumpers cycle units, D-pad navigates the panel, Ⓐ selects, left stick moves models during pile-in / consolidate).",
+				"The fight reticle is controller-only: it never appears with mouse and keyboard, and clears when the dialog closes."
+			]
+		},
+		{
 			"version": "0.88.0",
 			"date": "2026-07-22",
 			"summary": "You can now SEE which enemy you're targeting on a controller — and split fire without a mouse. In the Shooting phase the current target wears gold reticle brackets with a 'TARGET 2/3: <name>' banner: it appears on the first target automatically when a shooter is armed, D-pad ◀ ▶ visibly walks it between targets (the damage forecast follows), and A assigns it to the highlighted weapon. Aim each weapon at a different enemy with ▲ ▼ + ◀ ▶ + A, and when you fire one weapon's bearers at a second enemy, the split-fire dialog is now fully controller-operable: ◀ ▶ picks how many models switch, A confirms, B cancels. The Charge phase speaks the same language — the target row your D-pad steps to is bracketed on the board too, with the camera following.",

--- a/40k/dialogs/AttackAssignmentDialog.gd
+++ b/40k/dialogs/AttackAssignmentDialog.gd
@@ -8,6 +8,11 @@ signal attacks_confirmed(assignments: Array)
 # requested, so this only fires on unforeseen paths — but without it the
 # dialog is un-completable (nothing to assign) and the game self-locks.
 signal skip_fight_requested(unit_id: String)
+# Pad (controller): emitted with the unit_id of the target_list row the D-pad
+# ◀ ▶ cursor now sits on, so the FightController can bracket it on the board
+# with the shared gold reticle. Also fires once on open (auto-arm) when the pad
+# is the active device.
+signal pad_target_focus_changed(target_id: String)
 
 var unit_id: String = ""
 var eligible_targets: Dictionary = {}
@@ -19,6 +24,7 @@ var assignments_display: RichTextLabel = null
 var extra_attacks_weapons: Array = []  # T3-3: Track Extra Attacks weapons for auto-inclusion
 var extra_attacks_target_list: ItemList = null  # T3-3: Target selector for Extra Attacks weapons
 var all_to_target_button: Button = null  # T5-UX5: "All to Target" shortcut button
+var _pad_hint_label: Label = null  # Controller hint row (shown only when a pad is active)
 
 func setup(fighter_id: String, targets: Dictionary, phase) -> void:
 	WhiteDwarfTheme.apply_to_dialog(self)
@@ -252,9 +258,142 @@ func _build_ui() -> void:
 	assignments_display.name = "AssignmentsDisplay"
 	container.add_child(assignments_display)
 
+	# Pad (controller) hint row — the melee twin of the shooting phase's target
+	# ring, spelled out for a controller. Shown only when the pad is the active
+	# device; a mouse player never sees it. See _pad_handle_input.
+	_pad_hint_label = Label.new()
+	_pad_hint_label.name = "PadHintLabel"
+	_pad_hint_label.text = "▲▼ Weapon   ·   ◀▶ Target   ·   Ⓐ Assign   ·   ☰ Fight!   ·   Ⓑ Skip"
+	_pad_hint_label.add_theme_font_size_override("font_size", 12)
+	_pad_hint_label.modulate = Color(1, 1, 1, 0.75)
+	_pad_hint_label.visible = InputDeviceManager.is_pad_active()
+	container.add_child(_pad_hint_label)
+
 	add_child(container)
 
 	confirmed.connect(_on_confirmed)
+
+	# Pad: the ItemLists are driven by the D-pad through window_input (below), so
+	# demote them out of the focus chain — otherwise the dialog watcher / native
+	# ui_up-down would fight our stepping. Buttons keep focus for A-fallthrough.
+	for lst in [weapon_list, target_list, extra_attacks_target_list]:
+		if lst != null:
+			lst.focus_mode = Control.FOCUS_CLICK
+	window_input.connect(_pad_handle_input)
+	# Auto-arm the board reticle on the first shown frame when a pad is active,
+	# so ◀ ▶ / A have a visible target from the very first press.
+	about_to_popup.connect(_pad_arm_on_popup)
+
+
+# Pad: arm the reticle for the initially-selected target (index 0) when the
+# dialog pops with a pad active. Deferred a frame so the dialog is on-screen and
+# the FightController's connection is live.
+func _pad_arm_on_popup() -> void:
+	if _pad_hint_label != null:
+		_pad_hint_label.visible = InputDeviceManager.is_pad_active()
+	if not InputDeviceManager.is_pad_active():
+		return
+	call_deferred("_pad_emit_current_target")
+
+
+func _pad_emit_current_target() -> void:
+	var tid := _pad_current_target_id()
+	if tid != "":
+		pad_target_focus_changed.emit(tid)
+
+
+func _pad_current_target_id() -> String:
+	if target_list == null or target_list.item_count == 0:
+		return ""
+	var sel := target_list.get_selected_items()
+	var idx: int = sel[0] if not sel.is_empty() else 0
+	return str(target_list.get_item_metadata(idx))
+
+
+# Pad navigation for the whole attack dialog, handled on the dialog's own
+# window_input so it never fights PadRouter (an exclusive AcceptDialog is its
+# own viewport). Mirrors the shooting phase's controller mapping exactly:
+#   ▲ ▼   step the weapon list   (one melee weapon per model — 11e)
+#   ◀ ▶   step the target list   (updates the board reticle via the signal)
+#   Ⓐ     Add Assignment          (assign the selected weapon → target)
+#   ☰      Fight!                  (confirm + resolve — the phase-action button)
+#   Ⓑ     Skip / cancel           (ends the activation when a Skip button exists)
+func _pad_handle_input(event: InputEvent) -> void:
+	if not (event is InputEventJoypadButton) or not event.pressed:
+		return
+	match event.button_index:
+		JOY_BUTTON_DPAD_UP:
+			_pad_step_list(weapon_list, -1)
+			set_input_as_handled()
+		JOY_BUTTON_DPAD_DOWN:
+			_pad_step_list(weapon_list, 1)
+			set_input_as_handled()
+		JOY_BUTTON_DPAD_LEFT:
+			if _pad_step_list(target_list, -1):
+				_pad_emit_current_target()
+			set_input_as_handled()
+		JOY_BUTTON_DPAD_RIGHT:
+			if _pad_step_list(target_list, 1):
+				_pad_emit_current_target()
+			set_input_as_handled()
+		JOY_BUTTON_A:
+			_pad_assign()
+			set_input_as_handled()
+		JOY_BUTTON_START:
+			_on_confirmed()
+			set_input_as_handled()
+		JOY_BUTTON_B:
+			# End the fight when the dialog offers it (no-targets escape hatch);
+			# otherwise leave B for the dialog's own cancel/close.
+			var skip_btn := _find_child_button("SkipFightButton")
+			if skip_btn != null and skip_btn.visible and not skip_btn.disabled:
+				_on_skip_fight_pressed()
+				set_input_as_handled()
+
+
+# Step an ItemList's single selection with wrap; returns true when it moved.
+func _pad_step_list(lst: ItemList, dir: int) -> bool:
+	if lst == null or lst.item_count == 0:
+		return false
+	var sel := lst.get_selected_items()
+	var cur: int = sel[0] if not sel.is_empty() else (0 if dir > 0 else lst.item_count - 1)
+	var nxt := wrapi(cur + dir, 0, lst.item_count)
+	if nxt == cur:
+		return false
+	lst.select(nxt)
+	lst.ensure_current_is_visible()
+	return true
+
+
+# Pad Ⓐ = Add Assignment: assign the selected weapon to the selected target,
+# with a toast so a controller player (who can't see the mouse-only display
+# refresh at a glance) gets confirmation and knows ☰ resolves the fight.
+func _pad_assign() -> void:
+	if weapon_list == null or target_list == null:
+		return
+	if weapon_list.item_count == 0 or target_list.item_count == 0:
+		return
+	_on_assign_pressed()
+	var wsel := weapon_list.get_selected_items()
+	var tsel := target_list.get_selected_items()
+	if wsel.is_empty() or tsel.is_empty():
+		return
+	var wname := str(weapon_list.get_item_text(wsel[0])).split(" (")[0]
+	var tname := str(target_list.get_item_text(tsel[0])).split(" (")[0]
+	var toast := get_node_or_null("/root/ToastManager")
+	if toast != null:
+		toast.show_toast("✓ %s → %s — ☰ to Fight!" % [wname, tname])
+
+
+func _find_child_button(node_name: String) -> Button:
+	var q: Array = [self]
+	while not q.is_empty():
+		var n = q.pop_front()
+		if n is Button and str(n.name) == node_name:
+			return n
+		for c in n.get_children():
+			q.append(c)
+	return null
 
 func _on_assign_pressed() -> void:
 	print("[AttackAssignmentDialog] Assign button pressed")

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -99,6 +99,10 @@ var target_engagement_visuals: Array = []  # Engagement range circles around cha
 var charge_line_visual: Line2D
 var range_visual: Node2D
 var target_highlights: Node2D
+# Pad target reticle: gold brackets on the D-pad-stepped target row's unit
+# (shared visual language with the shooting phase — see PadTargetReticle.gd).
+const PadTargetReticleScript = preload("res://scripts/PadTargetReticle.gd")
+var pad_target_reticle: Node2D
 
 # T7-58: Charge arrow visuals - animated arrows from charger to targets
 var charge_arrow_visuals: Array = []  # Array of ChargeArrowVisual instances
@@ -153,6 +157,9 @@ func _exit_tree() -> void:
 		range_visual.queue_free()
 	if target_highlights and is_instance_valid(target_highlights):
 		target_highlights.queue_free()
+	if pad_target_reticle and is_instance_valid(pad_target_reticle):
+		pad_target_reticle.queue_free()
+		pad_target_reticle = null
 	_clear_charge_arrow_visuals()  # T7-58
 	_clear_charge_trajectory_preview()  # P3-127
 	_clear_movement_visuals()
@@ -772,6 +779,15 @@ func _create_charge_visuals() -> void:
 	target_highlights.name = "ChargeTargetHighlights"
 	board_root.add_child(target_highlights)
 
+	# Pad target reticle — same gold "the unit your next A applies to" brackets
+	# the shooting phase draws, here marking the D-pad ▲ ▼-stepped ELIGIBLE
+	# TARGETS row on the board (the gold list-row tint alone never told the
+	# player WHERE that unit actually stands).
+	pad_target_reticle = PadTargetReticleScript.new()
+	pad_target_reticle.name = "PadTargetReticle"
+	board_root.add_child(pad_target_reticle)
+	pad_target_reticle.clear()
+
 	# P3-127: Create charge trajectory preview
 	charge_trajectory_preview = ChargeTrajectoryPreview.new()
 	board_root.add_child(charge_trajectory_preview)
@@ -1379,8 +1395,15 @@ func _refresh_target_list() -> void:
 		var item_index = target_list.get_item_count() - 1
 		target_list.set_item_metadata(item_index, target_id)
 		print("DEBUG: Added target item ", item_index, ": '", display_text, "' with metadata: ", target_id)
-	
+
 	print("DEBUG: Target list now has ", target_list.get_item_count(), " items")
+
+	# Pad: bracket the first target row immediately (mirrors the shooting
+	# phase's auto-armed reticle) so ▲ ▼ / A always have a visible subject —
+	# the first press should MOVE the cursor, not conjure it.
+	if InputDeviceManager.is_pad_active() and target_list.get_item_count() > 0:
+		pad_target_cursor = 0
+		_update_pad_target_cursor_visual()
 
 func _on_target_list_gui_input(event: InputEvent) -> void:
 	# Own the LEFT-click selection so multi-target charge works on every platform.
@@ -1474,6 +1497,29 @@ func _sync_selected_targets_from_list() -> void:
 # pad_target_cursor.
 # ============================================================================
 var pad_target_cursor: int = -1
+
+# The unit id of the row the pad target cursor sits on ("" when unset).
+# PadRouter camera-follows this after a ▲ ▼ step, mirroring the shooting
+# phase's ◀ ▶ target walk — a stepped target can sit off-screen (12" is most
+# of a screen at combat zoom) and a bracket the player can't see is no better
+# than no bracket.
+func pad_current_target_id() -> String:
+	if not is_instance_valid(target_list):
+		return ""
+	if pad_target_cursor < 0 or pad_target_cursor >= target_list.get_item_count():
+		return ""
+	return str(target_list.get_item_metadata(pad_target_cursor))
+
+# Device-switch seam: arm/clear the pad target cursor + board reticle for the
+# active input device (PadRouter calls this when the device changes). Picking
+# the pad up mid-charge brackets the first row; the mouse taking over clears
+# the reticle via _refresh_pad_target_reticle's own device guard.
+func pad_sync_target_cursor() -> void:
+	if InputDeviceManager.is_pad_active() and is_instance_valid(target_list) \
+			and target_list.get_item_count() > 0 and pad_target_cursor < 0 \
+			and active_unit_id != "" and not awaiting_roll and not awaiting_movement:
+		pad_target_cursor = 0
+	_update_pad_target_cursor_visual()
 
 func pad_step_target(dir: int) -> bool:
 	if active_unit_id == "" or awaiting_roll or awaiting_movement:
@@ -1575,6 +1621,41 @@ func _update_pad_target_cursor_visual() -> void:
 			target_list.set_item_custom_bg_color(i, Color(0.94, 0.78, 0.31, 0.25))
 		else:
 			target_list.set_item_custom_bg_color(i, Color(0, 0, 0, 0))
+	_refresh_pad_target_reticle()
+
+# Board-side half of the pad target cursor: gold reticle brackets on the
+# stepped row's unit (same visual language as the shooting phase's D-pad ◀ ▶
+# target ring — the list-row tint alone never showed WHERE the unit stands).
+# Self-guarding: clears whenever the pad cursor has no live subject (no unit,
+# rows locked after declaring, cursor unset, or the mouse is driving).
+func _refresh_pad_target_reticle() -> void:
+	if pad_target_reticle == null or not is_instance_valid(pad_target_reticle):
+		return
+	if active_unit_id == "" or awaiting_roll or awaiting_movement \
+			or not is_instance_valid(target_list) \
+			or pad_target_cursor < 0 or pad_target_cursor >= target_list.get_item_count() \
+			or not InputDeviceManager.is_pad_active():
+		pad_target_reticle.clear()
+		return
+	var target_id := str(target_list.get_item_metadata(pad_target_cursor))
+	var unit = GameState.get_unit(target_id)
+	if unit.is_empty():
+		pad_target_reticle.clear()
+		return
+	var marks: Array = []
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var pos = _get_model_position(model)
+		if pos == Vector2.ZERO:
+			continue
+		marks.append({
+			"pos": pos,
+			"radius_px": Measurement.base_radius_px(model.get("base_mm", 32)) + 4.0,
+		})
+	var unit_name = str(unit.get("meta", {}).get("display_name", unit.get("meta", {}).get("name", target_id)))
+	var banner := "▶ TARGET %d/%d: %s" % [pad_target_cursor + 1, target_list.get_item_count(), unit_name]
+	pad_target_reticle.show_for_marks(marks, banner)
 
 func _update_target_hint_label() -> void:
 	# Prominent, DYNAMIC teaching copy for the ELIGIBLE TARGETS list. The whole
@@ -1666,6 +1747,9 @@ func _update_visuals() -> void:
 	_clear_charge_arrow_visuals()  # T7-58: Clear old arrows
 	_clear_charge_trajectory_preview()  # P3-127: Clear old trajectories
 	_clear_charge_range_circle()  # T-092: Clear 12" range overlay
+	# Pad reticle re-evaluates on every state change (declare/roll lock the
+	# rows → it clears itself; deselect → cleared via the active_unit guard).
+	_refresh_pad_target_reticle()
 
 	if active_unit_id == "":
 		return
@@ -3109,6 +3193,9 @@ func _on_declare_charge_pressed() -> void:
 	# with the next _refresh_target_list (unit re-select / next charge).
 	_set_target_list_locked(true)
 	_clear_charge_trajectory_preview()  # P3-127: Clear trajectory once charge is declared
+	# Rows locked → the pad's "next A applies to this row" contract is over;
+	# the reticle's own awaiting_roll guard clears it.
+	_refresh_pad_target_reticle()
 	_update_button_states()
 
 func _set_target_list_locked(locked: bool) -> void:

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -55,6 +55,12 @@ const PILE_IN_MAX_INCHES: float = 3.0
 var movement_visual: Line2D
 var range_visual: Node2D
 var target_highlights: Node2D
+# Pad target reticle: gold brackets marking the controller's current melee
+# target while the AttackAssignmentDialog is open (shared visual language with
+# the shooting / charge phases — see PadTargetReticle.gd). Driven by the
+# dialog's target_list ◀ ▶ stepping.
+const PadTargetReticleScript = preload("res://scripts/PadTargetReticle.gd")
+var pad_target_reticle: Node2D
 
 # T5-MP1: Drag preview sync throttle
 var _last_drag_preview_time: float = 0.0
@@ -151,6 +157,9 @@ func _exit_tree() -> void:
 		range_visual.queue_free()
 	if target_highlights and is_instance_valid(target_highlights):
 		target_highlights.queue_free()
+	if pad_target_reticle and is_instance_valid(pad_target_reticle):
+		pad_target_reticle.queue_free()
+		pad_target_reticle = null
 
 	# T5-V10: Clean up fight phase state banner
 	if fight_state_banner and is_instance_valid(fight_state_banner):
@@ -244,6 +253,14 @@ func _create_fight_visuals() -> void:
 	target_highlights = Node2D.new()
 	target_highlights.name = "FightTargetHighlights"
 	board_root.add_child(target_highlights)
+
+	# Pad target reticle — gold brackets on the melee target the controller's
+	# next Assign applies to (driven by the AttackAssignmentDialog's ◀ ▶ target
+	# stepping). Above the eligibility highlights so it always reads on top.
+	pad_target_reticle = PadTargetReticleScript.new()
+	pad_target_reticle.name = "PadTargetReticle"
+	board_root.add_child(pad_target_reticle)
+	pad_target_reticle.clear()
 
 func _setup_right_panel() -> void:
 	# Main.gd already handles cleanup before controller creation
@@ -1800,6 +1817,49 @@ func _create_selection_turn_style(color: Color) -> StyleBoxFlat:
 	style.border_width_bottom = 2
 	return style
 
+# Pad (controller): cycle keyboard focus among the ENABLED action buttons of
+# the currently-visible fight-panel section — the fighter-selection Fight_
+# buttons, or the pile-in / consolidate unit picks plus their End button. The
+# bumpers call this (via PadRouter) so "cycle a unit" means the same thing in
+# the fight phase as everywhere else, WITHOUT driving the informational FIGHT
+# SEQUENCE ItemList (whose generic bumper-cycle misfired SELECT_FIGHTER). A
+# then commits the focused button through the normal ui_accept path. Returns
+# true when a button was focused.
+func pad_cycle_fight_buttons(dir: int) -> bool:
+	var buttons := _pad_fight_action_buttons()
+	if buttons.is_empty():
+		return false
+	var focused = get_viewport().gui_get_focus_owner()
+	var idx := buttons.find(focused)
+	if idx == -1:
+		idx = 0 if dir > 0 else buttons.size() - 1
+	else:
+		idx = wrapi(idx + dir, 0, buttons.size())
+	buttons[idx].grab_focus()
+	return true
+
+# The enabled, visible action buttons of whichever fight-panel section is live,
+# in top-to-bottom order. Fighter selection takes priority; otherwise the
+# active global step (pile-in / consolidate) section.
+func _pad_fight_action_buttons() -> Array:
+	var roots: Array = []
+	if fight_selection_panel != null and is_instance_valid(fight_selection_panel) and fight_selection_panel.visible:
+		roots.append(fight_selection_panel)
+	if pile_in_step_panel != null and is_instance_valid(pile_in_step_panel) and pile_in_step_panel.visible:
+		roots.append(pile_in_step_panel)
+	if consolidation_step_panel != null and is_instance_valid(consolidation_step_panel) and consolidation_step_panel.visible:
+		roots.append(consolidation_step_panel)
+	var out: Array = []
+	for root in roots:
+		var q: Array = [root]
+		while not q.is_empty():
+			var n = q.pop_front()
+			if n is Button and n.visible and not n.disabled and n.focus_mode != Control.FOCUS_NONE:
+				out.append(n)
+			for c in n.get_children():
+				q.append(c)
+	return out
+
 func _on_fight_selection_unit_chosen(unit_id: String) -> void:
 	"""Submit SELECT_FIGHTER when a unit button is picked (single click)"""
 	print("DEBUG: FightController - Fighter picked from selection panel: ", unit_id)
@@ -2123,6 +2183,11 @@ func _on_attack_assignment_required(unit_id: String, targets: Dictionary) -> voi
 	print("[FightController] Attack assignment required for ", unit_id)
 	print("[FightController] Eligible targets: ", targets.keys())
 
+	# Mirror the dialog's target set onto the controller so the pad reticle
+	# (pad_show_target_reticle) can resolve the ring order + banner + board
+	# marks — the dialog owns the picker, but the board brackets live here.
+	eligible_targets = targets
+
 	# Resolve the attacking unit's owner from state directly — on the remote
 	# client current_fighter_owner is not set by the (host-only) SELECT_FIGHTER
 	# handler, so derive it from the unit that's actually assigning attacks.
@@ -2158,9 +2223,59 @@ func _on_attack_assignment_required(unit_id: String, targets: Dictionary) -> voi
 	dialog.setup(unit_id, targets, current_phase)
 	dialog.attacks_confirmed.connect(_on_attacks_confirmed)
 	dialog.skip_fight_requested.connect(_on_attack_dialog_skip_requested)
+	# Pad: the dialog drives the gold board reticle as ◀ ▶ steps its target
+	# list, and clears it when it closes — the melee twin of the shooting
+	# phase's target ring (so a controller player SEES which enemy the next
+	# Assign hits, not just a name in a list).
+	dialog.pad_target_focus_changed.connect(pad_show_target_reticle)
+	dialog.tree_exiting.connect(pad_clear_target_reticle)
 	get_tree().root.add_child(dialog)
 	print("[FightController] Showing attack assignment dialog...")
 	DialogUtils.popup_at_bottom(dialog)
+
+
+# Pad (controller) support: bracket `target_id` on the board as THE unit the
+# next Assign applies to — gold reticle brackets on every alive model plus a
+# "▶ TARGET n/m: NAME" banner (n/m walks the dialog's target-list order, which
+# mirrors eligible_targets). Called by the AttackAssignmentDialog on ◀ ▶
+# stepping and on open; safe no-op when the target is unknown or KBM is active.
+func pad_show_target_reticle(target_id: String) -> void:
+	if pad_target_reticle == null or not is_instance_valid(pad_target_reticle):
+		return
+	if not InputDeviceManager.is_pad_active():
+		pad_target_reticle.clear()
+		return
+	if not eligible_targets.has(target_id):
+		pad_target_reticle.clear()
+		return
+	var unit = current_phase.get_unit(target_id) if current_phase else GameState.get_unit(target_id)
+	if unit.is_empty():
+		pad_target_reticle.clear()
+		return
+	var marks: Array = []
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var pos = _get_model_position(model)
+		if pos == Vector2.ZERO:
+			continue
+		marks.append({
+			"pos": pos,
+			"radius_px": Measurement.base_radius_px(model.get("base_mm", 32)) + 4.0,
+		})
+	var ring: Array = eligible_targets.keys()
+	var idx := ring.find(target_id)
+	var unit_name = str(eligible_targets[target_id].get("unit_name", eligible_targets[target_id].get("name", target_id)))
+	var banner := "▶ TARGET %d/%d: %s" % [idx + 1, ring.size(), unit_name]
+	pad_target_reticle.show_for_marks(marks, banner)
+	# Frame the target in the UPPER strip — the AttackAssignmentDialog is
+	# bottom-anchored and would occlude a dead-centered target, so lift the
+	# bracketed unit into the clear top area (pad-only; no-op on KBM).
+	PadRouter.frame_unit_upper_if_pad(target_id)
+
+func pad_clear_target_reticle() -> void:
+	if pad_target_reticle != null and is_instance_valid(pad_target_reticle):
+		pad_target_reticle.clear()
 
 func _on_attack_dialog_skip_requested(unit_id: String) -> void:
 	"""Escape hatch from an AttackAssignmentDialog with no eligible targets:

--- a/40k/scripts/PadTargetReticle.gd
+++ b/40k/scripts/PadTargetReticle.gd
@@ -1,0 +1,98 @@
+extends Node2D
+class_name PadTargetReticle
+
+## Board-space marker for THE unit the pad's next A press applies to.
+##
+## The shared visual language for controller target-stepping across phases
+## (shooting D-pad ◀ ▶ ring, charge D-pad ▲ ▼ rows): every alive model of the
+## stepped enemy unit gets pulsing gold corner brackets OUTSIDE the steady
+## per-phase eligibility rings, and the unit's anchor model carries a
+## "▶ TARGET n/m: NAME" banner. Gold deliberately matches
+## AttackContextVisual.TARGET_COLOR — the game already teaches "gold = the
+## unit being hit" during wound allocation.
+##
+## Positions/radii arrive pre-converted to board px, so this script has NO
+## autoload dependencies and keeps compiling in bare headless harness runs.
+
+const RETICLE_COLOR := Color(0.94, 0.78, 0.31, 0.95)  # gold — matches the charge row tint
+const BRACKET_WIDTH := 3.5
+const BRACKET_GAP := 9.0       # px outside the base edge — clears the +4px eligible rings
+const BRACKET_SWEEP_DEG := 38.0  # arc length of each of the 4 corner brackets
+const BANNER_FONT_SIZE := 13
+
+# [{pos: Vector2, radius_px: float}, ...] — one per alive model.
+var marks: Array = []
+# Banner text, e.g. "▶ TARGET 2/3: WITCHSEEKERS". Empty = no banner.
+var banner_text: String = ""
+
+var _pulse: float = 1.0
+
+
+func show_for_marks(p_marks: Array, p_banner: String) -> void:
+	marks = p_marks
+	banner_text = p_banner
+	visible = true
+	queue_redraw()
+
+
+func clear() -> void:
+	marks = []
+	banner_text = ""
+	visible = false
+	queue_redraw()
+
+
+func is_showing() -> bool:
+	return visible and not marks.is_empty()
+
+
+func _process(_delta: float) -> void:
+	if not is_showing():
+		return
+	# Gentle ~1.5 Hz pulse — reads as "live cursor", distinct from the steady
+	# eligibility rings underneath.
+	var t = Time.get_ticks_msec() / 1000.0
+	_pulse = lerp(0.55, 1.0, (sin(t * 3.0) + 1.0) / 2.0)
+	queue_redraw()
+
+
+func _draw() -> void:
+	if marks.is_empty():
+		return
+	var color := RETICLE_COLOR
+	color.a *= _pulse
+
+	var topmost := Vector2.INF
+	var topmost_radius := 0.0
+	for m in marks:
+		var pos: Vector2 = m.pos
+		var radius: float = m.radius_px + BRACKET_GAP
+		_draw_corner_brackets(pos, radius, color)
+		if pos.y < topmost.y:
+			topmost = pos
+			topmost_radius = radius
+
+	if banner_text == "" or topmost == Vector2.INF:
+		return
+	var font: Font = ThemeDB.fallback_font
+	var text_size := font.get_string_size(banner_text, HORIZONTAL_ALIGNMENT_CENTER, -1, BANNER_FONT_SIZE)
+	var text_pos := topmost + Vector2(-text_size.x / 2.0, -(topmost_radius + 12.0))
+	var bg := Rect2(text_pos.x - 6, text_pos.y - BANNER_FONT_SIZE - 2, text_size.x + 12, BANNER_FONT_SIZE + 9)
+	draw_rect(bg, Color(0.05, 0.05, 0.05, 0.85), true)
+	draw_rect(bg, Color(RETICLE_COLOR, 0.9), false, 1.5)
+	draw_string(font, text_pos + Vector2(0.5, 0.5), banner_text, HORIZONTAL_ALIGNMENT_CENTER, -1, BANNER_FONT_SIZE, Color(0, 0, 0, 0.7))
+	draw_string(font, text_pos, banner_text, HORIZONTAL_ALIGNMENT_CENTER, -1, BANNER_FONT_SIZE, Color(1.0, 0.92, 0.75, 1.0))
+
+
+# Four arc segments at the NE/SE/SW/NW diagonals with gaps between — a
+# targeting bracket that cannot be mistaken for the full-circle rings the
+# phases already draw (green eligible / gold allocation).
+func _draw_corner_brackets(center: Vector2, radius: float, color: Color) -> void:
+	var sweep := deg_to_rad(BRACKET_SWEEP_DEG)
+	for i in range(4):
+		var mid := deg_to_rad(45.0 + 90.0 * i)
+		draw_arc(center, radius, mid - sweep / 2.0, mid + sweep / 2.0, 10, color, BRACKET_WIDTH, true)
+	# Small cardinal ticks make the bracket read as a reticle at a glance.
+	for i in range(4):
+		var dir := Vector2.RIGHT.rotated(deg_to_rad(90.0 * i))
+		draw_line(center + dir * (radius - 3.0), center + dir * (radius + 3.0), color, BRACKET_WIDTH * 0.75, true)

--- a/40k/scripts/PadTargetReticle.gd.uid
+++ b/40k/scripts/PadTargetReticle.gd.uid
@@ -1,0 +1,1 @@
+uid://c16iai55w0ijr

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -81,6 +81,11 @@ var los_visual: Line2D
 var range_visual: Node2D
 var target_highlights: Node2D
 var los_debug_visual: Node2D  # New LoS debug visualization
+# Pad target reticle: gold brackets marking the controller's current target
+# (see PadTargetReticle.gd + PadRouter._cycle_target). Runtime-loaded class so
+# this controller keeps compiling standalone headless.
+const PadTargetReticleScript = preload("res://scripts/PadTargetReticle.gd")
+var pad_target_reticle: Node2D
 
 # UI Elements
 var unit_selector: ItemList
@@ -308,6 +313,9 @@ func _exit_tree() -> void:
 		range_visual.queue_free()
 	if target_highlights and is_instance_valid(target_highlights):
 		target_highlights.queue_free()
+	if pad_target_reticle and is_instance_valid(pad_target_reticle):
+		pad_target_reticle.queue_free()
+		pad_target_reticle = null
 
 	# Clean up LoS debug drawings but do NOT free the node — it is the
 	# persistent BoardRoot layer shared with Main's phase-independent L
@@ -391,6 +399,14 @@ func _create_shooting_visuals() -> void:
 	target_highlights = Node2D.new()
 	target_highlights.name = "ShootingTargetHighlights"
 	board_root.add_child(target_highlights)
+
+	# Pad target reticle — the gold brackets marking THE unit the controller's
+	# next A press assigns to (driven by PadRouter's D-pad ◀ ▶ target ring).
+	# Above the eligibility rings so the "current target" always reads on top.
+	pad_target_reticle = PadTargetReticleScript.new()
+	pad_target_reticle.name = "PadTargetReticle"
+	board_root.add_child(pad_target_reticle)
+	pad_target_reticle.clear()
 
 	# T5-MP3: Create container for shooter-to-target visual lines (remote player feedback)
 	shooting_lines_container = Node2D.new()
@@ -969,6 +985,8 @@ func resync_from_phase() -> void:
 	_refresh_shooter_status()
 	_update_ui_state()
 	_refresh_unit_list(false)
+	# Pad: re-bracket a valid target for the resynced shooter (no-op on KBM).
+	PadRouter.sync_shoot_target_highlight()
 	_in_resync = false
 
 func _refresh_unit_list(auto_select: bool = true) -> void:
@@ -1704,6 +1722,10 @@ func _clear_visuals() -> void:
 	# Clear target highlights
 	_clear_target_highlights()
 
+	# Clear the pad target reticle (re-armed by PadRouter's sync when the next
+	# shooter goes active with the pad in hand)
+	pad_clear_target_reticle()
+
 	# Clear LoS debug visuals if present — shooter drawings only. A live
 	# held-L overview must survive shooter-workflow housekeeping (set_phase
 	# runs deferred on phase entry and would otherwise blank an overlay the
@@ -2179,6 +2201,12 @@ func _on_unit_selected_for_shooting(unit_id: String) -> void:
 	if shooter_changed:
 		_auto_assign_logged = false
 		_clear_target_chips()  # B1: fresh unit, fresh chip letters
+		# A weapon id kept from the PREVIOUS shooter is meaningless for this
+		# one — clearing it stops the pad's forecast preview (and anything
+		# else reading selected_weapon_id) from previewing a gun the new unit
+		# doesn't carry. The tree refresh below re-selects via the usual
+		# auto-select-single-weapon path.
+		selected_weapon_id = ""
 
 	# NEW: Hide auto-target button when selecting new shooter
 	if auto_target_button_container:
@@ -2218,6 +2246,10 @@ func _on_unit_selected_for_shooting(unit_id: String) -> void:
 		for target_id in eligible_targets:
 			_visualize_los_to_target(unit_id, target_id)
 
+	# Pad: a freshly-armed shooter immediately brackets its first target so
+	# D-pad ◀ ▶ / A have a visible subject from the first press (no-op on KBM).
+	PadRouter.sync_shoot_target_highlight()
+
 func _on_targets_available(unit_id: String, targets: Dictionary) -> void:
 	print("ShootingController: Targets available for ", unit_id, ": ", targets.size())
 	active_shooter_id = unit_id
@@ -2233,12 +2265,15 @@ func _on_targets_available(unit_id: String, targets: Dictionary) -> void:
 	# _on_unit_selected_for_shooting reports first; the dedup guard suppresses this one).
 	if eligible_targets.is_empty():
 		_report_no_eligible_targets(unit_id)
-	
+
 	# Trigger LoS visualization for each eligible target
 	if los_debug_visual and los_debug_visual.debug_enabled:
 		print("ShootingController: Visualizing LoS to ", targets.size(), " targets")
 		for target_id in targets:
 			_visualize_los_to_target(unit_id, target_id)
+
+	# Pad: bracket the first target for the freshly-armed shooter (no-op on KBM).
+	PadRouter.sync_shoot_target_highlight()
 
 func _on_shooting_begun(unit_id: String) -> void:
 	"""T5-MP3 + T5-V2: Handle shooting_begun signal. Draws animated shooting lines
@@ -3873,7 +3908,11 @@ func pad_step_weapon(dir: int) -> bool:
 	var rows: Array = []
 	var child: TreeItem = root.get_first_child()
 	while child != null:
-		rows.append(child)
+		# Disabled weapon rows (engaged non-pistols, 11e shooting-type gate…)
+		# are unselectable — TreeItem.select() on one silently no-ops, which
+		# made ▲ ▼ look dead whenever the step landed on such a row. Skip them.
+		if child.is_selectable(0):
+			rows.append(child)
 		child = child.get_next()
 	if rows.is_empty():
 		return false
@@ -3890,7 +3929,62 @@ func pad_step_weapon(dir: int) -> bool:
 	# calls — run the click handler explicitly unless the signal already did.
 	if str(selected_weapon_id) != str(row.get_metadata(0)):
 		_on_weapon_tree_item_selected()
+	# Keep the FORECAST panel tracking the pad's (weapon, target) pair — the
+	# stepped weapon should be previewed against the bracketed target, not
+	# whatever target the mouse hovered last.
+	if PadRouter.target_highlight_id != "" and eligible_targets.has(PadRouter.target_highlight_id):
+		_update_damage_preview(str(row.get_metadata(0)), str(PadRouter.target_highlight_id))
 	return true
+
+# Pad (controller) support: mark `target_id` as THE unit the next A press
+# assigns to — gold reticle brackets on every alive model plus a
+# "▶ TARGET n/m: NAME" banner (n/m walks the same sorted ring PadRouter
+# cycles). Also retargets the FORECAST damage preview so the player sees the
+# expected damage of the current weapon into the bracketed unit BEFORE
+# committing. Called by PadRouter on every D-pad ◀ ▶ step and on highlight
+# sync; safe no-op when the target is unknown.
+func pad_show_target_reticle(target_id: String) -> void:
+	if pad_target_reticle == null or not is_instance_valid(pad_target_reticle):
+		return
+	if not eligible_targets.has(target_id):
+		pad_target_reticle.clear()
+		return
+	var unit = current_phase.get_unit(target_id) if current_phase else GameState.get_unit(target_id)
+	if unit.is_empty():
+		pad_target_reticle.clear()
+		return
+	var marks: Array = []
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var pos = _get_model_position(model)
+		if pos == Vector2.ZERO:
+			continue
+		marks.append({
+			"pos": pos,
+			"radius_px": Measurement.base_radius_px(model.get("base_mm", 32)) + 4.0,
+		})
+	var ring: Array = eligible_targets.keys()
+	ring.sort()  # same order PadRouter._cycle_target walks
+	var idx := ring.find(target_id)
+	var unit_name = str(eligible_targets[target_id].get("unit_name", target_id))
+	var banner := "▶ TARGET %d/%d: %s" % [idx + 1, ring.size(), unit_name]
+	pad_target_reticle.show_for_marks(marks, banner)
+	# Preview the current weapon (selected row, else the first USABLE row —
+	# disabled rows can't be assigned, so previewing them would mislead).
+	var weapon_id := str(selected_weapon_id)
+	if weapon_id == "" and weapon_tree != null and weapon_tree.get_root() != null:
+		var child: TreeItem = weapon_tree.get_root().get_first_child()
+		while child != null and not child.is_selectable(0):
+			child = child.get_next()
+		if child != null:
+			weapon_id = str(child.get_metadata(0))
+	if weapon_id != "":
+		_update_damage_preview(weapon_id, target_id)
+
+func pad_clear_target_reticle() -> void:
+	if pad_target_reticle != null and is_instance_valid(pad_target_reticle):
+		pad_target_reticle.clear()
 
 func _on_weapon_tree_button_clicked(item: TreeItem, column: int, id: int, mouse_button_index: int) -> void:
 	if not item or column != 1:
@@ -5387,6 +5481,7 @@ func _open_split_fire_picker(weapon_id: String, target_id: String, split: Dictio
 	# Also queue_free on cancel/close
 	dialog.canceled.connect(func(): dialog.queue_free())
 
+	_pad_wire_spin_dialog(dialog, spin, vbox)
 	add_child(dialog)
 	DialogUtils.popup_at_bottom(dialog)
 
@@ -5439,8 +5534,40 @@ func _open_move_fire_picker(weapon_id: String, new_target_id: String, split: Dic
 	)
 	dialog.canceled.connect(func(): dialog.queue_free())
 
+	_pad_wire_spin_dialog(dialog, spin, vbox)
 	add_child(dialog)
 	DialogUtils.popup_at_bottom(dialog)
+
+# Pad (controller) support for the split-fire pickers: D-pad ◀ ▶ (and ▲ ▼)
+# steps the bearer-count SpinBox while the dialog is open, A confirms (the
+# InputDeviceManager watcher focuses the OK/Move button) and B cancels — the
+# whole model-level split is drivable without a mouse. The spin's internal
+# LineEdit leaves the pad focus chain (FOCUS_CLICK) so ui_left/ui_right can
+# never get swallowed by text-caret movement; mouse/typing still works.
+func _pad_wire_spin_dialog(dialog: AcceptDialog, spin: SpinBox, vbox: VBoxContainer) -> void:
+	var line_edit := spin.get_line_edit()
+	if line_edit != null:
+		line_edit.focus_mode = Control.FOCUS_CLICK
+	if InputDeviceManager.is_pad_active():
+		var hint := Label.new()
+		hint.name = "PadSpinHint"
+		hint.text = "◀ ▶  adjust   ·   Ⓐ confirm   ·   Ⓑ cancel"
+		hint.add_theme_font_size_override("font_size", 12)
+		hint.modulate = Color(1, 1, 1, 0.75)
+		vbox.add_child(hint)
+	# AcceptDialog is a Window with its own viewport: PadRouter never sees
+	# these presses, so the dialog handles the D-pad itself.
+	dialog.window_input.connect(func(event: InputEvent):
+		if not (event is InputEventJoypadButton) or not event.pressed:
+			return
+		match event.button_index:
+			JOY_BUTTON_DPAD_LEFT, JOY_BUTTON_DPAD_DOWN:
+				spin.value = max(spin.min_value, spin.value - 1)
+				dialog.set_input_as_handled()
+			JOY_BUTTON_DPAD_RIGHT, JOY_BUTTON_DPAD_UP:
+				spin.value = min(spin.max_value, spin.value + 1)
+				dialog.set_input_as_handled()
+	)
 
 # B4: Retarget `moved_ids` (currently committed to other targets) at
 # `new_target_id`. Composed of existing actions: clear each touched
@@ -5556,6 +5683,16 @@ func _post_assign_ui_update(weapon_id: String, target_id: String, chosen_model_i
 		var weapon_name = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
 		var target_name = eligible_targets.get(target_id, {}).get("unit_name", target_id)
 		dice_log_display.append_text("[color=green]✓ %d × %s → %s[/color]\n" % [chosen_model_ids.size(), weapon_name, target_name])
+
+	# Pad players don't read the dice log — say it where they look. Also tell
+	# them where the flow goes once every weapon has a target (Start confirms).
+	if InputDeviceManager.is_pad_active():
+		var toast_weapon = RulesEngine.get_weapon_profile(weapon_id).get("name", weapon_id)
+		var toast_target = eligible_targets.get(target_id, {}).get("unit_name", target_id)
+		if _count_unassigned_weapons() == 0:
+			ToastManager.show_toast("✓ %s → %s — all weapons assigned, Start confirms" % [toast_weapon, toast_target])
+		else:
+			ToastManager.show_toast("✓ %s → %s" % [toast_weapon, toast_target])
 
 	# Refresh damage preview
 	_last_preview_target_id = ""
@@ -6352,15 +6489,19 @@ func _on_weapon_tree_gui_input(event: InputEvent) -> void:
 			_hovered_weapon_id = ""
 			_hide_damage_preview()
 
-func _update_damage_preview(weapon_id: String) -> void:
+func _update_damage_preview(weapon_id: String, override_target_id: String = "") -> void:
 	"""P3-114: Calculate and display Mathhammer-style expected damage preview for a weapon.
-	Accounts for weapon keywords, ability effects, faction abilities, rerolls, FNP, etc."""
+	Accounts for weapon keywords, ability effects, faction abilities, rerolls, FNP, etc.
+	override_target_id (pad flow): preview into the reticle-bracketed unit
+	instead of the assigned/first target."""
 	if not damage_preview_panel or not damage_preview_label:
 		return
 
-	# Determine target: use assigned target, or first eligible target
+	# Determine target: pad reticle override, else assigned target, else first eligible
 	var target_id = ""
-	if weapon_assignments.has(weapon_id):
+	if override_target_id != "" and eligible_targets.has(override_target_id):
+		target_id = override_target_id
+	elif weapon_assignments.has(weapon_id):
 		target_id = weapon_assignments[weapon_id]
 	elif not eligible_targets.is_empty():
 		target_id = eligible_targets.keys()[0]

--- a/40k/tests/scenarios/sp/pad_charge_target_toggle.json
+++ b/40k/tests/scenarios/sp/pad_charge_target_toggle.json
@@ -11,7 +11,7 @@
   "rng_seed": 42,
   "transition_to_phase": 9,
   "disable_ai": true,
-  "description": "Pad charge flow: RB cycles the UNITS THAT CAN CHARGE list, D-pad ▲ ▼ walks the ELIGIBLE TARGETS rows with a gold cursor tint, A toggles the walked row in and out of the declaration (pad Click / Ctrl+Click — builds and trims a multi-charge), Start declares then rolls, and X skips another unit's charge. Battlewagon is parked near two Custodes units (one ~2.5\" away, one ~9\") and Boyz Alpha near the close one, so two units are chargeable. CP is zeroed for both players so a failed roll cannot pop the Command Re-roll dialog mid-scenario.",
+  "description": "Pad charge flow: RB cycles the UNITS THAT CAN CHARGE list; arming a unit with the pad AUTO-BRACKETS the first ELIGIBLE TARGETS row (gold row tint + the shared on-board PadTargetReticle with its TARGET n/m banner — same visual language as the shooting phase's D-pad target ring). D-pad ▲ ▼ walks the rows (reticle follows), A toggles the walked row in and out of the declaration (pad Click / Ctrl+Click — builds and trims a multi-charge), Start declares (reticle clears — rows lock) then rolls, and X skips another unit's charge. Battlewagon is parked near two Custodes units (one ~2.5\" away, one ~9\") and Boyz Alpha near the close one, so two units are chargeable. CP is zeroed for both players so a failed roll cannot pop the Command Re-roll dialog mid-scenario.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.8 },
     { "act": "expect_state", "path": "meta.phase", "equals": 9 },
@@ -31,14 +31,18 @@
     { "act": "execute_script", "script": "str(main.charge_controller.active_unit_id) != \"\"", "equals": true },
     { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"charger\", str(main.charge_controller.active_unit_id))" },
     { "act": "execute_script", "script": "main.charge_controller.eligible_targets.size()", "expect_min": 1 },
-    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": -1 },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 0 },
 
     { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar cc = m.charge_controller\nif str(cc.active_unit_id) != \"U_BATTLEWAGON_G\":\n\tfor i in range(cc.unit_selector.item_count):\n\t\tif str(cc.unit_selector.get_item_metadata(i)) == \"U_BATTLEWAGON_G\":\n\t\t\tcc.unit_selector.select(i)\n\t\t\tcc.unit_selector.item_selected.emit(i)\n\t\t\tbreak\nreturn str(cc.active_unit_id)", "equals": "U_BATTLEWAGON_G" },
     { "act": "execute_script", "script": "main.charge_controller.eligible_targets.size()", "equals": 2 },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 0 },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_reticle.is_showing()", "equals": true },
+    { "act": "execute_script", "script": "str(main.charge_controller.pad_target_reticle.banner_text).find(\"TARGET 1/2\") != -1", "equals": true },
 
     { "act": "simulate_joy_button", "button_index": 12 },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 0 },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 1 },
+    { "act": "execute_script", "script": "str(main.charge_controller.pad_target_reticle.banner_text).find(\"TARGET 2/2\") != -1", "equals": true },
     { "act": "execute_script", "script": "main.charge_controller.selected_targets.size()", "equals": 0 },
     { "act": "simulate_joy_button", "button_index": 0 },
     { "act": "wait_seconds", "seconds": 0.3 },
@@ -46,7 +50,8 @@
 
     { "act": "simulate_joy_button", "button_index": 12 },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 1 },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 0 },
+    { "act": "execute_script", "script": "str(main.charge_controller.pad_target_reticle.banner_text).find(\"TARGET 1/2\") != -1", "equals": true },
     { "act": "simulate_joy_button", "button_index": 0 },
     { "act": "wait_seconds", "seconds": 0.3 },
     { "act": "execute_script", "script": "main.charge_controller.selected_targets.size()", "equals": 2 },
@@ -63,6 +68,7 @@
     { "act": "simulate_joy_button", "button_index": 6 },
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "execute_script", "script": "main.charge_controller.awaiting_roll", "equals": true },
+    { "act": "execute_script", "script": "main.charge_controller.pad_target_reticle.is_showing()", "equals": false },
     { "act": "screenshot", "label": "02_start_declared_charge" },
 
     { "act": "simulate_joy_button", "button_index": 6 },

--- a/40k/tests/scenarios/sp/pad_fight_attack_reticle.json
+++ b/40k/tests/scenarios/sp/pad_fight_attack_reticle.json
@@ -1,0 +1,66 @@
+{
+  "id": "pad_fight_attack_reticle",
+  "covers": [
+    "controller.fight.attack_dialog_pad_nav",
+    "controller.fight.target_reticle",
+    "controller.fight.weapon_target_step",
+    "controller.fight.assign_and_fight",
+    "PadRouter",
+    "PadTargetReticle",
+    "FightController",
+    "AttackAssignmentDialog"
+  ],
+  "fixture": "stompa_fight_11e",
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Fight phase controller attack assignment — the melee twin of the shooting-phase target fix. With a fighter's AttackAssignmentDialog open and TWO eligible melee targets, the pad drives it exactly like the shooting phase: the current target wears the gold PadTargetReticle (brackets + '▶ TARGET n/m: NAME' banner), auto-armed on the first target and framed into the clear strip above the bottom-anchored dialog. D-pad ◀ ▶ walks the target list (the reticle + banner follow), ▲ ▼ steps the weapon list, Ⓐ adds the assignment, and ☰ (Menu) resolves the fight. The dialog is opened directly with two real targets so the ◀ ▶ walk is deterministic (the fixture's live engagement offers only one).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "execute_script", "script": "InputDeviceManager.claim_pad()" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var fc = tree.current_scene.fight_controller\nvar targets = {\n\t\"U_TELEMON_HEAVY_DREADNOUGHT_I\": {\"name\": GameState.get_unit_display_name(\"U_TELEMON_HEAVY_DREADNOUGHT_I\"), \"unit_name\": GameState.get_unit_display_name(\"U_TELEMON_HEAVY_DREADNOUGHT_I\")},\n\t\"U_CUSTODIAN_GUARD_B\": {\"name\": GameState.get_unit_display_name(\"U_CUSTODIAN_GUARD_B\"), \"unit_name\": GameState.get_unit_display_name(\"U_CUSTODIAN_GUARD_B\")}\n}\nfc.current_fighter_id = \"U_WARBOSS_B\"\nfc.current_fighter_owner = 2\nfc._on_attack_assignment_required(\"U_WARBOSS_B\", targets)\nreturn \"opening\"", "equals": "opening" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\") != null", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller.pad_target_reticle.is_showing()", "equals": true },
+    { "act": "execute_script", "script": "str(main.fight_controller.pad_target_reticle.banner_text).find(\"TARGET 1/2\") != -1", "equals": true },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").target_list.item_count", "equals": 2 },
+    { "act": "screenshot", "label": "01_dialog_open_reticle_target1" },
+
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").target_list.get_selected_items()[0]", "equals": 1 },
+    { "act": "execute_script", "script": "str(main.fight_controller.pad_target_reticle.banner_text).find(\"TARGET 2/2\") != -1", "equals": true },
+    { "act": "execute_script", "script": "str(main.fight_controller.pad_target_reticle.banner_text).find(\"Custodian Guard\") != -1", "equals": true },
+    { "act": "screenshot", "label": "02_dpad_right_target2" },
+
+    { "act": "simulate_joy_button", "button_index": 13 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").target_list.get_selected_items()[0]", "equals": 0 },
+    { "act": "execute_script", "script": "str(main.fight_controller.pad_target_reticle.banner_text).find(\"TARGET 1/2\") != -1", "equals": true },
+
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w0\", tree.root.get_node_or_null(\"AttackAssignmentDialog\").weapon_list.get_selected_items()[0])" },
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").weapon_list.get_selected_items()[0] != int(InputDeviceManager.get_meta(\"w0\"))", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").weapon_list.get_selected_items()[0] == int(InputDeviceManager.get_meta(\"w0\"))", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").assignments.size()", "equals": 1 },
+    { "act": "execute_script", "script": "str(tree.root.get_node_or_null(\"AttackAssignmentDialog\").assignments[0].get(\"target\", \"\"))", "equals": "U_TELEMON_HEAVY_DREADNOUGHT_I" },
+    { "act": "screenshot", "label": "03_assigned_via_A" },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\") == null", "equals": true },
+    { "act": "screenshot", "label": "04_menu_fight_confirmed" }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_fight_selection_bumper.json
+++ b/40k/tests/scenarios/sp/pad_fight_selection_bumper.json
@@ -1,0 +1,34 @@
+{
+  "id": "pad_fight_selection_bumper",
+  "covers": [
+    "controller.fight.selection_bumper_focus",
+    "controller.fight.no_informational_list_misfire",
+    "PadRouter",
+    "FightController"
+  ],
+  "fixture": "stompa_fight_11e",
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Fight phase controller selection: the bumpers cycle keyboard focus among the ENABLED fighter-selection buttons (Fight_<unit_id>) of the right panel — the fight phase's 'pick a unit' — and NOT the informational FIGHT SEQUENCE ItemList, whose generic bumper-cycle used to misfire SELECT_FIGHTER on the wrong unit. The scenario ends the global Pile-In step to reach fighter selection, presses RB, and asserts focus landed on a Fight_ button (a Button, not the ItemList) without a stray fighter having been committed by the press.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "execute_script", "multiline": true, "script": "var ph = PhaseManager.get_current_phase_instance()\nfor i in range(4):\n\tvar res = ph.execute_action({\"type\": \"END_PILE_IN\"})\n\tif not res.get(\"success\", false):\n\t\tbreak\nreturn ph._subphase_string_11e()", "equals": "FIGHTS_FIRST" },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "main.fight_controller.fight_selection_panel != null and main.fight_controller.fight_selection_panel.visible", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var f = tree.root.gui_get_focus_owner()\nif f == null:\n\treturn \"no focus\"\nif f is ItemList:\n\treturn \"FOCUS ON ITEMLIST (misfire)\"\nreturn str(f.name)", "equals": "Fight_U_WARBOSS_B" },
+    { "act": "execute_script", "multiline": true, "script": "return (tree.root.gui_get_focus_owner() is Button)", "equals": true },
+    { "act": "screenshot", "label": "01_bumper_focused_fighter_button" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "execute_script", "script": "str(main.fight_controller.current_fighter_id)", "equals": "U_WARBOSS_B" },
+    { "act": "screenshot", "label": "02_a_committed_fighter" }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_m2_shooting_native.json
+++ b/40k/tests/scenarios/sp/pad_m2_shooting_native.json
@@ -5,7 +5,7 @@
   "transition_to_phase": 8,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "M2 gate: a full shooting activation with ZERO virtual-cursor use. RB cycles to an eligible shooter (camera pans to it; bumpers ALWAYS cycle the acting unit per the bumper-only rule), D-pad ▶ walks the eligible-target ring (camera pans to the highlighted target), A assigns the target to the current weapon, Start confirms targets (context-dependent Menu), and the staged dice resolution is walked with A on watcher-focused dialog buttons until the shooter is marked has_shot. Since the cycle ring follows PHASE eligibility (every unit that can still shoot — engaged vehicles and no-target units included, matching Movement), the fixed RB presses may park on a shooter whose weapons are all disabled; before the target walk, the scenario cycles on (same _keyboard_cycle_units path a bumper press drives) until the armed shooter has an assignable weapon and a target.",
+  "description": "M2 gate: a full shooting activation with ZERO virtual-cursor use. RB cycles to an eligible shooter (camera pans to it; bumpers ALWAYS cycle the acting unit per the bumper-only rule — the target highlight AUTO-ARMS on the ring's FIRST entry via sync_shoot_target_highlight, it is never cycled by bumpers), D-pad ▶ walks the eligible-target ring (gold reticle + camera pan on the highlighted target), A assigns the target to the current weapon, Start confirms targets (context-dependent Menu), and the staged dice resolution is walked with A on watcher-focused dialog buttons until the shooter is marked has_shot. Since the cycle ring follows PHASE eligibility (every unit that can still shoot — engaged vehicles and no-target units included, matching Movement), the fixed RB presses may park on a shooter whose weapons are all disabled; before the target walk, the scenario cycles on (same _keyboard_cycle_units path a bumper press drives) until the armed shooter has an assignable weapon and a target.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 8 },
@@ -18,7 +18,7 @@
 
     { "act": "simulate_joy_button", "button_index": 10 },
     { "act": "wait_seconds", "seconds": 0.4 },
-    { "act": "execute_script", "script": "PadRouter.target_highlight_id", "equals": "" },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nif sc.eligible_targets.is_empty():\n\treturn str(PadRouter.target_highlight_id) == \"\"\nvar ring = sc.eligible_targets.keys()\nring.sort()\nreturn str(PadRouter.target_highlight_id) == str(ring[0])", "equals": true },
     { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id) != \"\"", "equals": true },
     { "act": "simulate_joy_button", "button_index": 9 },
     { "act": "wait_seconds", "seconds": 0.4 },

--- a/40k/tests/scenarios/sp/pad_shoot_target_reticle.json
+++ b/40k/tests/scenarios/sp/pad_shoot_target_reticle.json
@@ -1,0 +1,58 @@
+{
+  "id": "pad_shoot_target_reticle",
+  "covers": [
+    "controller.shooting.target_reticle",
+    "controller.shooting.target_cycle_visible",
+    "controller.shooting.weapon_level_split_fire",
+    "PadRouter",
+    "PadTargetReticle",
+    "ShootingController"
+  ],
+  "fixture": "shooting_phase",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "The controller-targeting fix (2026-07 report: 'two targets in range but ◀ ▶ appears to do nothing'): with a shooter armed, the pad's current target is now unmistakable — the FIRST pad press auto-brackets the first entry of the sorted target ring with the gold PadTargetReticle (corner brackets on every alive model + a '▶ TARGET n/m: NAME' banner) and the FORECAST panel previews the current weapon into it. D-pad ◀ ▶ then WALKS the ring: the highlight id, the reticle banner and the bracket marks all move together. A assigns the bracketed target to the stepped weapon; ▼ steps to the next weapon and a second ◀/A pair aims it at a DIFFERENT target — weapon-level split fire, pad only, with the pending_assignments split across two distinct target units at the end.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 8 },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar sc = m.shooting_controller\nfor i in range(sc.unit_selector.item_count):\n\tif str(sc.unit_selector.get_item_metadata(i)) == \"U_BATTLEWAGON_A\":\n\t\tsc.unit_selector.select(i)\n\t\tsc.unit_selector.item_selected.emit(i)\n\t\tbreak\nreturn str(sc.active_shooter_id)", "equals": "U_BATTLEWAGON_A" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "main.shooting_controller.eligible_targets.size()", "expect_min": 2 },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nvar ring = sc.eligible_targets.keys()\nring.sort()\nreturn str(PadRouter.target_highlight_id) == str(ring[0])", "equals": true },
+    { "act": "execute_script", "script": "main.shooting_controller.pad_target_reticle.is_showing()", "equals": true },
+    { "act": "execute_script", "script": "str(main.shooting_controller.pad_target_reticle.banner_text).find(\"TARGET 1/\") != -1", "equals": true },
+    { "act": "execute_script", "script": "str(main.shooting_controller.selected_weapon_id) != \"\"", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w1\", str(main.shooting_controller.selected_weapon_id))" },
+    { "act": "screenshot", "label": "01_first_target_auto_bracketed" },
+
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nvar ring = sc.eligible_targets.keys()\nring.sort()\nreturn str(PadRouter.target_highlight_id) == str(ring[1])", "equals": true },
+    { "act": "execute_script", "script": "str(main.shooting_controller.pad_target_reticle.banner_text).find(\"TARGET 2/\") != -1", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"t1\", str(PadRouter.target_highlight_id))" },
+    { "act": "screenshot", "label": "02_dpad_right_moved_reticle" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.weapon_assignments.get(InputDeviceManager.get_meta(\"w1\"), \"\")) == str(InputDeviceManager.get_meta(\"t1\"))", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.selected_weapon_id) != str(InputDeviceManager.get_meta(\"w1\"))", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"w2\", str(main.shooting_controller.selected_weapon_id))" },
+    { "act": "simulate_joy_button", "button_index": 13 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(PadRouter.target_highlight_id) != str(InputDeviceManager.get_meta(\"t1\"))", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"t2\", str(PadRouter.target_highlight_id))" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.weapon_assignments.get(InputDeviceManager.get_meta(\"w2\"), \"\")) == str(InputDeviceManager.get_meta(\"t2\"))", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var ph = PhaseManager.get_current_phase_instance()\nvar targets = {}\nfor a in ph.pending_assignments:\n\ttargets[str(a.target_unit_id)] = true\nreturn targets.size()", "expect_min": 2 },
+    { "act": "screenshot", "label": "03_two_weapons_two_targets_split" }
+  ]
+}

--- a/40k/tests/scenarios/sp/pad_split_fire_spin.json
+++ b/40k/tests/scenarios/sp/pad_split_fire_spin.json
@@ -1,0 +1,54 @@
+{
+  "id": "pad_split_fire_spin",
+  "covers": [
+    "controller.shooting.model_level_split_fire",
+    "controller.shooting.split_picker_dpad_spin",
+    "PadRouter",
+    "ShootingController"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "Model-level split fire, controller only (2026-07 report: the mouse-built split-fire flow was unreachable on pad): Witchseekers (4 × witchseeker flamer) are teleported between the Ork lines so three targets are eligible and no model is in engagement range. The session's first A press auto-brackets the first ring entry (Battlewagon) and assigns ALL 4 flamer bearers to it in one press (concentrated fire is the one-click default). D-pad ▶ walks the reticle to the Boyz and a second A on the SAME weapon opens the SplitFirePicker ('all bearers committed — move how many?'). The picker is now pad-operable: D-pad ▶ steps the bearer-count SpinBox (1 → 3) via the dialog's own window_input (an exclusive Window never lets PadRouter see the presses), and A confirms via the InputDeviceManager watcher-focused Move button. The final pending_assignments carry the exact split: 1 flamer stays on the Battlewagon, 3 move to the Boyz.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 8 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "execute_script", "multiline": true, "script": "var models = GameState.state.units[\"U_WITCHSEEKERS_D\"][\"models\"]\nfor i in range(models.size()):\n\tmodels[i][\"position\"] = {\"x\": 950.0 + (i % 2) * 42.0, \"y\": 1660.0 + int(i / 2.0) * 42.0}\nreturn models.size()", "equals": 4 },
+    { "act": "execute_script", "script": "main.shooting_controller._select_shooter_by_unit_id(\"U_WITCHSEEKERS_D\")" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.shooting_controller.active_shooter_id)", "equals": "U_WITCHSEEKERS_D" },
+    { "act": "execute_script", "script": "main.shooting_controller.eligible_targets.size()", "equals": 3 },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.7 },
+    { "act": "execute_script", "script": "str(PadRouter.target_highlight_id)", "equals": "U_BATTLEWAGON_G" },
+    { "act": "execute_script", "multiline": true, "script": "var ph = PhaseManager.get_current_phase_instance()\nif ph.pending_assignments.size() != 1:\n\treturn \"expected 1 assignment, got %d\" % ph.pending_assignments.size()\nvar a = ph.pending_assignments[0]\nreturn str(a.target_unit_id) + \":\" + str((a.model_ids as Array).size())", "equals": "U_BATTLEWAGON_G:4" },
+    { "act": "screenshot", "label": "01_all_bearers_on_first_target" },
+
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(PadRouter.target_highlight_id)", "equals": "U_BOYZ_E" },
+    { "act": "execute_script", "script": "str(main.shooting_controller.pad_target_reticle.banner_text).find(\"TARGET 2/3\") != -1", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.9 },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nvar d = sc.get_node_or_null(\"SplitFirePicker\")\nif d == null:\n\treturn \"no dialog\"\nvar spin = d.find_child(\"SplitFireSpin\", true, false)\nreturn str(int(spin.value)) + \"/\" + str(int(spin.max_value))", "equals": "1/4" },
+    { "act": "screenshot", "label": "02_split_picker_opened_by_pad" },
+
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.25 },
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.25 },
+    { "act": "execute_script", "multiline": true, "script": "var sc = tree.current_scene.shooting_controller\nvar d = sc.get_node_or_null(\"SplitFirePicker\")\nvar spin = d.find_child(\"SplitFireSpin\", true, false)\nreturn int(spin.value)", "equals": 3 },
+    { "act": "screenshot", "label": "03_dpad_stepped_spin_to_3" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.9 },
+    { "act": "execute_script", "multiline": true, "script": "var ph = PhaseManager.get_current_phase_instance()\nvar by_target = {}\nfor a in ph.pending_assignments:\n\tby_target[str(a.target_unit_id)] = (a.model_ids as Array).size()\nreturn str(by_target.get(\"U_BATTLEWAGON_G\", 0)) + \"+\" + str(by_target.get(\"U_BOYZ_E\", 0))", "equals": "1+3" },
+    { "act": "execute_script", "script": "main.shooting_controller.get_node_or_null(\"SplitFirePicker\") == null", "equals": true },
+    { "act": "screenshot", "label": "04_split_committed_1_and_3" }
+  ]
+}


### PR DESCRIPTION
## What & why

On a controller, the Shooting phase's D-pad ◀▶ target cycling was invisible (camera pan only — indistinguishable from "nothing happened" when targets sit close together), and split fire was mouse-only. This PR fixes that and extends the same treatment across every phase that picks a target, so the controller behaves consistently.

One rule everywhere: **the unit your next ⓐ press applies to is bracketed on the board** — pulsing gold corner brackets on every model + a `▶ TARGET n/m: NAME` banner. It's controller-only (never shown for mouse) and clears the moment the mouse takes over.

### Shooting phase
- New `PadTargetReticle` — gold brackets + `TARGET n/m` banner on the current target. Auto-armed on the first target when a shooter is armed, so ⓐ always has a visible subject and ◀▶'s first press visibly moves the bracket.
- The FORECAST damage preview follows the pad pair: stepped weapon (▲▼) vs bracketed target (◀▶).
- Per-weapon split fire on pad: ▲▼ steps weapon rows (skipping disabled rows), ◀▶ picks target, ⓐ assigns — each gun at a different enemy, with confirming toasts.
- Per-model split fire on pad: the split-fire picker's "how many models" SpinBox is now D-pad-steppable (◀▶ / ▲▼), ⓐ confirms, ⓑ cancels.
- ⓐ no longer dies silently when every weapon is disabled (toast explains → ⓧ skips).

### Charge phase
- The ▲▼-stepped ELIGIBLE TARGETS row is bracketed on the board with the same reticle + banner; the camera follows the stepped target; row 0 auto-brackets on arming; reticle clears on declare.

### Fight phase (previously **zero** pad support)
- The Assign Attacks dialog is fully controller-drivable via its own `window_input`: ▲▼ weapon, ◀▶ target (board reticle follows, framed into the clear strip above the bottom-anchored dialog), ⓐ Add Assignment (toast), ☰ Fight! (resolve), ⓑ end fight. On-dialog hint row shown only on a pad.
- Bumpers now cycle the fighter-selection / pile-in / consolidate **buttons** instead of the informational Fight Sequence list, which used to misfire `SELECT_FIGHTER` on the wrong unit.
- Added a Fight-phase controller hint bar.

## Validation

All windowed (driven against the running UI via the `addons/godot_mcp` bridge — `simulate_joy_button` on real controls, asserting live state + screenshots), per the project's feature-validation gate:

- New: `pad_shoot_target_reticle`, `pad_split_fire_spin`, `pad_fight_attack_reticle` (38/38), `pad_fight_selection_bumper`.
- Updated: `pad_charge_target_toggle`, `pad_m2_shooting_native`.
- No regressions across the prior pad suite and the existing fight scenarios; `verify_delivery` returns PASS (no log errors, reticle visible, targets stepped) for both the shooting and fight paths.

Player-facing changelog entries added (v0.85.0 shooting/charge, v0.86.0 fight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne)_