### PR TITLE
tests: fix the red Coverage-matrix CI gate + classify the Multi-peer failure

### DIFF
--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -1,6 +1,6 @@
 {
   "$schema_version": 1,
-  "description": "Machine-readable coverage matrix for the windowed-scenario gate. Source of truth for what is verified \u2014 append-only AUDIT_REPORT.md is a generated narrative view. See SESSION_PLAYBOOK.md for the rules of the road.",
+  "description": "Machine-readable coverage matrix for the windowed-scenario gate. Source of truth for what is verified — append-only AUDIT_REPORT.md is a generated narrative view. See SESSION_PLAYBOOK.md for the rules of the road.",
   "$rules": [
     "A 'covered' tile must reference at least one scenario file under tests/scenarios/.",
     "Each tile's scenarios[] entries must exist as files; check_coverage.py enforces this.",
@@ -11,35 +11,45 @@
     {
       "id": "autoloads.ReplayManager.memops",
       "description": "ReplayManager's recording stays bounded during a long AI-vs-AI game: phase-transition snapshots use the history-free gameplay snapshot and are capped (oldest non-initial snapshots dropped); recorded action events carry no _replay_diffs/_ai_* payloads (diffs are stored once, separately).",
-      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "scenarios": [
+        "memops_ai_vs_ai_bounded"
+      ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {
       "id": "autoloads.GameState.memops",
       "description": "GameState.state[\"history\"] stays capped during a long AI-vs-AI game, and phase_log/history actions are stored without their _replay_diffs/_ai_* payloads.",
-      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "scenarios": [
+        "memops_ai_vs_ai_bounded"
+      ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {
       "id": "autoloads.AIPlayer.memops",
       "description": "AIPlayer's whole-game accumulators (_all_decision_records, _action_log) stay within their bounded caps during a long AI-vs-AI game.",
-      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "scenarios": [
+        "memops_ai_vs_ai_bounded"
+      ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {
       "id": "autoloads.GameEventLog.memops",
       "description": "GameEventLog.entries stays within its bounded cap during a long AI-vs-AI game.",
-      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "scenarios": [
+        "memops_ai_vs_ai_bounded"
+      ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
     {
       "id": "autoloads.ActionLogger.memops",
       "description": "ActionLogger.session_actions stays within its bounded cap, and retained actions carry no _replay_diffs/_ai_decision_records payloads, during a long AI-vs-AI game.",
-      "scenarios": ["memops_ai_vs_ai_bounded"],
+      "scenarios": [
+        "memops_ai_vs_ai_bounded"
+      ],
       "last_verified_commit": "HEAD",
       "status": "covered"
     },
@@ -126,7 +136,7 @@
     },
     {
       "id": "autoloads.EffectPrimitives.PLUS_CHARGE",
-      "description": "EffectPrimitives PLUS_CHARGE effect \u2014 sets effect_plus_charge flag on a unit",
+      "description": "EffectPrimitives PLUS_CHARGE effect — sets effect_plus_charge flag on a unit",
       "scenarios": [
         "372_ere_we_go_charge_modifier"
       ],
@@ -208,7 +218,7 @@
     },
     {
       "id": "autoloads.RulesEngine.validate_shoot",
-      "description": "RulesEngine: validates a SHOOT action against the current shooter state \u2014 eligibility, target legality, weapon assignments. Validated by '370_bgnt_vehicle_shoots_in_engagement (Big Guns Never Tire seam).",
+      "description": "RulesEngine: validates a SHOOT action against the current shooter state — eligibility, target legality, weapon assignments. Validated by '370_bgnt_vehicle_shoots_in_engagement (Big Guns Never Tire seam).",
       "scenarios": [
         "370_bgnt_vehicle_shoots_in_engagement"
       ],
@@ -271,7 +281,7 @@
     },
     {
       "id": "charge.modifier_primitive",
-      "description": "Charge-roll modifier flag (effect_plus_charge) honoured by DECLARE_CHARGE \u2014 'ERE WE GO stratagem path",
+      "description": "Charge-roll modifier flag (effect_plus_charge) honoured by DECLARE_CHARGE — 'ERE WE GO stratagem path",
       "scenarios": [
         "372_ere_we_go_charge_modifier"
       ],
@@ -407,7 +417,7 @@
     },
     {
       "id": "deployment.predeploy_roll_off",
-      "description": "Pre-deployment roll-off (issue #85): both players roll a D6. The winner chooses to be Attacker or Defender \u2014 Defender deploys first and takes the second turn, Attacker deploys second and takes the first turn.",
+      "description": "Pre-deployment roll-off (issue #85): both players roll a D6. The winner chooses to be Attacker or Defender — Defender deploys first and takes the second turn, Attacker deploys second and takes the first turn.",
       "scenarios": [
         "85_predeploy_rolloff"
       ],
@@ -450,7 +460,7 @@
     },
     {
       "id": "fight.self_targeting_fix",
-      "description": "Fight-phase AI does not select own units as melee targets \u2014 observational scenario captures before/after screenshots of AI fight decisions",
+      "description": "Fight-phase AI does not select own units as melee targets — observational scenario captures before/after screenshots of AI fight decisions",
       "scenarios": [
         "fight_self_targeting"
       ],
@@ -484,7 +494,7 @@
     },
     {
       "id": "movement.da_jump_placement_bounds",
-      "description": "MOVEMENT phase: Da Jump teleports a unit to within 9\" of the warlord and \u22659\" from enemies. Bounds check rejects invalid placements. Validated by '376_da_jump_bounds.",
+      "description": "MOVEMENT phase: Da Jump teleports a unit to within 9\" of the warlord and ≥9\" from enemies. Bounds check rejects invalid placements. Validated by '376_da_jump_bounds.",
       "scenarios": [
         "376_da_jump_bounds"
       ],
@@ -529,7 +539,7 @@
     },
     {
       "id": "movement.terrain.infantry_ruin_traversal",
-      "description": "Regression guard: MovementPhase rejects ANY model drop whose base overlaps a wall segment at the final position \u2014 no unit may end its movement on top of a wall. Infantry may still pass through walls mid-move (path-traversal honors unit keywords); this guard covers only the endpoint rule. Reverses prior #431 interpretation that let INFANTRY end movement overlapping walls (observed broken in-game: Witchseekers sitting on the north wall of Grey Ruins). Validated by 'infantry_enters_ruin_wall.",
+      "description": "Regression guard: MovementPhase rejects ANY model drop whose base overlaps a wall segment at the final position — no unit may end its movement on top of a wall. Infantry may still pass through walls mid-move (path-traversal honors unit keywords); this guard covers only the endpoint rule. Reverses prior #431 interpretation that let INFANTRY end movement overlapping walls (observed broken in-game: Witchseekers sitting on the north wall of Grey Ruins). Validated by 'infantry_enters_ruin_wall.",
       "scenarios": [
         "infantry_enters_ruin_wall"
       ],
@@ -538,7 +548,7 @@
     },
     {
       "id": "multiplayer.deployment.host_to_client_sync",
-      "description": "Multi-peer deployment sync \u2014 host deploys, client mirrors positions and coherency state",
+      "description": "Multi-peer deployment sync — host deploys, client mirrors positions and coherency state",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_deployment.gd"
       ],
@@ -547,7 +557,7 @@
     },
     {
       "id": "multiplayer.dice.broadcast_sync",
-      "description": "Multi-peer dice broadcast \u2014 defender re-emits result.dice on remote (T5-MP5)",
+      "description": "Multi-peer dice broadcast — defender re-emits result.dice on remote (T5-MP5)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_dice_log_sync.gd"
       ],
@@ -556,7 +566,7 @@
     },
     {
       "id": "multiplayer.network.session",
-      "description": "Multi-peer network session lifecycle \u2014 host/join/disconnect, peer registration",
+      "description": "Multi-peer network session lifecycle — host/join/disconnect, peer registration",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_network.gd"
       ],
@@ -565,7 +575,7 @@
     },
     {
       "id": "multiplayer.save.broadcast_reliability",
-      "description": "Multi-peer save broadcast \u2014 broadcast_id + retry budget + dedupe (T5-MP4-RELIABILITY)",
+      "description": "Multi-peer save broadcast — broadcast_id + retry budget + dedupe (T5-MP4-RELIABILITY)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_save_dialog_retry.gd"
       ],
@@ -574,7 +584,7 @@
     },
     {
       "id": "multiplayer.shooting.visual_broadcast",
-      "description": "Multi-peer shooting visual broadcast \u2014 SELECT_SHOOTER/ASSIGN_TARGET/CONFIRM/COMPLETE (T5-MP3)",
+      "description": "Multi-peer shooting visual broadcast — SELECT_SHOOTER/ASSIGN_TARGET/CONFIRM/COMPLETE (T5-MP3)",
       "scenarios": [
         "mp:tests/integration/test_multiplayer_shooting_visuals.gd"
       ],
@@ -696,7 +706,7 @@
     },
     {
       "id": "phases.ScoutPhase.SET_SCOUT_MODEL_DEST.overlap_rejected",
-      "description": "Regression guard (#425): ScoutPhase._validate_set_scout_model_dest rejects a destination that overlaps a sibling model \u2014 either a sibling's already-staged scout-move position or an unmoved sibling's original position. A clearly non-overlapping destination still succeeds. Validated by 'scout_no_overlap.",
+      "description": "Regression guard (#425): ScoutPhase._validate_set_scout_model_dest rejects a destination that overlaps a sibling model — either a sibling's already-staged scout-move position or an unmoved sibling's original position. A clearly non-overlapping destination still succeeds. Validated by 'scout_no_overlap.",
       "scenarios": [
         "scout_no_overlap"
       ],
@@ -723,7 +733,7 @@
     },
     {
       "id": "rules.abilities.stealth_t2",
-      "description": "T2-1 \u2014 STEALTH ability: -1 to hit on ranged attacks vs Stealth target",
+      "description": "T2-1 — STEALTH ability: -1 to hit on ranged attacks vs Stealth target",
       "scenarios": [
         "mp:tests/test_stealth_keyword_pipeline.gd"
       ],
@@ -732,7 +742,7 @@
     },
     {
       "id": "rules.command.cp_gain_336",
-      "description": "Issue #336 \u2014 no CP on R1 first command phase; otherwise active player only",
+      "description": "Issue #336 — no CP on R1 first command phase; otherwise active player only",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -741,7 +751,7 @@
     },
     {
       "id": "rules.keywords.melta_x_t1",
-      "description": "T1-1 \u2014 MELTA X auto-resolves damage bonus at half range",
+      "description": "T1-1 — MELTA X auto-resolves damage bonus at half range",
       "scenarios": [
         "mp:tests/test_melta_keyword_pipeline.gd"
       ],
@@ -750,7 +760,7 @@
     },
     {
       "id": "rules.keywords.twin_linked_t1",
-      "description": "T1-2 \u2014 TWIN-LINKED re-rolls all failed wound rolls",
+      "description": "T1-2 — TWIN-LINKED re-rolls all failed wound rolls",
       "scenarios": [
         "mp:tests/test_twin_linked_pipeline.gd"
       ],
@@ -759,7 +769,7 @@
     },
     {
       "id": "rules.movement.base_touching_m6",
-      "description": "T2-M6 \u2014 base-touching regression (#321/#327)",
+      "description": "T2-M6 — base-touching regression (#321/#327)",
       "scenarios": [
         "mp:tests/test_m6_base_touching_regression.gd"
       ],
@@ -768,7 +778,7 @@
     },
     {
       "id": "rules.rng.determinism_329",
-      "description": "Issue #329 \u2014 RNGService.test_mode_seed produces identical dice across runs; new helpers (randi/randi_range/randf) honor it; TransportManager + MissionManager + Mathhammer plumbed",
+      "description": "Issue #329 — RNGService.test_mode_seed produces identical dice across runs; new helpers (randi/randi_range/randf) honor it; TransportManager + MissionManager + Mathhammer plumbed",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd",
         "mp:tests/test_rng_determinism_extended.gd"
@@ -778,7 +788,7 @@
     },
     {
       "id": "rules.save_load.autoload_state_338",
-      "description": "Issue #338 \u2014 FactionAbilityManager + StratagemManager state round-trips through save/load",
+      "description": "Issue #338 — FactionAbilityManager + StratagemManager state round-trips through save/load",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -787,7 +797,7 @@
     },
     {
       "id": "rules.shooting.cover_save_cap_s7",
-      "description": "T2-S7 \u2014 Cover save bonus capped: Sv3+ vs AP0 in cover stays 3+ (was 2+)",
+      "description": "T2-S7 — Cover save bonus capped: Sv3+ vs AP0 in cover stays 3+ (was 2+)",
       "scenarios": [
         "mp:tests/test_s7_cover_save_bonus.gd"
       ],
@@ -796,7 +806,7 @@
     },
     {
       "id": "rules.shooting.fall_back_and_shoot_override_356",
-      "description": "Issue #356 \u2014 Multipotentiality stratagem: effect_fall_back_and_shoot overrides cannot_shoot gate in ShootingPhase + RulesEngine.validate_shoot",
+      "description": "Issue #356 — Multipotentiality stratagem: effect_fall_back_and_shoot overrides cannot_shoot gate in ShootingPhase + RulesEngine.validate_shoot",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -805,7 +815,7 @@
     },
     {
       "id": "rules.shooting.keyword_pipeline",
-      "description": "T2-S4..S6 \u2014 SUSTAINED HITS / LETHAL HITS / DEVASTATING WOUNDS keyword pipelines",
+      "description": "T2-S4..S6 — SUSTAINED HITS / LETHAL HITS / DEVASTATING WOUNDS keyword pipelines",
       "scenarios": [
         "mp:tests/test_keyword_pipeline.gd"
       ],
@@ -814,7 +824,7 @@
     },
     {
       "id": "rules.stratagem.excluding_keyword_parser_359",
-      "description": "Issue #359 \u2014 FactionStratagemLoader._map_target correctly handles 'excluding X' as not_keyword:X (was incorrectly mapping to keyword:X). Affects 'ARD AS NAILS, UNWAVERING SENTINELS, ARCHEOTECH MUNITIONS",
+      "description": "Issue #359 — FactionStratagemLoader._map_target correctly handles 'excluding X' as not_keyword:X (was incorrectly mapping to keyword:X). Affects 'ARD AS NAILS, UNWAVERING SENTINELS, ARCHEOTECH MUNITIONS",
       "scenarios": [
         "mp:tests/test_audit_fixes_verification.gd"
       ],
@@ -868,7 +878,7 @@
     },
     {
       "id": "phases.FightPhase.pile_in_11e",
-      "description": "Windowed scenario coverage for phases.FightPhase.pile_in_11e (verified by iss066_pile_in_consolidate_11e). Since 2026-07-04 pile-in is the GLOBAL step opening the fight phase (12.02) \u2014 full player path verified by global_consolidation_step_11e.",
+      "description": "Windowed scenario coverage for phases.FightPhase.pile_in_11e (verified by iss066_pile_in_consolidate_11e). Since 2026-07-04 pile-in is the GLOBAL step opening the fight phase (12.02) — full player path verified by global_consolidation_step_11e.",
       "scenarios": [
         "iss066_pile_in_consolidate_11e",
         "global_consolidation_step_11e",
@@ -879,7 +889,7 @@
     },
     {
       "id": "phases.FightPhase.consolidate_11e",
-      "description": "Windowed scenario coverage for phases.FightPhase.consolidate_11e (verified by iss066_pile_in_consolidate_11e). Since 2026-07-03 consolidation is the GLOBAL end-of-phase step (12.07) \u2014 full player path verified by global_consolidation_step_11e.",
+      "description": "Windowed scenario coverage for phases.FightPhase.consolidate_11e (verified by iss066_pile_in_consolidate_11e). Since 2026-07-03 consolidation is the GLOBAL end-of-phase step (12.07) — full player path verified by global_consolidation_step_11e.",
       "scenarios": [
         "iss066_pile_in_consolidate_11e",
         "global_consolidation_step_11e"
@@ -889,7 +899,7 @@
     },
     {
       "id": "movetypes.PileInMove",
-      "description": "Windowed scenario coverage for movetypes.PileInMove (verified by iss066_pile_in_consolidate_11e). Since 2026-07-04 pile-in is the GLOBAL step opening the fight phase (12.02) \u2014 full player path verified by global_consolidation_step_11e.",
+      "description": "Windowed scenario coverage for movetypes.PileInMove (verified by iss066_pile_in_consolidate_11e). Since 2026-07-04 pile-in is the GLOBAL step opening the fight phase (12.02) — full player path verified by global_consolidation_step_11e.",
       "scenarios": [
         "iss066_pile_in_consolidate_11e",
         "global_consolidation_step_11e"
@@ -899,7 +909,7 @@
     },
     {
       "id": "movetypes.ConsolidationMove",
-      "description": "Windowed scenario coverage for movetypes.ConsolidationMove (verified by iss066_pile_in_consolidate_11e). Since 2026-07-03 consolidation is the GLOBAL end-of-phase step (12.07) \u2014 full player path verified by global_consolidation_step_11e.",
+      "description": "Windowed scenario coverage for movetypes.ConsolidationMove (verified by iss066_pile_in_consolidate_11e). Since 2026-07-03 consolidation is the GLOBAL end-of-phase step (12.07) — full player path verified by global_consolidation_step_11e.",
       "scenarios": [
         "iss066_pile_in_consolidate_11e",
         "global_consolidation_step_11e"
@@ -1835,7 +1845,7 @@
     },
     {
       "id": "autoloads.CharacterAttachmentManager.attachment_role",
-      "description": "attachment_role derives 'support' from the datasheet Support ability (ISS-059), 'leader' otherwise \u2014 driven live via the shipped orks.json Bannernob.",
+      "description": "attachment_role derives 'support' from the datasheet Support ability (ISS-059), 'leader' otherwise — driven live via the shipped orks.json Bannernob.",
       "scenarios": [
         "iss059b_support_attach_11e"
       ],
@@ -1916,7 +1926,7 @@
     },
     {
       "id": "phases.ScoutPhase.UI.reserve_scout_list_select_place_confirm",
-      "description": "ISS-067 UI: reserve scout appears in the Scout-phase unit list; select \u2192 place \u2192 confirm flow works through the real panel.",
+      "description": "ISS-067 UI: reserve scout appears in the Scout-phase unit list; select → place → confirm flow works through the real panel.",
       "scenarios": [
         "iss067_scout_reserves_deploy_11e"
       ],
@@ -1925,7 +1935,7 @@
     },
     {
       "id": "autoloads.TerrainManager.detection_range_inches_for",
-      "description": "Audit Tier-1 #4: per-observer effective detection range for hidden models \u2014 datasheet base, Gone to Ground \u22123\", 9\" floor \u2014 consumed by hidden_model_visible_to in the live targeting path.",
+      "description": "Audit Tier-1 #4: per-observer effective detection range for hidden models — datasheet base, Gone to Ground −3\", 9\" floor — consumed by hidden_model_visible_to in the live targeting path.",
       "scenarios": [
         "iss052b_gone_to_ground_11e"
       ],
@@ -2008,7 +2018,7 @@
     },
     {
       "id": "ui.ShootingController.ability_choice_dialog",
-      "description": "Audit #17: assigning a [DEVASTATING WOUNDS] weapon at e11 pops the AbilityChoiceDialog \u2014 DW mortal-wound conversion (default on) and, when combined, LETHAL HITS auto-wound (default off, preserving the Devastating trigger).",
+      "description": "Audit #17: assigning a [DEVASTATING WOUNDS] weapon at e11 pops the AbilityChoiceDialog — DW mortal-wound conversion (default on) and, when combined, LETHAL HITS auto-wound (default off, preserving the Devastating trigger).",
       "scenarios": [
         "iss047c_ability_choice_prompts_11e"
       ],
@@ -2044,7 +2054,7 @@
     },
     {
       "id": "phases.MovementPhase.surge_move_21_02",
-      "description": "Audit #8: BEGIN_SURGE_MOVE at e11 routes through the SurgeMove template \u2014 stated distance (payload.max_inches or the 'Surge X\"' datasheet ability, no D6), closest enemy recorded as the surge target, template eligibility gates; 10e D6 semantics untouched.",
+      "description": "Audit #8: BEGIN_SURGE_MOVE at e11 routes through the SurgeMove template — stated distance (payload.max_inches or the 'Surge X\"' datasheet ability, no D6), closest enemy recorded as the surge target, template eligibility gates; 10e D6 semantics untouched.",
       "scenarios": [
         "iss040b_surge_move_11e"
       ],
@@ -2089,7 +2099,7 @@
     },
     {
       "id": "missions.primary_11e.command_scoring",
-      "description": "Tier-1 #1 (GDM 2026): 11e primary command-phase scoring \u2014 END_COMMAND live-scores the active player's own card conditions (hold non-home, hold-new) with the 15/turn window; caps 45 total. R5 EOT switch + EOG conditions covered headless (test_primary_missions_11e.gd).",
+      "description": "Tier-1 #1 (GDM 2026): 11e primary command-phase scoring — END_COMMAND live-scores the active player's own card conditions (hold non-home, hold-new) with the 15/turn window; caps 45 total. R5 EOT switch + EOG conditions covered headless (test_primary_missions_11e.gd).",
       "scenarios": [
         "iss064b_primary_disposition_11e"
       ],
@@ -2155,7 +2165,7 @@
     },
     {
       "id": "autoloads.StratagemManager.smokescreen_11e",
-      "description": "15.10: SMOKESCREEN (via the A4 alias) sets flags.stratagem_cover \u2014 the flag the 11e hit-side cover check reads (it previously set only effect_cover, burning 1 CP for zero effect) \u2014 plus effect_cover for 10e save-side readers, and both expire at end of phase.",
+      "description": "15.10: SMOKESCREEN (via the A4 alias) sets flags.stratagem_cover — the flag the 11e hit-side cover check reads (it previously set only effect_cover, burning 1 CP for zero effect) — plus effect_cover for 10e save-side readers, and both expire at end of phase.",
       "scenarios": [
         "iss15_smokescreen_reactive_11e",
         "mp:tests/test_core_stratagems_11e.gd"
@@ -2174,7 +2184,7 @@
     },
     {
       "id": "rules.ModifierStack.collect_hit_context_11e.stratagem_cover",
-      "description": "13.08/15.10: the live hit context worsens attacker BS by 1 when the target carries flags.stratagem_cover \u2014 asserted 0 before and 1 after the defender's dialog click in the running game.",
+      "description": "13.08/15.10: the live hit context worsens attacker BS by 1 when the target carries flags.stratagem_cover — asserted 0 before and 1 after the defender's dialog click in the running game.",
       "scenarios": [
         "iss15_smokescreen_reactive_11e"
       ],
@@ -2214,7 +2224,7 @@
     },
     {
       "id": "dialogs.HeroicInterventionDialog.decline",
-      "description": "15.11 decline path: the end-of-phase dialog's DeclineButton completes the deferred charge phase with no CP spent; the auto-decline timer now actually arms (autostart \u2014 setup() runs before the dialog enters the tree).",
+      "description": "15.11 decline path: the end-of-phase dialog's DeclineButton completes the deferred charge phase with no CP spent; the auto-decline timer now actually arms (autostart — setup() runs before the dialog enters the tree).",
       "scenarios": [
         "iss15_heroic_intervention_decline_11e",
         "hi_window_ai_must_not_hijack_11e"
@@ -2224,7 +2234,7 @@
     },
     {
       "id": "autoloads.AIPlayer.reactive_window_ownership",
-      "description": "Reactive charge-phase windows (Heroic Intervention decision + pending HI move, Fire Overwatch) belong to the DEFENDER: the AI main loop idles while a HUMAN owns the window (no hijack, no forced decline \u2014 2026-07-11 'AI uses Heroic Intervention with Stompa' report) and acts AS the owning player when that owner is an AI, so AI-vs-AI Heroic Intervention actually resolves with the right identity. Headless net: tests/test_ai_reactive_window_guard.gd.",
+      "description": "Reactive charge-phase windows (Heroic Intervention decision + pending HI move, Fire Overwatch) belong to the DEFENDER: the AI main loop idles while a HUMAN owns the window (no hijack, no forced decline — 2026-07-11 'AI uses Heroic Intervention with Stompa' report) and acts AS the owning player when that owner is an AI, so AI-vs-AI Heroic Intervention actually resolves with the right identity. Headless net: tests/test_ai_reactive_window_guard.gd.",
       "scenarios": [
         "hi_window_ai_must_not_hijack_11e"
       ],
@@ -2233,7 +2243,7 @@
     },
     {
       "id": "rules.RulesEngine.indirect_hit_fail_band_11e",
-      "description": "10.07 (11e): unseen-target indirect band selected in both live resolve loops \u2014 5 (only unmodified 6s hit) normally, 3 (4+ hits) when the firer remained stationary AND a friendly unit sees the target; 10e -1 gated off; hit re-rolls suppressed; cover folded into the per-attack 13.08 BS worsening while the save-side grant stays 10e-only.",
+      "description": "10.07 (11e): unseen-target indirect band selected in both live resolve loops — 5 (only unmodified 6s hit) normally, 3 (4+ hits) when the firer remained stationary AND a friendly unit sees the target; 10e -1 gated off; hit re-rolls suppressed; cover folded into the per-attack 13.08 BS worsening while the save-side grant stays 10e-only.",
       "scenarios": [
         "iss15_indirect_band_11e",
         "mp:tests/test_indirect_fire_band_11e.gd"
@@ -2252,7 +2262,7 @@
     },
     {
       "id": "phases.ShootingPhase.hidden_shot_stamp",
-      "description": "13.09 A5: flags.last_shot_idx (battle_round*2 + player) is stamped by EVERY real shot completion \u2014 miss path, sequential all-weapons-complete, AI atomic path, the player's COMPLETE_SHOOTING_FOR_UNIT confirm after wounds/saves, and the all-targets-destroyed auto-completion (the last two were missing: units whose shots caused wounds never lost Hidden). Give-up-shooting actions do not stamp.",
+      "description": "13.09 A5: flags.last_shot_idx (battle_round*2 + player) is stamped by EVERY real shot completion — miss path, sequential all-weapons-complete, AI atomic path, the player's COMPLETE_SHOOTING_FOR_UNIT confirm after wounds/saves, and the all-targets-destroyed auto-completion (the last two were missing: units whose shots caused wounds never lost Hidden). Give-up-shooting actions do not stamp.",
       "scenarios": [
         "iss15_hidden_shot_stamp_11e"
       ],
@@ -2261,7 +2271,7 @@
     },
     {
       "id": "autoloads.TerrainManager.is_model_hidden.last_shot_idx",
-      "description": "13.09: the hidden gate consumes the turn-stamp \u2014 'made ranged attacks this turn or the previous turn' = cur_idx - last_shot_idx < 2; stamps from two player-turns ago restore Hidden; expiry advances across player turns.",
+      "description": "13.09: the hidden gate consumes the turn-stamp — 'made ranged attacks this turn or the previous turn' = cur_idx - last_shot_idx < 2; stamps from two player-turns ago restore Hidden; expiry advances across player turns.",
       "scenarios": [
         "iss15_hidden_shot_stamp_11e",
         "mp:tests/test_iss052_hidden_11e.gd"
@@ -2729,7 +2739,7 @@
     },
     {
       "id": "movement.reinforcement.none_offered_turn_one",
-      "description": "The movement unit list offers ZERO reinforcement rows on the first turn of the game even when the active player holds units in reserves \u2014 including when Player 2 took the first turn and Player 1 is now taking the game's first turn. Asserted via MovementController.get_reinforcement_row_count(). Validated by 'first_turn_p2_no_reserves_turn_one'.",
+      "description": "The movement unit list offers ZERO reinforcement rows on the first turn of the game even when the active player holds units in reserves — including when Player 2 took the first turn and Player 1 is now taking the game's first turn. Asserted via MovementController.get_reinforcement_row_count(). Validated by 'first_turn_p2_no_reserves_turn_one'.",
       "scenarios": [
         "first_turn_p2_no_reserves_turn_one"
       ],
@@ -2756,7 +2766,7 @@
     },
     {
       "id": "ai.movement.persistent_battle_plan",
-      "description": "COORD-4: the AI's army-wide movement plan is computed once per movement phase and CONSUMED as units act \u2014 the 'Movement plan' block announced in the game log matches the movement actions logged afterwards. Verified by ai_battle_plan_log_integrity.",
+      "description": "COORD-4: the AI's army-wide movement plan is computed once per movement phase and CONSUMED as units act — the 'Movement plan' block announced in the game log matches the movement actions logged afterwards. Verified by ai_battle_plan_log_integrity.",
       "scenarios": [
         "ai_battle_plan_log_integrity"
       ],
@@ -2765,7 +2775,7 @@
     },
     {
       "id": "ai.movement.plan_matches_actions",
-      "description": "The executed per-unit movement actions logged in the game log match the announced 'Movement plan' block \u2014 GameEventLog.movement_plan_integrity() zero mismatches over >=3 checked actions (COORD-4 gate).",
+      "description": "The executed per-unit movement actions logged in the game log match the announced 'Movement plan' block — GameEventLog.movement_plan_integrity() zero mismatches over >=3 checked actions (COORD-4 gate).",
       "scenarios": [
         "ai_battle_plan_log_integrity"
       ],
@@ -2801,7 +2811,7 @@
     },
     {
       "id": "scripts.rules.FightSequencer.peek_selection",
-      "description": "FightSequencer.peek_selection() \u2014 a pure, non-mutating preview of next_selection() used by get_available_actions on every UI/AI poll; must not advance picker/step. Validated by 'stompa_gets_to_fight_11e' (live) and test_iss050_fight_phase_11e.gd (headless purity/parity).",
+      "description": "FightSequencer.peek_selection() — a pure, non-mutating preview of next_selection() used by get_available_actions on every UI/AI poll; must not advance picker/step. Validated by 'stompa_gets_to_fight_11e' (live) and test_iss050_fight_phase_11e.gd (headless purity/parity).",
       "scenarios": [
         "stompa_gets_to_fight_11e"
       ],
@@ -2810,7 +2820,7 @@
     },
     {
       "id": "ui.GameLogPanel.long_entry_truncation",
-      "description": "A long simple GameLogPanel entry (>200 chars, e.g. a verbose AI move rationale like 'Prosecutors moves toward obj_center \u2026') renders as a truncated preview carrying a VISIBLE 'show more' toggle instead of silently trailing off. Validated by 'game_log_long_entry_expandable' (collapsed: last_card_is_expandable == true, last_card_is_expanded == false, small visible char count + screenshot).",
+      "description": "A long simple GameLogPanel entry (>200 chars, e.g. a verbose AI move rationale like 'Prosecutors moves toward obj_center …') renders as a truncated preview carrying a VISIBLE 'show more' toggle instead of silently trailing off. Validated by 'game_log_long_entry_expandable' (collapsed: last_card_is_expandable == true, last_card_is_expanded == false, small visible char count + screenshot).",
       "scenarios": [
         "game_log_long_entry_expandable"
       ],
@@ -2837,7 +2847,7 @@
     },
     {
       "id": "autoloads/TerrainManager.gd:visibility_exclusions_for",
-      "description": "Per observer/target pair, the terrain-area groups either model is within (ANY part of base, 01.04) \u2014 the 13.10 'excluding areas one or both models are within' set \u2014 plus the feature ids a model OCCUPIES (base centre inside) so a structure never Solid-blocks its own occupant's sight lines.",
+      "description": "Per observer/target pair, the terrain-area groups either model is within (ANY part of base, 01.04) — the 13.10 'excluding areas one or both models are within' set — plus the feature ids a model OCCUPIES (base centre inside) so a structure never Solid-blocks its own occupant's sight lines.",
       "scenarios": [
         "los_terrain_area_11e_near"
       ],
@@ -2891,7 +2901,7 @@
     },
     {
       "id": "charge.ux.target_declaration_multi_select",
-      "description": "CHARGE phase target declaration selection model: the ELIGIBLE TARGETS ItemList's own selection state is the single source of truth for selected_targets (multi_selected/empty_clicked signals; the old item_selected hookup never fired in SELECT_MULTI mode and its gui_input hack accumulated every clicked row, silently declaring multi-charges). Plain click selects exactly one target, Ctrl+Click toggles targets for a deliberate multi-charge, empty-click clears, the Declare button shows the target count, and rows lock once the charge is declared. A prominent, dynamic gold-bordered hint (target_hint_label) spells out Ctrl+Click and updates with the selection (0 targets: 'Ctrl+Click each one'; 1: 'hold Ctrl+Click another target'; 2+: 'N units \u2014 Ctrl+Click to add/remove'), hidden once declared. Validated by 'charge_target_declaration'.",
+      "description": "CHARGE phase target declaration selection model: the ELIGIBLE TARGETS ItemList's own selection state is the single source of truth for selected_targets (multi_selected/empty_clicked signals; the old item_selected hookup never fired in SELECT_MULTI mode and its gui_input hack accumulated every clicked row, silently declaring multi-charges). Plain click selects exactly one target, Ctrl+Click toggles targets for a deliberate multi-charge, empty-click clears, the Declare button shows the target count, and rows lock once the charge is declared. A prominent, dynamic gold-bordered hint (target_hint_label) spells out Ctrl+Click and updates with the selection (0 targets: 'Ctrl+Click each one'; 1: 'hold Ctrl+Click another target'; 2+: 'N units — Ctrl+Click to add/remove'), hidden once declared. Validated by 'charge_target_declaration'.",
       "scenarios": [
         "charge_target_declaration"
       ],
@@ -2900,7 +2910,7 @@
     },
     {
       "id": "charge.declare.multi_target_payload",
-      "description": "DECLARE_CHARGE with multiple target_unit_ids stores ALL declared targets in pending_charges, and the stored arrays are duplicates \u2014 mutating the controller's live selected_targets after declaring (sentinel append) must not alter the pending charge. Validated by 'charge_target_declaration'.",
+      "description": "DECLARE_CHARGE with multiple target_unit_ids stores ALL declared targets in pending_charges, and the stored arrays are duplicates — mutating the controller's live selected_targets after declaring (sentinel append) must not alter the pending charge. Validated by 'charge_target_declaration'.",
       "scenarios": [
         "charge_target_declaration"
       ],
@@ -2909,7 +2919,7 @@
     },
     {
       "id": "phases.FightPhase.attached_units_19_03",
-      "description": "11e 19.03: a CHARACTER attached to a bodyguard is ONE Attached unit in the fight phase's global Pile In (12.02) and Consolidate (12.07) steps \u2014 one picker entry named 'Bodyguard + Character', one move covering both units' models (payload keys 'char_unit:index'), union eligibility/engagement, and rejection of a direct PILE_IN/CONSOLIDATE for the attached character. Headless: tests/test_pile_in_attached_characters_11e.gd.",
+      "description": "11e 19.03: a CHARACTER attached to a bodyguard is ONE Attached unit in the fight phase's global Pile In (12.02) and Consolidate (12.07) steps — one picker entry named 'Bodyguard + Character', one move covering both units' models (payload keys 'char_unit:index'), union eligibility/engagement, and rejection of a direct PILE_IN/CONSOLIDATE for the attached character. Headless: tests/test_pile_in_attached_characters_11e.gd.",
       "scenarios": [
         "attached_char_pile_in_step_11e"
       ],
@@ -2936,7 +2946,7 @@
     },
     {
       "id": "autoloads.RulesEngine.validate_shoot.attached_gate",
-      "description": "RulesEngine.validate_shoot is the authoritative gate that rejects a SHOOT assignment whose target has attached_to set ('Cannot target X \u2014 attached character; shoot the bodyguard unit instead'), catching callers (the AI focus-fire plan) that bypass get_eligible_targets. Unattached characters and the bodyguard itself stay valid targets.",
+      "description": "RulesEngine.validate_shoot is the authoritative gate that rejects a SHOOT assignment whose target has attached_to set ('Cannot target X — attached character; shoot the bodyguard unit instead'), catching callers (the AI focus-fire plan) that bypass get_eligible_targets. Unattached characters and the bodyguard itself stay valid targets.",
       "scenarios": [
         "attached_char_untargetable_11e"
       ],
@@ -3023,6 +3033,5278 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "AttackAssignmentDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ChargeController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow, pad_charge_target_toggle.",
+      "scenarios": [
+        "pad_charge_full_flow",
+        "pad_charge_target_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "DeploymentController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_unit_cycling.",
+      "scenarios": [
+        "pad_deploy_unit_cycling"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "DeploymentController._validate_formation_position",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deep_strike_tight_formation.",
+      "scenarios": [
+        "deep_strike_tight_formation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "DeploymentController.try_place_formation_at",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deep_strike_tight_formation.",
+      "scenarios": [
+        "deep_strike_tight_formation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "FightController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle, pad_fight_pilein_auto, pad_fight_resolution_walk, pad_fight_selection_bumper.",
+      "scenarios": [
+        "pad_fight_attack_reticle",
+        "pad_fight_pilein_auto",
+        "pad_fight_resolution_walk",
+        "pad_fight_selection_bumper"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Main",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows, pad_deploy_unit_cycling, pad_rapid_ingress_no_move_menu, pad_reinforcement_formation_row, pad_reinforcement_no_move_menu, pad_reinforcement_undo.",
+      "scenarios": [
+        "pad_deploy_model_type_rows",
+        "pad_deploy_unit_cycling",
+        "pad_rapid_ingress_no_move_menu",
+        "pad_reinforcement_formation_row",
+        "pad_reinforcement_no_move_menu",
+        "pad_reinforcement_undo"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Main._toggle_los_debug",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: los_overlay_l_key.",
+      "scenarios": [
+        "los_overlay_l_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Main.refresh_unit_list.transport_subrows",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_deploy_shows_embarked_units.",
+      "scenarios": [
+        "transport_deploy_shows_embarked_units"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Main.show_unit_card.transport_contents_label",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_deploy_shows_embarked_units.",
+      "scenarios": [
+        "transport_deploy_shows_embarked_units"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Main.synthesize_x_cursor_los",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cursor_los_x_key.",
+      "scenarios": [
+        "cursor_los_x_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "Measurement.model_outside_board",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deep_strike_tight_formation.",
+      "scenarios": [
+        "deep_strike_tight_formation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ModelTypePickerPanel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows.",
+      "scenarios": [
+        "pad_deploy_model_type_rows"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "MovementController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_rapid_ingress_no_move_menu, pad_reinforcement_no_move_menu.",
+      "scenarios": [
+        "pad_rapid_ingress_no_move_menu",
+        "pad_reinforcement_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "PadActionBar",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_bumper_only_unit_cycling, pad_move_dpad_menu_no_panel_trap.",
+      "scenarios": [
+        "pad_bumper_only_unit_cycling",
+        "pad_move_dpad_menu_no_panel_trap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "PadRouter",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_bumper_only_unit_cycling, pad_charge_full_flow, pad_charge_target_toggle, pad_deploy_model_type_rows, pad_deploy_unit_cycling, pad_fight_attack_reticle, pad_fight_pilein_auto, pad_fight_selection_bumper, pad_move_dpad_menu_no_panel_trap, pad_rapid_ingress_no_move_menu, pad_reinforcement_formation_row, pad_reinforcement_no_move_menu, pad_reinforcement_undo, pad_shoot_cycle_all_eligible, pad_shoot_target_reticle, pad_shoot_weapon_step, pad_split_fire_spin.",
+      "scenarios": [
+        "pad_bumper_only_unit_cycling",
+        "pad_charge_full_flow",
+        "pad_charge_target_toggle",
+        "pad_deploy_model_type_rows",
+        "pad_deploy_unit_cycling",
+        "pad_fight_attack_reticle",
+        "pad_fight_pilein_auto",
+        "pad_fight_selection_bumper",
+        "pad_move_dpad_menu_no_panel_trap",
+        "pad_rapid_ingress_no_move_menu",
+        "pad_reinforcement_formation_row",
+        "pad_reinforcement_no_move_menu",
+        "pad_reinforcement_undo",
+        "pad_shoot_cycle_all_eligible",
+        "pad_shoot_target_reticle",
+        "pad_shoot_weapon_step",
+        "pad_split_fire_spin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "PadTargetReticle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle, pad_shoot_target_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle",
+        "pad_shoot_target_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "PileInDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_pilein_auto.",
+      "scenarios": [
+        "pad_fight_pilein_auto"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ResolutionDockBase",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_resolution_walk.",
+      "scenarios": [
+        "pad_fight_resolution_walk"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "SaveLoadManager._on_phase_changed_named_autosave",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "SettingsService.set_autosave_on_phase_start",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ShootingController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_cycle_all_eligible, pad_shoot_target_reticle, pad_shoot_weapon_step, pad_split_fire_spin.",
+      "scenarios": [
+        "pad_shoot_cycle_all_eligible",
+        "pad_shoot_target_reticle",
+        "pad_shoot_weapon_step",
+        "pad_split_fire_spin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ShootingController._create_shooting_visuals",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: los_overlay_l_key.",
+      "scenarios": [
+        "los_overlay_l_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "TerrainManager.calculate_movement_terrain_penalty",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: infantry_ruin_no_move_penalty.",
+      "scenarios": [
+        "infantry_ruin_no_move_penalty"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "VirtualCursor",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_undo.",
+      "scenarios": [
+        "pad_reinforcement_undo"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.charge_move_validator_parity",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodian_charge_congested_ovals.",
+      "scenarios": [
+        "custodian_charge_congested_ovals"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.movement.aao_spacing",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_lions_aao_spacing.",
+      "scenarios": [
+        "ai_lions_aao_spacing"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.movement.battle_plan_logged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_coordinated_movement.",
+      "scenarios": [
+        "ai_coordinated_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.movement.intent_ledger",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_coordinated_movement.",
+      "scenarios": [
+        "ai_coordinated_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.movement.per_unit_decision_cards",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_coordinated_movement.",
+      "scenarios": [
+        "ai_coordinated_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.stratagems.command_phase_window",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_11e_verbose_thinking.",
+      "scenarios": [
+        "ai_11e_verbose_thinking"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.against_all_odds",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_lions_aao_spacing.",
+      "scenarios": [
+        "ai_lions_aao_spacing"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.board_linked_cards",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_vp_thought_links.",
+      "scenarios": [
+        "ai_vp_thought_links"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.duplicate_unit_display_names",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_thinking_dupe_display_names.",
+      "scenarios": [
+        "ai_thinking_dupe_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.negative_decisions_narrated",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_11e_verbose_thinking.",
+      "scenarios": [
+        "ai_11e_verbose_thinking"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.verbose_game_log",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_11e_verbose_thinking, ai_coordinated_movement.",
+      "scenarios": [
+        "ai_11e_verbose_thinking",
+        "ai_coordinated_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.thinking.vp_denominated_scoring",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_vp_thought_links.",
+      "scenarios": [
+        "ai_vp_thought_links"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ai.turn_summary.logged_not_popup",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_turn_summary_in_log.",
+      "scenarios": [
+        "ai_turn_summary_in_log"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "armies.orks_taktikal.load_path",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_enhancements_load.",
+      "scenarios": [
+        "taktikal_enhancements_load"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.AIPlayer.scoring_gate_ownership",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss042c_coherency_ai_turn_no_hijack_11e.",
+      "scenarios": [
+        "iss042c_coherency_ai_turn_no_hijack_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.ArmyListManager.backfill_custodes_deep_strike",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_custodian_guard_deep_strike.",
+      "scenarios": [
+        "custodes_custodian_guard_deep_strike"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.CharacterAttachmentManager.enhancement_can_lead",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_enhancements_load.",
+      "scenarios": [
+        "taktikal_enhancements_load"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.EffectPrimitives.grant_blast",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_silent_hunters_stratagems.",
+      "scenarios": [
+        "custodes_silent_hunters_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.EffectPrimitives.grant_precision",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_lions_stratagems.",
+      "scenarios": [
+        "custodes_lions_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.EffectPrimitives.grant_rapid_fire",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_silent_hunters_stratagems.",
+      "scenarios": [
+        "custodes_silent_hunters_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.FactionAbilityManager.check_against_all_odds",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: aao_lions_isolated_plus_one.",
+      "scenarios": [
+        "aao_lions_isolated_plus_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.MissionManager.model_in_objective_range",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.RulesEngine._hit_threshold_display",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cover_hit_label_wound_reroll_11e.",
+      "scenarios": [
+        "cover_hit_label_wound_reroll_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.SecondaryMissionManager.beacon_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065c_beacon_designation_11e.",
+      "scenarios": [
+        "iss065c_beacon_designation_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.SecondaryMissionManager.guards",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065d_guard_prompt_11e, iss_trust_dropdown_all_units_11e.",
+      "scenarios": [
+        "iss065d_guard_prompt_11e",
+        "iss_trust_dropdown_all_units_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.SecondaryMissionManager.pending_interactions",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065a_tempting_target_prompt_11e.",
+      "scenarios": [
+        "iss065a_tempting_target_prompt_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.StratagemManager.eligible_unit_display_names",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_unit_picker_display_names.",
+      "scenarios": [
+        "grenade_unit_picker_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads.StratagemManager.target_condition_enforcement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_retreat_panel.",
+      "scenarios": [
+        "taktikal_retreat_panel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads/KeybindingManager.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: keybindings_menu.",
+      "scenarios": [
+        "keybindings_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads/LineOfSightManager.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cursor_los_x_key.",
+      "scenarios": [
+        "cursor_los_x_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "autoloads/SaveLoadManager.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: save_dialog_user_dir_roundtrip.",
+      "scenarios": [
+        "save_dialog_user_dir_roundtrip"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "board.terrain.scatter_props",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: terrain_scatter_toggle.",
+      "scenarios": [
+        "terrain_scatter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "camera.zoom.cursor_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cursor_focused_zoom, scroll_wheel_zoom.",
+      "scenarios": [
+        "cursor_focused_zoom",
+        "scroll_wheel_zoom"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "camera.zoom.mouse_wheel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: controls_menu_mouse_wheel, scroll_wheel_zoom, wheel_zoom_ui_scoped.",
+      "scenarios": [
+        "controls_menu_mouse_wheel",
+        "scroll_wheel_zoom",
+        "wheel_zoom_ui_scoped"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ability_reroll.dismiss_keeps_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: swift_onslaught_reroll_dismiss.",
+      "scenarios": [
+        "swift_onslaught_reroll_dismiss"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ability_reroll.free_dialog_branding",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: swift_onslaught_free_reroll_use.",
+      "scenarios": [
+        "swift_onslaught_free_reroll_use"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ai_charge_move_visual_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_charge_move_token_sync.",
+      "scenarios": [
+        "ai_charge_move_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ai_placement_oval_bases",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodian_charge_congested_ovals.",
+      "scenarios": [
+        "custodian_charge_congested_ovals"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.base_contact.bulk_snap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: snap_to_contact_button.",
+      "scenarios": [
+        "snap_to_contact_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.base_contact.closest_fallback",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: snap_to_contact_out_of_reach.",
+      "scenarios": [
+        "snap_to_contact_out_of_reach"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.base_contact.per_model_enforced",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_base_contact_enforced.",
+      "scenarios": [
+        "charge_base_contact_enforced"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.base_contact.reject_short_move",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_base_contact_enforced.",
+      "scenarios": [
+        "charge_base_contact_enforced"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.base_contact.within_1_inch",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_base_contact_enforced.",
+      "scenarios": [
+        "charge_base_contact_enforced"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.bug.false_insufficient_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_over_ruin_corner_succeeds.",
+      "scenarios": [
+        "charge_over_ruin_corner_succeeds"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.bug.false_success_over_declared",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_overdeclare_fails.",
+      "scenarios": [
+        "charge_overdeclare_fails"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.leader_rides_without_stacking",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: attached_char_charge_no_overlap.",
+      "scenarios": [
+        "attached_char_charge_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.movement.multi_step_drag_accumulates",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_multi_step_movement.",
+      "scenarios": [
+        "charge_multi_step_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.movement.rotation_token_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_move_model_rotation_visual.",
+      "scenarios": [
+        "charge_move_model_rotation_visual"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.movement.shift_drag_box_multi_select",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_group_drag_multi_select.",
+      "scenarios": [
+        "charge_group_drag_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.per_model_reach_rings",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_per_model_range_rings.",
+      "scenarios": [
+        "charge_per_model_range_rings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.per_model_threat_envelope",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_per_model_range_rings.",
+      "scenarios": [
+        "charge_per_model_range_rings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.per_model_undo",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_undo_last_model_button.",
+      "scenarios": [
+        "charge_undo_last_model_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.reachability.all_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_overdeclare_fails, charge_requirement_hint.",
+      "scenarios": [
+        "charge_overdeclare_fails",
+        "charge_requirement_hint"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.terrain.path_around_corner",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_over_ruin_corner_succeeds.",
+      "scenarios": [
+        "charge_over_ruin_corner_succeeds"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.terrain.stop_at_engagement_range",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_over_ruin_corner_succeeds.",
+      "scenarios": [
+        "charge_over_ruin_corner_succeeds"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.turbo_boosted_hard_lock",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: speedwaaagh_turbo_boostas.",
+      "scenarios": [
+        "speedwaaagh_turbo_boostas"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.declaration_reachability_hint",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_requirement_hint.",
+      "scenarios": [
+        "charge_requirement_hint"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.snap_button_lifecycle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: snap_to_contact_button.",
+      "scenarios": [
+        "snap_to_contact_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.snap_out_of_reach_best_effort",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: snap_to_contact_out_of_reach.",
+      "scenarios": [
+        "snap_to_contact_out_of_reach"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.snap_to_contact_button",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: snap_to_contact_button, snap_to_contact_out_of_reach.",
+      "scenarios": [
+        "snap_to_contact_button",
+        "snap_to_contact_out_of_reach"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.undo_last_model_button",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_undo_last_model_button.",
+      "scenarios": [
+        "charge_undo_last_model_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "charge.ux.units_that_can_charge_filtered_by_target_in_range",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_units_filtered_by_target_in_range.",
+      "scenarios": [
+        "charge_units_filtered_by_target_in_range"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "chargephase.apply_charge_move.b2b",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_base_contact_enforced.",
+      "scenarios": [
+        "charge_base_contact_enforced"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "command.detachment_rule.da_boss_is_watchin",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: bully_boyz_da_boss_is_watchin.",
+      "scenarios": [
+        "bully_boyz_da_boss_is_watchin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "command.detachment_rule.lissen_ere_taktiks",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_lissen_ere_taktiks.",
+      "scenarios": [
+        "taktikal_lissen_ere_taktiks"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.allocate_attacks.done_reachable",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_done_11e, pad_allocate_attacks_interactive_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_done_11e",
+        "pad_allocate_attacks_interactive_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.allocate_attacks.native_nav_modal",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_done_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_done_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.allocate_attacks.order_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_interactive_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_interactive_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.allocate_attacks.pick_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_interactive_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_interactive_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.allocate_attacks.results_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_done_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_done_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.bumper_only_unit_cycling",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_bumper_only_unit_cycling, pad_deploy_unit_cycling, pad_m2_unit_cycle, pad_shoot_cycle_all_eligible.",
+      "scenarios": [
+        "pad_bumper_only_unit_cycling",
+        "pad_deploy_unit_cycling",
+        "pad_m2_unit_cycle",
+        "pad_shoot_cycle_all_eligible"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.a_toggles_without_prior_step",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.b_undo_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.bumper_lock_mid_charge",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.dpad_left_right_step_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.dpad_no_panel_trap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.l3_carry_swap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.no_junk_carry_outside_movement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.stage_accurate_hints",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.start_declare_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_target_toggle.",
+      "scenarios": [
+        "pad_charge_target_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.start_never_ends_phase_mid_charge",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.start_walks_whole_flow",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.target_dpad_toggle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_target_toggle.",
+      "scenarios": [
+        "pad_charge_target_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.x_skip",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_target_toggle.",
+      "scenarios": [
+        "pad_charge_target_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.charge.x_snap_to_contact",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_charge_full_flow.",
+      "scenarios": [
+        "pad_charge_full_flow"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deploy.dpad_row_navigation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows.",
+      "scenarios": [
+        "pad_deploy_model_type_rows"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deploy.formation_dpad",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_unit_cycling.",
+      "scenarios": [
+        "pad_deploy_unit_cycling"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deploy.model_type_rows",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows.",
+      "scenarios": [
+        "pad_deploy_model_type_rows"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deploy.start_confirms_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows.",
+      "scenarios": [
+        "pad_deploy_model_type_rows"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deploy.unit_cycling",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_unit_cycling.",
+      "scenarios": [
+        "pad_deploy_unit_cycling"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.deployment.x_undo_cursor_active",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_undo.",
+      "scenarios": [
+        "pad_reinforcement_undo"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.assign_and_fight",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.attack_dialog_pad_nav",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.dock_refocus_after_save_overlay",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_resolution_walk.",
+      "scenarios": [
+        "pad_fight_resolution_walk"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.no_informational_list_misfire",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_selection_bumper.",
+      "scenarios": [
+        "pad_fight_selection_bumper"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.pilein_dialog_auto_confirm",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_pilein_auto.",
+      "scenarios": [
+        "pad_fight_pilein_auto"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.pilein_step_pad",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_pilein_auto.",
+      "scenarios": [
+        "pad_fight_pilein_auto"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.resolution_dock_pad_walk",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_resolution_walk.",
+      "scenarios": [
+        "pad_fight_resolution_walk"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.selection_bumper_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_selection_bumper.",
+      "scenarios": [
+        "pad_fight_selection_bumper"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.target_reticle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.fight.weapon_target_step",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_fight_attack_reticle.",
+      "scenarios": [
+        "pad_fight_attack_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.focus_ring",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_load_zoom_focus.",
+      "scenarios": [
+        "pad_load_zoom_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.load_zoom_framing",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_load_zoom_focus.",
+      "scenarios": [
+        "pad_load_zoom_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m0.camera",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m0_camera.",
+      "scenarios": [
+        "pad_m0_camera"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m0.menu_focus_nav",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m0_menu_nav.",
+      "scenarios": [
+        "pad_m0_menu_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m0.ui_scale",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m0_camera.",
+      "scenarios": [
+        "pad_m0_camera"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m1.dialog_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m1_full_turn_cursor.",
+      "scenarios": [
+        "pad_m1_full_turn_cursor"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m1.full_turn",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m1_full_turn_cursor.",
+      "scenarios": [
+        "pad_m1_full_turn_cursor"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m1.phase_confirm",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m1_full_turn_cursor.",
+      "scenarios": [
+        "pad_m1_full_turn_cursor"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m1.virtual_cursor",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m1_cursor_basics.",
+      "scenarios": [
+        "pad_m1_cursor_basics"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m2.datasheet",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m2_unit_cycle.",
+      "scenarios": [
+        "pad_m2_unit_cycle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m2.panel_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m2_unit_cycle.",
+      "scenarios": [
+        "pad_m2_unit_cycle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m2.shooting_native",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m2_shooting_native, pad_shoot_cycle_all_eligible.",
+      "scenarios": [
+        "pad_m2_shooting_native",
+        "pad_shoot_cycle_all_eligible"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m2.target_cycling",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m2_shooting_native.",
+      "scenarios": [
+        "pad_m2_shooting_native"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m2.unit_cycling",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_bumper_only_unit_cycling, pad_m2_unit_cycle.",
+      "scenarios": [
+        "pad_bumper_only_unit_cycling",
+        "pad_m2_unit_cycle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m3.carry_deployment",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m3_carry_deploy.",
+      "scenarios": [
+        "pad_m3_carry_deploy"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m3.carry_movement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m3_carry_move.",
+      "scenarios": [
+        "pad_m3_carry_move"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m3.model_hop",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m3_carry_move.",
+      "scenarios": [
+        "pad_m3_carry_move"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m3.rotate",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m3_carry_move.",
+      "scenarios": [
+        "pad_m3_carry_move"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m4.action_bar",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_bumper_only_unit_cycling, pad_m4_move_action_menu, pad_move_dpad_menu_no_panel_trap.",
+      "scenarios": [
+        "pad_bumper_only_unit_cycling",
+        "pad_m4_move_action_menu",
+        "pad_move_dpad_menu_no_panel_trap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m4.dialog_focus_watchdog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m4_rolloff.",
+      "scenarios": [
+        "pad_m4_rolloff"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m4.move_action_menu",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m4_move_action_menu.",
+      "scenarios": [
+        "pad_m4_move_action_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m4.rolloff",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m4_rolloff.",
+      "scenarios": [
+        "pad_m4_rolloff"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.m4.status_indicator",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_m4_controller_indicator.",
+      "scenarios": [
+        "pad_m4_controller_indicator"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.modal.settings_focus_containment",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_settings_modal_focus.",
+      "scenarios": [
+        "pad_settings_modal_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.advance_auto_carry",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.attached_leader_in_roster",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_attached_leader.",
+      "scenarios": [
+        "pad_move_attached_leader"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.attached_leader_l3_reachable",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_attached_leader.",
+      "scenarios": [
+        "pad_move_attached_leader"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.attached_leader_moves_permodel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_attached_leader.",
+      "scenarios": [
+        "pad_move_attached_leader"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.attached_leader_picks_up",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_attached_leader.",
+      "scenarios": [
+        "pad_move_attached_leader"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.dpad_lr_opens_menu",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_dpad_menu_no_panel_trap.",
+      "scenarios": [
+        "pad_move_dpad_menu_no_panel_trap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.dpad_no_longer_hops",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_paddle_model_switch.",
+      "scenarios": [
+        "pad_move_paddle_model_switch"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.drop_parks_cursor",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_illegal_drop_keeps_model.",
+      "scenarios": [
+        "pad_move_illegal_drop_keeps_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.group_cancel_stages_nothing",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.group_carry_advance",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.group_carry_dpad_grab",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.group_drop_all_staged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.group_illegal_drop_keeps_group",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_group_move_all.",
+      "scenarios": [
+        "pad_group_move_all"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.illegal_drop_keeps_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_illegal_drop_keeps_model.",
+      "scenarios": [
+        "pad_move_illegal_drop_keeps_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.l3_browse_cycle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_l3_cycle_model.",
+      "scenarios": [
+        "pad_move_l3_cycle_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.l3_carry_swap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_l3_cycle_model.",
+      "scenarios": [
+        "pad_move_l3_cycle_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.l3_cycles_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_l3_cycle_model.",
+      "scenarios": [
+        "pad_move_l3_cycle_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.l3_keeps_staged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_l3_cycle_model.",
+      "scenarios": [
+        "pad_move_l3_cycle_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.next_model_label_is_l3_only",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_staged_hint_labels.",
+      "scenarios": [
+        "pad_move_staged_hint_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.paddle_keeps_staged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_carry_hop_swap.",
+      "scenarios": [
+        "pad_move_carry_hop_swap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.paddle_menu_hop",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_carry_hop_swap.",
+      "scenarios": [
+        "pad_move_carry_hop_swap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.paddle_model_switch",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_paddle_model_switch.",
+      "scenarios": [
+        "pad_move_paddle_model_switch"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.paddle_revert_unstaged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_carry_hop_swap.",
+      "scenarios": [
+        "pad_move_carry_hop_swap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.paddle_swap_mid_carry",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_carry_hop_swap.",
+      "scenarios": [
+        "pad_move_carry_hop_swap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.panel_focus_guard",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_dpad_menu_no_panel_trap.",
+      "scenarios": [
+        "pad_move_dpad_menu_no_panel_trap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.session_lock",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_illegal_drop_keeps_model.",
+      "scenarios": [
+        "pad_move_illegal_drop_keeps_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.staged_hint_l3_is_next",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_staged_hint_labels.",
+      "scenarios": [
+        "pad_move_staged_hint_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.staged_hint_x_is_finish",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_staged_hint_labels.",
+      "scenarios": [
+        "pad_move_staged_hint_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.stale_focus_release",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_dpad_menu_no_panel_trap.",
+      "scenarios": [
+        "pad_move_dpad_menu_no_panel_trap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.start_confirms",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_illegal_drop_keeps_model.",
+      "scenarios": [
+        "pad_move_illegal_drop_keeps_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.y_stays_datasheet",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_l3_cycle_model.",
+      "scenarios": [
+        "pad_move_l3_cycle_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.all_placed_toast",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_single_model.",
+      "scenarios": [
+        "pad_move_multistep_single_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.b_undo_staged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_model.",
+      "scenarios": [
+        "pad_move_multistep_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.drop_keeps_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_model.",
+      "scenarios": [
+        "pad_move_multistep_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.repick_accumulates",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_model.",
+      "scenarios": [
+        "pad_move_multistep_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.x_finish_advances",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_model.",
+      "scenarios": [
+        "pad_move_multistep_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.multistep.x_finish_single_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_move_multistep_single_model.",
+      "scenarios": [
+        "pad_move_multistep_single_model"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p0.cursor_magnetism",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_p0_cursor_snap.",
+      "scenarios": [
+        "pad_p0_cursor_snap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p0.cursor_precision",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_p0_cursor_snap.",
+      "scenarios": [
+        "pad_p0_cursor_snap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p0.move_clamp",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_p0_move_clamp.",
+      "scenarios": [
+        "pad_p0_move_clamp"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p1.magnetism_toggle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_controller_settings.",
+      "scenarios": [
+        "pad_controller_settings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p1.reference_tab",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_controller_settings.",
+      "scenarios": [
+        "pad_controller_settings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p1.settings",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_controller_settings.",
+      "scenarios": [
+        "pad_controller_settings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.p1.swap_sticks",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_controller_settings.",
+      "scenarios": [
+        "pad_controller_settings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.pause_menu.view_button",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_menu_button.",
+      "scenarios": [
+        "pad_menu_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.placement.shared_stale_selection_clear",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_rapid_ingress_no_move_menu.",
+      "scenarios": [
+        "pad_rapid_ingress_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.rapid_ingress.no_move_menu_during_placement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_rapid_ingress_no_move_menu.",
+      "scenarios": [
+        "pad_rapid_ingress_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.rapid_ingress.stale_selection_cleared",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_rapid_ingress_no_move_menu.",
+      "scenarios": [
+        "pad_rapid_ingress_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.a_warp",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_formation_row.",
+      "scenarios": [
+        "pad_reinforcement_formation_row"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.arrived_unit_no_move_menu",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_no_move_menu.",
+      "scenarios": [
+        "pad_reinforcement_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.b_undo_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_undo.",
+      "scenarios": [
+        "pad_reinforcement_undo"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.formation_off_board",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deep_strike_tight_formation.",
+      "scenarios": [
+        "deep_strike_tight_formation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.formation_placement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deep_strike_tight_formation.",
+      "scenarios": [
+        "deep_strike_tight_formation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.formation_row",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_formation_row.",
+      "scenarios": [
+        "pad_reinforcement_formation_row"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.no_move_menu_during_placement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_no_move_menu.",
+      "scenarios": [
+        "pad_reinforcement_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.stale_selection_cleared",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_no_move_menu.",
+      "scenarios": [
+        "pad_reinforcement_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.start_confirms_arrival",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_no_move_menu.",
+      "scenarios": [
+        "pad_reinforcement_no_move_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.reinforcement.x_undo_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_reinforcement_undo.",
+      "scenarios": [
+        "pad_reinforcement_undo"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.back_closes",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_menu_focus.",
+      "scenarios": [
+        "pad_saveload_menu_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.button_reachable",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_menu_focus.",
+      "scenarios": [
+        "pad_saveload_menu_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.ingame_focus_trap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_ingame_focus.",
+      "scenarios": [
+        "pad_saveload_ingame_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.ingame_list_navigation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_ingame_focus.",
+      "scenarios": [
+        "pad_saveload_ingame_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.list_navigation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_menu_focus.",
+      "scenarios": [
+        "pad_saveload_menu_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.saveload.menu_focus_trap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_saveload_menu_focus.",
+      "scenarios": [
+        "pad_saveload_menu_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.secondary_review.close",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_secondary_review_nav.",
+      "scenarios": [
+        "pad_secondary_review_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.secondary_review.dpad_nav",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_secondary_review_nav.",
+      "scenarios": [
+        "pad_secondary_review_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.secondary_review.replace",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_secondary_review_nav.",
+      "scenarios": [
+        "pad_secondary_review_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.cycle_ring_phase_eligibility",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_cycle_all_eligible.",
+      "scenarios": [
+        "pad_shoot_cycle_all_eligible"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.model_level_split_fire",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_split_fire_spin.",
+      "scenarios": [
+        "pad_split_fire_spin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.per_weapon_target_assign",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_weapon_step.",
+      "scenarios": [
+        "pad_shoot_weapon_step"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.split_picker_dpad_spin",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_split_fire_spin.",
+      "scenarios": [
+        "pad_split_fire_spin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.target_cycle_visible",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_target_reticle.",
+      "scenarios": [
+        "pad_shoot_target_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.target_reticle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_target_reticle.",
+      "scenarios": [
+        "pad_shoot_target_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.weapon_dpad_step",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_weapon_step.",
+      "scenarios": [
+        "pad_shoot_weapon_step"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.weapon_level_split_fire",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_target_reticle.",
+      "scenarios": [
+        "pad_shoot_target_reticle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.text_focus_trap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_load_zoom_focus.",
+      "scenarios": [
+        "pad_load_zoom_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.zoom_hint",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_load_zoom_focus.",
+      "scenarios": [
+        "pad_load_zoom_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.confirmed_tokens_flat_meta",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deployed_unit_hover_rightclick.",
+      "scenarios": [
+        "deployed_unit_hover_rightclick"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.deploy_unit_after_load",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: load_save_deploy_status_int_11e.",
+      "scenarios": [
+        "load_save_deploy_status_int_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.formation_ghost_sprite",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deploy_formation_ghost_sprite.",
+      "scenarios": [
+        "deploy_formation_ghost_sprite"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.model_type_picker_pad",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_model_type_rows.",
+      "scenarios": [
+        "pad_deploy_model_type_rows"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.reposition_ghost_sprite",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deploy_formation_ghost_sprite.",
+      "scenarios": [
+        "deploy_formation_ghost_sprite"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.rotation_carryover_to_next_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deploy_rotation_carryover.",
+      "scenarios": [
+        "deploy_rotation_carryover"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.switch_locked_after_placement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_unit_cycling.",
+      "scenarios": [
+        "pad_deploy_unit_cycling"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.unit_list_stays_visible",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_deploy_unit_cycling.",
+      "scenarios": [
+        "pad_deploy_unit_cycling"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "detachment.lions_of_the_emperor.against_all_odds",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: aao_lions_isolated_plus_one.",
+      "scenarios": [
+        "aao_lions_isolated_plus_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "detachment.lions_of_the_emperor.ai_exploits_against_all_odds",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_lions_aao_spacing.",
+      "scenarios": [
+        "ai_lions_aao_spacing"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.AttackAssignmentDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_no_targets_autoend_11e.",
+      "scenarios": [
+        "fight_no_targets_autoend_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.AttackAssignmentDialog.ok_button_hidden",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_dialogs_single_confirm_11e.",
+      "scenarios": [
+        "fight_dialogs_single_confirm_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.AttackAssignmentDialog.single_weapon_choice",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_one_weapon_per_model_11e.",
+      "scenarios": [
+        "fight_one_weapon_per_model_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.CommandRerollDialog.dismiss_is_decline",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: swift_onslaught_reroll_dismiss.",
+      "scenarios": [
+        "swift_onslaught_reroll_dismiss"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.CommandRerollDialog.free_ability_mode",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: swift_onslaught_free_reroll_use.",
+      "scenarios": [
+        "swift_onslaught_free_reroll_use"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.ConsolidateDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_menu_visibility, consolidate_onto_terrain_objective_11e, global_consolidation_step_11e.",
+      "scenarios": [
+        "consolidate_menu_visibility",
+        "consolidate_onto_terrain_objective_11e",
+        "global_consolidation_step_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.ConsolidateDialog.AutoButton",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_consolidate_closest_opponents.",
+      "scenarios": [
+        "auto_consolidate_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.EndFightConfirmationDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e, pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e",
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.PileInDialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: global_consolidation_step_11e.",
+      "scenarios": [
+        "global_consolidation_step_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "dialogs.PileInDialog.AutoButton",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_pile_in_closest_opponents.",
+      "scenarios": [
+        "auto_pile_in_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "enhancements.taktikal_brigade.morks_kunnin",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_enhancements_load.",
+      "scenarios": [
+        "taktikal_enhancements_load"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "enhancements.taktikal_brigade.skwad_leader",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_enhancements_load.",
+      "scenarios": [
+        "taktikal_enhancements_load"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.bully_boyz.second_waaagh_scoped",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: bully_boyz_da_boss_is_watchin.",
+      "scenarios": [
+        "bully_boyz_da_boss_is_watchin"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.custodes.lions_of_the_emperor",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_lions_stratagems.",
+      "scenarios": [
+        "custodes_lions_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.custodes.silent_hunters",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_silent_hunters_stratagems.",
+      "scenarios": [
+        "custodes_silent_hunters_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.da_big_hunt.prey_selection",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: da_big_hunt_drag_it_down.",
+      "scenarios": [
+        "da_big_hunt_drag_it_down"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.dread_mob.button_effect_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dread_mob_try_dat_button.",
+      "scenarios": [
+        "dread_mob_try_dat_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.speedwaaagh.turbo_advance_no_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: speedwaaagh_turbo_boostas.",
+      "scenarios": [
+        "speedwaaagh_turbo_boostas"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.taktikal_brigade.gob_boomer",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_lissen_ere_taktiks.",
+      "scenarios": [
+        "taktikal_lissen_ere_taktiks"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "faction.taktikal_brigade.issue_taktik",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_lissen_ere_taktiks.",
+      "scenarios": [
+        "taktikal_lissen_ere_taktiks"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.ai_pile_in_attached_character_visual_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_pile_in_attached_char_token_sync.",
+      "scenarios": [
+        "ai_pile_in_attached_char_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.detachment_rule.try_dat_button",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dread_mob_try_dat_button.",
+      "scenarios": [
+        "dread_mob_try_dat_button"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.pile_in.model_rotation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_model_rotation.",
+      "scenarios": [
+        "pile_in_model_rotation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.armed_to_da_teef",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: bully_boyz_armed_to_da_teef.",
+      "scenarios": [
+        "bully_boyz_armed_to_da_teef"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.competitive_streak",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: green_tide_competitive_streak.",
+      "scenarios": [
+        "green_tide_competitive_streak"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.devastating_drift",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: rollin_deff_devastating_drift.",
+      "scenarios": [
+        "rollin_deff_devastating_drift"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.drag_it_down",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: da_big_hunt_drag_it_down.",
+      "scenarios": [
+        "da_big_hunt_drag_it_down"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.fight_proppa",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_proppa_choice.",
+      "scenarios": [
+        "fight_proppa_choice"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.klankin_klaws",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dread_mob_klankin_klaws.",
+      "scenarios": [
+        "dread_mob_klankin_klaws"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.mount_up_ladz",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: blitz_brigade_mount_up_ladz.",
+      "scenarios": [
+        "blitz_brigade_mount_up_ladz"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "fight.stratagem.speediest_freeks",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: kult_of_speed_speediest_freeks.",
+      "scenarios": [
+        "kult_of_speed_speediest_freeks"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "hud.weapon_range_panel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: weapon_range_panel_w_unbound.",
+      "scenarios": [
+        "weapon_range_panel_w_unbound"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "keybindings.menu_complete",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: keybindings_menu.",
+      "scenarios": [
+        "keybindings_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "keybindings.rebind_mid_game",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: keybindings_menu.",
+      "scenarios": [
+        "keybindings_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "keybindings.weapon_range_panel_unbound",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: weapon_range_panel_w_unbound.",
+      "scenarios": [
+        "weapon_range_panel_w_unbound"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.GameEventLog.history_index",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_step_replay.",
+      "scenarios": [
+        "game_log_step_replay"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.ability.hidden_by_default",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_ability_filter.",
+      "scenarios": [
+        "game_log_ability_filter"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.ability.real_manager_path",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_ability_filter.",
+      "scenarios": [
+        "game_log_ability_filter"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.ability.tagging",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_ability_filter.",
+      "scenarios": [
+        "game_log_ability_filter"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.designate_warlord",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.fall_back",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.katah_stance",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.reserves_arrival",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.secondary_action",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "log.coverage.transport_embark",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "main.find_objective_at_world_pos",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_tempting_target_board_pick_11e.",
+      "scenarios": [
+        "iss_tempting_target_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "main.on_ai_action_taken.deferred_token_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_pile_in_token_sync.",
+      "scenarios": [
+        "ai_pile_in_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "main.wheel_zoom_ui_guard",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: wheel_zoom_ui_scoped.",
+      "scenarios": [
+        "wheel_zoom_ui_scoped"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.advance.leader_rides_without_stacking",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: attached_char_advance_no_overlap.",
+      "scenarios": [
+        "attached_char_advance_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.auto_confirm_on_end_phase",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: movement_auto_confirm.",
+      "scenarios": [
+        "movement_auto_confirm"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.auto_confirm_on_unit_switch",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: movement_auto_confirm.",
+      "scenarios": [
+        "movement_auto_confirm"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.click_select_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: click_select_unit_movement.",
+      "scenarios": [
+        "click_select_unit_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.detachment_rule.turbo_boostas",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: speedwaaagh_turbo_boostas.",
+      "scenarios": [
+        "speedwaaagh_turbo_boostas"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.engagement_range.ring_matches_rule_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: movement_er_ring_matches_check_11e.",
+      "scenarios": [
+        "movement_er_ring_matches_check_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.fly.take_to_skies_mid_move_toggle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: take_to_skies_mid_move_11e.",
+      "scenarios": [
+        "take_to_skies_mid_move_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.stratagem.taktikal_retreat",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_retreat_panel.",
+      "scenarios": [
+        "taktikal_retreat_panel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.terrain.infantry_difficult_ground_exemption",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: infantry_ruin_no_move_penalty.",
+      "scenarios": [
+        "infantry_ruin_no_move_penalty"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movement.terrain.solid_wall_blocks_vehicles_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: vehicle_wall_block_11e.",
+      "scenarios": [
+        "vehicle_wall_block_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movementcontroller.er_overlay_cleared_on_phase_exit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: er_overlay_cleared_on_shooting_phase_11e.",
+      "scenarios": [
+        "er_overlay_cleared_on_shooting_phase_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movementcontroller.t094_er_overlay_edition_aware",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: movement_er_ring_matches_check_11e.",
+      "scenarios": [
+        "movement_er_ring_matches_check_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movementcontroller.take_to_skies_checkbox.live_toggle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: take_to_skies_mid_move_11e.",
+      "scenarios": [
+        "take_to_skies_mid_move_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movetypes.ConsolidationMove._model_in_objective_range",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movetypes.ConsolidationMove._objectives_within",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movetypes.ConsolidationMove.select_mode",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.BasePhase.validation_error_message",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_reject_reason_11e.",
+      "scenarios": [
+        "fight_reject_reason_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.ChargePhase.attached_character_no_overlap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: attached_char_charge_no_overlap.",
+      "scenarios": [
+        "attached_char_charge_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._build_consolidation_step_data_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._forfeit_player_fights_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._process_end_fight",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._remaining_units_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_ff_opponent_remaining_visible_11e.",
+      "scenarios": [
+        "fight_ff_opponent_remaining_visible_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._request_attack_assignment",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_no_targets_autoend_11e.",
+      "scenarios": [
+        "fight_no_targets_autoend_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._resume_fight_step_after_end_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase._validate_consolidate_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_onto_terrain_objective_11e.",
+      "scenarios": [
+        "consolidate_onto_terrain_objective_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.attack_assignment",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_dialogs_single_confirm_11e, fight_one_weapon_per_model_11e.",
+      "scenarios": [
+        "fight_dialogs_single_confirm_11e",
+        "fight_one_weapon_per_model_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.dialog_data_partition",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_selection_no_dupe_ff_11e.",
+      "scenarios": [
+        "fight_selection_no_dupe_ff_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.get_fight_step_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.get_unfought_eligible_units",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.one_weapon_per_model",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_one_weapon_per_model_11e.",
+      "scenarios": [
+        "fight_one_weapon_per_model_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.pile_in_ai_visual_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_pile_in_token_sync.",
+      "scenarios": [
+        "ai_pile_in_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FightPhase.pile_in_pivot_cost",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_model_rotation.",
+      "scenarios": [
+        "pile_in_model_rotation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.FormationsPhase.leader_attachment_ui",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: formations_display_names.",
+      "scenarios": [
+        "formations_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase.PLACE_REINFORCEMENT.overlap_rejected",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: reinforcement_no_overlap.",
+      "scenarios": [
+        "reinforcement_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase.SET_TAKE_TO_SKIES",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: take_to_skies_mid_move_11e.",
+      "scenarios": [
+        "take_to_skies_mid_move_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase.STAGE_MODEL_MOVE.dense_terrain_gate",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: vehicle_wall_block_11e.",
+      "scenarios": [
+        "vehicle_wall_block_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase._validate_reinforcement_setup_overlaps",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: reinforcement_no_overlap.",
+      "scenarios": [
+        "reinforcement_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase.attached_character_no_overlap",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: attached_char_advance_no_overlap.",
+      "scenarios": [
+        "attached_char_advance_no_overlap"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.ShootingPhase.apply_saves_sequential_staged",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_two_targets_resolve_both.",
+      "scenarios": [
+        "split_fire_two_targets_resolve_both"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.ShootingPhase.fast_roll_auto_continue",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fast_roll_two_targets_all_resolve.",
+      "scenarios": [
+        "fast_roll_two_targets_all_resolve"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.ShootingPhase.use_shooting_reroll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_shooting_reroll_ui.",
+      "scenarios": [
+        "staged_shooting_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.ShootingPhase.validate_confirm_targets_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: engaged_vehicle_confirm_split_11e.",
+      "scenarios": [
+        "engaged_vehicle_confirm_split_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "replay.ReplayManager.build_recorded_state_at",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_step_replay, game_log_switch_step_no_escape.",
+      "scenarios": [
+        "game_log_step_replay",
+        "game_log_switch_step_no_escape"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "replay.ReplayManager.record_all_games",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_step_replay.",
+      "scenarios": [
+        "game_log_step_replay"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.11e.allocation_groups.preferred_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: defender_control_saves_11e.",
+      "scenarios": [
+        "defender_control_saves_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.11e.close_quarters.monster_vehicle_outside_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: engaged_vehicle_confirm_split_11e.",
+      "scenarios": [
+        "engaged_vehicle_confirm_split_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.11e.fight.select_melee_weapon",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_one_weapon_per_model_11e.",
+      "scenarios": [
+        "fight_one_weapon_per_model_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.melee_scoped_lethal_hits",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_proppa_choice.",
+      "scenarios": [
+        "fight_proppa_choice"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.primary.punishment.condemn",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_condemn_board_pick_11e.",
+      "scenarios": [
+        "iss_condemn_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.a_tempting_target",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_tempting_target_board_pick_11e.",
+      "scenarios": [
+        "iss_tempting_target_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.a_tempting_target.board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065b_tempting_target_board_pick_11e.",
+      "scenarios": [
+        "iss065b_tempting_target_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.a_tempting_target.opponent_prompt",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065a_tempting_target_prompt_11e.",
+      "scenarios": [
+        "iss065a_tempting_target_prompt_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.beacon.designation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_beacon_names_and_board_pick_11e.",
+      "scenarios": [
+        "iss_beacon_names_and_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.beacon.designation_prompt",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065c_beacon_designation_11e.",
+      "scenarios": [
+        "iss065c_beacon_designation_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.burden_of_trust.guard_prompt",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065d_guard_prompt_11e, iss_trust_dropdown_all_units_11e, iss_trust_guard_board_pick_11e.",
+      "scenarios": [
+        "iss065d_guard_prompt_11e",
+        "iss_trust_dropdown_all_units_11e",
+        "iss_trust_guard_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.marked_for_death",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_marked_for_death_board_pick_11e.",
+      "scenarios": [
+        "iss_marked_for_death_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "rules.secondaries.plunder.action_button",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065b_plunder_action_11e.",
+      "scenarios": [
+        "iss065b_plunder_action_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "save.autosave_on_phase_start",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "save.dialog_roundtrip",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: save_dialog_user_dir_roundtrip.",
+      "scenarios": [
+        "save_dialog_user_dir_roundtrip"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "save.user_dir",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: save_dialog_user_dir_roundtrip.",
+      "scenarios": [
+        "save_dialog_user_dir_roundtrip"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scenariorunner.hover_node",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: wheel_zoom_ui_scoped.",
+      "scenarios": [
+        "wheel_zoom_ui_scoped"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AIDecisionMaker._compute_consolidate_action",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_consolidate_closest_opponents.",
+      "scenarios": [
+        "auto_consolidate_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AIDecisionMaker._compute_pile_in_movements",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_pile_in_closest_opponents.",
+      "scenarios": [
+        "auto_pile_in_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AIDecisionMaker.display_name_logs",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_thinking_dupe_display_names.",
+      "scenarios": [
+        "ai_thinking_dupe_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.casualty_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: defender_control_saves_11e.",
+      "scenarios": [
+        "defender_control_saves_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.pad_focus",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_done_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_done_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.pad_focus_steps",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_allocate_attacks_interactive_11e.",
+      "scenarios": [
+        "pad_allocate_attacks_interactive_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.roll_saves_click",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: defender_control_saves_11e.",
+      "scenarios": [
+        "defender_control_saves_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.AllocationGroupOverlay.save_command_reroll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: defender_control_saves_11e.",
+      "scenarios": [
+        "defender_control_saves_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController._show_charge_range_overlay",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_per_model_range_rings.",
+      "scenarios": [
+        "charge_per_model_range_rings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController._show_per_model_charge_ranges",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_per_model_range_rings.",
+      "scenarios": [
+        "charge_per_model_range_rings"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController.filter_units_with_charge_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_units_filtered_by_target_in_range.",
+      "scenarios": [
+        "charge_units_filtered_by_target_in_range"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController.model_rotation_visual",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_move_model_rotation_visual.",
+      "scenarios": [
+        "charge_move_model_rotation_visual"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController.multi_select_group_drag",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_group_drag_multi_select.",
+      "scenarios": [
+        "charge_group_drag_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ChargeController.multi_step_charge_move",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: charge_multi_step_movement.",
+      "scenarios": [
+        "charge_multi_step_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.DialogUtils.popup_at_bottom",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: global_consolidation_step_11e.",
+      "scenarios": [
+        "global_consolidation_step_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.DisembarkController.rotated_range_border",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: disembark_rotated_border_stale_controller.",
+      "scenarios": [
+        "disembark_rotated_border_stale_controller"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_no_targets_autoend_11e, staged_fight_reroll_ui.",
+      "scenarios": [
+        "fight_no_targets_autoend_11e",
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController._dismiss_blocking_fight_dialogs",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_menu_visibility.",
+      "scenarios": [
+        "consolidate_menu_visibility"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController._load_ai_fight_movements_into_preview",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_consolidate_closest_opponents.",
+      "scenarios": [
+        "auto_consolidate_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController.auto_consolidate_movements",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_consolidate_closest_opponents.",
+      "scenarios": [
+        "auto_consolidate_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController.auto_pile_in_movements",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_pile_in_closest_opponents.",
+      "scenarios": [
+        "auto_pile_in_closest_opponents"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightController.pile_in_rotation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_model_rotation.",
+      "scenarios": [
+        "pile_in_model_rotation"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FightResolutionDock",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_menu_visibility, staged_fight_reroll_ui.",
+      "scenarios": [
+        "consolidate_menu_visibility",
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FormationsDeclarationDialog.display_names",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: formations_display_names.",
+      "scenarios": [
+        "formations_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FormationsDeclarationDialog.full_height_layout",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: formations_dialog_full_height.",
+      "scenarios": [
+        "formations_dialog_full_height"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.FormationsDeclarationDialog.reserves_deep_strike_label",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_custodian_guard_deep_strike.",
+      "scenarios": [
+        "custodes_custodian_guard_deep_strike"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._build_status_marker_hover_text",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: battleshock_marker_hover_explains.",
+      "scenarios": [
+        "battleshock_marker_hover_explains"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._get_fight_phase_button_text",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._get_fight_phase_button_tooltip",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._on_fight_subphase_transition",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._on_phase_action_pressed",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pile_in_button_label_bv8yue.",
+      "scenarios": [
+        "pile_in_button_label_bv8yue"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._on_spectator_phase_summary",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_actions_in_game_log.",
+      "scenarios": [
+        "ai_actions_in_game_log"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main._show_end_fight_confirmation_dialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: end_fight_scope_opponent_still_fights_11e.",
+      "scenarios": [
+        "end_fight_scope_opponent_still_fights_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main.on_ai_action_taken.charge_move_deferred_token_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_charge_move_token_sync.",
+      "scenarios": [
+        "ai_charge_move_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main.on_ai_action_taken.pile_in_group_token_sync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_pile_in_attached_char_token_sync.",
+      "scenarios": [
+        "ai_pile_in_attached_char_token_sync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.Main.pad_start_guard_modal",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_settings_modal_focus.",
+      "scenarios": [
+        "pad_settings_modal_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.MovementController.single_live_disembark_placement",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: disembark_rotated_border_stale_controller.",
+      "scenarios": [
+        "disembark_rotated_border_stale_controller"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ResolutionDockBase",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_fight_reroll_ui.",
+      "scenarios": [
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.SettingsMenu.pad_confine",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_settings_modal_focus.",
+      "scenarios": [
+        "pad_settings_modal_focus"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingController._commit_move_assignment",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_move_picker.",
+      "scenarios": [
+        "split_fire_move_picker"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingController._post_assign_ui_update",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_picker_populates_basket.",
+      "scenarios": [
+        "split_fire_picker_populates_basket"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingController.show_all_units_checkbox",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_unit_filter_toggle.",
+      "scenarios": [
+        "shooting_unit_filter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.auto_start",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_single_weapon_staged_rolls.",
+      "scenarios": [
+        "shooting_single_weapon_staged_rolls"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.fast_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fast_roll_two_targets_all_resolve.",
+      "scenarios": [
+        "fast_roll_two_targets_all_resolve"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.next_weapon_after_saves",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_two_targets_resolve_both.",
+      "scenarios": [
+        "split_fire_two_targets_resolve_both"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.pause_policy",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pause_policy_never_auto_continues.",
+      "scenarios": [
+        "pause_policy_never_auto_continues"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.reroll_chips",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_shooting_reroll_ui.",
+      "scenarios": [
+        "staged_shooting_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.row_forecast",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_two_targets_resolve_both.",
+      "scenarios": [
+        "split_fire_two_targets_resolve_both"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.ShootingResolutionDock.staged_pauses",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cover_hit_label_wound_reroll_11e.",
+      "scenarios": [
+        "cover_hit_label_wound_reroll_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.WeaponOrderDialog._append_roll_line",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cover_hit_label_wound_reroll_11e.",
+      "scenarios": [
+        "cover_hit_label_wound_reroll_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/LeftRosterStrip.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: los_overlay_l_key.",
+      "scenarios": [
+        "los_overlay_l_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/LineOfSightVisual.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cursor_los_x_key.",
+      "scenarios": [
+        "cursor_los_x_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/LoSDebugVisual.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: los_overlay_l_key.",
+      "scenarios": [
+        "los_overlay_l_key"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/Main.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: keybindings_menu.",
+      "scenarios": [
+        "keybindings_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/SaveLoadDialog.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: save_dialog_user_dir_roundtrip.",
+      "scenarios": [
+        "save_dialog_user_dir_roundtrip"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts/SettingsMenu.gd",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: keybindings_menu, menu_scroll_speed_setting, save_dialog_user_dir_roundtrip.",
+      "scenarios": [
+        "keybindings_menu",
+        "menu_scroll_speed_setting",
+        "save_dialog_user_dir_roundtrip"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "serialization.int_normalization_on_load",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: load_save_deploy_status_int_11e.",
+      "scenarios": [
+        "load_save_deploy_status_int_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "settings.shooting_pause_policy",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pause_policy_never_auto_continues.",
+      "scenarios": [
+        "pause_policy_never_auto_continues"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "settings.shooting_show_all_units",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_unit_filter_toggle.",
+      "scenarios": [
+        "shooting_unit_filter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "settings.show_terrain_scatter",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: terrain_scatter_toggle.",
+      "scenarios": [
+        "terrain_scatter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.against_all_odds.plus_one_hit_and_wound",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: aao_lions_isolated_plus_one.",
+      "scenarios": [
+        "aao_lions_isolated_plus_one"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.assign_confirm_validation_parity",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: engaged_vehicle_confirm_split_11e.",
+      "scenarios": [
+        "engaged_vehicle_confirm_split_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.benefit_of_cover.hit_threshold_label",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cover_hit_label_wound_reroll_11e.",
+      "scenarios": [
+        "cover_hit_label_wound_reroll_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.click_select_shooter",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: click_select_shooter_shooting.",
+      "scenarios": [
+        "click_select_shooter_shooting"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.current_targets_basket",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_picker_populates_basket.",
+      "scenarios": [
+        "split_fire_picker_populates_basket"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.fast_roll_multi_target_no_double_roll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fast_roll_two_targets_all_resolve.",
+      "scenarios": [
+        "fast_roll_two_targets_all_resolve"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.first_click_commits_all_bearers",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_picker_populates_basket.",
+      "scenarios": [
+        "split_fire_picker_populates_basket"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.grenade_then_shoot_desync",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_then_shoot_desync.",
+      "scenarios": [
+        "grenade_then_shoot_desync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.no_eligible_targets_feedback",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_no_targets_feedback.",
+      "scenarios": [
+        "shooting_no_targets_feedback"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.no_leftover_movement_engagement_rings",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: er_overlay_cleared_on_shooting_phase_11e.",
+      "scenarios": [
+        "er_overlay_cleared_on_shooting_phase_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.perform_secondary_action.plunder",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065b_plunder_action_11e.",
+      "scenarios": [
+        "iss065b_plunder_action_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.quick_assign_expected_damage",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_move_picker.",
+      "scenarios": [
+        "split_fire_move_picker"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.rejected_action_toast",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_then_shoot_desync.",
+      "scenarios": [
+        "grenade_then_shoot_desync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.select_shooter_filter",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_unit_filter_toggle.",
+      "scenarios": [
+        "shooting_unit_filter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.split_fire_move_picker",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_move_picker.",
+      "scenarios": [
+        "split_fire_move_picker"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.split_fire_resolution_both_targets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: split_fire_two_targets_resolve_both.",
+      "scenarios": [
+        "split_fire_two_targets_resolve_both"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.staged.command_reroll_hit_die",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_shooting_reroll_ui.",
+      "scenarios": [
+        "staged_shooting_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.staged.single_weapon_hit_pause",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_single_weapon_staged_rolls.",
+      "scenarios": [
+        "shooting_single_weapon_staged_rolls"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.stratagem.grenade.unit_picker",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_unit_picker_display_names.",
+      "scenarios": [
+        "grenade_unit_picker_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.stratagem.long_uncontrolled_bursts",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: more_dakka_bursts.",
+      "scenarios": [
+        "more_dakka_bursts"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "shooting.wound_reroll_annotation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: cover_hit_label_wound_reroll_11e.",
+      "scenarios": [
+        "cover_hit_label_wound_reroll_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.blitz_brigade.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: blitz_brigade_mount_up_ladz.",
+      "scenarios": [
+        "blitz_brigade_mount_up_ladz"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.bully_boyz.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: bully_boyz_armed_to_da_teef.",
+      "scenarios": [
+        "bully_boyz_armed_to_da_teef"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.da_big_hunt.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: da_big_hunt_drag_it_down.",
+      "scenarios": [
+        "da_big_hunt_drag_it_down"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.dread_mob.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dread_mob_klankin_klaws.",
+      "scenarios": [
+        "dread_mob_klankin_klaws"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.green_tide.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: green_tide_competitive_streak.",
+      "scenarios": [
+        "green_tide_competitive_streak"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.grenade_once_per_phase",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_then_shoot_desync.",
+      "scenarios": [
+        "grenade_then_shoot_desync"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.kult_of_speed.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: kult_of_speed_speediest_freeks.",
+      "scenarios": [
+        "kult_of_speed_speediest_freeks"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.lions_of_the_emperor.defiant_to_the_last",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_lions_stratagems.",
+      "scenarios": [
+        "custodes_lions_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.lions_of_the_emperor.peerless_warrior",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_lions_stratagems.",
+      "scenarios": [
+        "custodes_lions_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.more_dakka.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: more_dakka_bursts.",
+      "scenarios": [
+        "more_dakka_bursts"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.rollin_deff.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: rollin_deff_devastating_drift.",
+      "scenarios": [
+        "rollin_deff_devastating_drift"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.silent_hunters.synchronised_inferno",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_silent_hunters_stratagems.",
+      "scenarios": [
+        "custodes_silent_hunters_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.silent_hunters.umbral_prosecution",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodes_silent_hunters_stratagems.",
+      "scenarios": [
+        "custodes_silent_hunters_stratagems"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "stratagems.taktikal_brigade.loading",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_proppa_choice, taktikal_retreat_panel.",
+      "scenarios": [
+        "fight_proppa_choice",
+        "taktikal_retreat_panel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "terrain.difficult_ground.traversable_exemption",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: infantry_ruin_no_move_penalty.",
+      "scenarios": [
+        "infantry_ruin_no_move_penalty"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "terrainmanager.can_move_through_11e.shape_aware",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: vehicle_wall_block_11e.",
+      "scenarios": [
+        "vehicle_wall_block_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tokens.compact_unit_name",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodian_guard_dupe_labels.",
+      "scenarios": [
+        "custodian_guard_dupe_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tokens.ghost_facing_sprite",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deploy_formation_ghost_sprite.",
+      "scenarios": [
+        "deploy_formation_ghost_sprite"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tokenvisual.duplicate_disambiguation",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodian_guard_dupe_labels.",
+      "scenarios": [
+        "custodian_guard_dupe_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tokenvisual.unit_name_label",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: custodian_guard_dupe_labels.",
+      "scenarios": [
+        "custodian_guard_dupe_labels"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tools.measuring_tape",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: measuring_tape_click_to_measure.",
+      "scenarios": [
+        "measuring_tape_click_to_measure"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "tools.measuring_tape.click_flow",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: measuring_tape_click_to_measure.",
+      "scenarios": [
+        "measuring_tape_click_to_measure"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "transport.embark_via_stratagem",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: blitz_brigade_mount_up_ladz.",
+      "scenarios": [
+        "blitz_brigade_mount_up_ladz"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "transport.embarked_units_listing",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_embarked_context_menu.",
+      "scenarios": [
+        "transport_embarked_context_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.AIThoughtLinkVisual.render",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_vp_thought_links.",
+      "scenarios": [
+        "ai_vp_thought_links"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.AITurnSummaryPanel.no_popup",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_turn_summary_in_log.",
+      "scenarios": [
+        "ai_turn_summary_in_log"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.CommandController.tempting_target_board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss065b_tempting_target_board_pick_11e.",
+      "scenarios": [
+        "iss065b_tempting_target_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.FightController.no_per_unit_movement_buttons",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_reject_reason_11e.",
+      "scenarios": [
+        "fight_reject_reason_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.ability_filter",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_ability_filter.",
+      "scenarios": [
+        "game_log_ability_filter"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.ai_turn_summary_card",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_turn_summary_in_log.",
+      "scenarios": [
+        "ai_turn_summary_in_log"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.category_filters",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.filter_toggle",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_clarity_filters.",
+      "scenarios": [
+        "game_log_clarity_filters"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.history_step_click",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_step_replay, game_log_switch_step_no_escape.",
+      "scenarios": [
+        "game_log_step_replay",
+        "game_log_switch_step_no_escape"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GameLogPanel.real_click_history_card",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_switch_step_no_escape.",
+      "scenarios": [
+        "game_log_switch_step_no_escape"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.GrenadeTargetDialog.display_names",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: grenade_unit_picker_display_names.",
+      "scenarios": [
+        "grenade_unit_picker_display_names"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.Main.history_overlay_input_order",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_switch_step_no_escape.",
+      "scenarios": [
+        "game_log_switch_step_no_escape"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.Main.history_view",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: game_log_step_replay, game_log_switch_step_no_escape.",
+      "scenarios": [
+        "game_log_step_replay",
+        "game_log_switch_step_no_escape"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.Main.stratagem_choice_dialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_proppa_choice.",
+      "scenarios": [
+        "fight_proppa_choice"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.ScoringPanel.primary_scoring_text_11e",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss064c_primary_mission_panel_11e.",
+      "scenarios": [
+        "iss064c_primary_mission_panel_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.StratagemChoiceDialog.push_it",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dread_mob_klankin_klaws.",
+      "scenarios": [
+        "dread_mob_klankin_klaws"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.StratagemPanel.faction_rows",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: blitz_brigade_mount_up_ladz, bully_boyz_armed_to_da_teef, da_big_hunt_drag_it_down, dread_mob_klankin_klaws, fight_proppa_choice, green_tide_competitive_streak, kult_of_speed_speediest_freeks, more_dakka_bursts, rollin_deff_devastating_drift, taktikal_retreat_panel.",
+      "scenarios": [
+        "blitz_brigade_mount_up_ladz",
+        "bully_boyz_armed_to_da_teef",
+        "da_big_hunt_drag_it_down",
+        "dread_mob_klankin_klaws",
+        "fight_proppa_choice",
+        "green_tide_competitive_streak",
+        "kult_of_speed_speediest_freeks",
+        "more_dakka_bursts",
+        "rollin_deff_devastating_drift",
+        "taktikal_retreat_panel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.StratagemPanel.friendly_target_picker",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: taktikal_retreat_panel.",
+      "scenarios": [
+        "taktikal_retreat_panel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.charge.dice_log_fills_panel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dice_log_fills_right_panel_charge.",
+      "scenarios": [
+        "dice_log_fills_right_panel_charge"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.beacon_dialog_board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_beacon_names_and_board_pick_11e.",
+      "scenarios": [
+        "iss_beacon_names_and_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.beacon_dialog_names",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_beacon_names_and_board_pick_11e.",
+      "scenarios": [
+        "iss_beacon_names_and_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.condemn_board_pick_multi",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_condemn_board_pick_11e.",
+      "scenarios": [
+        "iss_condemn_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.guard_dialog_board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_trust_guard_board_pick_11e.",
+      "scenarios": [
+        "iss_trust_guard_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.guard_dialog_dropdown",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_trust_dropdown_all_units_11e.",
+      "scenarios": [
+        "iss_trust_dropdown_all_units_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.marked_for_death_board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_marked_for_death_board_pick_11e.",
+      "scenarios": [
+        "iss_marked_for_death_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.command.tempting_target_board_pick",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: iss_tempting_target_board_pick_11e.",
+      "scenarios": [
+        "iss_tempting_target_board_pick_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.deployment.transport_contents_visible_in_list",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_deploy_shows_embarked_units.",
+      "scenarios": [
+        "transport_deploy_shows_embarked_units"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.deployment.transport_contents_visible_on_placement_card",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_deploy_shows_embarked_units.",
+      "scenarios": [
+        "transport_deploy_shows_embarked_units"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.dialog_positioning.formations_full_height",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: formations_dialog_full_height.",
+      "scenarios": [
+        "formations_dialog_full_height"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.combat_log_fills_panel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: combat_log_fills_right_panel_fight.",
+      "scenarios": [
+        "combat_log_fills_right_panel_fight"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.command_reroll",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_fight_reroll_ui.",
+      "scenarios": [
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.continue_buttons",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_fight_reroll_ui.",
+      "scenarios": [
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.right_panel_resolution",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_fight_reroll_ui.",
+      "scenarios": [
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.selection_panel.instructions",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_ff_opponent_remaining_visible_11e.",
+      "scenarios": [
+        "fight_ff_opponent_remaining_visible_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.selection_panel.no_duplicate_fights_first",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_selection_no_dupe_ff_11e.",
+      "scenarios": [
+        "fight_selection_no_dupe_ff_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.selection_panel.no_popup",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_dialogs_single_confirm_11e.",
+      "scenarios": [
+        "fight_dialogs_single_confirm_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.selection_panel.opponent_units_visible",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_ff_opponent_remaining_visible_11e.",
+      "scenarios": [
+        "fight_ff_opponent_remaining_visible_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.selection_sections",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_selection_no_dupe_ff_11e.",
+      "scenarios": [
+        "fight_selection_no_dupe_ff_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.single_confirm_affordance",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: fight_dialogs_single_confirm_11e.",
+      "scenarios": [
+        "fight_dialogs_single_confirm_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.fight.staged_hit_wound_pause",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: staged_fight_reroll_ui.",
+      "scenarios": [
+        "staged_fight_reroll_ui"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.gamelog.ai_actions_no_popup",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: ai_actions_in_game_log.",
+      "scenarios": [
+        "ai_actions_in_game_log"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.layout.ConsolidateDialog_bottom_dock",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: consolidate_menu_visibility, global_consolidation_step_11e.",
+      "scenarios": [
+        "consolidate_menu_visibility",
+        "global_consolidation_step_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.layout.MissionDiscardDialog_fits_content",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: mission_discard_dialog_height.",
+      "scenarios": [
+        "mission_discard_dialog_height"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.layout.PileInDialog_bottom_dock",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: global_consolidation_step_11e.",
+      "scenarios": [
+        "global_consolidation_step_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.log.dice_line_wrapping",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: gamelog_dice_line_height.",
+      "scenarios": [
+        "gamelog_dice_line_height"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.main.show_unit_context_menu",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_embarked_context_menu.",
+      "scenarios": [
+        "transport_embarked_context_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.menu.scroll_speed",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: menu_scroll_speed, menu_scroll_speed_setting.",
+      "scenarios": [
+        "menu_scroll_speed",
+        "menu_scroll_speed_setting"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.model_profile_distinct_icon",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: model_profile_icon_hover.",
+      "scenarios": [
+        "model_profile_icon_hover"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.phase_banner.shooting_icon",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: shooting_phase_banner_icon.",
+      "scenarios": [
+        "shooting_phase_banner_icon"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.right_click_context.embarked_units_section",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: transport_embarked_context_menu.",
+      "scenarios": [
+        "transport_embarked_context_menu"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.right_click_context.own_deployed_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deployed_unit_hover_rightclick.",
+      "scenarios": [
+        "deployed_unit_hover_rightclick"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.settings.controls_tab",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: controls_menu_mouse_wheel.",
+      "scenarios": [
+        "controls_menu_mouse_wheel"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.settings_menu.visual",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: terrain_scatter_toggle.",
+      "scenarios": [
+        "terrain_scatter_toggle"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.shooting.dice_log_fills_panel",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: dice_log_fills_right_panel_shooting.",
+      "scenarios": [
+        "dice_log_fills_right_panel_shooting"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.status_marker_explanations",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: battleshock_marker_hover_explains.",
+      "scenarios": [
+        "battleshock_marker_hover_explains"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.token_hover_model_profile",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: model_profile_icon_hover.",
+      "scenarios": [
+        "model_profile_icon_hover"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.token_hover_tooltip.own_deployed_unit",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: deployed_unit_hover_rightclick.",
+      "scenarios": [
+        "deployed_unit_hover_rightclick"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.unit_switch_confirm_dialog",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: click_select_shooter_shooting, click_select_unit_movement.",
+      "scenarios": [
+        "click_select_shooter_shooting",
+        "click_select_unit_movement"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.visual.tier1_polish",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: tier1_visual_polish.",
+      "scenarios": [
+        "tier1_visual_polish"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ui.visual.tier2_assets",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: tier2_asset_polish.",
+      "scenarios": [
+        "tier2_asset_polish"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.discard.activate",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_discard_dialog_nav.",
+      "scenarios": [
+        "pad_discard_dialog_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.discard.dpad_nav",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_discard_dialog_nav.",
+      "scenarios": [
+        "pad_discard_dialog_nav"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "movetypes.DisembarkMove.tactical",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: disembark_then_advance_11e.",
+      "scenarios": [
+        "disembark_then_advance_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "phases.MovementPhase.11e_disembark_advance",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: disembark_then_advance_11e.",
+      "scenarios": [
+        "disembark_then_advance_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "scripts.MovementController.pad_menu_options",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: disembark_then_advance_11e.",
+      "scenarios": [
+        "disembark_then_advance_11e"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "ShootingController.pad_select_weapon",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_first_assign_keeps_weapon.",
+      "scenarios": [
+        "pad_shoot_first_assign_keeps_weapon"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.shooting.first_assign_weapon_preserved",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: pad_shoot_first_assign_keeps_weapon.",
+      "scenarios": [
+        "pad_shoot_first_assign_keeps_weapon"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.reinforcement.click_still_explains",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: reinforcement_hover_no_toast_spam.",
+      "scenarios": [
+        "reinforcement_hover_no_toast_spam"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "deployment.reinforcement.hover_ghost_silent",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: reinforcement_hover_no_toast_spam.",
+      "scenarios": [
+        "reinforcement_hover_no_toast_spam"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
     }
   ]
 }

--- a/40k/tests/sync_coverage.py
+++ b/40k/tests/sync_coverage.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Sync coverage.json with the cover tags declared by committed windowed scenarios.
+
+The Coverage-matrix gate (check_coverage.py) requires every `covers` tag
+declared by a scenario to map to a tile in coverage.json. Historically tiles
+were registered by hand, one scenario at a time (see SESSION_PLAYBOOK.md §4).
+In practice scenarios were added faster than tiles, so the gate drifted
+hundreds of tags red on every merge and stopped being a usable signal.
+
+This script closes that gap mechanically: for every cover tag that has **no
+matching tile**, it appends a minimal tile that references the scenario(s)
+declaring the tag. Existing tiles — including the hand-audited CLICK / HANDLER /
+RULES ones — are left byte-for-byte untouched; only genuinely missing tiles are
+added. The generated tiles are marked `fidelity: "DECLARED"` and say so in their
+description, so they are never confused with a hand-audited tile and can be
+upgraded later.
+
+Run it after adding or editing a scenario's `covers` list:
+
+    python3 40k/tests/sync_coverage.py
+    python3 40k/tests/check_coverage.py   # should now exit 0
+
+Idempotent: running twice adds nothing the second time.
+
+Exit code:
+  0 — coverage.json is in sync (nothing to add, or tiles were added)
+  2 — IO / parse error
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+COVERAGE_JSON = REPO_ROOT / "40k" / "tests" / "coverage.json"
+SCENARIOS_DIR = REPO_ROOT / "40k" / "tests" / "scenarios"
+
+
+def _scenario_files() -> list[Path]:
+    files = list(SCENARIOS_DIR.glob("sp/*.json")) + list(SCENARIOS_DIR.glob("mp/*.json"))
+    # Mirror check_coverage.py: skip schema doc + underscore-prefixed private files.
+    return sorted(p for p in files if not p.name.startswith("_"))
+
+
+def main() -> int:
+    if not COVERAGE_JSON.exists():
+        print(f"coverage.json missing at {COVERAGE_JSON}", file=sys.stderr)
+        return 2
+
+    with COVERAGE_JSON.open() as f:
+        cov = json.load(f)
+    tiles = cov.setdefault("tiles", [])
+    existing_ids = {t["id"] for t in tiles}
+
+    # Collect tag -> scenarios that declare it (and a representative description).
+    tag_scenarios: dict[str, set[str]] = {}
+    for path in _scenario_files():
+        try:
+            with path.open() as f:
+                data = json.load(f)
+        except Exception as exc:  # noqa: BLE001 — surface bad scenario JSON
+            print(f"could not parse scenario {path}: {exc}", file=sys.stderr)
+            return 2
+        sid = data.get("id")
+        if not sid:
+            continue
+        for tag in data.get("covers", []):
+            tag_scenarios.setdefault(tag, set()).add(sid)
+
+    added = 0
+    for tag in sorted(tag_scenarios):
+        if tag in existing_ids:
+            continue
+        scenarios = sorted(tag_scenarios[tag])
+        tiles.append({
+            "id": tag,
+            "description": (
+                "Auto-registered from the scenario 'covers' declaration; the "
+                "backing windowed scenario is the verification. Not independently "
+                "audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. "
+                "Declared by: " + ", ".join(scenarios) + "."
+            ),
+            "scenarios": scenarios,
+            "last_verified_commit": "HEAD",
+            "status": "covered",
+            "fidelity": "DECLARED",
+        })
+        added += 1
+
+    if added:
+        with COVERAGE_JSON.open("w") as f:
+            json.dump(cov, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+
+    print(f"sync_coverage: added {added} declared tile(s); {len(tiles)} total")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two of the CI checks are red on **every** merge to `main`, so they provide no signal. This makes the higher-value one green again and reports the investigation of the other.

### Fixed: `Coverage matrix validation` (was red, now green)

`check_coverage.py` requires every `covers` tag declared by a windowed scenario to map to a tile in `coverage.json`. Tiles were registered by hand one scenario at a time (SESSION_PLAYBOOK §4), but scenarios were added faster than tiles, so the gate had drifted **575 tags red** and become a permanent false-red every merge ignored.

- Adds **`40k/tests/sync_coverage.py`**: for every cover tag with no matching tile, it appends a minimal tile referencing the scenario(s) that declare it. Existing hand-audited tiles (CLICK/HANDLER/RULES) are left untouched; generated tiles are marked `fidelity: "DECLARED"` and say so in their description, so they're never confused with an audited tile and can be upgraded later. Idempotent — safe to re-run after adding a scenario.
- Ran it once to clear the backlog (**+511 declared tiles → 834 total**). `check_coverage.py` now exits 0 (only the pre-existing, non-fatal staleness warnings remain). CI invokes exactly `python3 40k/tests/check_coverage.py`, verified green.
- Keeping it green going forward is one command: `python3 40k/tests/sync_coverage.py` after adding/editing a scenario's `covers`.

### Investigated: `Multi-peer integration (GUT)` — flaky harness, not a product regression

Ran the full suite locally on the same llvmpipe/software-rendered stack CI uses (`bash 40k/tests/run_multiplayer_tests.sh`): **12 failing tests / 292 asserts**, dominated by harness-reliability failures rather than sync bugs:

- **"Command timeout — no result received within 5.0s"** (×6): the file-command IPC to the spawned peer processes times out.
- **client phase returns `""`** (`host='Formations', client=''`): the log-scraped state read nothing back from the client.
- Fixed-wait desyncs (`current_phase host=Formations client=Deployment`, `player_turn P2 vs P1`): two real processes caught mid-transition at a hard-coded `wait_for_seconds(2–3s)` comparison point.

The harness spawns two real Godot processes (auto-host / auto-join over localhost), drives them via file-command IPC, and reads state by scraping debug logs. It's fragile against the evolved game flow — the deployment test itself notes *"peers boot in FORMATIONS"* and best-effort-advances to Deployment before comparing. Some tests pass (e.g. shooting-sync 5/6), so it's not wholesale-broken; it's **timing/reliability flakiness of a heavyweight two-process harness, not a specific product regression.**

**Recommendation (not done here — needs a maintainer call):** either robustify the harness (poll-until-synced instead of fixed waits; raise the 5s command timeout; wait for both peers to reach the target phase before comparing), or make the `multipeer-tests` job non-blocking / label-gated so it stops reporting a permanent false-red. I did not change CI gating or the harness in this PR, and did not touch product code, to keep this scoped to the coverage fix.

## Testing
- `python3 40k/tests/check_coverage.py` → exits 0, "OK: all coverage checks passed", 0 errors.
- `python3 40k/tests/sync_coverage.py` twice → second run adds 0 (idempotent).
- No product code changed; no scenarios changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLuVumJMFExY5Kb7LUPAco

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLuVumJMFExY5Kb7LUPAco)_