### PR TITLE
Add windowed test for Rapid Ingress formation placement guards

### DIFF
--- a/40k/tests/scenarios/sp/rapid_ingress_formation_guards.json
+++ b/40k/tests/scenarios/sp/rapid_ingress_formation_guards.json
@@ -1,0 +1,34 @@
+{
+  "id": "rapid_ingress_formation_guards",
+  "covers": [
+    "controller.reinforcement.rapid_ingress_formation",
+    "Main._begin_rapid_ingress_placement",
+    "DeploymentController.try_place_formation_at"
+  ],
+  "fixture": "ri_pretrigger",
+  "rng_seed": 42,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "Verifies the Deep Strike formation fixes apply to the Rapid Ingress entry point (a different Main.gd function than normal reserves arrival, but the same is_reinforcement_mode + try_place_formation_at path). Drives _begin_rapid_ingress_placement for U_BOYZ_F (deep_strike), arms TIGHT, and checks: (a) a formation at no-man's-land centre places (reinforcement-zone fix from PR #718), and (b) a formation whose left base overhangs the board edge is rejected (off-board guard from this branch).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+    { "act": "execute_script", "multiline": true, "script": "GameState.state.units.U_BOYZ_F.reserve_type = \"deep_strike\"\nreturn GameState.state.units.U_BOYZ_F.reserve_type", "equals": "deep_strike" },
+
+    { "act": "execute_script", "multiline": true, "script": "var m = tree.current_scene\nm._begin_rapid_ingress_placement(\"U_BOYZ_F\")\nreturn m.deployment_controller.is_reinforcement_mode and m.deployment_controller.is_placing()", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.deployment_controller.unit_id", "equals": "U_BOYZ_F" },
+
+    { "act": "execute_script", "script": "main.deployment_controller.set_formation_mode(\"TIGHT\")" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.deployment_controller.formation_mode", "equals": "TIGHT" },
+    { "act": "screenshot", "label": "01_rapid_ingress_tight_armed" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(880, 1200))\nreturn dc.get_placed_count()", "equals": 5 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "screenshot", "label": "02_rapid_ingress_formation_placed" },
+
+    { "act": "execute_script", "multiline": true, "script": "var dc = tree.current_scene.deployment_controller\ndc.try_place_formation_at(Vector2(115, 900))\nreturn dc.get_placed_count()", "equals": 5 },
+    { "act": "screenshot", "label": "03_rapid_ingress_off_board_rejected" }
+  ]
+}


### PR DESCRIPTION
## Summary

Test-only follow-up to #718 and #734. Rapid Ingress (and Kunnin' Infiltrator) placement runs through a **different** `Main.gd` entry point (`_begin_rapid_ingress_placement`) than a normal reserves arrival, but it sets the same `is_reinforcement_mode` flag and reuses `DeploymentController.try_place_formation_at`. So the two Deep Strike formation fixes — the reinforcement-zone validation (#718) and the off-board base guard (#734) — apply to it automatically.

This scenario locks that in so a future refactor of the Rapid Ingress entry point can't silently regress formation placement:
- Drives `_begin_rapid_ingress_placement` for a `deep_strike` unit and confirms it enters reinforcement placement.
- Arms TIGHT formation.
- Asserts a centre-of-board formation **places** (5 models) — the #718 fix.
- Asserts a formation whose left base overhangs the board edge is **rejected** (stays 5) — the #734 fix.

No production code changes; pure test addition (no version bump).

## Verification

Ran live: 15/15 assertions pass (`get_placed_count()` = 5 for the valid drop, stays 5 for the off-board drop), screenshot confirms "Models: 5/20" placed via the Rapid Ingress path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au

---
_Generated by [Claude Code](https://claude.ai/code/session_01YW1GaTwYsrkvRaPGwS48au)_