### PR TITLE
Fix controller hint: "Next Model" is L3-only in mid-move squad movement

### DIFF
--- a/40k/autoloads/PadHintBar.gd
+++ b/40k/autoloads/PadHintBar.gd
@@ -26,6 +26,11 @@ const M0_HINTS := [
 var _panel: PanelContainer
 var _row: HBoxContainer
 
+# The [glyph_id, label] pairs currently rendered, verbatim from the last
+# set_hints() call. Exposed so windowed scenarios can assert exactly which chips
+# the player sees (e.g. that "Next Model" only ever rides L3, never X).
+var current_hints: Array = []
+
 
 func _ready() -> void:
 	layer = 90
@@ -36,11 +41,23 @@ func _ready() -> void:
 
 
 func set_hints(hints: Array) -> void:
+	current_hints = hints.duplicate(true)
 	for child in _row.get_children():
 		child.queue_free()
 	for hint in hints:
 		_row.add_child(GlyphDB.make_chip(str(hint[0]), str(hint[1])))
 	_panel.visible = not hints.is_empty() and InputDeviceManager.is_pad_active()
+
+
+# The label currently paired with `glyph_id` in the hint bar, or "" if that
+# button has no chip in the active context. Lets windowed scenarios assert what
+# the player actually reads for a given button (e.g. that L3 — not X — carries
+# the "Next Model" label in the multi-step movement state).
+func label_for(glyph_id: String) -> String:
+	for hint in current_hints:
+		if str(hint[0]) == glyph_id:
+			return str(hint[1])
+	return ""
 
 
 func _on_device_changed(mode: int) -> void:

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -206,16 +206,22 @@ const HINTS_MOVE := [
 ]
 # Movement mid-move with a model just dropped and models still un-placed (the
 # multi-step state): the dropped model KEEPS focus — A picks it back up to keep
-# spending its remaining move, X seals it and hands over the next un-placed
-# model, a D-pad press lifts every still-unmoved model as one group (any move
-# mode — staged drops keep their spots), B undoes the last staged model, L3
-# (and the paddles where Steam Input forwards them) browses models freely. The
-# bumpers stay locked to this unit until the move is confirmed or undone.
+# spending its remaining move, X "Finish Model" seals it and hands over the next
+# un-placed model, a D-pad press lifts every still-unmoved model as one group (any
+# move mode — staged drops keep their spots), B undoes the last staged model, L3
+# (and the paddles where Steam Input forwards them) browses models freely. L3
+# keeps its one label — "Next Model", the same as every other non-carry movement
+# state — so "Next Model" always means the L3 model-switcher and never collides
+# with X: X is "Finish Model" here (matching the carry set), never "Next Model".
+# (The reported controller confusion: this state used to relabel "Next Model"
+# onto X and demote L3 to "Browse Models", so for one transient state "Next Model"
+# jumped buttons.) The bumpers stay locked to this unit until the move is
+# confirmed or undone.
 const HINTS_MOVE_STAGED := [
 	["a", "Move Model"],
-	["x", "Next Model"],
+	["x", "Finish Model"],
 	["dpad", "Grab All"],
-	["l3", "Browse Models"],
+	["l3", "Next Model"],
 	["b", "Undo Model"],
 	["y", "Datasheet"],
 	["menu", "Confirm Move"],
@@ -1217,7 +1223,7 @@ func _drop_carry(regrab_group := true) -> bool:
 func _refresh_hints_settled() -> void:
 	# A drop's synthetic release travels the input queue and its
 	# STAGE_MODEL_MOVE lands a frame or two later; refresh the hint bar after
-	# that so the multi-step affordances (A Move Model / X Next Model / B Undo
+	# that so the multi-step affordances (A Move Model / X Finish Model / B Undo
 	# Model) appear right at the drop instead of only on the next press.
 	await get_tree().process_frame
 	await get_tree().process_frame
@@ -1295,7 +1301,7 @@ func _carry_next_unplaced_model() -> void:
 # The active unit's combined move roster: its own alive models plus those of
 # every attached character, as ordered {source_unit_id, model_id} entries. An
 # attached leader forms one unit with its bodyguard and moves WITH it, so the
-# per-model pad flow (L3/paddle browse, X "Next Model", the auto-advance after a
+# per-model pad flow (L3/paddle browse, X "Finish Model", the auto-advance after a
 # drop) hands you the leader's model too — the leader is included by default, not
 # only via the D-pad group grab. Model ids collide between the two units, so each
 # entry keeps its source unit id; staging routes through the active unit's move
@@ -2086,7 +2092,7 @@ func _movement_session_locked() -> bool:
 
 
 # True while the active movement unit still has at least one alive model with
-# no staged destination — the multi-step state where X ("Next Model") has
+# no staged destination — the multi-step state where X ("Finish Model") has
 # somewhere to advance to.
 func _movement_has_unplaced_models() -> bool:
 	var mc := _movement_controller()

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.89.1",
+			"date": "2026-07-22",
+			"summary": "Fixed a confusing controller hint while moving a squad model-by-model. In the brief state right after you drop a model with Ⓐ while other models still need placing, the bottom hint bar used to move the 'Next Model' label onto Ⓧ and rename L3 to 'Browse Models' — so for that one state 'Next Model' jumped from L3 (where it sits in every other movement state) onto Ⓧ. Now Ⓧ reads 'Finish Model' (matching what it says while carrying) and L3 always reads 'Next Model'. 'Next Model' is the L3 button, always.",
+			"changes": [
+				"Movement (controller): after dropping a model with Ⓐ while models remain unplaced, the hint bar now shows 'Ⓧ Finish Model' and 'L3 Next Model' — previously it showed 'Ⓧ Next Model' and 'L3 Browse Models', which made it look like Ⓧ had become the model-switch button.",
+				"'Next Model' now refers only ever to L3 (the left-stick click), consistently across selecting a unit, the move menu, mid-move, and once all models are placed. Ⓧ is 'Finish Model' everywhere it seals a model and advances to the next un-placed one."
+			]
+		},
+		{
 			"version": "0.89.0",
 			"date": "2026-07-22",
 			"summary": "The controller target-picking treatment now reaches the Fight phase. The Assign Attacks dialog is fully controller-operable — the melee twin of the shooting fix: D-pad ▲▼ steps the weapon, ◀▶ steps the target (the enemy you're about to hit wears the same gold reticle brackets + 'TARGET n/m' banner, auto-armed and lifted into the clear strip above the dialog so it's never hidden), Ⓐ adds the assignment, and ☰ resolves the fight. Picking which unit fights, and the pile-in / consolidate unit picks, are reachable with the bumpers + D-pad too — the bumpers no longer misfire on the fight-order list.",

--- a/40k/tests/scenarios/sp/pad_move_staged_hint_labels.json
+++ b/40k/tests/scenarios/sp/pad_move_staged_hint_labels.json
@@ -1,0 +1,62 @@
+{
+  "id": "pad_move_staged_hint_labels",
+  "covers": [
+    "controller.move.staged_hint_x_is_finish",
+    "controller.move.staged_hint_l3_is_next",
+    "controller.move.next_model_label_is_l3_only"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Regression guard for the reported controller confusion: while moving a multi-model unit's individual models, the transient 'model dropped, others still un-placed' state (HINTS_MOVE_STAGED) used to relabel 'Next Model' onto X and demote L3 to 'Browse Models', so for one state 'Next Model' jumped from L3 to X. Drive that exact state — select U_WITCHSEEKERS_C, open the move menu, choose Move (auto-carry), swap to a model, drop it as a waypoint while two models remain un-placed — then assert the hint bar the player reads: X is 'Finish Model' (matching the carry set), L3 is 'Next Model' (matching every other non-carry movement state), and X is NEVER 'Next Model'. Proves 'Next Model' is an L3-only label.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": false },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 0 },
+
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 140.0 },
+    { "act": "simulate_joy_button", "button_index": 7 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "PadRouter.carry_model_index", "equals": 1 },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 0 },
+
+    { "act": "pad_cursor_glide", "x": 910.0, "y": 100.0 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 1 },
+
+    { "act": "wait_seconds", "seconds": 0.4 },
+
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "execute_script", "script": "PadHintBar.get_node(\"PadHintPanel\").visible", "equals": true },
+
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"x\")", "equals": "Finish Model" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"l3\")", "equals": "Next Model" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"x\")", "not_equals": "Next Model" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"a\")", "equals": "Move Model" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"menu\")", "equals": "Confirm Move" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"dpad\")", "equals": "Grab All" },
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"b\")", "equals": "Undo Model" },
+
+    { "act": "screenshot", "label": "01_staged_x_finish_l3_next" }
+  ]
+}


