### PR TITLE
Close Rapid Ingress placement gaps (stale selection + null controller)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.1",
+			"date": "2026-07-22",
+			"summary": "Rapid Ingress now works from the controller, closing two bugs left over from the earlier deep-strike fix. Using the Rapid Ingress stratagem to bring a unit on used to silently do nothing if it was your first placement of the Movement phase (the stratagem spent the CP but no placement UI ever appeared). And, like a normal reserves arrival, starting a Rapid Ingress placement now clears whatever unit you had selected, so the controller can't pop that other unit's Move / Advance / Stay Still menu or confirm its move underneath the placement.",
+			"changes": [
+				"Fixed Rapid Ingress silently doing nothing when it was the first placement of a Movement phase: the placement controller is freed at the start of every phase and Rapid Ingress — unlike the normal reserves / Scout / Kunnin' placement paths — never recreated it, so the whole placement never started. It now recreates the controller on demand.",
+				"Starting a Rapid Ingress placement now clears the previously selected unit's movement selection (auto-confirming any pending move first), matching a normal Deep Strike / Strategic Reserves arrival — so nothing you press during placement can act on that other unit, and Start no longer risks confirming its move mid-placement.",
+				"Both placement entry points now share one helper for this cleanup, so the two flows stay in step."
+			]
+		},
+		{
 			"version": "0.92.0",
 			"date": "2026-07-22",
 			"summary": "You can now walk the dice resolution on a controller in both the Shooting and Fight phases. The staged roll dock (Roll to Wound ▶ → Continue to Saving Throws ▶ → …) auto-focuses its button on a controller, so A advances each step — and it re-grabs focus after the defender's save-allocation overlay hands control back, so the roll no longer gets stuck between weapons. Previously the dock only responded to Space/Enter, leaving a controller unable to advance the rolls at all.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -2300,6 +2300,23 @@ func _reinforcement_try_switch_unit(new_unit_id: String) -> bool:
 	_reinforcement_placement_type = ""
 	return true
 
+# A placement session (reinforcement arrival OR Rapid Ingress) makes the
+# arriving unit the acting unit. Auto-confirm the previously selected unit's
+# pending move (same QoL as switching units in the list), then DROP the stale
+# movement selection — leaving it set meant the pad's move-mode menu (Move /
+# Advance / Stay Still) and Start's confirm-move fallback could still act on
+# that unit underneath the placement session, which is how deep-striking with
+# the controller showed movement options instead of a deploy confirm. Shared
+# by both placement entry points so Rapid Ingress gets the same protection as
+# a normal reserves arrival.
+func _clear_stale_movement_selection_for_placement() -> void:
+	if movement_controller and is_instance_valid(movement_controller) \
+			and str(movement_controller.active_unit_id) != "":
+		movement_controller._auto_confirm_pending_move(str(movement_controller.active_unit_id))
+		movement_controller._clear_selection()
+		movement_controller.active_unit_id = ""
+		movement_controller._update_selected_unit_display()
+
 func _begin_reinforcement_placement(unit_id: String) -> void:
 	"""Start placing a reserve unit on the battlefield as reinforcement"""
 	var unit = GameState.get_unit(unit_id)
@@ -2311,19 +2328,7 @@ func _begin_reinforcement_placement(unit_id: String) -> void:
 	if not _reinforcement_try_switch_unit(unit_id):
 		return
 
-	# The arriving unit is the acting unit now. Auto-confirm the previously
-	# selected unit's pending move (same QoL as switching units in the list),
-	# then DROP the stale movement selection — leaving it set meant the pad's
-	# move-mode menu (Move / Advance / Stay Still) and Start's confirm-move
-	# fallback could still act on that unit underneath the placement session,
-	# which is how deep-striking with the controller showed movement options
-	# instead of a deploy confirm.
-	if movement_controller and is_instance_valid(movement_controller) \
-			and str(movement_controller.active_unit_id) != "":
-		movement_controller._auto_confirm_pending_move(str(movement_controller.active_unit_id))
-		movement_controller._clear_selection()
-		movement_controller.active_unit_id = ""
-		movement_controller._update_selected_unit_display()
+	_clear_stale_movement_selection_for_placement()
 
 	var unit_name = unit.get("meta", {}).get("name", unit_id)
 	# NULL-safe: loaded saves can carry "reserve_type": null, and the value
@@ -2747,11 +2752,28 @@ func _begin_rapid_ingress_placement(unit_id: String) -> void:
 	if unit.is_empty():
 		return
 
+	# Same as a normal reserves arrival: the Rapid-Ingressing unit is the acting
+	# unit now, so drop any stale movement selection. Without this the controller
+	# could still pop the previously selected unit's move menu (the PadRouter
+	# placement guard blocks that) OR — the narrower residual — Start's
+	# confirm-move fallback could confirm that unit's staged move mid-placement.
+	_clear_stale_movement_selection_for_placement()
+
 	var unit_name = unit.get("meta", {}).get("name", unit_id)
 	var reserve_type = unit.get("reserve_type", "strategic_reserves")
 	var type_label = "Deep Strike" if reserve_type == "deep_strike" else "Strategic Reserves"
 
 	print("Main: Beginning Rapid Ingress placement for %s (%s)" % [unit_name, type_label])
+
+	# Ensure the deployment controller exists — it is freed and nulled on every
+	# phase transition (setup_phase_controllers), and Rapid Ingress can be the
+	# first placement of the Movement phase. The normal reinforcement / scout /
+	# Kunnin' paths all recreate it on demand; Rapid Ingress previously did not,
+	# so the whole `if deployment_controller:` block below silently no-op'd and
+	# the stratagem spent CP with no placement UI ever appearing.
+	if not deployment_controller:
+		print("Main: Creating deployment controller for Rapid Ingress placement")
+		setup_deployment_controller()
 
 	# Use the deployment controller to handle model placement
 	if deployment_controller:

--- a/40k/tests/scenarios/sp/pad_rapid_ingress_no_move_menu.json
+++ b/40k/tests/scenarios/sp/pad_rapid_ingress_no_move_menu.json
@@ -1,0 +1,58 @@
+{
+  "id": "pad_rapid_ingress_no_move_menu",
+  "covers": [
+    "controller.rapid_ingress.stale_selection_cleared",
+    "controller.rapid_ingress.no_move_menu_during_placement",
+    "controller.placement.shared_stale_selection_clear",
+    "PadRouter",
+    "MovementController",
+    "Main"
+  ],
+  "fixture": "ri_pretrigger",
+  "rng_seed": 42,
+  "edition": 11,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Rapid Ingress placement gets the same controller protection as a normal reserves arrival. Rapid Ingress starts placement through _begin_rapid_ingress_placement (NOT _begin_reinforcement_placement), so it previously skipped the stale-movement-selection clear: MovementController.active_unit_id kept pointing at whatever unit was selected before, so pad_menu_options still reported that stale unit's Move / Advance / Stay Still options and Start's confirm-move fallback could confirm its staged move mid-placement. Both entry points now share _clear_stale_movement_selection_for_placement(). This drives the Rapid Ingress placement entry point directly (the stratagem CP trigger is pre-existing and separately covered) and asserts the stale selection is cleared, no move menu is offered, and the pad placement affordances (A cursor warp, D-pad panel focus) still work.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_state", "path": "units.U_BATTLEWAGON_G.status", "equals": 7 },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar list = m.movement_controller.unit_list\nfor i in range(list.item_count):\n\tif str(list.get_item_metadata(i)) == \"U_WARBOSS_B\":\n\t\tlist.select(i)\n\t\tlist.item_selected.emit(i)\n\t\treturn true\nreturn false", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WARBOSS_B" },
+    { "act": "execute_script", "script": "main.movement_controller.pad_menu_options().size() > 0", "equals": true },
+    { "act": "screenshot", "label": "01_stale_unit_selected_before_rapid_ingress" },
+
+    { "act": "execute_script", "script": "main._begin_rapid_ingress_placement(\"U_BATTLEWAGON_G\")" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.deployment_controller.is_placing()", "equals": true },
+    { "act": "execute_script", "script": "main.deployment_controller.is_reinforcement_mode", "equals": true },
+    { "act": "execute_script", "script": "str(main.deployment_controller.unit_id)", "equals": "U_BATTLEWAGON_G" },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "" },
+    { "act": "execute_script", "script": "main.movement_controller.pad_menu_options().size()", "equals": 0 },
+    { "act": "execute_script", "script": "main._pad_placement_active()", "equals": true },
+    { "act": "screenshot", "label": "02_rapid_ingress_placement_stale_selection_cleared" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": false },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() != null", "equals": true },
+    { "act": "screenshot", "label": "03_dpad_during_rapid_ingress_no_move_menu" },
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.get_viewport().gui_get_focus_owner() == null", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": false },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": true },
+    { "act": "screenshot", "label": "04_a_warps_cursor_over_rapid_ingress_placement" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": false }
+  ]
+}


