### PR TITLE
fix(shooting): human UI for Distraction Grot reactive save (audit P0 #3)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.10",
+			"date": "2026-07-22",
+			"summary": "Fixed: when your Orks are shot at, you can now choose to use Distraction Grot for a 5+ invulnerable save. A dialog appears asking whether to activate it — previously only the AI could make this choice, so if you were the human defender the game paused with no way to respond.",
+			"changes": [
+				"Shooting phase: added the Distraction Grot prompt for a human defender. When one of your eligible units is targeted, you get an Activate / Decline dialog for the 5+ invulnerable save; choosing either continues shooting resolution as normal. The AI still resolves its own defenders automatically."
+			]
+		},
+		{
 			"version": "0.92.9",
 			"date": "2026-07-22",
 			"summary": "Fixed: a Custodes Blade Champion's Moment Shackle is now playable by a human. At the start of the Fight phase you get a dialog to choose the effect (Watcher's Axe — 12 Attacks, or a 2+ invulnerable save) or Decline — previously the phase waited for a choice that only the AI could make, so a human Custodes player was stuck.",

--- a/40k/dialogs/DistractionGrotDialog.gd
+++ b/40k/dialogs/DistractionGrotDialog.gd
@@ -1,0 +1,114 @@
+extends AcceptDialog
+
+# DistractionGrotDialog - UI for the Orks' Distraction Grot reactive save.
+#
+# DISTRACTION GROT (Orks — free reactive, once per battle)
+# WHEN: Shooting phase, after a unit with a Grot Oiler / Distraction Grots is
+#       selected as the target of an attack.
+# EFFECT: Until the end of the phase, models in the target unit have a 5+
+#         invulnerable save against the shooting.
+#
+# Before this dialog existed the choice was reachable only by the AI (via
+# AIPlayer). When a human was the DEFENDER, ShootingPhase emitted
+# distraction_grot_available but the ShootingController never listened — so the
+# phase paused awaiting USE/DECLINE_DISTRACTION_GROT with no way for the human
+# to respond (soft-lock). This dialog is the missing UI.
+
+signal distraction_grot_chosen(unit_id: String, use_ability: bool)
+
+var unit_id: String = ""
+var player: int = 0
+var unit_name: String = ""
+
+func setup(p_unit_id: String, p_player: int) -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	unit_id = p_unit_id
+	player = p_player
+
+	var unit = GameState.get_unit(unit_id)
+	var _dgd_meta = unit.get("meta", {})
+	unit_name = _dgd_meta.get("display_name", _dgd_meta.get("name", unit_id))
+
+	title = "Distraction Grot — %s" % unit_name
+	min_size = DialogConstants.SMALL
+
+	# Custom buttons only — hide the default OK.
+	get_ok_button().visible = false
+
+	_build_ui()
+
+func _build_ui() -> void:
+	var main_container = VBoxContainer.new()
+	main_container.custom_minimum_size = Vector2(DialogConstants.SMALL.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "DISTRACTION GROT"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", Color.GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(header)
+
+	var subheader = Label.new()
+	subheader.text = "Orks — free reactive (once per battle)"
+	subheader.add_theme_font_size_override("font_size", 12)
+	subheader.add_theme_color_override("font_color", Color.GRAY)
+	subheader.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(subheader)
+
+	main_container.add_child(HSeparator.new())
+
+	var desc_label = Label.new()
+	desc_label.text = "Until the end of the phase, this unit has a 5+ invulnerable save against the incoming shooting."
+	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc_label.add_theme_font_size_override("font_size", 13)
+	desc_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(desc_label)
+
+	var spacer = Control.new()
+	spacer.custom_minimum_size = Vector2(0, 10)
+	main_container.add_child(spacer)
+
+	var unit_label = Label.new()
+	unit_label.text = "%s is being shot at. Activate Distraction Grot for a 5+ invulnerable save?" % unit_name
+	unit_label.add_theme_font_size_override("font_size", 14)
+	unit_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	unit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(unit_label)
+
+	main_container.add_child(HSeparator.new())
+
+	var button_container = HBoxContainer.new()
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
+
+	var use_button = Button.new()
+	use_button.name = "UseButton"
+	use_button.text = "Activate Distraction Grot"
+	use_button.custom_minimum_size = Vector2(220, 50)
+	use_button.pressed.connect(_on_use_pressed)
+	button_container.add_child(use_button)
+
+	var btn_spacer = Control.new()
+	btn_spacer.custom_minimum_size = Vector2(20, 0)
+	button_container.add_child(btn_spacer)
+
+	var decline_button = Button.new()
+	decline_button.name = "DeclineButton"
+	decline_button.text = "Decline"
+	decline_button.custom_minimum_size = Vector2(150, 50)
+	decline_button.pressed.connect(_on_decline_pressed)
+	button_container.add_child(decline_button)
+
+	main_container.add_child(button_container)
+	add_child(main_container)
+
+func _on_use_pressed() -> void:
+	print("DistractionGrotDialog: Player %d activates Distraction Grot for %s" % [player, unit_name])
+	emit_signal("distraction_grot_chosen", unit_id, true)
+	hide()
+	queue_free()
+
+func _on_decline_pressed() -> void:
+	print("DistractionGrotDialog: Player %d declines Distraction Grot for %s" % [player, unit_name])
+	emit_signal("distraction_grot_chosen", unit_id, false)
+	hide()
+	queue_free()

--- a/40k/dialogs/DistractionGrotDialog.gd.uid
+++ b/40k/dialogs/DistractionGrotDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://d0m87l88oeeon

--- a/40k/dialogs/MomentShackleDialog.gd.uid
+++ b/40k/dialogs/MomentShackleDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://dq0a2epmn0pq6

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -831,6 +831,7 @@ func phase_signal_map() -> Dictionary:
 		"ai_shooting_visual": _on_ai_shooting_visual,  # T7-38
 		"sentinel_storm_available": _on_sentinel_storm_available,  # P1-10
 		"throat_slittas_available": _on_throat_slittas_available,  # P1-12
+		"distraction_grot_available": _on_distraction_grot_available,  # audit P0: human defender UI
 	}
 
 func set_phase(phase: BasePhase) -> void:
@@ -3699,6 +3700,53 @@ func _on_sentinel_storm_chosen(unit_id: String, use_ability: bool) -> void:
 		active_shooter_id = ""
 		weapon_assignments.clear()
 		_clear_visuals()
+
+# ============================================================================
+# AUDIT P0: DISTRACTION GROT — DEFENDER'S 5+ INVULN REACTIVE
+# ============================================================================
+
+func _on_distraction_grot_available(unit_id: String, player: int) -> void:
+	"""Show the Distraction Grot prompt to a HUMAN defender. The phase pauses
+	awaiting USE/DECLINE_DISTRACTION_GROT; previously the controller ignored the
+	signal, so a human defender was soft-locked. AIPlayer resolves the AI
+	defender (its own is_ai_player guard), so skip AI here to avoid a
+	double-submit."""
+	print("[ShootingController] Distraction Grot available for %s (defending player %d)" % [unit_id, player])
+
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(player):
+		print("[ShootingController] Distraction Grot belongs to AI player %d — AIPlayer handles it" % player)
+		return
+
+	# Multiplayer: only the defending seat chooses.
+	if NetworkManager and NetworkManager.is_networked() \
+			and NetworkManager.get_local_player() != player:
+		print("[ShootingController] Distraction Grot is P%d's choice — local seat waits" % player)
+		return
+
+	var dialog = preload("res://dialogs/DistractionGrotDialog.gd").new()
+	dialog.name = "DistractionGrotDialog"
+	dialog.setup(unit_id, player)
+	dialog.distraction_grot_chosen.connect(_on_distraction_grot_chosen)
+	get_tree().root.add_child(dialog)
+	DialogUtils.popup_at_bottom(dialog)
+
+func _on_distraction_grot_chosen(unit_id: String, use_ability: bool) -> void:
+	"""Dispatch the defender's Distraction Grot decision."""
+	if use_ability:
+		print("[ShootingController] Player activates Distraction Grot for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "USE_DISTRACTION_GROT",
+			"actor_unit_id": unit_id
+		})
+		if dice_log_display:
+			dice_log_display.append_text("[b][color=gold]DISTRACTION GROT! 5+ invulnerable save.[/color][/b]\n")
+	else:
+		print("[ShootingController] Player declines Distraction Grot for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "DECLINE_DISTRACTION_GROT",
+			"actor_unit_id": unit_id
+		})
 
 # ============================================================================
 # P1-12: THROAT SLITTAS — MORTAL WOUNDS PROMPT