### PR DESCRIPTION
## Problem

While moving a squad model-by-model on a controller, one transient state made the bottom hint bar show **Ⓧ = "Next Model"** — even though L3 is the model-switch button everywhere else. It was hard to reproduce because it only appears for a moment: right after you drop a model with **Ⓐ** (as a waypoint) while other models still need placing.

The Movement phase has four controller hint states, and "Next Model" was used inconsistently:

| State | When | Ⓧ chip | L3 chip |
|---|---|---|---|
| unit selected / move menu | before moving | — | **Next Model** |
| carrying a model | model in hand | Finish Model | Swap Model |
| **dropped a model, others unplaced** | **the surprise state** | **Next Model** ← | Browse Models |
| all models placed | awaiting confirm | — | **Next Model** |

So in that third state, the "Next Model" label jumped from L3 onto Ⓧ — the reported confusion.

## Fix

Make "Next Model" refer to exactly one button. In `HINTS_MOVE_STAGED` (`PadRouter.gd`):

- **Ⓧ → "Finish Model"** — matches `HINTS_CARRY_MOVE` (same underlying `_finish_model_and_advance` action: seal this model, advance to the next un-placed one).
- **L3 → "Next Model"** — matches every other non-carry movement state.

Button behaviour is unchanged; this is purely the labels. The two verbs stay distinct: **L3 "Next Model"** freely browses/cycles all models, **Ⓧ "Finish Model"** commits the current one and jumps to the next unplaced.

