### PR TITLE
fix(command): render Battle-shock UI when the Command phase is active (audit P0 #1)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.8",
+			"date": "2026-07-22",
+			"summary": "Fixed: the Command phase Battle-shock controls now actually appear. When one of your units is below (or at) half-strength, the right-hand Command panel shows a 'Roll Battle-shock: <unit>' button (and the 'Insane Bravery' stratagem button when available) so you can take the test yourself — previously this whole section silently never rendered and the test was only ever auto-resolved.",
+			"changes": [
+				"Command phase: the Battle-shock section (Roll Battle-shock buttons + Insane Bravery) now renders for the human player. It was only built once during startup before the phase was attached, so it always early-returned and never showed; it is now (re)built when the Command phase becomes active and refreshes as tests are taken."
+			]
+		},
+		{
 			"version": "0.92.7",
 			"date": "2026-07-22",
 			"summary": "Placing a unit from reserves (Deep Strike / Strategic Reserves / Rapid Ingress) no longer spams a stack of red 'must be within 6\" of a board edge' warnings while you move the cursor over an illegal spot. The ghost still turns red to show you can't drop there, and clicking to place still tells you exactly why — but simply hovering is now quiet.",

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -949,6 +949,29 @@ func _refresh_ui() -> void:
 			if p2_label:
 				p2_label.text = "Player 2 (%s): %d CP" % [GameState.get_faction_name(2), p2_cp]
 
+		# Rebuild the battle-shock section. BUG FIX: it was only ever built from
+		# _setup_right_panel() during _ready(), when current_phase is still null —
+		# so _setup_battle_shock_section() early-returned and the "Roll Battle-shock"
+		# / "Insane Bravery" buttons never rendered for a human. set_phase() (which
+		# sets current_phase) calls _refresh_ui(), so rebuilding here makes the
+		# section appear once the phase is attached, and refresh as tests resolve.
+		# Placed before the faction rebuild so the sequential appends land in the
+		# intended order (objectives → battle-shock → faction → secondary).
+		var old_shock_section = command_panel.get_node_or_null("BattleShockSection")
+		if old_shock_section:
+			var bs_idx = old_shock_section.get_index()
+			if bs_idx > 0:
+				var bs_prev = command_panel.get_child(bs_idx - 1)
+				# The separator before the section is a gold ColorRect (see
+				# _add_command_gold_separator), not an HSeparator — check both so it
+				# doesn't leak a 2px line on every refresh.
+				if bs_prev is HSeparator or bs_prev is ColorRect:
+					command_panel.remove_child(bs_prev)
+					bs_prev.queue_free()
+			command_panel.remove_child(old_shock_section)
+			old_shock_section.queue_free()
+		_setup_battle_shock_section(command_panel)
+
 		# Rebuild the faction abilities section to reflect Oath of Moment / Waaagh! changes
 		var old_faction_section = command_panel.get_node_or_null("FactionAbilitiesSection")
 		if old_faction_section:

--- a/40k/tests/scenarios/sp/command_battleshock_ui_renders.json
+++ b/40k/tests/scenarios/sp/command_battleshock_ui_renders.json
@@ -1,0 +1,62 @@
+{
+  "id": "command_battleshock_ui_renders",
+  "covers": [
+    "scripts.CommandController.battle_shock_ui",
+    "audit_P0.command_battleshock_render"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 6,
+  "disable_ai": true,
+  "description": "AUDIT P0: the Command-phase Battle-shock UI (Roll Battle-shock button) must actually RENDER for a human. Regression net for the fix where _setup_battle_shock_section early-returned during _ready (current_phase null) and was never rebuilt, so the button never appeared. U_KOMMANDOS_H starts at exactly half-strength (11e battle-shock trigger); after it is queued, the CommandController must show a BattleShockSection with a 'Roll Battle-shock' button.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 6 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    {
+      "act": "execute_script",
+      "script": "GameState.state[\"units\"][\"U_KOMMANDOS_H\"][\"flags\"].merge({\"battle_shocked\": false}, true)"
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.set_edition(11)",
+      "equals": 11
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.get_current_phase_instance()._identify_units_needing_tests()"
+    },
+    {
+      "act": "execute_script",
+      "script": "\"U_KOMMANDOS_H\" in PhaseManager.get_current_phase_instance()._units_needing_test",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var acts = PhaseManager.get_current_phase_instance().get_available_actions()\nvar found = false\nfor a in acts:\n\tif a.get(\"type\", \"\") == \"BATTLE_SHOCK_TEST\" and a.get(\"unit_id\", \"\") == \"U_KOMMANDOS_H\":\n\t\tfound = true\nreturn found",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var cc = tree.current_scene.get_node_or_null(\"CommandController\")\nif cc == null:\n\treturn \"NO_CONTROLLER\"\ncc._refresh_ui()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 4 },
+    {
+      "act": "execute_script",
+      "script": "var panel = SceneRefs.main_path(\"HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nif panel == null:\n\treturn \"NO_PANEL\"\nvar sec = panel.get_node_or_null(\"BattleShockSection\")\nreturn sec != null and sec.is_visible_in_tree()",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var panel = SceneRefs.main_path(\"HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nvar sec = panel.get_node_or_null(\"BattleShockSection\") if panel else null\nif sec == null:\n\treturn \"NO_SECTION\"\nvar btns = sec.find_children(\"*\", \"Button\", true, false)\nvar found = false\nfor b in btns:\n\tif String(b.text).contains(\"Battle-shock\"):\n\t\tfound = true\nreturn found",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "battleshock_section_rendered" }
+  ]
+}


### PR DESCRIPTION
## Summary

First fix from the controller audit (P0 #1). The Command-phase **Battle-shock UI never rendered** for a human player: `_setup_battle_shock_section()` early-returns when `current_phase` is null, and it was only ever called from `_setup_right_panel()` during `_ready()` — which runs *before* `set_phase()` attaches the phase. So the "Roll Battle-shock" / "Insane Bravery" buttons were never built, and battle-shock tests were only ever auto-resolved at phase end.

## Fix

Rebuild the section in `_refresh_ui()` (called from `set_phase()` once the phase is attached, and on every refresh), mirroring how the faction-abilities and secondary-mission sections are already rebuilt there. It's placed before the faction rebuild so the sequential appends land in the intended panel order, and the preceding gold `ColorRect` separator is removed on rebuild so it doesn't leak a line each refresh.

## Validation

New windowed scenario `command_battleshock_ui_renders.json` loads a below-half unit into the live Command phase and asserts, against the running UI, that:
- `get_available_actions()` yields a `BATTLE_SHOCK_TEST` for the unit (state → action bridge),
- the `BattleShockSection` node exists and `is_visible_in_tree()`,
- it contains a **"Roll Battle-shock" button** — the exact control that was missing.

Result: **13/13 pass.** Existing Command-phase scenarios (`iss065_at_half_battleshock_11e`, `382_cp_grant_both_players`) still pass — no regression.

Player-facing, so `version_history.json` is bumped to 0.92.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_