### PR TITLE
fix(fight): human UI for Blade Champion Moment Shackle (audit P0 #2)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.9",
+			"date": "2026-07-22",
+			"summary": "Fixed: a Custodes Blade Champion's Moment Shackle is now playable by a human. At the start of the Fight phase you get a dialog to choose the effect (Watcher's Axe — 12 Attacks, or a 2+ invulnerable save) or Decline — previously the phase waited for a choice that only the AI could make, so a human Custodes player was stuck.",
+			"changes": [
+				"Fight phase: added the Moment Shackle choice dialog for the human player. When your Blade Champion is eligible, the choice is offered at the start of the Fight phase (before piling in); picking an effect or declining then continues into the Pile In step as normal. The AI continues to resolve it automatically."
+			]
+		},
+		{
 			"version": "0.92.8",
 			"date": "2026-07-22",
 			"summary": "Fixed: the Command phase Battle-shock controls now actually appear. When one of your units is below (or at) half-strength, the right-hand Command panel shows a 'Roll Battle-shock: <unit>' button (and the 'Insane Bravery' stratagem button when available) so you can take the test yourself — previously this whole section silently never rendered and the test was only ever auto-resolved.",

--- a/40k/dialogs/MomentShackleDialog.gd
+++ b/40k/dialogs/MomentShackleDialog.gd
@@ -1,0 +1,138 @@
+extends AcceptDialog
+
+# MomentShackleDialog - UI for the Blade Champion's Moment Shackle choice at the
+# start of the Fight phase.
+#
+# MOMENT SHACKLE (Adeptus Custodes — Blade Champion datasheet ability)
+# WHEN: Start of the Fight phase, before any unit fights (once per battle).
+# EFFECT: Select one:
+#   - Watcher's Axe gains +X Attacks (modelled as flags.moment_shackle_attacks_12)
+#   - The bearer's unit gains a 2+ invulnerable save this phase
+# Declining spends nothing.
+#
+# Before this dialog existed the choice was reachable only by the AI (via
+# get_available_actions()), and the phase blocked on USE/DECLINE_MOMENT_SHACKLE
+# — so a human Custodes player was soft-locked. This dialog is the missing UI.
+
+signal moment_shackle_chosen(unit_id: String, choice: String, player: int)
+
+var unit_id: String = ""
+var player: int = 0
+var unit_name: String = ""
+
+func setup(p_unit_id: String, p_player: int) -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	unit_id = p_unit_id
+	player = p_player
+
+	var unit = GameState.get_unit(unit_id)
+	var _msd_meta = unit.get("meta", {})
+	unit_name = _msd_meta.get("display_name", _msd_meta.get("name", unit_id))
+
+	title = "Moment Shackle — %s" % unit_name
+	min_size = DialogConstants.MEDIUM
+
+	# Custom buttons only — hide the default OK.
+	get_ok_button().visible = false
+
+	_build_ui()
+
+func _build_ui() -> void:
+	var main_container = VBoxContainer.new()
+	main_container.name = "Content"
+	main_container.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "MOMENT SHACKLE"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", Color.GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(header)
+
+	var subheader = Label.new()
+	subheader.text = "Adeptus Custodes — Blade Champion (once per battle)"
+	subheader.add_theme_font_size_override("font_size", 12)
+	subheader.add_theme_color_override("font_color", Color.GRAY)
+	subheader.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(subheader)
+
+	main_container.add_child(HSeparator.new())
+
+	var unit_label = Label.new()
+	unit_label.text = "%s — choose a Moment Shackle effect for this Fight phase:" % unit_name
+	unit_label.add_theme_font_size_override("font_size", 14)
+	unit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	unit_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	main_container.add_child(unit_label)
+
+	main_container.add_child(HSeparator.new())
+
+	var button_container = VBoxContainer.new()
+	button_container.name = "Buttons"
+
+	# Attacks button
+	var attacks_button = Button.new()
+	attacks_button.name = "AttacksButton"
+	attacks_button.text = "Watcher's Axe — 12 Attacks"
+	attacks_button.custom_minimum_size = Vector2(400, 50)
+	attacks_button.pressed.connect(_on_attacks_pressed)
+	button_container.add_child(attacks_button)
+
+	var attacks_desc = Label.new()
+	attacks_desc.text = "The bearer's Watcher's Axe makes a fixed 12 Attacks this phase."
+	attacks_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	attacks_desc.add_theme_font_size_override("font_size", 11)
+	attacks_desc.add_theme_color_override("font_color", Color.LIGHT_GRAY)
+	button_container.add_child(attacks_desc)
+
+	var spacer = Control.new()
+	spacer.custom_minimum_size = Vector2(0, 10)
+	button_container.add_child(spacer)
+
+	# Invuln button
+	var invuln_button = Button.new()
+	invuln_button.name = "InvulnButton"
+	invuln_button.text = "2+ Invulnerable Save"
+	invuln_button.custom_minimum_size = Vector2(400, 50)
+	invuln_button.pressed.connect(_on_invuln_pressed)
+	button_container.add_child(invuln_button)
+
+	var invuln_desc = Label.new()
+	invuln_desc.text = "The bearer's unit has a 2+ invulnerable save this phase."
+	invuln_desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	invuln_desc.add_theme_font_size_override("font_size", 11)
+	invuln_desc.add_theme_color_override("font_color", Color.LIGHT_GRAY)
+	button_container.add_child(invuln_desc)
+
+	var spacer2 = Control.new()
+	spacer2.custom_minimum_size = Vector2(0, 10)
+	button_container.add_child(spacer2)
+
+	# Decline button
+	var decline_button = Button.new()
+	decline_button.name = "DeclineButton"
+	decline_button.text = "Decline"
+	decline_button.custom_minimum_size = Vector2(400, 36)
+	decline_button.pressed.connect(_on_decline_pressed)
+	button_container.add_child(decline_button)
+
+	main_container.add_child(button_container)
+	add_child(main_container)
+
+func _on_attacks_pressed() -> void:
+	print("MomentShackleDialog: Player %d — %s chooses 12 Attacks" % [player, unit_name])
+	emit_signal("moment_shackle_chosen", unit_id, "attacks_12", player)
+	hide()
+	queue_free()
+
+func _on_invuln_pressed() -> void:
+	print("MomentShackleDialog: Player %d — %s chooses 2+ invuln" % [player, unit_name])
+	emit_signal("moment_shackle_chosen", unit_id, "invuln_2", player)
+	hide()
+	queue_free()
+
+func _on_decline_pressed() -> void:
+	print("MomentShackleDialog: Player %d — %s declines Moment Shackle" % [player, unit_name])
+	emit_signal("moment_shackle_chosen", unit_id, "decline", player)
+	hide()
+	queue_free()

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -33,6 +33,7 @@ signal subphase_transition(from_subphase: String, to_subphase: String)
 signal epic_challenge_opportunity(unit_id: String, player: int)
 signal counter_offensive_opportunity(player: int, eligible_units: Array)
 signal katah_stance_required(unit_id: String, player: int)
+signal moment_shackle_required(unit_id: String, player: int)  # Blade Champion Moment Shackle choice at start of Fight phase (human UI)
 signal dread_foe_resolved(unit_id: String, result: Dictionary)  # P1-17: Dread Foe mortal wounds result
 signal saves_required(save_data_list: Array)  # P0-58: Interactive wound allocation for defender
 signal sweeping_advance_available(unit_id: String, player: int, in_engagement: bool, move_distance: float)  # Sweeping Advance opportunity
@@ -268,10 +269,30 @@ func _initialize_fight_sequence() -> void:
 	emit_signal("fight_order_determined", combatants)
 	emit_signal("fight_sequence_updated", combatants)
 
+	# 11e: the Blade Champion's Moment Shackle is chosen at the START of the
+	# Fight phase, before any unit fights. Offer it first (gating the opening
+	# Pile In step); once every pending choice is resolved the pile-in begins.
+	# The AI resolves it via get_available_actions(); a human needs the dialog
+	# that moment_shackle_required drives — without this the phase soft-locked.
+	if _maybe_offer_moment_shackle():
+		return
+
 	# 11e 12.02: the fight phase OPENS with the global Pile In step — both
 	# players pile in their eligible units (active player first) before any
 	# unit is selected to fight.
 	_begin_pile_in_step_11e()
+
+# Offer the next pending Moment Shackle choice to the active player. Returns
+# true if a choice is now outstanding (caller must NOT proceed to pile-in yet),
+# false when there is nothing pending. Emits moment_shackle_required so the
+# human dialog appears; the AI reads the same choice from get_available_actions.
+func _maybe_offer_moment_shackle() -> bool:
+	if _moment_shackle_pending_units.is_empty():
+		return false
+	var uid = _moment_shackle_pending_units[0]
+	log_phase_message("MOMENT SHACKLE: offering choice for %s (player %d)" % [uid, get_current_player()])
+	emit_signal("moment_shackle_required", uid, get_current_player())
+	return true
 
 func _check_for_combats() -> void:
 	var combatants = _combatants_11e()
@@ -5232,6 +5253,11 @@ func _process_use_moment_shackle(action: Dictionary) -> Dictionary:
 		log_phase_message("Moment Shackle: %s — 2+ invulnerable save this phase" % unit_name)
 		DebugLogger.info("[10][INFO] Moment Shackle: %s chose 2+ invulnerable save" % unit_name)
 
+	# Offer the next pending Moment Shackle choice, or open the Pile In step now
+	# that every choice is resolved (mirrors the fight-start gate).
+	if not _maybe_offer_moment_shackle():
+		_begin_pile_in_step_11e()
+
 	return create_result(true, diffs)
 
 func _process_decline_moment_shackle(action: Dictionary) -> Dictionary:
@@ -5240,6 +5266,11 @@ func _process_decline_moment_shackle(action: Dictionary) -> Dictionary:
 	var unit = GameState.state.get("units", {}).get(unit_id, {})
 	var unit_name = unit.get("meta", {}).get("name", unit_id)
 	log_phase_message("Moment Shackle: %s declined" % unit_name)
+
+	# Offer the next pending choice, or open the Pile In step (see above).
+	if not _maybe_offer_moment_shackle():
+		_begin_pile_in_step_11e()
+
 	return create_result(true, [])
 
 

--- a/40k/scripts/FightController.gd
+++ b/40k/scripts/FightController.gd
@@ -624,6 +624,8 @@ func set_phase(phase: BasePhase) -> void:
 			phase.counter_offensive_opportunity.connect(_on_counter_offensive_opportunity)
 		if phase.has_signal("katah_stance_required") and not phase.katah_stance_required.is_connected(_on_katah_stance_required):
 			phase.katah_stance_required.connect(_on_katah_stance_required)
+		if phase.has_signal("moment_shackle_required") and not phase.moment_shackle_required.is_connected(_on_moment_shackle_required):
+			phase.moment_shackle_required.connect(_on_moment_shackle_required)
 		if phase.has_signal("dread_foe_resolved") and not phase.dread_foe_resolved.is_connected(_on_dread_foe_resolved):
 			phase.dread_foe_resolved.connect(_on_dread_foe_resolved)
 		# P0-58: Connect saves_required signal for interactive melee wound allocation
@@ -2074,6 +2076,56 @@ func _on_katah_stance_selected(unit_id: String, stance: String, player: int) -> 
 		else:
 			stance_display = "Rendax (Lethal Hits)"
 		dice_log_display.append_text("[color=gold]MARTIAL KA'TAH: %s assumes %s stance[/color]\n" % [unit_name, stance_display])
+
+func _on_moment_shackle_required(unit_id: String, player: int) -> void:
+	"""Show the Blade Champion's Moment Shackle choice at the start of the Fight
+	phase. AI resolves it via get_available_actions(), so this only drives the
+	human dialog (previously missing — the phase soft-locked a human here)."""
+	print("[FightController] Moment Shackle choice required for %s (player %d)" % [unit_id, player])
+
+	# AI player: it submits USE/DECLINE_MOMENT_SHACKLE from get_available_actions().
+	# Do not also pop a dialog (that would double-submit).
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(player):
+		print("[FightController] Moment Shackle belongs to AI player %d — no dialog" % player)
+		return
+
+	# Multiplayer: only the owning seat chooses.
+	if NetworkManager and NetworkManager.is_networked() \
+			and NetworkManager.get_local_player() != player:
+		print("[FightController] Moment Shackle is P%d's choice — local seat waits" % player)
+		return
+
+	var dialog_script = load("res://dialogs/MomentShackleDialog.gd")
+	if not dialog_script:
+		push_error("Failed to load MomentShackleDialog.gd")
+		return
+
+	var dialog = AcceptDialog.new()
+	dialog.set_script(dialog_script)
+	dialog.name = "MomentShackleDialog"
+	dialog.setup(unit_id, player)
+	dialog.moment_shackle_chosen.connect(_on_moment_shackle_chosen)
+	get_tree().root.add_child(dialog)
+	DialogUtils.popup_at_bottom(dialog)
+	print("[FightController] Moment Shackle dialog shown for %s" % unit_id)
+
+func _on_moment_shackle_chosen(unit_id: String, choice: String, player: int) -> void:
+	"""Dispatch the Moment Shackle decision from the dialog."""
+	print("[FightController] Moment Shackle chosen: %s for %s" % [choice, unit_id])
+	if choice == "decline":
+		emit_signal("fight_action_requested", {
+			"type": "DECLINE_MOMENT_SHACKLE",
+			"unit_id": unit_id,
+			"player": player
+		})
+	else:
+		emit_signal("fight_action_requested", {
+			"type": "USE_MOMENT_SHACKLE",
+			"unit_id": unit_id,
+			"choice": choice,
+			"player": player
+		})
 
 func _on_dread_foe_resolved(unit_id: String, result: Dictionary) -> void:
 	"""P1-17: Display Dread Foe mortal wounds result in dice log"""

--- a/40k/tests/scenarios/sp/fight_moment_shackle_ui.json
+++ b/40k/tests/scenarios/sp/fight_moment_shackle_ui.json
@@ -1,0 +1,65 @@
+{
+  "id": "fight_moment_shackle_ui",
+  "covers": [
+    "scripts.FightController.moment_shackle_ui",
+    "phases.FightPhase.moment_shackle",
+    "audit_P0.fight_moment_shackle"
+  ],
+  "fixture": "audit_fights_last",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "AUDIT P0: the Blade Champion's Moment Shackle choice must have a human UI. Regression net for the fix adding moment_shackle_required signal + MomentShackleDialog. The phase used to block on USE/DECLINE_MOMENT_SHACKLE with no signal and no controller dialog, so a human was soft-locked. Here the active player's unit is given the Moment Shackle ability and queued; the dialog must appear, and choosing an effect must resolve (flag set, pending cleared, dialog gone).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+    {
+      "act": "execute_script",
+      "script": "var u = GameState.state[\"units\"][\"U_BOYZ_FL\"]\nvar meta = u.get(\"meta\", {})\nvar abilities = meta.get(\"abilities\", [])\nabilities.append({\"name\": \"Moment Shackle\"})\nmeta[\"abilities\"] = abilities\nu[\"meta\"] = meta\nif not u.has(\"flags\"):\n\tu[\"flags\"] = {}\nu[\"flags\"][\"moment_shackle_used\"] = false\nvar fp = PhaseManager.get_current_phase_instance()\nfp._moment_shackle_pending_units = [\"U_BOYZ_FL\"]\nfp._maybe_offer_moment_shackle()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"MomentShackleDialog\")\nreturn d != null and d.visible",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"MomentShackleDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nvar btns = d.find_children(\"*\", \"Button\", true, false)\nvar has_attacks = false\nvar has_decline = false\nfor b in btns:\n\tvar t = String(b.text)\n\tif t.contains(\"12 Attacks\"):\n\t\thas_attacks = true\n\tif t.contains(\"Decline\"):\n\t\thas_decline = true\nreturn has_attacks and has_decline",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "moment_shackle_dialog_shown" },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"MomentShackleDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nd._on_attacks_pressed()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "return GameState.state[\"units\"][\"U_BOYZ_FL\"].get(\"flags\", {}).get(\"moment_shackle_used\", false)",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "return PhaseManager.get_current_phase_instance()._moment_shackle_pending_units.size()",
+      "multiline": true,
+      "equals": 0
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node_or_null(\"MomentShackleDialog\") == null",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "after_moment_shackle_resolved" }
+  ]
+}


