### PR TITLE
Fight pile-in/consolidate: controller-operable step dialogs

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -245,7 +245,7 @@ const HINTS_FIGHT := [
 	["rb", "Cycle Units"],
 	["dpad", "Navigate Panel"],
 	["a", "Select"],
-	["ls", "Move Models"],
+	["ls", "Point"],
 	["y", "Datasheet"],
 	["menu", "End Phase"],
 	["view", "Pause Menu"],

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.90.0",
+			"date": "2026-07-22",
+			"summary": "Piling in and consolidating now work on a controller. The Pile-In and Consolidate step dialogs are controller-operable: Ⓨ runs Auto Pile In / Auto Consolidate (moves every model optimally toward the closest enemy — the no-drag path, since the on-screen cursor can't press-and-hold to drag a model by hand), ☰ Confirms the move, and Ⓑ Skips. A hint row in each dialog spells this out on a controller. Previously these steps had no working controller path at all.",
+			"changes": [
+				"Fight phase Pile-In and Consolidate step dialogs are now controller-drivable: Ⓨ = Auto Pile In / Auto Consolidate (optimal move toward the closest enemy), ☰ (Menu) = Confirm Move, Ⓑ = Skip. Each dialog shows a controller hint row (only when a pad is in use).",
+				"This closes the last gap in the Fight phase's controller support: previously the pile-in / consolidate model moves could only be done by mouse-dragging, which a controller cannot do (the virtual cursor clicks, it can't press-and-hold to drag).",
+				"Manual per-model dragging during pile-in / consolidate remains a mouse affordance; on a controller, Auto Pile In / Auto Consolidate handles the move."
+			]
+		},
+		{
 			"version": "0.89.0",
 			"date": "2026-07-22",
 			"summary": "The controller target-picking treatment now reaches the Fight phase. The Assign Attacks dialog is fully controller-operable — the melee twin of the shooting fix: D-pad ▲▼ steps the weapon, ◀▶ steps the target (the enemy you're about to hit wears the same gold reticle brackets + 'TARGET n/m' banner, auto-armed and lifted into the clear strip above the dialog so it's never hidden), Ⓐ adds the assignment, and ☰ resolves the fight. Picking which unit fights, and the pile-in / consolidate unit picks, are reachable with the bumpers + D-pad too — the bumpers no longer misfire on the fight-order list.",

--- a/40k/dialogs/ConsolidateDialog.gd
+++ b/40k/dialogs/ConsolidateDialog.gd
@@ -125,6 +125,18 @@ func _build_ui() -> void:
 	info.add_theme_color_override("font_color", _LEGEND_COLOR)
 	container.add_child(info)
 
+	# Pad (controller) hint row — shown only when the pad is the active device.
+	# Consolidating on a controller uses Auto Consolidate (Ⓨ) then Confirm (☰);
+	# manual per-model drag stays a mouse affordance.
+	var pad_hint := Label.new()
+	pad_hint.name = "PadHintLabel"
+	pad_hint.text = "Ⓨ Auto Consolidate   ·   ☰ Confirm   ·   Ⓑ Skip"
+	pad_hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	pad_hint.add_theme_font_size_override("font_size", 12)
+	pad_hint.modulate = Color(1, 1, 1, 0.8)
+	pad_hint.visible = InputDeviceManager.is_pad_active()
+	container.add_child(pad_hint)
+
 	add_child(container)
 
 	confirmed.connect(_on_confirmed)
@@ -137,9 +149,49 @@ func _build_ui() -> void:
 	# Set minimum size for dialog
 	min_size = DialogConstants.SMALL
 
-	# CRITICAL: Allow input to pass through to the battlefield
+	# CRITICAL: Allow input to pass through to the battlefield. MUST stay inside
+	# _build_ui() (a pile-in-dialog revision once orphaned this below a function
+	# def, leaving the dialog modal and blocking the board drag).
 	exclusive = false
 	unresizable = false
+
+	# Pad: drive the action row off the dialog's own window_input (mirrors the
+	# Pile-In dialog) — ☰ Confirm, Ⓑ Skip, Ⓨ Auto Consolidate.
+	window_input.connect(_pad_handle_input)
+	about_to_popup.connect(_pad_refresh_hint)
+
+# Pad: keep the hint row in sync with the active device when the dialog pops.
+func _pad_refresh_hint() -> void:
+	var h := get_node_or_null("Content/PadHintLabel")
+	if h != null:
+		h.visible = InputDeviceManager.is_pad_active()
+
+# Pad navigation for the Consolidate step dialog: ☰ Confirms, Ⓑ Skips, Ⓨ runs
+# Auto Consolidate (the no-drag fast path). Manual per-model drag stays a mouse
+# affordance (the on-screen cursor click can't press-and-hold to drag a model).
+func _pad_handle_input(event: InputEvent) -> void:
+	if not (event is InputEventJoypadButton) or not event.pressed:
+		return
+	match event.button_index:
+		JOY_BUTTON_START:
+			_pad_press("ConfirmButton")
+			set_input_as_handled()
+		JOY_BUTTON_B:
+			_pad_press("SkipButton")
+			set_input_as_handled()
+		JOY_BUTTON_Y:
+			_pad_press("AutoButton")
+			set_input_as_handled()
+
+func _pad_press(button_name: String) -> void:
+	var q: Array = [self]
+	while not q.is_empty():
+		var n = q.pop_front()
+		if n is Button and str(n.name) == button_name and n.visible and not n.disabled:
+			n.emit_signal("pressed")
+			return
+		for c in n.get_children():
+			q.append(c)
 
 func update_movements(movements: Dictionary) -> void:
 	"""Called by FightController when user drags models"""

--- a/40k/dialogs/PileInDialog.gd
+++ b/40k/dialogs/PileInDialog.gd
@@ -120,6 +120,19 @@ func _build_ui() -> void:
 	info.add_theme_color_override("font_color", _LEGEND_COLOR)
 	container.add_child(info)
 
+	# Pad (controller) hint row — shown only when the pad is the active device.
+	# Piling in on a controller uses Auto Pile In (Ⓨ) — the optimal no-drag
+	# move toward the closest enemy — then Confirm (☰). Manual per-model drag
+	# stays a mouse affordance (the on-screen cursor click can't press-and-hold).
+	var pad_hint := Label.new()
+	pad_hint.name = "PadHintLabel"
+	pad_hint.text = "Ⓨ Auto Pile In   ·   ☰ Confirm   ·   Ⓑ Skip"
+	pad_hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	pad_hint.add_theme_font_size_override("font_size", 12)
+	pad_hint.modulate = Color(1, 1, 1, 0.8)
+	pad_hint.visible = InputDeviceManager.is_pad_active()
+	container.add_child(pad_hint)
+
 	add_child(container)
 
 	confirmed.connect(_on_confirmed)
@@ -132,9 +145,52 @@ func _build_ui() -> void:
 	# Set minimum size for dialog
 	min_size = DialogConstants.SMALL
 
-	# CRITICAL: Allow input to pass through to the battlefield
+	# CRITICAL: Allow input to pass through to the battlefield. MUST stay inside
+	# _build_ui() — an earlier revision accidentally pushed this below a function
+	# definition, leaving the dialog exclusive (modal), which blocked the board
+	# drag from reaching FightController.
 	exclusive = false
 	unresizable = false
+
+	# Pad: the step dialog's action row is driven off the dialog's own
+	# window_input so it never fights PadRouter — ☰ Confirm, Ⓑ Skip, Ⓨ Auto.
+	window_input.connect(_pad_handle_input)
+	about_to_popup.connect(_pad_refresh_hint)
+
+# Pad: keep the hint row in sync with the active device when the dialog pops.
+func _pad_refresh_hint() -> void:
+	var h := get_node_or_null("Content/PadHintLabel")
+	if h != null:
+		h.visible = InputDeviceManager.is_pad_active()
+
+# Pad navigation for the Pile-In step dialog (mirrors the attack dialog): ☰
+# (Menu/Start) Confirms the move, Ⓑ Skips it, Ⓨ runs Auto Pile In — the
+# no-drag fast path that moves every model toward the closest enemy. The manual
+# model carry stays a mouse affordance (the on-screen cursor click can't
+# press-and-hold to drag a model).
+func _pad_handle_input(event: InputEvent) -> void:
+	if not (event is InputEventJoypadButton) or not event.pressed:
+		return
+	match event.button_index:
+		JOY_BUTTON_START:
+			_pad_press("ConfirmButton")
+			set_input_as_handled()
+		JOY_BUTTON_B:
+			_pad_press("SkipButton")
+			set_input_as_handled()
+		JOY_BUTTON_Y:
+			_pad_press("AutoButton")
+			set_input_as_handled()
+
+func _pad_press(button_name: String) -> void:
+	var q: Array = [self]
+	while not q.is_empty():
+		var n = q.pop_front()
+		if n is Button and str(n.name) == button_name and n.visible and not n.disabled:
+			n.emit_signal("pressed")
+			return
+		for c in n.get_children():
+			q.append(c)
 
 func update_movements(movements: Dictionary) -> void:
 	"""Called by FightController when user drags models"""

--- a/40k/tests/scenarios/sp/pad_fight_pilein_auto.json
+++ b/40k/tests/scenarios/sp/pad_fight_pilein_auto.json
@@ -1,0 +1,44 @@
+{
+  "id": "pad_fight_pilein_auto",
+  "covers": [
+    "controller.fight.pilein_step_pad",
+    "controller.fight.pilein_dialog_auto_confirm",
+    "PadRouter",
+    "FightController",
+    "PileInDialog"
+  ],
+  "fixture": "stompa_fight_11e",
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Fight phase global Pile-In step on a controller. At phase entry the Pile-In step panel is up; the bumpers focus its action buttons (a Button, not the informational Fight Sequence list). Selecting a unit (Ⓐ) opens the PileInDialog, which is fully pad-operable from its own window_input: Ⓨ runs Auto Pile In (the no-drag optimal move toward the closest enemy — manual per-model drag stays a mouse affordance since the virtual-cursor click can't press-and-hold), and ☰ (Menu) presses Confirm Move to commit the pile-in. A pad hint row spells this out. Validates the previously-broken pile-in is now completable end-to-end on a pad.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_step_panel != null and main.fight_controller.pile_in_step_panel.visible", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var f = tree.root.gui_get_focus_owner()\nif f == null:\n\treturn \"no focus\"\nif f is ItemList:\n\treturn \"MISFIRE: itemlist\"\nreturn \"button:\" + str(f.name)", "equals": "button:EndPileInButton" },
+
+    { "act": "execute_script", "multiline": true, "script": "var fc = tree.current_scene.fight_controller\nvar btn = null\nvar q = [fc.pile_in_step_panel]\nwhile not q.is_empty():\n\tvar n = q.pop_front()\n\tif n is Button and str(n.name) == \"PileIn_U_WARBOSS_B\":\n\t\tbtn = n\n\tfor c in n.get_children():\n\t\tq.append(c)\nif btn == null:\n\treturn \"no button\"\nbtn.grab_focus()\nreturn str(tree.root.gui_get_focus_owner().name)", "equals": "PileIn_U_WARBOSS_B" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"PileInDialog\") != null", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_active", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node_or_null(\"PileInDialog\")\nvar h = d.get_node_or_null(\"Content/PadHintLabel\")\nreturn h != null and h.visible", "equals": true },
+    { "act": "screenshot", "label": "01_pilein_dialog_open" },
+
+    { "act": "simulate_joy_button", "button_index": 3 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"PileInDialog\").model_movements.size()", "expect_min": 1 },
+    { "act": "screenshot", "label": "02_auto_pilein_moved" },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"PileInDialog\") == null", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller.pile_in_active", "equals": false },
+    { "act": "screenshot", "label": "03_pilein_confirmed" }
+  ]
+}


### PR DESCRIPTION
## What & why

Closes the last Fight-phase controller gap. I verified live that pile-in on a pad was **fully broken**: the interactive model move is mouse-drag only (`_handle_pile_in_input`), and the virtual cursor's Ⓐ is a click — it can't press-and-hold to drag a model — so a controller could not pile in or consolidate at all.

The **PileInDialog** and **ConsolidateDialog** now drive their action row from their own `window_input` (both are non-exclusive, so PadRouter is never fought):
- **Ⓨ** = Auto Pile In / Auto Consolidate — moves every model optimally toward the closest enemy (the practical no-drag pad path)
- **☰** (Start) = Confirm Move
- **Ⓑ** = Skip

Each dialog shows a controller hint row, only when the pad is active. Manual per-model dragging stays a mouse affordance — a manual Ⓐ-carry was rejected because it conflicts with the dialog's watcher-focused Confirm button (Ⓐ activates it).

## Regression caught + fixed during validation

An earlier revision inserted the `_pad_handle_input`/`_pad_press` function definitions *inside* `_build_ui()`, which orphaned the trailing `exclusive = false` out of the function — leaving the pile-in dialog **modal**, blocking the board drag that the mouse pile-in scenarios rely on (`attached_char_pile_in_step_11e` and `global_consolidation_step_11e` both went red). Fixed by keeping `exclusive = false` inside `_build_ui()` and moving the pad functions after it; both scenarios are green again.

## Validation

All windowed, driven against the running UI via the `addons/godot_mcp` bridge:

- **New `pad_fight_pilein_auto`**: bumpers focus the pile-in panel buttons (not the informational list), Ⓐ opens the PileInDialog, Ⓨ auto-piles a model, ☰ confirms — the previously-broken pile-in now completes end-to-end.
- ConsolidateDialog pad nav verified live (Ⓨ auto moved a model; ☰ presses Confirm identically to a mouse click).
- Regression sweep green: `attached_char_pile_in_step_11e`, `global_consolidation_step_11e`, `auto_pile_in/consolidate_closest_opponents`, `ai_pile_in_token_sync`, `consolidate_menu_visibility`, plus the pad fight scenarios.

Player-facing changelog entry added (v0.90.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne)_