### PR TITLE
Resolution dock: walk the staged dice rolls on a controller (Shooting + Fight)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.0",
+			"date": "2026-07-22",
+			"summary": "You can now walk the dice resolution on a controller in both the Shooting and Fight phases. The staged roll dock (Roll to Wound ▶ → Continue to Saving Throws ▶ → …) auto-focuses its button on a controller, so A advances each step — and it re-grabs focus after the defender's save-allocation overlay hands control back, so the roll no longer gets stuck between weapons. Previously the dock only responded to Space/Enter, leaving a controller unable to advance the rolls at all.",
+			"changes": [
+				"The staged resolution dock (shared by Shooting and Fight) now focuses its primary button (Roll to Wound / Continue to Saving Throws / Done) whenever it becomes actionable and a controller is in use, so A advances the dice resolution step by step. On keyboard/mouse nothing changes — focus is never stolen, Space/Enter still work.",
+				"A watchdog re-focuses that button the moment focus is lost — specifically after the defender's save-allocation overlay closes and the dock re-stages the next weapon, which previously left the button unfocused and the controller stuck mid-resolution.",
+				"This completes controller support for the Fight phase end-to-end: select a fighter, pile in (Auto), assign attacks (weapon/target with the gold reticle), Fight!, and now walk the whole hit → wound → saves → next-weapon → done resolution with A — no mouse required."
+			]
+		},
+		{
 			"version": "0.91.0",
 			"date": "2026-07-22",
 			"summary": "Controller pop-up audit: the in-game Settings/pause menu now traps the D-pad. Opened with a controller, its D-pad no longer walks off into the buttons on the battlefield behind it — focus is held inside the menu until you close it (B / the View button). And while ANY full-screen pop-up is open (Settings, Save/Load, the Allocate Attacks / Roll Saves window), pressing Start (☰) no longer ends the phase underneath it.",

--- a/40k/scripts/ResolutionDockBase.gd
+++ b/40k/scripts/ResolutionDockBase.gd
@@ -337,6 +337,8 @@ func _on_stage_paused(stage: String, info: Dictionary) -> void:
 		return
 	if stage == "complete":
 		_handle_complete(info)
+		# Pad: focus the now-actionable "Done ✔" button so A finishes the dock.
+		call_deferred("_pad_focus_primary")
 		return
 	current_index = int(info.get("current_index", current_index))
 	_mark_done_below(current_index)
@@ -364,6 +366,9 @@ func _on_stage_paused(stage: String, info: Dictionary) -> void:
 	fast_button.text = "Fast Roll ⏩"
 	_populate_reroll_chips(stage, info)
 	_rebuild_queue()
+	# Pad: focus the primary button so A advances to the next stage (deferred so
+	# the button's enabled/laid-out state settles first).
+	call_deferred("_pad_focus_primary")
 
 func on_saves_pending(target_name: String) -> void:
 	if state == "idle":
@@ -396,6 +401,45 @@ func _on_primary_pressed() -> void:
 			emit_signal("action_requested", {"type": "CONTINUE_TO_SAVES"})
 		_:
 			_primary_pressed_other(state)
+
+# Pad (controller) support: the dock is a right-panel VBoxContainer, not a
+# dialog, so nothing focuses its primary button — a controller player had no
+# way to advance the staged resolution (keyboard uses Space/Enter). When the
+# pad is the active device, focus the primary button each time it becomes
+# actionable so A advances it (and the D-pad reaches the Command Re-roll chips
+# / Fast Roll beside it). No-op on keyboard/mouse — focus is never stolen there.
+func _pad_active() -> bool:
+	var idm = get_node_or_null("/root/InputDeviceManager")
+	return idm != null and idm.has_method("is_pad_active") and idm.is_pad_active()
+
+func _pad_focus_primary() -> void:
+	if not _pad_active():
+		return
+	if is_instance_valid(primary_button) and primary_button.visible and not primary_button.disabled:
+		primary_button.grab_focus()
+
+# Low-rate watchdog (mirrors InputDeviceManager's dialog-focus watcher): the
+# deferred focus above can race the defender's save-allocation overlay closing —
+# the overlay frees its focused button a frame after the dock re-stages the next
+# weapon, leaving focus NULL and the pad stuck on an actionable-but-unfocused
+# "Roll to Wound ▶". Re-grab the primary button ONLY when focus is genuinely
+# lost (null), so deliberate D-pad navigation to the Fast Roll / Command Re-roll
+# chips beside it is never fought. Skipped during awaiting_saves (the overlay
+# owns focus then) and on keyboard/mouse.
+var _pad_refocus_accum: float = 0.0
+const _PAD_REFOCUS_INTERVAL := 0.25
+
+func _process(delta: float) -> void:
+	if state == "idle" or state == "awaiting_saves" or not _pad_active():
+		return
+	_pad_refocus_accum += delta
+	if _pad_refocus_accum < _PAD_REFOCUS_INTERVAL:
+		return
+	_pad_refocus_accum = 0.0
+	if not (is_instance_valid(primary_button) and primary_button.visible and not primary_button.disabled):
+		return
+	if get_viewport().gui_get_focus_owner() == null:
+		primary_button.grab_focus()
 
 # ---------------------------------------------------------------------------
 # Command Re-roll chips

--- a/40k/tests/scenarios/sp/pad_fight_resolution_walk.json
+++ b/40k/tests/scenarios/sp/pad_fight_resolution_walk.json
@@ -1,0 +1,64 @@
+{
+  "id": "pad_fight_resolution_walk",
+  "covers": [
+    "controller.fight.resolution_dock_pad_walk",
+    "controller.fight.dock_refocus_after_save_overlay",
+    "ResolutionDockBase",
+    "FightController"
+  ],
+  "fixture": "stompa_fight_11e",
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Fight resolution on a controller. The staged-resolution dock (shared ResolutionDockBase, right panel) had no pad path — its primary button was never focused, so A could not advance 'Roll to Wound ▶'. Now, when the pad is active, the dock focuses its primary button each time it becomes actionable, and a low-rate watchdog re-grabs it when focus is lost (the defender's save-allocation overlay frees its focused button a frame after the dock re-stages the next weapon, which used to strand the pad). This scenario drives a real fight to resolution (Warboss vs a Witchseeker squad moved into engagement) and validates the mechanism deterministically: after Fight! the dock is active with its primary button focused; force-clearing focus is repaired by the watchdog within its interval; A advances staged_hits → staged_wounds (dock re-focused) → awaiting_saves (the save-allocation overlay takes focus, ConfirmButton). The full end-to-end walk to completion is verified live in-session (the exact press-count depends on the dice animation timing, which is fragile to assert step-by-step here).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+
+    { "act": "execute_script", "multiline": true, "script": "var wb = GameState.state.units[\"U_WARBOSS_B\"].models[0].position\nvar base = Vector2(float(wb.x) + 60.0, float(wb.y))\nvar ws = GameState.state.units[\"U_WITCHSEEKERS_C\"].models\nfor i in range(ws.size()):\n\tws[i][\"position\"] = {\"x\": base.x + (i % 3) * 40.0, \"y\": base.y + int(i / 3.0) * 40.0}\nreturn ws.size()", "expect_min": 1 },
+    { "act": "execute_script", "multiline": true, "script": "var ph = PhaseManager.get_current_phase_instance()\nfor i in range(4):\n\tvar r = ph.execute_action({\"type\": \"END_PILE_IN\"})\n\tif not r.get(\"success\", false):\n\t\tbreak\nreturn ph._subphase_string_11e()", "equals": "FIGHTS_FIRST" },
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var fc = tree.current_scene.fight_controller\nvar q = [fc.fight_selection_panel]\nwhile not q.is_empty():\n\tvar n = q.pop_front()\n\tif n is Button and str(n.name) == \"Fight_U_WARBOSS_B\":\n\t\tn.grab_focus()\n\tfor c in n.get_children():\n\t\tq.append(c)\nreturn str(tree.root.gui_get_focus_owner().name)", "equals": "Fight_U_WARBOSS_B" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 1.5 },
+
+    { "act": "execute_script", "multiline": true, "script": "var dlg = null\nfor n in tree.root.get_children():\n\tif n is AcceptDialog and n.visible:\n\t\tdlg = n\nif dlg == null:\n\treturn \"no epic\"\nvar btn = null\nvar q = [dlg]\nwhile not q.is_empty():\n\tvar x = q.pop_front()\n\tif x is Button and str(x.text).to_lower().find(\"decline\") != -1:\n\t\tbtn = x\n\tfor c in x.get_children():\n\t\tq.append(c)\nif btn != null:\n\tbtn.emit_signal(\"pressed\")\n\treturn \"declined\"\nreturn \"no decline\"", "equals": "declined" },
+    { "act": "wait_seconds", "seconds": 2.0 },
+
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\") != null", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var ad = tree.root.get_node_or_null(\"AttackAssignmentDialog\")\nfor i in range(ad.weapon_list.item_count):\n\tif str(ad.weapon_list.get_item_text(i)).to_lower().find(\"klaw\") != -1:\n\t\tad.weapon_list.select(i)\nvar picked = \"\"\nfor i in range(ad.target_list.item_count):\n\tif str(ad.target_list.get_item_metadata(i)) == \"U_WITCHSEEKERS_C\":\n\t\tad.target_list.select(i)\n\t\tpicked = \"U_WITCHSEEKERS_C\"\nreturn picked", "equals": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "tree.root.get_node_or_null(\"AttackAssignmentDialog\").assignments.size()", "expect_min": 1 },
+
+    { "act": "simulate_joy_button", "button_index": 6 },
+    { "act": "wait_seconds", "seconds": 3.0 },
+
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.is_active()", "equals": true },
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.state", "equals": "staged_hits" },
+    { "act": "execute_script", "script": "str(tree.root.gui_get_focus_owner().name)", "equals": "DockPrimaryButton" },
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.primary_button.has_focus()", "equals": true },
+    { "act": "screenshot", "label": "01_dock_primary_focused" },
+
+    { "act": "execute_script", "script": "tree.root.gui_get_focus_owner().release_focus()" },
+    { "act": "execute_script", "script": "tree.root.gui_get_focus_owner() == null", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "str(tree.root.gui_get_focus_owner().name) if tree.root.gui_get_focus_owner() != null else \"none\"", "equals": "DockPrimaryButton" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.state", "equals": "staged_wounds" },
+    { "act": "execute_script", "script": "str(tree.root.gui_get_focus_owner().name)", "equals": "DockPrimaryButton" },
+    { "act": "screenshot", "label": "02_advanced_to_wounds" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.5 },
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.state", "equals": "awaiting_saves" },
+    { "act": "execute_script", "script": "main.fight_controller.fight_resolution_dock.primary_button.disabled", "equals": true },
+    { "act": "screenshot", "label": "03_reached_save_stage" }
+  ]
+}


### PR DESCRIPTION
## What & why

I verified live that the staged resolution dock (shared `ResolutionDockBase`, right panel) had **no controller path**: its primary button was never focused, so A/Start could not advance "Roll to Wound ▶". The dock was walkable only by keyboard Space/Enter — a controller player reached resolution and got stuck.

## Fix (benefits both Shooting and Fight — they share the dock)

- When the pad is the active device, focus the dock's primary button each time it becomes actionable (every staged pause + the final Done), so **A advances the resolution**. No-op on keyboard/mouse — focus is never stolen, Space/Enter still work.
- A low-rate `_process` watchdog re-grabs the primary button **only when focus is genuinely lost (null)**: the defender's save-allocation overlay frees its focused button a frame after the dock re-stages the *next* weapon, which left the pad stuck on an actionable-but-unfocused button. Skipped during `awaiting_saves` (the overlay owns focus then) and when focus is on another dock control (Fast Roll / Command Re-roll chips), so deliberate D-pad navigation is never fought.

The defender's `AllocationGroupOverlay` already had pad support; this connects the dock stages to it so the whole **hit → wound → saves → next weapon → complete** chain walks on A alone.

## Validation

All windowed, via the `addons/godot_mcp` bridge:

- **New `pad_fight_resolution_walk`**: drives a real fight to resolution, asserts the dock auto-focuses its primary button after Fight!, the watchdog repairs a force-cleared focus within its interval, and A advances `staged_hits → staged_wounds → awaiting_saves` — deterministically.
- Full end-to-end walk to completion (`fought=true`, including the re-focus after the save overlay) verified live in-session, seeded and unseeded, 0 errors.
- No regressions: `pad_m2_shooting_native` (shooting dock), the pad fight scenarios, and `fight_dialogs_single_confirm_11e` stay green.

This completes controller support for the Fight phase end-to-end. Player-facing changelog entry added (v0.91.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZoGqfCtiRcpcuTM9wYwne)_