### PR TITLE
Controller pop-up audit: settings menu D-pad trap + Start-guard under any modal

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.91.0",
+			"date": "2026-07-22",
+			"summary": "Controller pop-up audit: the in-game Settings/pause menu now traps the D-pad. Opened with a controller, its D-pad no longer walks off into the buttons on the battlefield behind it — focus is held inside the menu until you close it (B / the View button). And while ANY full-screen pop-up is open (Settings, Save/Load, the Allocate Attacks / Roll Saves window), pressing Start (☰) no longer ends the phase underneath it.",
+			"changes": [
+				"Settings / pause menu: with a controller, the D-pad is now confined to the menu while it's open — previously a direction press could move the highlight onto a control drawn behind the menu (an army/unit dropdown, a HUD button), off the menu entirely. Closing the menu restores everything. Mouse and keyboard are unaffected.",
+				"Start (☰ / Menu button) is now ignored while any full-screen pop-up owns the controller — the Settings menu, the Save/Load dialog, or the Allocate Attacks / Roll Saves window — so you can't accidentally end the phase or confirm something underneath the pop-up. The View/Select button still opens and closes the pause menu as before.",
+				"This uses the same 'pop-up owns the D-pad' handling already added for the Save/Load dialog and the Allocate Attacks window, so every full-screen pop-up now behaves consistently on a controller."
+			]
+		},
+		{
 			"version": "0.90.1",
 			"date": "2026-07-22",
 			"summary": "Fixed a confusing controller hint while moving a squad model-by-model. In the brief state right after you drop a model with Ⓐ while other models still need placing, the bottom hint bar used to move the 'Next Model' label onto Ⓧ and rename L3 to 'Browse Models' — so for that one state 'Next Model' jumped from L3 (where it sits in every other movement state) onto Ⓧ. Now Ⓧ reads 'Finish Model' (matching what it says while carrying) and L3 always reads 'Next Model'. 'Next Model' is the L3 button, always.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -5525,6 +5525,17 @@ func _is_text_input_focused() -> bool:
 	return focused is LineEdit or focused is TextEdit
 
 
+## True while a full-screen modal that owns the pad is visible — any member of
+## the "pad_native_nav_modal" group (SaveLoadDialog, AllocationGroupOverlay,
+## SettingsMenu). Guards the pad Start (End-Phase) handler so it can't fire
+## underneath an open modal. The View button (pause cascade) stays live.
+func _pad_native_nav_modal_open() -> bool:
+	for n in get_tree().get_nodes_in_group("pad_native_nav_modal"):
+		if is_instance_valid(n) and n is CanvasItem and n.is_visible_in_tree():
+			return true
+	return false
+
+
 # M1 controller support: Menu/Start presses the phase action button behind a
 # confirmation, reusing whatever the button currently does/says.
 var _pad_phase_confirm: ConfirmationDialog = null
@@ -5549,6 +5560,17 @@ func _input(event: InputEvent) -> void:
 	# M2: in the shooting phase with an armed shooter + assignments, Start
 	# means "Confirm Targets" instead (PRP §4.3 — context-dependent Menu).
 	if event.is_action_pressed("pad_phase_action"):
+		# A full-screen modal in the "pad_native_nav_modal" group (Save/Load
+		# dialog, the 11e Allocate Attacks / roll-saves overlay, the settings
+		# menu) owns the pad until dismissed — Start must NOT confirm targets /
+		# end the phase / pop the phase-confirm underneath it. Those modals
+		# drive themselves with native ui_* focus navigation and their own
+		# buttons; Start has no meaning while one is up. (The View button —
+		# pad_menu_action — is deliberately NOT guarded so the pause cascade
+		# stays reachable as the escape hatch.)
+		if _pad_native_nav_modal_open():
+			get_viewport().set_input_as_handled()
+			return
 		if (current_phase == GameStateData.Phase.MOVEMENT or current_phase == GameStateData.Phase.CHARGE) \
 				and PadRouter \
 				and PadRouter.has_method("confirm_from_carry") and PadRouter.confirm_from_carry():

--- a/40k/scripts/SettingsMenu.gd
+++ b/40k/scripts/SettingsMenu.gd
@@ -65,13 +65,38 @@ var _keybinding_reset_buttons: Dictionary = {}  # action_id -> Button
 # Whether to show "Return to Main Menu" button (only in-game)
 var show_return_to_menu: bool = false
 
+# ── Controller (D-pad) focus support ──────────────────────────────────
+# This menu is a full-screen plain Control overlay, so — exactly like the
+# Save/Load dialog and the 11e allocation overlay — Godot does NOT confine
+# keyboard/pad focus to it. Verified live: with the menu open and a pad active,
+# a D-pad press in ANY direction walks focus OUT to the ~26 focusable controls
+# drawn BEHIND it (MainMenu buttons, or the in-game HUD). Mirroring those two
+# modals we (1) join the "pad_native_nav_modal" group so PadRouter keeps its
+# board handlers off us and Main ignores the Start (End-Phase) press while
+# we're open, and (2) confine focus to our own subtree while a pad is active
+# (external focusables demoted to FOCUS_NONE, restored on close / device
+# switch). Keyboard/mouse behaviour is deliberately untouched: no confinement
+# unless the pad is the active device.
+const PAD_MODAL_GROUP := "pad_native_nav_modal"
+var _pad_focus_confined: bool = false
+var _pad_confined_controls: Array = []
+
 func _ready() -> void:
+	# Join before building so PadRouter/Main see the membership immediately.
+	add_to_group(PAD_MODAL_GROUP)
 	_build_ui()
 	_load_current_settings()
 	_connect_signals()
 	# M0 controller foundations: land pad focus somewhere visible so D-pad
 	# navigation works the moment the overlay opens.
 	_close_button.grab_focus()
+	# Controller: trap directional focus inside the menu (pad only) so the
+	# D-pad can't walk into the UI behind it, and follow device switches.
+	var idm := _idm()
+	if idm != null and idm.has_signal("device_changed") and not idm.device_changed.is_connected(_on_pad_device_changed):
+		idm.device_changed.connect(_on_pad_device_changed)
+	if _pad_active():
+		_confine_pad_focus()
 	print("[SettingsMenu] P3-111: Ready")
 
 func _build_ui() -> void:
@@ -772,17 +797,27 @@ func _on_autosave_phase_start_toggled(pressed: bool) -> void:
 
 func _on_close_pressed() -> void:
 	print("[SettingsMenu] Closed")
+	# Restore focus modes BEFORE emitting: a settings_closed handler that
+	# re-focuses the opener (e.g. MainMenu's Settings button) must find it
+	# focusable again. _exit_tree's release would run only at end-of-frame.
+	_release_pad_focus_confinement()
 	settings_closed.emit()
 	queue_free()
 
 func _on_save_load_pressed() -> void:
 	print("[SettingsMenu] Save/Load requested")
+	# Release FIRST so the handoff hands SaveLoadDialog a clean, all-focusable
+	# baseline to run its OWN confinement against — otherwise our end-of-frame
+	# _exit_tree restore would re-enable the controls SaveLoadDialog just
+	# demoted, breaking its focus trap.
+	_release_pad_focus_confinement()
 	save_load_requested.emit()
 	settings_closed.emit()
 	queue_free()
 
 func _on_return_to_menu_pressed() -> void:
 	print("[SettingsMenu] Returning to main menu")
+	_release_pad_focus_confinement()
 	settings_closed.emit()
 	queue_free()
 	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
@@ -835,3 +870,79 @@ func _unhandled_input(event: InputEvent) -> void:
 	if event.is_action_pressed("ui_cancel"):
 		_on_close_pressed()
 		get_viewport().set_input_as_handled()
+
+
+# ============================================================================
+# Controller (D-pad) focus support — see the PAD_MODAL_GROUP block near the top.
+# Mirrors AllocationGroupOverlay / SaveLoadDialog so every full-screen modal
+# traps the pad the same way.
+# ============================================================================
+
+func _idm() -> Node:
+	# Lazy autoload lookup (autoload ids are not compile-time resolvable in the
+	# bare headless harness runs this menu must keep compiling under).
+	return get_node_or_null("/root/InputDeviceManager")
+
+
+func _pad_active() -> bool:
+	var idm := _idm()
+	return idm != null and idm.has_method("is_pad_active") and idm.is_pad_active()
+
+
+func _on_pad_device_changed(_mode: int) -> void:
+	# Player switched device while the menu is open. On the pad, confine and
+	# keep focus in the menu; back on KBM, release so keyboard focus is not
+	# trapped.
+	if not is_inside_tree():
+		return
+	if _pad_active():
+		if not _pad_focus_confined:
+			_confine_pad_focus()
+		if _close_button != null and is_instance_valid(_close_button):
+			_close_button.grab_focus()
+	else:
+		_release_pad_focus_confinement()
+
+
+# Trap directional focus inside this menu: demote every focusable Control
+# OUTSIDE our subtree to FOCUS_NONE (restored on close / KBM). Idempotent —
+# guarded by _pad_focus_confined.
+func _confine_pad_focus() -> void:
+	if _pad_focus_confined:
+		return
+	var scene := get_tree().current_scene
+	if scene == null:
+		return
+	_pad_confined_controls.clear()
+	var queue: Array = [scene]
+	while not queue.is_empty():
+		var n: Node = queue.pop_front()
+		if n == self:
+			continue  # skip our own subtree — its controls must stay focusable
+		if n is Control and n.focus_mode == Control.FOCUS_ALL:
+			_pad_confined_controls.append(n)
+			n.focus_mode = Control.FOCUS_NONE
+		for child in n.get_children():
+			queue.append(child)
+	_pad_focus_confined = true
+	print("[SettingsMenu] pad focus confined (%d external controls demoted)" % _pad_confined_controls.size())
+
+
+func _release_pad_focus_confinement() -> void:
+	if not _pad_focus_confined:
+		return
+	for c in _pad_confined_controls:
+		if is_instance_valid(c):
+			c.focus_mode = Control.FOCUS_ALL
+	_pad_confined_controls.clear()
+	_pad_focus_confined = false
+	print("[SettingsMenu] pad focus confinement released")
+
+
+func _exit_tree() -> void:
+	# Belt-and-braces: restore focus modes and drop the device hook if any close
+	# path was missed (idempotent — the flag guards a double release).
+	_release_pad_focus_confinement()
+	var idm := _idm()
+	if idm != null and idm.has_signal("device_changed") and idm.device_changed.is_connected(_on_pad_device_changed):
+		idm.device_changed.disconnect(_on_pad_device_changed)

--- a/40k/tests/scenarios/sp/pad_settings_modal_focus.json
+++ b/40k/tests/scenarios/sp/pad_settings_modal_focus.json
@@ -1,0 +1,46 @@
+{
+  "id": "pad_settings_modal_focus",
+  "covers": [
+    "controller.modal.settings_focus_containment",
+    "scripts.SettingsMenu.pad_confine",
+    "scripts.Main.pad_start_guard_modal"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "CONTROLLER MODAL FOCUS (SettingsMenu): the in-game pause/settings menu is a full-screen plain-Control overlay that previously let the D-pad walk focus OUT to the HUD controls drawn behind it (verified live on main: from the focused Close button, all 4 directional neighbours pointed OUTSIDE the menu). With the pad active it now (1) confines directional focus to itself — every focusable Control outside its subtree is demoted, so find_valid_focus_neighbor in every direction stays inside the menu or is null — and (2) Main ignores the pad Start (End-Phase) press while it is open, so the phase can't end underneath it. The View button (pad_menu_action) still toggles it closed, and closing restores the demoted controls' focus.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "execute_script", "script": "InputDeviceManager.claim_pad()" },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.state.meta.phase)", "equals": 6 },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"phase_before\", int(GameState.state.meta.phase))" },
+
+    { "act": "simulate_joy_button", "button_index": 4 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": true },
+    { "act": "execute_script", "script": "main._settings_menu.is_in_group(\"pad_native_nav_modal\")", "equals": true },
+    { "act": "execute_script", "script": "main._settings_menu._pad_focus_confined", "equals": true },
+    { "act": "screenshot", "label": "01_settings_open_pad" },
+
+    { "act": "execute_script", "multiline": true, "script": "var sm = tree.current_scene._settings_menu\nvar f = tree.root.gui_get_focus_owner()\nreturn f != null and sm.is_ancestor_of(f)", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var sm = tree.current_scene._settings_menu\nvar f = tree.root.gui_get_focus_owner()\nvar sides = [SIDE_TOP, SIDE_BOTTOM, SIDE_LEFT, SIDE_RIGHT]\nvar escapes = 0\nfor s in sides:\n\tvar n = f.find_valid_focus_neighbor(s)\n\tif n != null and not sm.is_ancestor_of(n):\n\t\tescapes += 1\nreturn escapes", "equals": 0 },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": true },
+    { "act": "execute_script", "script": "int(GameState.state.meta.phase) == InputDeviceManager.get_meta(\"phase_before\")", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var c = tree.current_scene._pad_phase_confirm\nreturn c == null or not is_instance_valid(c) or not c.visible", "equals": true },
+    { "act": "screenshot", "label": "02_start_did_not_end_phase" },
+
+    { "act": "execute_script", "multiline": true, "script": "var sm = tree.current_scene._settings_menu\nvar cnt = 0\nfor c in sm._pad_confined_controls:\n\tif is_instance_valid(c) and c.focus_mode == Control.FOCUS_NONE:\n\t\tcnt += 1\nreturn cnt > 0", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 4 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "is_instance_valid(main._settings_menu)", "equals": false },
+    { "act": "execute_script", "multiline": true, "script": "var n = 0\nfor b in tree.current_scene.find_children(\"*\", \"Button\", true, false):\n\tif b.is_visible_in_tree() and b.focus_mode == Control.FOCUS_ALL:\n\t\tn += 1\nreturn n > 0", "equals": true },
+    { "act": "screenshot", "label": "03_settings_closed_focus_restored" }
+  ]
+}


### PR DESCRIPTION
## Ask

The "Allocate Attacks / Roll Saves" window was not selectable/controllable with a controller. Audit all pop-up windows so an open window owns the D-pad until dismissed, with sensible exceptions.

## What changed since this PR opened

While this was in flight, `main` shipped its own controller work (now at 0.90.1). PR **#726/#729 already fixed the reported bug** — the 11e Allocate Attacks / Roll Saves window is fully D-pad controllable on main via the `pad_native_nav_modal` self-confinement pattern (the same one `SaveLoadDialog` already used). This PR was **rebuilt on top of current main** to avoid a competing mechanism and now closes only the **two remaining pop-up gaps** the audit found, using main's established pattern.

## Audit result (on current main)

- AcceptDialog/ConfirmationDialog windows (~40): handled by the InputDeviceManager watcher + exclusive-Window routing. ✓
- SaveLoadDialog, AllocationGroupOverlay (11e saves): handled via `pad_native_nav_modal`. ✓
- **SettingsMenu** (in-game pause menu): plain-Control full-screen overlay that did **not** trap the pad → **gap, fixed here.**
- **Pad Start (End-Phase)**: no guard, so Start fired *underneath* any open modal → **fixed here.**
- DatasheetModal: read-only card with no focusable controls (nothing to navigate) — sensible exception, left as-is.
- WoundAllocationOverlay (10e): unused at edition 11 — left as-is.

## Change

- **SettingsMenu** joins `pad_native_nav_modal` and confines external focus to itself while a pad is active (restored on close / KBM switch), mirroring `AllocationGroupOverlay`/`SaveLoadDialog`. The Save/Load hand-off releases the trap *before* emitting so `SaveLoadDialog`'s own confinement starts from a clean baseline.
- **Main** ignores the pad Start action while any `pad_native_nav_modal` member is visible. The View button (pause cascade) stays live as the escape hatch.

## Validation

Verified the gap **live on current main** first (per project rule — no assumed limitations): with SettingsMenu open, `find_valid_focus_neighbor` from the focused Close button pointed **OUTSIDE** the menu in all four directions (26 focusable controls behind it).

- **NEW** `tests/scenarios/sp/pad_settings_modal_focus.json` — pad-only, **26/26 PASS**: focus stays inside the menu (`escapes: 0`), Start doesn't end the phase while it's open, external controls demoted then restored on close (144 controls demoted/restored, traced live).
- Regressions green: `pad_menu_button`, `pad_m0_menu_nav`, `pad_saveload_ingame_focus`, `pad_saveload_menu_focus`, `pad_controller_settings`, `pad_m4_rolloff`, `defender_control_saves_11e`.
- Debug log clean (0 ERROR lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019bdVnntHrWbXm1gW8MoK71