### PR TITLE
Offer Advance after a tactical disembark (controller + mouse)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.5",
+			"date": "2026-07-22",
+			"summary": "A unit that disembarks from a transport that hasn't moved yet can now Advance, not just make a Normal move — on both the controller and the mouse. Previously the post-disembark move was silently locked to Normal, so there was no way to Advance a squad you'd just dropped off (18.04: a tactical disembark lets the unit 'make a normal OR advance move').",
+			"changes": [
+				"Movement — after a unit disembarks from a stationary transport, the move-mode choice is now open (Normal / Advance / Remain Still) instead of being forced to Normal. Pick Advance to roll the D6 and move M + Advance as usual.",
+				"Controller — the move menu (Ⓐ / D-pad) that appears after placing your disembarked models now offers Advance alongside Move and Stay Still, matching how you choose Advance for any other move. Previously the controller only showed the Move / Next Model controls with no way to Advance.",
+				"Mouse — the Advance mode radio is now shown and enabled after disembarking (it was greyed out before)."
+			]
+		},
+		{
 			"version": "0.92.4",
 			"date": "2026-07-22",
 			"summary": "Controller fix (follow-up to the secondary-missions pop-up): the end-of-turn 'Discard for CP?' pop-up can now be used with a controller. Previously the D-pad never highlighted anything in that window, so a pad player couldn't discard a secondary mission for +1 CP or choose to end the turn without discarding — the only way past it was the mouse. Now the D-pad moves a visible selector through each mission's 'Discard' button and the 'End Turn Without Discarding' button, A activates the highlighted one, and the controller hint bar shows Navigate / Select / Close.",

--- a/40k/phases/MovementPhase.gd
+++ b/40k/phases/MovementPhase.gd
@@ -8351,7 +8351,16 @@ func _initialize_movement_for_disembarked_unit(unit_id: String) -> void:
 	# Set up active movement similar to BEGIN_NORMAL_MOVE
 	active_moves[unit_id] = {
 		"mode": "NORMAL",
-		"mode_locked": true,  # Lock to normal move since they just disembarked
+		# 18.04: after a tactical disembark the unit "is then selected to make a
+		# normal OR advance move" — so default to Normal but leave the mode
+		# decision OPEN (not locked). Locking to Normal here hid the Advance
+		# option from BOTH the mouse mode radios and the pad move menu (the
+		# PadActionBar), even though the transport hadn't moved and the unit was
+		# fully eligible to Advance. Unlocking lets the player pick Advance the
+		# same way they would for any other move; switching to Advance recreates
+		# active_moves via BEGIN_ADVANCE (rolling the D6), so the default Normal
+		# state here is only the starting point.
+		"mode_locked": false,
 		"completed": false,
 		"move_cap_inches": move_inches,
 		"advance_roll": 0,

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -2832,6 +2832,13 @@ func _post_disembark_ui_update(unit_id: String) -> void:
 
 		_update_selected_unit_display()
 		_update_fall_back_visibility()
+		# 18.04: a tactical disembark lets the unit make a normal OR advance move.
+		# Set up the mode radios with the decision OPEN (the phase left mode_locked
+		# false) so the Advance option is offered on BOTH the mouse (mode radios)
+		# and the pad (the PadActionBar move menu reads radio visibility/enabled).
+		# Without this the radios stay stale/disabled after disembark and neither
+		# surface exposes Advance — the reported controller gap.
+		_reset_mode_selection_for_new_unit(unit_id)
 		emit_signal("ui_update_requested")
 
 		# Find and select the unit in the list

--- a/40k/tests/scenarios/sp/disembark_then_advance_11e.json
+++ b/40k/tests/scenarios/sp/disembark_then_advance_11e.json
@@ -1,0 +1,91 @@
+{
+  "id": "disembark_then_advance_11e",
+  "covers": [
+    "phases.MovementPhase.11e_disembark_advance",
+    "movetypes.DisembarkMove.tactical",
+    "scripts.MovementController.pad_menu_options"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "18.04 TACTICAL disembark: a stationary transport lets the disembarked unit be 'then selected to make a normal OR advance move'. Regression net for the reported controller gap where the post-disembark move was locked to Normal, hiding Advance from the mouse mode radios AND the pad move menu. A clean transport + squad (owner 2) is injected on empty board so the disembarked unit is unengaged and genuinely eligible to advance. Asserts: after a successful tactical disembark the move-mode decision is OPEN (mode_locked=false), the pad move menu (pad_menu_options) offers ADVANCE, the mouse Advance radio is enabled, and BEGIN_ADVANCE resolves to an Advance move (cap = M + D6).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    {
+      "act": "execute_script",
+      "comment": "Inject a stationary Trukk carrying a Boyz squad (owner 2 = active player) on clear board (1600,700), then refresh the phase snapshot so get_unit() sees them.",
+      "multiline": true,
+      "script": "GameState.state.units[\"Z_TRUKK\"] = {\"id\":\"Z_TRUKK\",\"owner\":2,\"status\":2,\"flags\":{},\"transport_data\":{\"capacity\":12,\"embarked_units\":[\"Z_BOYZ\"]},\"meta\":{\"name\":\"Test Trukk\",\"keywords\":[\"VEHICLE\",\"TRANSPORT\"],\"stats\":{\"move\":12}},\"models\":[{\"id\":\"t0\",\"alive\":true,\"wounds\":10,\"current_wounds\":10,\"base_mm\":100,\"base_type\":\"circular\",\"position\":{\"x\":1600,\"y\":700},\"rotation\":0.0}]}\nGameState.state.units[\"Z_BOYZ\"] = {\"id\":\"Z_BOYZ\",\"owner\":2,\"status\":2,\"embarked_in\":\"Z_TRUKK\",\"flags\":{},\"meta\":{\"name\":\"Test Boyz\",\"keywords\":[\"INFANTRY\"],\"stats\":{\"move\":6}},\"models\":[{\"id\":\"z0\",\"alive\":true,\"wounds\":1,\"current_wounds\":1,\"base_mm\":32,\"base_type\":\"circular\",\"position\":null},{\"id\":\"z1\",\"alive\":true,\"wounds\":1,\"current_wounds\":1,\"base_mm\":32,\"base_type\":\"circular\",\"position\":null},{\"id\":\"z2\",\"alive\":true,\"wounds\":1,\"current_wounds\":1,\"base_mm\":32,\"base_type\":\"circular\",\"position\":null}]}\nPhaseManager.get_current_phase_instance().game_state_snapshot = GameState.state.duplicate(true)\nreturn GameState.state.units.has(\"Z_BOYZ\")",
+      "equals": true
+    },
+    { "act": "expect_state", "path": "units.Z_BOYZ.embarked_in", "equals": "Z_TRUKK" },
+    { "act": "screenshot", "label": "01_squad_embarked" },
+    {
+      "act": "dispatch_action",
+      "action": {
+        "type": "CONFIRM_DISEMBARK",
+        "actor_unit_id": "Z_BOYZ",
+        "payload": {
+          "positions": [
+            { "x": 1600.0, "y": 850.0 },
+            { "x": 1670.0, "y": 850.0 },
+            { "x": 1530.0, "y": 850.0 }
+          ],
+          "can_setup_tactical": true
+        }
+      }
+    },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "expect_state", "path": "units.Z_BOYZ.embarked_in", "equals": null },
+    { "act": "expect_state", "path": "units.Z_BOYZ.flags.cannot_move", "equals": false },
+    { "act": "wait_frames", "frames": 3 },
+    {
+      "act": "execute_script",
+      "comment": "Core fix: a tactical disembark leaves the move-mode decision OPEN (was locked to NORMAL, which hid Advance).",
+      "script": "PhaseManager.get_current_phase_instance().active_moves.get(\"Z_BOYZ\", {}).get(\"mode_locked\", true)",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "comment": "Pad surface: the PadActionBar move menu offers ADVANCE. Mirror the controller-side post-disembark UI update (the real disembark-completed handler calls this) so the mode radios the menu reads are set up.",
+      "multiline": true,
+      "script": "var mc = tree.current_scene.movement_controller\nmc._post_disembark_ui_update(\"Z_BOYZ\")\nvar ids = []\nfor o in mc.pad_menu_options():\n\tids.append(str(o.get(\"id\", \"\")))\nreturn \"ADVANCE\" in ids",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "comment": "Mouse surface: the Advance mode radio is visible and enabled after disembark.",
+      "multiline": true,
+      "script": "var ar = tree.current_scene.movement_controller.advance_radio\nreturn ar != null and ar.visible and not ar.disabled",
+      "equals": true
+    },
+    { "act": "screenshot", "label": "02_disembarked_advance_offered" },
+    {
+      "act": "execute_script",
+      "comment": "Advance is a VALID action for the freshly (unengaged) disembarked unit.",
+      "multiline": true,
+      "script": "var v = PhaseManager.get_current_phase_instance().validate_action({\"type\": \"BEGIN_ADVANCE\", \"actor_unit_id\": \"Z_BOYZ\"})\nreturn v.get(\"valid\", false)",
+      "equals": true
+    },
+    {
+      "act": "dispatch_action",
+      "action": { "type": "BEGIN_ADVANCE", "actor_unit_id": "Z_BOYZ", "payload": {} }
+    },
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    {
+      "act": "dispatch_action",
+      "comment": "The advance roll offers a Command Re-roll; decline it to resolve the roll.",
+      "action": { "type": "DECLINE_COMMAND_REROLL", "actor_unit_id": "Z_BOYZ" }
+    },
+    {
+      "act": "execute_script",
+      "comment": "The move is now an Advance with cap = M(6) + advance roll (>6) — the disembarked unit actually advanced.",
+      "multiline": true,
+      "script": "var am = PhaseManager.get_current_phase_instance().active_moves.get(\"Z_BOYZ\", {})\nreturn am.get(\"mode\", \"\") == \"ADVANCE\" and am.get(\"move_cap_inches\", 0.0) > 6.0",
+      "equals": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

When a unit disembarks from a transport that hasn't moved yet, it should be able to make a **Normal or Advance** move (11e rule 18.04: a tactical disembark means the unit "is then selected to make a normal OR advance move"). But the post-disembark move was silently locked to Normal, so there was no way to Advance a squad you'd just dropped off — on either the controller or the mouse.

### Root cause
`MovementPhase._initialize_movement_for_disembarked_unit` created the follow-up move with `mode_locked = true`. That lock hid Advance on both surfaces:
- **Controller**: `pad_menu_options()` returned empty (mode resolved/locked), so the PadActionBar move menu never opened — the hint bar showed the staged-move controls (Move Model / Next Model / Grab All / …) with no Advance chip. This is the reported gap.
- **Mouse**: `_reset_mode_selection_for_new_unit` disables the mode radios when the mode is locked, greying out Advance.

The engine already knew the rule (`DisembarkMove` sets `pending_post_disembark_move`) — only the UI-facing move state was wrong.

## Changes
- **`MovementPhase.gd`** — `_initialize_movement_for_disembarked_unit` now leaves `mode_locked = false`, so the Normal/Advance decision stays open (default Normal). Applies to the 11e tactical path and the 10e "transport hasn't moved" path. Switching to Advance recreates the move via `BEGIN_ADVANCE` (rolling the D6) as usual.
- **`MovementController.gd`** — `_post_disembark_ui_update` now calls `_reset_mode_selection_for_new_unit` so the mode radios are set up. This fixes both surfaces at once: the mouse radios show Advance, and the pad menu (which reads radio visibility/enabled) exposes it too. Consistent with how a normal unit selection offers the mode choice.
- **`data/version_history.json`** — changelog entry (v0.89.1).
- **`tests/scenarios/sp/disembark_then_advance_11e.json`** — new windowed regression scenario.

Advance stays gated by normal eligibility, so an engaged disembark still can't advance (correct).

## Validation
- New windowed scenario `disembark_then_advance_11e` passes **19/0**: after a tactical disembark the move mode is unlocked, the pad move menu offers `ADVANCE`, the mouse Advance radio is enabled, and `BEGIN_ADVANCE` resolves to an Advance move (cap = M + D6).
- Drove the live windowed game via the MCP bridge: the pad move menu returns `["Move", "Advance", "Stay Still"]`; pressing **A** after disembark opens it; the hint bar recomputes to "A Move Menu"; the advance resolves (e.g. M 6" + D6 3" = 9"). `verify_delivery` = PASS with zero errors.
- Existing `iss058_disembark_11e` (16/0) and `51_confirm_movement_mode` (11/0) windowed scenarios and the disembark/transport headless suites (`test_iss058_disembark_11e`, `test_t080_disembark_remain_stationary`, `test_transport_audit_2026_07`) still pass — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014SfsPV8T4KZy8TqTN7EHmx

---
_Generated by [Claude Code](https://claude.ai/code/session_014SfsPV8T4KZy8TqTN7EHmx)_