### PR TITLE
fix(redeploy): End Redeployment always valid — resolve soft-lock (audit P0 #4)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.11",
+			"date": "2026-07-22",
+			"summary": "Fixed: the pre-battle Redeployment step no longer gets stuck. If you have a unit with a redeployment ability, you can now always press End Redeployment to move on — redeployment is optional, so any units you don't redeploy just stay where they deployed. Previously the phase refused to end while a redeploy unit was unresolved, and there was no way to resolve it, so it could stall.",
+			"changes": [
+				"Redeployment phase: End Redeployment is now always allowed (redeployment is optional). Ending treats any still-pending redeploy units as declined — they keep their deployed positions. This clears a soft-lock for armies with a redeployment ability. (A dedicated UI to actually perform a redeploy move is a separate follow-up.)"
+			]
+		},
+		{
 			"version": "0.92.10",
 			"date": "2026-07-22",
 			"summary": "Fixed: when your Orks are shot at, you can now choose to use Distraction Grot for a 5+ invulnerable save. A dialog appears asking whether to activate it — previously only the AI could make this choice, so if you were the human defender the game paused with no way to respond.",

--- a/40k/phases/RedeploymentPhase.gd
+++ b/40k/phases/RedeploymentPhase.gd
@@ -254,14 +254,16 @@ func _validate_skip_redeploy(action: Dictionary) -> Dictionary:
 	return {"valid": true, "errors": []}
 
 func _validate_end_redeployment_phase(action: Dictionary) -> Dictionary:
-	# Can only end if no units remain pending for any player
-	var total_pending = 0
-	for player in redeploy_units_pending:
-		total_pending += redeploy_units_pending[player].size()
-
-	if total_pending > 0:
-		return {"valid": false, "errors": ["Redeploy units still pending: %d" % total_pending]}
-
+	# Redeployment is OPTIONAL (Core Rules: rules that ALLOW players to redeploy
+	# certain units). A player may always decline to redeploy any of their
+	# remaining eligible units, so ending the phase is always valid — units left
+	# pending simply stay where they were deployed.
+	#
+	# Previously this returned invalid while ANY unit was pending. Because the
+	# Redeployment phase has no human UI to resolve a redeploy unit, a human
+	# with a redeploy-capable unit could neither act nor end the phase — a
+	# soft-lock (audit P0). Ending now clears the pending list (see
+	# _process_end_redeployment_phase).
 	return {"valid": true, "errors": []}
 
 # ========================================
@@ -385,6 +387,15 @@ func _process_skip_redeploy(action: Dictionary) -> Dictionary:
 
 func _process_end_redeployment_phase(action: Dictionary) -> Dictionary:
 	log_phase_message("Redeployment phase ending")
+	# Any units still pending are treated as declining to redeploy — they keep
+	# their deployed positions. Clear the pending lists so downstream state is
+	# clean and no later check re-blocks on them.
+	for player in redeploy_units_pending:
+		for unit_id in redeploy_units_pending[player]:
+			if not redeploy_units_completed.has(unit_id):
+				redeploy_units_completed.append(unit_id)
+	redeploy_units_pending.clear()
+	active_redeploy.clear()
 	emit_signal("phase_completed")
 	return create_result(true, [])
 

--- a/40k/tests/scenarios/sp/redeployment_optional_end.json
+++ b/40k/tests/scenarios/sp/redeployment_optional_end.json
@@ -1,0 +1,54 @@
+{
+  "id": "redeployment_optional_end",
+  "covers": [
+    "phases.RedeploymentPhase.optional_end",
+    "audit_P0.redeployment_softlock"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "AUDIT P0: the Redeployment phase must never soft-lock a human. Redeployment is optional, so a player may decline to redeploy remaining units. A player-1 unit is given a redeploy ability and the phase entered so it does NOT auto-skip (pending > 0); END_REDEPLOYMENT_PHASE must now validate and complete (previously it was rejected while any unit was pending, with no UI to resolve them = soft-lock).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    {
+      "act": "execute_script",
+      "script": "var uid = \"\"\nfor id in GameState.state[\"units\"]:\n\tif GameState.state[\"units\"][id].get(\"owner\", 0) == 1:\n\t\tuid = id\n\t\tbreak\nif uid == \"\":\n\treturn \"NO_UNIT\"\nvar u = GameState.state[\"units\"][uid]\nvar meta = u.get(\"meta\", {})\nvar abilities = meta.get(\"abilities\", [])\nabilities.append({\"name\": \"Redeploy\"})\nmeta[\"abilities\"] = abilities\nu[\"meta\"] = meta\nGameState.set_active_player(1)\nPhaseManager.transition_to_phase(2)\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 6 },
+    {
+      "act": "execute_script",
+      "script": "return GameState.state[\"meta\"][\"phase\"]",
+      "multiline": true,
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nvar total = 0\nfor p in fp.redeploy_units_pending:\n\ttotal += fp.redeploy_units_pending[p].size()\nreturn total",
+      "multiline": true,
+      "expect_min": 1
+    },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nvar v = fp.validate_action({\"type\": \"END_REDEPLOYMENT_PHASE\", \"player\": 1})\nreturn v.get(\"valid\", false)",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "redeployment_pending_can_end" },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nvar r = fp.execute_action({\"type\": \"END_REDEPLOYMENT_PHASE\", \"player\": 1})\nreturn r.get(\"success\", false)",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 6 },
+    {
+      "act": "execute_script",
+      "script": "return GameState.state[\"meta\"][\"phase\"] != 2",
+      "multiline": true,
+      "equals": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fourth and final P0 from the controller audit. The Redeployment phase refused `END_REDEPLOYMENT_PHASE` while any unit was pending, but it has **no human UI** to resolve a redeploy unit — so a human whose army has a redeployment ability could neither act nor end the phase (**soft-lock**). (It auto-skips cleanly only when no unit has a redeploy ability.)

## Fix

Redeployment is **optional** by rule (Core Rules: rules that *allow* redeploying certain units), so ending is now always valid. Units left pending are treated as declined and keep their deployed positions; `_process_end_redeployment_phase` clears the pending lists on end. This reuses the existing generic **"End Redeployment"** button — no new UI.

This is a minimal-unblock fix: it removes the soft-lock. A dedicated UI to actually *perform* a redeploy move (drag models / send to reserves) is a separate follow-up feature, noted in the changelog.

## Validation

New windowed scenario `redeployment_optional_end.json` gives a player-1 unit a redeploy ability, enters the phase so it does **not** auto-skip (pending > 0), and asserts against the running game that `END_REDEPLOYMENT_PHASE` now validates, completes, and advances the phase. Result: **10/10 pass**.

Player-facing, so `version_history.json` → 0.92.11.

---

This completes the **P0 tier** (player-gets-stuck bugs): #1 battle-shock UI (#742), #2 Moment Shackle (#745), #3 Distraction Grot (#746), #4 redeployment (this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_