### PR TITLE
Controller: drop the keyboard "[S]" hint on the Stratagems button when a pad is active

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.3",
+			"date": "2026-07-22",
+			"summary": "Controller polish: the top-bar Stratagems button no longer shows a keyboard '[S]' hint you can't press on a controller. While you're playing with a pad it simply reads 'Stratagems' (you reach it by moving panel focus with the D-pad and pressing A); pick the mouse or keyboard back up and the '[S]' hint returns.",
+			"changes": [
+				"The Stratagems button drops its '[S]' keyboard-shortcut hint while a controller is the active device — it reads 'Stratagems' — and restores '[S] Stratagems' the moment you use the mouse or keyboard. Mirrors the device-aware hint on the End-Phase button."
+			]
+		},
+		{
 			"version": "0.92.2",
 			"date": "2026-07-22",
 			"summary": "Deep Strike / Strategic Reserves formations can no longer be placed with a model's base hanging off the table edge. Because Strategic Reserves arrive within 6\" of a board edge, it was possible to drop a Tight/Spread formation right on the edge so the outermost model's base overhung the battlefield — the reinforcement check only looked at each model's centre, not its full base. Formation placement now applies the same whole-base-on-board guard the single-model placement already used.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -12,6 +12,11 @@ const UnitStatsCardPopupScript = preload("res://scripts/UnitStatsCardPopup.gd")
 # button ends the phase instead of a key they don't have.
 const GlyphDB = preload("res://scripts/input/GlyphDB.gd")
 const _PHASE_ACTION_KBM_PREFIX := "[Enter] "
+# The Stratagems button carries the keyboard "[S] " hint (Main.tscn). A pad has
+# no single Stratagems key — it reaches the button via D-pad panel focus + A —
+# so the "[S] " is dropped while a controller is active rather than showing a
+# key the player can't press.
+const _STRATAGEM_KBM_PREFIX := "[S] "
 
 # UI z_index layering constants — ensure panels always render above all board elements
 const UI_PANEL_Z: int = 500      # HUD panels (left, right, bottom, stats, logs)
@@ -289,6 +294,10 @@ func _ready() -> void:
 	# controller could end the phase at all.
 	if InputDeviceManager and not InputDeviceManager.device_changed.is_connected(_on_input_device_changed):
 		InputDeviceManager.device_changed.connect(_on_input_device_changed)
+	# Initial pass in case a pad is already the active device at startup (the
+	# phase button self-corrects via update_ui_for_phase; the stratagem button
+	# has no other refresh path, so seed it here).
+	_sync_stratagem_button_glyph()
 
 	# Clear stale game event log entries from previous sessions
 	# GameEventLog is an autoload that persists across scene reloads
@@ -10141,6 +10150,22 @@ func _sync_phase_action_glyph() -> void:
 
 func _on_input_device_changed(_mode: int) -> void:
 	_sync_phase_action_glyph()
+	_sync_stratagem_button_glyph()
+
+# Drop / restore the Stratagems button's "[S] " keyboard hint for the active
+# device: pad → "Stratagems" (reached via D-pad panel focus + A, no key), KBM →
+# "[S] Stratagems". Idempotent — strips any existing prefix before re-applying —
+# so it survives repeated device switches and any future dynamic relabel.
+func _sync_stratagem_button_glyph() -> void:
+	if not stratagem_panel_button or not is_instance_valid(stratagem_panel_button):
+		return
+	var bare: String = stratagem_panel_button.text
+	if bare.begins_with(_STRATAGEM_KBM_PREFIX):
+		bare = bare.substr(_STRATAGEM_KBM_PREFIX.length())
+	if InputDeviceManager and InputDeviceManager.is_pad_active():
+		stratagem_panel_button.text = bare
+	else:
+		stratagem_panel_button.text = _STRATAGEM_KBM_PREFIX + bare
 
 func _get_phase_button_text(phase: GameStateData.Phase) -> String:
 	return _phase_action_prefix() + _get_phase_action_label(phase)

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -3014,6 +3014,15 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "ui.stratagem_button.device_glyph",
+      "description": "The top-bar Stratagems button drops its keyboard '[S] ' hint while a controller is active ('Stratagems') and restores it for keyboard/mouse ('[S] Stratagems'), because a pad reaches the button via D-pad panel focus + A rather than an 'S' key. Re-stamped live on InputDeviceManager.device_changed and idempotent across repeated device switches.",
+      "scenarios": [
+        "717_controller_stratagem_button_glyph"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/717_controller_stratagem_button_glyph.json
+++ b/40k/tests/scenarios/sp/717_controller_stratagem_button_glyph.json
@@ -1,0 +1,25 @@
+{
+  "id": "717_controller_stratagem_button_glyph",
+  "covers": [
+    "ui.stratagem_button.device_glyph"
+  ],
+  "fixture": "New Game",
+  "description": "Controller UX: the top-bar Stratagems button carries a keyboard '[S] ' hint (Main.tscn), but a controller has no single Stratagems key — it reaches the button via D-pad panel focus + A. So while a pad is the active device the '[S] ' prefix is dropped ('Stratagems') and restored ('[S] Stratagems') for keyboard/mouse. Driven through the real InputDeviceManager.device_changed signal, so this also proves the Main handler is wired to re-stamp the label live.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.input_mode = InputDeviceManager.InputMode.KBM\nnode._sync_stratagem_button_glyph()\nreturn node.stratagem_panel_button.text",
+      "equals": "[S] Stratagems" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.claim_pad()\nreturn node.stratagem_panel_button.text",
+      "equals": "Stratagems" },
+
+    { "act": "screenshot", "label": "01_pad_stratagem_button_no_key" },
+
+    { "act": "execute_script", "multiline": true, "node": "/root/Main",
+      "script": "InputDeviceManager.input_mode = InputDeviceManager.InputMode.KBM\nInputDeviceManager.device_changed.emit(InputDeviceManager.InputMode.KBM)\nreturn node.stratagem_panel_button.text",
+      "equals": "[S] Stratagems" }
+  ]
+}