## Changes

- `PadRouter.gd`: relabel the two `HINTS_MOVE_STAGED` chips; sync the code comments that still described Ⓧ as "Next Model".
- `PadHintBar.gd`: add `current_hints` + `label_for()` so windowed scenarios can assert exactly which label a button shows (additive, no behaviour change).
- `tests/scenarios/sp/pad_move_staged_hint_labels.json`: new windowed scenario driving a multi-model unit into the staged state; asserts Ⓧ="Finish Model", L3="Next Model", and Ⓧ≠"Next Model".
- `version_history.json`: 0.89.1 entry.

## Validation

- New scenario passes (37 assertions, 0 failures); screenshot confirms the corrected bar: `Ⓐ Move Model · Ⓧ Finish Model · ✚ Grab All · L3 Next Model · Ⓑ Undo Model · Ⓨ Datasheet · ☰ Confirm Move`.
- Regression: `pad_move_multistep_model`, `pad_move_multistep_single_model`, `pad_move_l3_cycle_model`, `pad_move_carry_hop_swap` all pass (215 assertions, 0 failures).
- No `ERROR`/`SCRIPT ERROR` lines in the debug log while exercising the path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153NZ1mjWV5yvfy8WKpGM5B

---
_Generated by [Claude Code](https://claude.ai/code/session_0153NZ1mjWV5yvfy8WKpGM5B)_