### PR TITLE
Guard reinforcement/infiltrator formations against off-board bases

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.2",
+			"date": "2026-07-22",
+			"summary": "Deep Strike / Strategic Reserves formations can no longer be placed with a model's base hanging off the table edge. Because Strategic Reserves arrive within 6\" of a board edge, it was possible to drop a Tight/Spread formation right on the edge so the outermost model's base overhung the battlefield — the reinforcement check only looked at each model's centre, not its full base. Formation placement now applies the same whole-base-on-board guard the single-model placement already used.",
+			"changes": [
+				"Placing a reinforcement (Deep Strike / Strategic Reserves) or Infiltrators unit in Tight or Spread formation now rejects the drop if any model's base would extend off the battlefield, with 'Models cannot be placed off the board' — matching the single-model placement rule.",
+				"This closes an edge case where a formation anchored near a board edge could leave the outer models' centres on the table but their bases overhanging it."
+			]
+		},
+		{
 			"version": "0.92.1",
 			"date": "2026-07-22",
 			"summary": "Rapid Ingress now works from the controller, closing two bugs left over from the earlier deep-strike fix. Using the Rapid Ingress stratagem to bring a unit on used to silently do nothing if it was your first placement of the Movement phase (the stratagem spent the CP but no placement UI ever appeared). And, like a normal reserves arrival, starting a Rapid Ingress placement now clears whatever unit you had selected, so the controller can't pop that other unit's Move / Advance / Stay Still menu or confirm its move underneath the placement.",

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -633,6 +633,19 @@ func try_place_formation_at(world_pos: Vector2) -> void:
 			model = unit_data["models"][idx]
 
 		var validate_rot = formation_rotations[i] if i < formation_rotations.size() else 0.0
+		# Issue #87 parity with the single-model try_place_at(): no part of any
+		# base may extend off the battlefield. Applies to all modes — normal
+		# deployment zones are already inset so this is a safety net there, but
+		# for reinforcement (Deep Strike / Strategic Reserves, which arrive within
+		# 6" of a board edge) and infiltrators the zone check is bypassed, so this
+		# is the ONLY edge guard. The per-mode validators below only test the
+		# model centre, not the full base footprint.
+		var edge_model: Dictionary = model.duplicate()
+		edge_model["rotation"] = validate_rot
+		if Measurement.model_outside_board(pos, edge_model):
+			all_valid = false
+			error_msg = "Models cannot be placed off the board"
+			break
 		if not _validate_formation_position(pos, model, zone, validate_rot):
 			all_valid = false
 			# _validate_formation_position already surfaced the specific reason

--- a/40k/tests/scenarios/sp/deep_strike_tight_formation.json
+++ b/40k/tests/scenarios/sp/deep_strike_tight_formation.json
@@ -2,14 +2,16 @@
   "id": "deep_strike_tight_formation",
   "covers": [
     "controller.reinforcement.formation_placement",
+    "controller.reinforcement.formation_off_board",
     "DeploymentController._validate_formation_position",
-    "DeploymentController.try_place_formation_at"
+    "DeploymentController.try_place_formation_at",
+    "Measurement.model_outside_board"
   ],
   "fixture": "ri_pretrigger",
   "rng_seed": 42,
   "transition_to_phase": 7,
   "disable_ai": true,
-  "description": "Deep Strike + TIGHT formation regression (GH bug): placing a formation from Deep Strike at a spot that is a LEGAL deep-strike position (on the board, >9\" from all enemies) but OUTSIDE the owning player's deployment zone was being falsely rejected with 'Formation would place models outside deployment zone or overlapping'. Root cause: _validate_formation_position only branched on is_infiltrators_mode, so reinforcement placements fell through to the deployment-zone check. This drives the real reinforcement UI path (select reserves unit -> TIGHT formation -> try_place_formation_at) at board-centre no-man's-land (880,1200) and asserts the 5-model formation actually places. Negative case: the next TIGHT group dropped 5.5\" from the enemy Witchseekers is still rejected, proving the >9\" reinforcement gate stays enforced.",
+  "description": "Deep Strike + TIGHT formation regression (GH bug): placing a formation from Deep Strike at a spot that is a LEGAL deep-strike position (on the board, >9\" from all enemies) but OUTSIDE the owning player's deployment zone was being falsely rejected with 'Formation would place models outside deployment zone or overlapping'. Root cause: _validate_formation_position only branched on is_infiltrators_mode, so reinforcement placements fell through to the deployment-zone check. This drives the real reinforcement UI path (select reserves unit -> TIGHT formation -> try_place_formation_at) at board-centre no-man's-land (880,1200) and asserts the 5-model formation actually places. Negative case 1: the next TIGHT group dropped 5.5\" from the enemy Witchseekers is still rejected, proving the >9\" reinforcement gate stays enforced. Negative case 2 (off-board edge guard): a TIGHT group anchored at (115,900) leaves the left model's CENTRE on the board (~x=12) but its 32mm base hanging over the left edge (~x=-13); reinforcement/infiltrator validators only test the centre, so before the edge fix the whole row placed off the table. Asserts the group is rejected (placed count stays 5) — mirrors the single-model try_place_at() board-edge guard.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.0 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
@@ -37,6 +39,11 @@
 
     { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(880, 270))\nreturn dc.get_placed_count()", "equals": 5 },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "screenshot", "label": "03_near_enemy_group_still_rejected" }
+    { "act": "screenshot", "label": "03_near_enemy_group_still_rejected" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\nvar r = dc.calculate_tight_formation(Vector2(115, 900), 5, 32, 0.0, [])\nvar cx = r[\"positions\"][0].x\nreturn cx > 0.0 and (cx - 25.2) < 0.0", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(115, 900))\nreturn dc.get_placed_count()", "equals": 5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "04_off_board_edge_group_rejected" }
   ]
 }