--- a/40k/tests/scenarios/sp/shooting_distraction_grot_ui.json
+++ b/40k/tests/scenarios/sp/shooting_distraction_grot_ui.json
@@ -1,0 +1,58 @@
+{
+  "id": "shooting_distraction_grot_ui",
+  "covers": [
+    "scripts.ShootingController.distraction_grot_ui",
+    "phases.ShootingPhase.distraction_grot",
+    "audit_P0.shooting_distraction_grot"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "AUDIT P0: the Orks' Distraction Grot reactive must have a human-defender UI. The phase emits distraction_grot_available and pauses awaiting USE/DECLINE, but the ShootingController never listened, so a human defender was soft-locked. Here the prompt is raised for a human-owned Ork unit; the dialog must appear with Activate/Decline, and Decline must clear the pending state (unblocking the phase).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nfp.awaiting_distraction_grot = true\nfp.distraction_grot_pending_unit = \"U_BOYZ_E\"\nfp.resolution_state = {\"phase\": \"awaiting_distraction_grot\", \"assignments\": []}\nfp.emit_signal(\"distraction_grot_available\", \"U_BOYZ_E\", 2)\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"DistractionGrotDialog\")\nreturn d != null and d.visible",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"DistractionGrotDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nvar btns = d.find_children(\"*\", \"Button\", true, false)\nvar has_use = false\nvar has_decline = false\nfor b in btns:\n\tvar t = String(b.text)\n\tif t.contains(\"Distraction Grot\"):\n\t\thas_use = true\n\tif t.contains(\"Decline\"):\n\t\thas_decline = true\nreturn has_use and has_decline",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "distraction_grot_dialog_shown" },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"DistractionGrotDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nd._on_decline_pressed()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "return PhaseManager.get_current_phase_instance().awaiting_distraction_grot",
+      "multiline": true,
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node_or_null(\"DistractionGrotDialog\") == null",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "after_distraction_grot_declined" }
+  ]
+}