### PR DESCRIPTION
## Problem

Follow-up to the device-adaptive End-Phase button (#715, v0.83.2). The top-bar **Stratagems** button is labelled `[S] Stratagems` in `Main.tscn`, but a controller has no single Stratagems key — a pad player reaches the button through the D-pad panel-focus chain (`PadRouter._enter_panel_focus` walks `HUD_Right` then `HUD_Bottom`) and presses **A**. So the `[S]` advertises a key they can't press.

## Change

While a pad is the active device the button now reads **`Stratagems`**; on keyboard/mouse it restores **`[S] Stratagems`**.

- Re-stamped live via the same `InputDeviceManager.device_changed` handler the phase button uses (`_on_input_device_changed` → new `_sync_stratagem_button_glyph`).
- Seed call in `_ready` for the pad-already-active-at-startup case.
- The swap is idempotent (strips any existing prefix before re-applying), so it survives repeated device switches.

Purely additive — no keyboard-path behaviour changes.

## Validation

Windowed, via the `addons/godot_mcp` bridge:
- `[S] Stratagems` (KBM) ⇄ `Stratagems` (pad) ⇄ `[S] Stratagems`, driven through the **real** `device_changed` signal (proves the handler is wired, not just the helper).
- Screenshot shows the pad-mode top bar with `Stratagems` (no `[S]`) beside `[☰] End Command Phase`; 0 errors in the debug log.
- New scenario `40k/tests/scenarios/sp/717_controller_stratagem_button_glyph.json` — **5/5 pass**; coverage tile registered.
- Existing `715_controller_end_phase_glyph` regression-passes **8/8** after the shared-handler change.

Bumped version to **0.83.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015LFpc9f5trxXpbBs7DVKBf)_