### PR DESCRIPTION
## Summary

Follow-up to #718. While fixing Deep Strike formation placement I found an adjacent gap: **formation placement doesn't stop a model's base from hanging off the board edge**, unlike single-model placement.

`try_place_formation_at` validates each model via `_validate_formation_position`, whose reinforcement/infiltrator branches call `_validate_reinforcement_position` / `_validate_infiltrators_position` — both of which only test the model **centre** is on-board, not the full base footprint. The single-model path (`try_place_at`) already guards this with `Measurement.model_outside_board`, but the formation path never did. This is reachable in normal play because **Strategic Reserves must arrive within 6" of a board edge**, so a formation anchored on the edge can leave the outer models' centres on the table while their bases overhang it.

## Fix

Add the same shape-aware, rotation-aware `Measurement.model_outside_board` check to the `try_place_formation_at` validation loop, before the per-mode validators. It runs for every mode — a harmless safety net for normal deployment (whose zones are inset) and the only edge guard for reinforcement/infiltrator drops — and rejects with `Models cannot be placed off the board`, matching the single-model message.

## Validation

Extended the `deep_strike_tight_formation.json` windowed scenario:
- A **geometry pre-check** asserts the `(115,900)` tight-formation anchor leaves the left model's centre on-board (~x=12) but its 32mm base off the left edge (~x=-13) — proving the test exercises the centre-on/base-off case specifically.
- Asserts the drop is **rejected** (placed count stays 5).

Before/after (isolated — #718 already on `main`, so a stash reverts only this change):
- **Without this fix:** the off-board row places → `10` models placed (bases hanging off the table)
- **With this fix:** rejected → `5` placed

The PR #718 reinforcement-zone assertions stay green, and the debug log shows the off-board toast firing with no new script errors (the only log noise is the pre-existing MCP-bridge HTTP-header parse warnings present in every run).

## Changelog

Version bumped to `0.84.2` in `40k/data/version_history.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au)_