### PR DESCRIPTION
## Summary

Third fix from the controller audit (P0 #3). `ShootingPhase` emits `distraction_grot_available` and pauses awaiting `USE`/`DECLINE_DISTRACTION_GROT`, but the `ShootingController` never listened for it. `AIPlayer` only handles AI defenders (guarded by `is_ai_player`), so when a **human was the defender** the phase soft-locked — no prompt, no way to respond.

## Fix (mirrors Sentinel Storm)

- **ShootingController**: add `distraction_grot_available` to `phase_signal_map` and handle it — show the dialog to the local human defender, skipping AI defenders (AIPlayer resolves those) and non-owning multiplayer seats, so there's no double-submit. Dispatch `USE`/`DECLINE_DISTRACTION_GROT` with `actor_unit_id`.
- **New `DistractionGrotDialog`** (modelled on `SentinelStormDialog`): Activate / Decline for the 5+ invulnerable save.
- Also commits `MomentShackleDialog.gd.uid` (companion of the P0 #2 dialog, missed in that PR — this repo tracks dialog `.uid` files).

## Validation

New windowed scenario `shooting_distraction_grot_ui.json` raises the prompt for a human-owned Ork unit in the live Shooting phase and asserts:
- the `DistractionGrotDialog` renders (visible) with Activate/Decline,
- declining clears `awaiting_distraction_grot`, unblocking the phase.

Result: **12/12 pass**, with a screenshot of the rendered dialog. The pre-existing failure in `374_panoptispex_ignores_cover` reproduces identically on clean `main`, so it is not a regression from this change.

Player-facing, so `version_history.json` → 0.92.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_