### PR DESCRIPTION
## Summary

Second fix from the controller audit (P0 #2). The Custodes Blade Champion's **Moment Shackle** was reachable only by the AI: the Fight phase blocks on `USE`/`DECLINE_MOMENT_SHACKLE` (via a `get_available_actions()` short-circuit) but emitted no signal and the controller had no dialog — so a human Custodes player was **soft-locked** at the start of the Fight phase.

## Fix (mirrors the existing Ka'tah-stance flow)

- **FightPhase**: add a `moment_shackle_required` signal and `_maybe_offer_moment_shackle()`. The opening Pile-In step is now gated behind the choice; resolving it (use or decline) offers the next pending unit, then begins pile-in.
- **FightController**: connect the signal and show the dialog for the local human only — AI and remote seats skip it (they resolve via their own paths), so there's no double-submit.
- **New `MomentShackleDialog`** (modelled on `KatahStanceDialog`): three choices — *Watcher's Axe — 12 Attacks*, *2+ Invulnerable Save*, *Decline*.

## Validation

New windowed scenario `fight_moment_shackle_ui.json` queues a Moment Shackle unit in the live Fight phase and asserts, against the running UI:
- the `MomentShackleDialog` renders (visible) with the correct buttons,
- choosing "12 Attacks" resolves: `moment_shackle_used` flag set, pending list cleared, dialog freed.

Result: **14/14 pass**, with a screenshot of the rendered dialog. Fight-phase regression set (including both pile-in scenarios) still green.

Player-facing, so `version_history.json` → 0.92.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_