### PR TITLE
Root-cause fix: restore terrain to Godot types in live state on load

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -1532,17 +1532,32 @@ func load_from_snapshot(snapshot: Dictionary) -> void:
 		var terrain_layout = state.board.get("terrain_layout", "")
 		var terrain_features = state.board.get("terrain_features", [])
 
+		var terrain_restored := false
 		if terrain_layout != "":
 			# Preferred path: reload terrain from JSON layout file
 			# This avoids issues with PackedVector2Array/Vector2 serialization over network
 			print("[GameState] Reloading terrain from layout: ", terrain_layout)
 			terrain_manager.load_terrain_layout(terrain_layout)
+			terrain_restored = true
 		elif terrain_features.size() > 0:
 			# Fallback: restore terrain features from snapshot data
 			# Convert any dict-format Vector2/polygon data back to Godot types
 			var restored_features = _restore_terrain_types(terrain_features)
 			terrain_manager.terrain_features = restored_features
 			terrain_manager.emit_signal("terrain_loaded", terrain_manager.terrain_features)
+			terrain_restored = true
+
+		# ROOT FIX (wall/terrain LoS): mirror the now-Godot-typed terrain back into
+		# the LIVE state so state.board.terrain_features matches TerrainManager. A
+		# multiplayer snapshot arrives as raw JSON — terrain polygons/walls are {x,y}
+		# dicts with no "_type" marker, so they never pass through
+		# StateSerializer._restore_complex_types — and _restore_terrain_types only
+		# fixed up TerrainManager's copy. Anything reading the live state directly
+		# (rather than a create_snapshot() copy, which overwrites terrain from
+		# TerrainManager) would then see dict-format walls, which silently failed to
+		# block line of sight. Keeping the two copies in the same format closes that.
+		if terrain_restored and terrain_manager.terrain_features.size() > 0:
+			state.board["terrain_features"] = terrain_manager.terrain_features.duplicate(true)
 
 	# Load secondary mission state if present (autoload)
 	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")


### PR DESCRIPTION
## Summary

Follow-up to #724, which added defensive coercion so the wall LoS/movement checks tolerate `{x,y}`-dict wall coordinates. This PR fixes the **root cause** of those dict-format walls.

### Root cause

`GameState.load_from_snapshot` restored `TerrainManager.terrain_features` to Godot types (`Vector2` / `PackedVector2Array`) via `_restore_terrain_types`, but left **`state.board.terrain_features`** — the live copy — as the raw snapshot data.

On the multiplayer path a snapshot arrives as **raw JSON**, so its terrain polygons and wall `start`/`end` are `{x,y}` dicts with no `_type` marker; they never pass through `StateSerializer._restore_complex_types` (which only runs on the save/load path). `create_snapshot()` masked this for most reads because it overwrites a snapshot's terrain from `TerrainManager` — but anything reading the **live state** directly saw dict-format walls, and the wall checks then errored inside `Geometry2D` and treated the wall as absent (letting units see/shoot/move through it).

### Fix

After restoring terrain on load, mirror `TerrainManager`'s Godot-typed terrain back into `state.board.terrain_features`, so the live state and `TerrainManager` never diverge. Covers polygons, walls, position, and size in one step.

### Investigation of other `Vector2` fields (per the "same gap elsewhere?" question)

- **Model positions** — stored as `{x,y}` dicts *natively* and read through `_get_model_position` / `.x`/`.y` access, which works for both forms. No gap.
- **Terrain polygons in LoS** — `_segment_intersects_polygon` / `_point_in_polygon` already coerce dict vertices. No gap.
- **Movement polygon check** (`_point_in_expanded_polygon`) — uses `.x`/`.y`, which works for dicts and `Vector2`. No gap.
- **Wall `start`/`end`** — the *only* fields passed straight into strict `Geometry2D` calls; that's why they alone broke. Fixed defensively in #724 and now at the source here.

## Validation

Headless reproduction (before → after): a network-style snapshot with dict-format terrain, loaded via `load_from_snapshot`:

| | before | after |
|---|---|---|
| `state.board.terrain_features` wall `start` | **Dict** | **Vector2** |
| `state.board.terrain_features` polygon vertex | **Dict** | **Vector2** |
| `TerrainManager` wall `start` | Vector2 | Vector2 |
| `create_snapshot()` wall `start` | Vector2 | Vector2 |

No player-visible behavior change beyond what #724 already delivered — this removes the underlying state divergence so the coercion is belt-and-suspenders and no future geometry consumer can trip over dict-format terrain from the live state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6CHGjqvgMrnVoTBgHGaRV

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6CHGjqvgMrnVoTBgHGaRV)_