### PR DESCRIPTION
Follow-up to the deep-strike controller fix (#721). Rapid Ingress starts placement through `_begin_rapid_ingress_placement` — a separate entry point from `_begin_reinforcement_placement` — so it had missed two protections in the same area.

## 1. Stale movement selection not cleared

Like the reserves-arrival path before its fix, Rapid Ingress left `MovementController.active_unit_id` pointing at the previously selected unit. `pad_menu_options` still reported that unit's Move / Advance / Stay Still options, and Start's confirm-move fallback could confirm its staged move mid-placement. (The PadRouter placement guard from #721 already blocked the menu from *opening*, but the stale selection itself was never dropped — the narrower residual gap I flagged when #721 merged.)

**Fix:** extracted the reserves path's cleanup into `_clear_stale_movement_selection_for_placement()` and call it from **both** placement entry points, so they stay in step.

## 2. Deployment controller never recreated (more severe)

The deployment controller is freed and nulled on every phase transition (`setup_phase_controllers`), and Rapid Ingress can be the first placement of a Movement phase. The normal reinforcement / Scout / Kunnin' paths all recreate it on demand via `if not deployment_controller: setup_deployment_controller()` — **Rapid Ingress did not**, so its whole `if deployment_controller:` block silently no-op'd: the stratagem spent the CP with no placement UI ever appearing.

**Fix:** added the same on-demand recreation guard.

## Validation (windowed, edition 11 — the project gate)

- New scenario `tests/scenarios/sp/pad_rapid_ingress_no_move_menu.json` drives the Rapid Ingress placement entry point with a stale unit selected, then asserts placement starts, the stale selection is cleared (`active_unit_id == ""`), no move menu is offered (`pad_menu_options` empty), and the pad placement affordances still work (D-pad panel focus, A cursor warp). **Both fixes are load-bearing** — on the unfixed code it fails at the `is_placing` check (null controller) *and* the `active_unit_id` / `pad_menu_options` checks (stale selection); passes with the fix. Screenshot shows "Rapid Ingress: placing Battlewagon" with "Selected Unit: None Selected".
- Regressions green: `pad_reinforcement_no_move_menu`, `pad_reinforcement_formation_row`, `pad_m4_move_action_menu`.

Version bumped to **0.92.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NY6EkCeTxRugLwW5AMnoY

---
_Generated by [Claude Code](https://claude.ai/code/session_017NY6EkCeTxRugLwW5AMnoY)_