### PR TITLE
Stop reinforcement/deploy placement spamming validation toasts on hover

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.2",
+			"date": "2026-07-22",
+			"summary": "Placing a unit from reserves (Deep Strike / Strategic Reserves / Rapid Ingress) no longer spams a stack of red 'must be within 6\" of a board edge' warnings while you move the cursor over an illegal spot. The ghost still turns red to show you can't drop there, and clicking to place still tells you exactly why — but simply hovering is now quiet.",
+			"changes": [
+				"Fixed reinforcement / Deep Strike placement stacking a new validation toast every frame while hovering an illegal spot (it piled up to the 5-toast maximum). The per-frame ghost-colour check no longer shows toasts — it just reddens the ghost — while actually clicking to place still surfaces the specific reason (too close to an enemy, not within 6\" of a board edge, off the board, etc.).",
+				"Same fix applies to Infiltrators placement, formation (Spread / Tight) reinforcement drops, and dragging an already-placed model during deployment — all of which had the same per-frame toast spam."
+			]
+		},
+		{
 			"version": "0.92.1",
 			"date": "2026-07-22",
 			"summary": "Rapid Ingress now works from the controller, closing two bugs left over from the earlier deep-strike fix. Using the Rapid Ingress stratagem to bring a unit on used to silently do nothing if it was your first placement of the Movement phase (the stratagem spent the CP but no placement UI ever appeared). And, like a normal reserves arrival, starting a Rapid Ingress placement now clears whatever unit you had selected, so the controller can't pop that other unit's Move / Advance / Stay Still menu or confirm its move underneath the placement.",

--- a/40k/scripts/DeploymentController.gd
+++ b/40k/scripts/DeploymentController.gd
@@ -1919,7 +1919,7 @@ func _process(delta: float) -> void:
 		reposition_ghost.position = mouse_pos
 		var unit_data = GameState.get_unit(unit_id)
 		var model_data = unit_data["models"][reposition_model_index]
-		var is_valid = _validate_reposition(mouse_pos, model_data, reposition_model_index)
+		var is_valid = _validate_reposition(mouse_pos, model_data, reposition_model_index, true)
 		reposition_ghost.set_validity(is_valid)
 		# Show coherency distance during repositioning too
 		var rot = 0.0
@@ -1962,14 +1962,18 @@ func _process(delta: float) -> void:
 		var is_valid = false
 
 		if is_reinforcement_mode:
-			# Reinforcement mode: validate >9" from enemies instead of deployment zone
-			is_valid = _validate_reinforcement_position(mouse_pos, model_data, rotation)
+			# Reinforcement mode: validate >9" from enemies instead of deployment zone.
+			# silent=true — this is the per-frame ghost-colour check; a failure just
+			# reddens the ghost, it must NOT stack a toast every frame (the click in
+			# try_place_at surfaces the reason).
+			is_valid = _validate_reinforcement_position(mouse_pos, model_data, rotation, true)
 			# Also check model overlap
 			if is_valid and _overlaps_with_existing_models_shape(mouse_pos, model_data, rotation):
 				is_valid = false
 		elif is_infiltrators_mode:
 			# Infiltrators mode: validate >9" from enemy zone and enemy models
-			is_valid = _validate_infiltrators_position(mouse_pos, model_data, rotation)
+			# (silent per-frame — see the reinforcement branch above).
+			is_valid = _validate_infiltrators_position(mouse_pos, model_data, rotation, true)
 			# Also check model overlap
 			if is_valid and _overlaps_with_existing_models_shape(mouse_pos, model_data, rotation):
 				is_valid = false
@@ -2321,11 +2325,18 @@ func _update_formation_ghost_positions(mouse_pos: Vector2) -> void:
 
 			# MA-18: Use each model's actual data for validation
 			var model_data_for_validation = formation_model_data[i] if i < formation_model_data.size() else formation_model_data[0]
-			var is_valid = _validate_formation_position(positions[i], model_data_for_validation, zone, model_rot)
+			# silent=true — per-frame formation-ghost colour check; a failure just
+			# reddens the ghosts instead of stacking a toast per model per frame
+			# (the click path in try_place_formation_at surfaces the reason).
+			var is_valid = _validate_formation_position(positions[i], model_data_for_validation, zone, model_rot, true)
 			ghost.set_validity(is_valid)
 
-func _validate_formation_position(pos: Vector2, model_data: Dictionary, zone: PackedVector2Array, model_rotation: float = 0.0) -> bool:
-	"""Validate a single position in a formation"""
+func _validate_formation_position(pos: Vector2, model_data: Dictionary, zone: PackedVector2Array, model_rotation: float = 0.0, silent: bool = false) -> bool:
+	"""Validate a single position in a formation. silent=true suppresses the
+	reinforcement/infiltrator failure toasts — the per-frame formation-ghost
+	colour check passes it so hovering an illegal drop just reddens the ghosts
+	instead of stacking a toast per model per frame; the click path (formation
+	placement) leaves it false so a rejected drop still explains why."""
 	if is_reinforcement_mode:
 		# Reinforcement (Deep Strike / Strategic Reserves): reinforcements arrive
 		# across the whole battlefield, NOT the owning player's deployment zone,
@@ -2334,13 +2345,13 @@ func _validate_formation_position(pos: Vector2, model_data: Dictionary, zone: Pa
 		# zone check. Mirrors the single-model path in try_place_at()/_process();
 		# without this branch a formation dropped in a legal Deep Strike spot
 		# would be falsely rejected as "outside deployment zone".
-		if not _validate_reinforcement_position(pos, model_data, model_rotation):
+		if not _validate_reinforcement_position(pos, model_data, model_rotation, silent):
 			return false
 		if _overlaps_with_existing_models_shape(pos, model_data, model_rotation):
 			return false
 	elif is_infiltrators_mode:
 		# In Infiltrators mode, use Infiltrators validation instead of zone check
-		if not _validate_infiltrators_position(pos, model_data, model_rotation):
+		if not _validate_infiltrators_position(pos, model_data, model_rotation, silent):
 			return false
 		if _overlaps_with_existing_models_shape(pos, model_data, model_rotation):
 			return false
@@ -2429,21 +2440,25 @@ func _update_model_repositioning(mouse_pos: Vector2) -> void:
 	var world_pos = _get_world_mouse_position()
 	reposition_ghost.position = world_pos
 
-	# Validate new position
+	# Validate new position. silent=true — runs on every mouse-motion event to
+	# recolour the ghost; a failure must not stack a toast per motion (the drop
+	# in _end_model_repositioning surfaces the reason).
 	var unit_data = GameState.get_unit(unit_id)
 	var model_data = unit_data["models"][reposition_model_index]
-	var is_valid = _validate_reposition(world_pos, model_data, reposition_model_index)
+	var is_valid = _validate_reposition(world_pos, model_data, reposition_model_index, true)
 
 	reposition_ghost.set_validity(is_valid)
 
-func _validate_reposition(world_pos: Vector2, model_data: Dictionary, model_index: int) -> bool:
-	"""Validate if repositioning is allowed at the given position"""
+func _validate_reposition(world_pos: Vector2, model_data: Dictionary, model_index: int, silent: bool = false) -> bool:
+	"""Validate if repositioning is allowed at the given position. silent=true
+	suppresses the Infiltrators failure toasts for the per-frame reposition-ghost
+	colour check; the drop path leaves it false."""
 	var active_player = GameState.get_active_player()
 	var rotation = temp_rotations[model_index] if model_index < temp_rotations.size() else 0.0
 
 	if is_infiltrators_mode:
 		# In Infiltrators mode, use Infiltrators validation instead of zone check
-		if not _validate_infiltrators_position(world_pos, model_data, rotation):
+		if not _validate_infiltrators_position(world_pos, model_data, rotation, silent):
 			return false
 	else:
 		var zone = BoardState.get_deployment_zone_for_player(active_player)
@@ -2551,15 +2566,20 @@ func _cancel_model_repositioning() -> void:
 
 	_cleanup_repositioning()
 
-func _validate_reinforcement_position(world_pos: Vector2, model_data: Dictionary, rotation: float) -> bool:
-	"""Validate a reinforcement placement position (Deep Strike / Strategic Reserves)"""
+func _validate_reinforcement_position(world_pos: Vector2, model_data: Dictionary, rotation: float, silent: bool = false) -> bool:
+	"""Validate a reinforcement placement position (Deep Strike / Strategic Reserves).
+	silent=true suppresses the failure toasts — the per-frame ghost-colour check
+	(_process) passes it so hovering an illegal spot just reddens the ghost instead
+	of stacking a new toast every frame; the click path (try_place_at) leaves it
+	false so a rejected placement still explains why."""
 	var px_per_inch = 40.0
 	var board_width_px = GameState.state.board.size.width * px_per_inch
 	var board_height_px = GameState.state.board.size.height * px_per_inch
 
 	# Must be on the board
 	if world_pos.x < 0 or world_pos.x > board_width_px or world_pos.y < 0 or world_pos.y > board_height_px:
-		_show_toast("Must be on the battlefield")
+		if not silent:
+			_show_toast("Must be on the battlefield")
 		return false
 
 	# Must be >9" from all enemy models (edge-to-edge)
@@ -2575,7 +2595,8 @@ func _validate_reinforcement_position(world_pos: Vector2, model_data: Dictionary
 		var dist_inches = dist_px / px_per_inch
 		var edge_dist = dist_inches - model_radius_inches - enemy_radius_inches
 		if edge_dist < 9.0:
-			_show_toast("Must be >9\" from enemy models (%.1f\")" % edge_dist)
+			if not silent:
+				_show_toast("Must be >9\" from enemy models (%.1f\")" % edge_dist)
 			return false
 
 	# Strategic Reserves: must be within 6" of a battlefield edge
@@ -2590,7 +2611,8 @@ func _validate_reinforcement_position(world_pos: Vector2, model_data: Dictionary
 		var board_h = GameState.state.board.size.height
 		var dist_to_edge = min(pos_inches_x, board_w - pos_inches_x, pos_inches_y, board_h - pos_inches_y)
 		if dist_to_edge > 6.0:
-			_show_toast("Strategic Reserves must be within 6\" of a board edge (%.1f\")" % dist_to_edge)
+			if not silent:
+				_show_toast("Strategic Reserves must be within 6\" of a board edge (%.1f\")" % dist_to_edge)
 			return false
 
 	# Omni-scramblers: cannot be set up within 12" of enemy units with Omni-scramblers
@@ -2602,20 +2624,24 @@ func _validate_reinforcement_position(world_pos: Vector2, model_data: Dictionary
 		var dist_inches = dist_px / px_per_inch
 		var edge_dist = dist_inches - model_radius_inches - omni_radius_inches
 		if edge_dist < 12.0:
-			_show_toast("Cannot deploy within 12\" of Omni-scramblers (%s) (%.1f\")" % [omni.get("unit_name", "unknown"), edge_dist])
+			if not silent:
+				_show_toast("Cannot deploy within 12\" of Omni-scramblers (%s) (%.1f\")" % [omni.get("unit_name", "unknown"), edge_dist])
 			return false
 
 	return true
 
-func _validate_infiltrators_position(world_pos: Vector2, model_data: Dictionary, rotation: float) -> bool:
-	"""Validate an Infiltrators deployment position: anywhere on the board, >9 inches from enemy deployment zone and >9 inches from enemy models"""
+func _validate_infiltrators_position(world_pos: Vector2, model_data: Dictionary, rotation: float, silent: bool = false) -> bool:
+	"""Validate an Infiltrators deployment position: anywhere on the board, >9 inches from enemy deployment zone and >9 inches from enemy models.
+	silent=true suppresses the failure toasts for the per-frame ghost-colour check
+	(see _validate_reinforcement_position); the click path leaves it false."""
 	var px_per_inch = 40.0
 	var board_width_px = GameState.state.board.size.width * px_per_inch
 	var board_height_px = GameState.state.board.size.height * px_per_inch
 
 	# Must be on the board
 	if world_pos.x < 0 or world_pos.x > board_width_px or world_pos.y < 0 or world_pos.y > board_height_px:
-		_show_toast("Must be on the battlefield")
+		if not silent:
+			_show_toast("Must be on the battlefield")
 		return false
 
 	var active_player = GameState.get_active_player()
@@ -2633,7 +2659,8 @@ func _validate_infiltrators_position(world_pos: Vector2, model_data: Dictionary,
 
 		# Check if model center is inside enemy zone
 		if Geometry2D.is_point_in_polygon(world_pos, enemy_zone_poly_pixels):
-			_show_toast("Infiltrators must be >9\" from enemy deployment zone")
+			if not silent:
+				_show_toast("Infiltrators must be >9\" from enemy deployment zone")
 			return false
 
 		# Find minimum distance from model center to any edge of the enemy zone
@@ -2646,7 +2673,8 @@ func _validate_infiltrators_position(world_pos: Vector2, model_data: Dictionary,
 				min_dist_px = dist
 		var edge_dist_inches = (min_dist_px / px_per_inch) - model_radius_inches
 		if edge_dist_inches < 9.0:
-			_show_toast("Infiltrators must be >9\" from enemy deployment zone (%.1f\")" % edge_dist_inches)
+			if not silent:
+				_show_toast("Infiltrators must be >9\" from enemy deployment zone (%.1f\")" % edge_dist_inches)
 			return false
 
 	# Must be >9" from all enemy models (edge-to-edge)
@@ -2658,7 +2686,8 @@ func _validate_infiltrators_position(world_pos: Vector2, model_data: Dictionary,
 		var dist_inches = dist_px / px_per_inch
 		var edge_dist = dist_inches - model_radius_inches - enemy_radius_inches
 		if edge_dist < 9.0:
-			_show_toast("Infiltrators must be >9\" from enemy models (%.1f\")" % edge_dist)
+			if not silent:
+				_show_toast("Infiltrators must be >9\" from enemy models (%.1f\")" % edge_dist)
 			return false
 
 	return true

--- a/40k/tests/scenarios/sp/reinforcement_hover_no_toast_spam.json
+++ b/40k/tests/scenarios/sp/reinforcement_hover_no_toast_spam.json
@@ -1,0 +1,40 @@
+{
+  "id": "reinforcement_hover_no_toast_spam",
+  "covers": [
+    "deployment.reinforcement.hover_ghost_silent",
+    "deployment.reinforcement.click_still_explains",
+    "DeploymentController"
+  ],
+  "fixture": "ri_pretrigger",
+  "rng_seed": 42,
+  "edition": 11,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Reinforcement / Deep Strike placement no longer spams validation toasts while you hover. The per-frame ghost-colour check (_process) reused the click-path validators, which each call _show_toast on failure — so hovering an illegal drop stacked a new 'Strategic Reserves must be within 6\" of a board edge' toast every frame until it hit MAX_TOASTS (the 5-toast pile). The validators now take a silent flag: the per-frame ghost check passes it (just reddens the ghost), while the click path (try_place_at) still surfaces the reason. Starts a Battlewagon Strategic-Reserves placement, hovers the board centre (>6\" from every edge = illegal) for over a second and asserts ZERO toasts accumulate, then dispatches an actual placement at the same illegal spot and asserts a toast DOES appear.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    { "act": "expect_state", "path": "units.U_BATTLEWAGON_G.status", "equals": 7 },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nvar list = m.movement_controller.unit_list\nfor i in range(list.item_count):\n\tif str(list.get_item_metadata(i)) == \"U_BATTLEWAGON_G\":\n\t\tlist.select(i)\n\t\tlist.item_selected.emit(i)\n\t\treturn true\nreturn false", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "main.deployment_controller.is_placing()", "equals": true },
+    { "act": "execute_script", "script": "main.deployment_controller.is_reinforcement_mode", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "for t in ToastManager.active_toasts.duplicate():\n\tif is_instance_valid(t):\n\t\tt.queue_free()\nToastManager.active_toasts.clear()\nreturn ToastManager.active_toasts.size()", "equals": 0 },
+
+    { "act": "hover_board_at", "x": 880, "y": 1200 },
+    { "act": "wait_seconds", "seconds": 1.3 },
+    { "act": "execute_script", "script": "ToastManager.active_toasts.size()", "equals": 0 },
+    { "act": "screenshot", "label": "01_hover_illegal_spot_no_toast_stack" },
+
+    { "act": "hover_board_at", "x": 700, "y": 1300 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "ToastManager.active_toasts.size()", "equals": 0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nm.deployment_controller.try_place_at(Vector2(880, 1200))\nreturn ToastManager.active_toasts.size() >= 1", "equals": true },
+    { "act": "execute_script", "script": "main.deployment_controller.get_placed_count()", "equals": 0 },
+    { "act": "screenshot", "label": "02_click_illegal_spot_shows_one_toast" }
+  ]
+}


### PR DESCRIPTION
Cosmetic follow-up flagged during the deep-strike work: hovering an illegal placement spot stacked a pile of red validation toasts (visible in the earlier deep-strike screenshots — up to the 5-toast `MAX_TOASTS` cap).

## Cause

`DeploymentController._process` recolours the placement ghost every frame by calling the **click-path validators** (`_validate_reinforcement_position` / `_validate_infiltrators_position` / `_validate_formation_position`), and each of those calls `_show_toast` on failure. So every frame the cursor sat over an illegal spot, a new toast was created. The mouse-motion reposition update (`_update_model_repositioning`) had the same problem. Normal deployment never showed this because its per-frame path uses the non-toasting polygon checks (`_circle_wholly_in_polygon` / `_shape_wholly_in_polygon`) — only reinforcement / Infiltrators / formation modes regressed by reusing the toasting validators for per-frame colouring.

## Fix

Gave the four validators a `silent := false` flag that suppresses the failure toasts, and pass `silent = true` from the per-frame ghost-colour call sites (single-model `_process`, formation-ghost update, reposition update). The click paths (`try_place_at` / `try_place_formation_at` / reposition drop) keep the default `false`, so a rejected placement still explains why — with a single toast. The ghost still reddens on hover either way, so the player still gets immediate "can't drop here" feedback.

## Validation (windowed, edition 11 — the project gate)

- New scenario `tests/scenarios/sp/reinforcement_hover_no_toast_spam.json`: starts a Battlewagon Strategic-Reserves placement, hovers the board centre (>6″ from every edge = illegal) for >1s and asserts **zero** toasts accumulate (`ToastManager.active_toasts.size() == 0`); pre-fix that assertion sees **5** (the `MAX_TOASTS` pile). Then dispatches an actual placement at the same illegal spot and asserts exactly one toast appears — proving the click path still explains the rejection. Fails pre-fix, passes with the fix. Screenshots show the clean hover and the single click toast.
- Regressions green: `deep_strike_tight_formation`, `iss068_infiltrators_8in_11e`, `87_no_offboard_deploy`, `pad_reinforcement_formation_row`, `pad_reinforcement_undo`.

Version bumped to **0.92.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017NY6EkCeTxRugLwW5AMnoY

---
_Generated by [Claude Code](https://claude.ai/code/session_017NY6EkCeTxRugLwW5AMnoY)_