### PR TITLE
feat(movement): human UI for Orks Bomb Squigs reactive (audit P1)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.12",
+			"date": "2026-07-22",
+			"summary": "Orks can now use Bomb Squigs by hand. After an eligible unit makes a Normal move, a dialog lets you pick which enemy unit takes D3 mortal wounds (or Decline) — previously only the AI could trigger this, so a human player never got the option.",
+			"changes": [
+				"Movement phase: added the Bomb Squigs prompt for a human player. When one of your units makes a Normal move and has the ability, you get a dialog with a button per eligible enemy target (and Decline). The MovementPhase already offered this to the AI only; the MovementController now listens for it too."
+			]
+		},
+		{
 			"version": "0.92.11",
 			"date": "2026-07-22",
 			"summary": "Fixed: the pre-battle Redeployment step no longer gets stuck. If you have a unit with a redeployment ability, you can now always press End Redeployment to move on — redeployment is optional, so any units you don't redeploy just stay where they deployed. Previously the phase refused to end while a redeploy unit was unresolved, and there was no way to resolve it, so it could stall.",

--- a/40k/dialogs/BombSquigsDialog.gd
+++ b/40k/dialogs/BombSquigsDialog.gd
@@ -1,0 +1,110 @@
+extends AcceptDialog
+
+# BombSquigsDialog - UI for the Orks' Bomb Squigs reactive ability.
+#
+# BOMB SQUIGS (Orks — free, once per battle)
+# WHEN: Movement phase, after a unit with Bomb Squigs makes a Normal move.
+# EFFECT: Select one eligible enemy unit; it suffers D3 mortal wounds.
+#
+# Before this dialog existed the choice was reachable only by the AI (AIPlayer).
+# A human player got no prompt — the phase set _bomb_squigs_pending_unit and
+# emitted bomb_squigs_available, but the MovementController never listened, so
+# the ability was unusable by a human (audit P1). This dialog is the missing UI.
+
+signal bomb_squigs_chosen(actor_unit_id: String, target_unit_id: String, use_ability: bool)
+
+var actor_unit_id: String = ""
+var player: int = 0
+var actor_name: String = ""
+var eligible_targets: Array = []
+
+func setup(p_actor_unit_id: String, p_player: int, p_targets: Array) -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	actor_unit_id = p_actor_unit_id
+	player = p_player
+	eligible_targets = p_targets
+
+	var unit = GameState.get_unit(actor_unit_id)
+	var _bsd_meta = unit.get("meta", {})
+	actor_name = _bsd_meta.get("display_name", _bsd_meta.get("name", actor_unit_id))
+
+	title = "Bomb Squigs — %s" % actor_name
+	min_size = DialogConstants.MEDIUM
+
+	get_ok_button().visible = false
+	_build_ui()
+
+func _build_ui() -> void:
+	var main_container = VBoxContainer.new()
+	main_container.name = "Content"
+	main_container.custom_minimum_size = Vector2(DialogConstants.MEDIUM.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "BOMB SQUIGS"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", Color.GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(header)
+
+	var subheader = Label.new()
+	subheader.text = "Orks — free (once per battle)"
+	subheader.add_theme_font_size_override("font_size", 12)
+	subheader.add_theme_color_override("font_color", Color.GRAY)
+	subheader.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(subheader)
+
+	main_container.add_child(HSeparator.new())
+
+	var prompt = Label.new()
+	prompt.text = "%s can loose its Bomb Squigs — pick an enemy unit to suffer D3 mortal wounds:" % actor_name
+	prompt.add_theme_font_size_override("font_size", 14)
+	prompt.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	prompt.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(prompt)
+
+	main_container.add_child(HSeparator.new())
+
+	var button_container = VBoxContainer.new()
+	button_container.name = "Buttons"
+
+	for t in eligible_targets:
+		var tid := ""
+		if t is Dictionary:
+			tid = t.get("target_unit_id", "")
+		else:
+			tid = str(t)
+		if tid == "":
+			continue
+		var tunit = GameState.get_unit(tid)
+		var tname = tunit.get("meta", {}).get("display_name", tunit.get("meta", {}).get("name", tid))
+		var tbtn = Button.new()
+		tbtn.text = "Bomb Squigs → %s" % tname
+		tbtn.custom_minimum_size = Vector2(400, 44)
+		tbtn.pressed.connect(_on_target_pressed.bind(tid))
+		button_container.add_child(tbtn)
+
+	var spacer = Control.new()
+	spacer.custom_minimum_size = Vector2(0, 8)
+	button_container.add_child(spacer)
+
+	var decline_button = Button.new()
+	decline_button.name = "DeclineButton"
+	decline_button.text = "Decline"
+	decline_button.custom_minimum_size = Vector2(400, 36)
+	decline_button.pressed.connect(_on_decline_pressed)
+	button_container.add_child(decline_button)
+
+	main_container.add_child(button_container)
+	add_child(main_container)
+
+func _on_target_pressed(target_unit_id: String) -> void:
+	print("BombSquigsDialog: %s bombs %s" % [actor_name, target_unit_id])
+	emit_signal("bomb_squigs_chosen", actor_unit_id, target_unit_id, true)
+	hide()
+	queue_free()
+
+func _on_decline_pressed() -> void:
+	print("BombSquigsDialog: %s declines Bomb Squigs" % actor_name)
+	emit_signal("bomb_squigs_chosen", actor_unit_id, "", false)
+	hide()
+	queue_free()

--- a/40k/dialogs/BombSquigsDialog.gd.uid
+++ b/40k/dialogs/BombSquigsDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://04vs7v1bqq2p

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -851,6 +851,11 @@ func set_phase(phase) -> void:  # Remove type hint to accept any phase
 			if phase.has_signal("scatter_opportunity"):
 				if not phase.scatter_opportunity.is_connected(_on_scatter_opportunity):
 					phase.scatter_opportunity.connect(_on_scatter_opportunity)
+				# audit P1: Bomb Squigs — human had no UI; the phase emitted
+				# bomb_squigs_available but only AIPlayer listened.
+				if phase.has_signal("bomb_squigs_available"):
+					if not phase.bomb_squigs_available.is_connected(_on_bomb_squigs_available):
+						phase.bomb_squigs_available.connect(_on_bomb_squigs_available)
 
 			# Update the game state snapshot reference
 			if phase.has_method("get_game_state_snapshot"):
@@ -5216,6 +5221,39 @@ func _on_scatter_declined(player: int) -> void:
 # ===================================================
 # KUNNIN' INFILTRATOR HANDLING (OA-24)
 # ===================================================
+
+func _on_bomb_squigs_available(unit_id: String, player: int, eligible_targets: Array) -> void:
+	"""audit P1: show the Orks' Bomb Squigs prompt to a human. The phase set
+	_bomb_squigs_pending_unit and emitted this signal, but only AIPlayer listened
+	(guarded by is_ai_player) — so a human could never use it. Skip AI and
+	non-owning MP seats to avoid a double-submit."""
+	print("[MovementController] Bomb Squigs available for %s (player %d, %d targets)" % [unit_id, player, eligible_targets.size()])
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(player):
+		return
+	if NetworkManager and NetworkManager.is_networked() \
+			and NetworkManager.get_local_player() != player:
+		return
+	var dialog = preload("res://dialogs/BombSquigsDialog.gd").new()
+	dialog.name = "BombSquigsDialog"
+	dialog.setup(unit_id, player, eligible_targets)
+	dialog.bomb_squigs_chosen.connect(_on_bomb_squigs_chosen)
+	get_tree().root.add_child(dialog)
+	DialogUtils.popup_at_bottom(dialog)
+
+func _on_bomb_squigs_chosen(actor_unit_id: String, target_unit_id: String, use_ability: bool) -> void:
+	"""Dispatch the Bomb Squigs decision from the dialog."""
+	if use_ability:
+		emit_signal("move_action_requested", {
+			"type": "USE_BOMB_SQUIGS",
+			"actor_unit_id": actor_unit_id,
+			"target_unit_id": target_unit_id
+		})
+	else:
+		emit_signal("move_action_requested", {
+			"type": "DECLINE_BOMB_SQUIGS",
+			"actor_unit_id": actor_unit_id
+		})
 
 func _on_kunnin_infiltrator_available(unit_id: String, player: int) -> void:
 	"""Handle Kunnin' Infiltrator activation — notify UI that redeployment placement is needed.

--- a/40k/tests/scenarios/sp/movement_bomb_squigs_ui.json
+++ b/40k/tests/scenarios/sp/movement_bomb_squigs_ui.json
@@ -1,0 +1,68 @@
+{
+  "id": "movement_bomb_squigs_ui",
+  "covers": [
+    "scripts.MovementController.bomb_squigs_ui",
+    "phases.MovementPhase.bomb_squigs",
+    "audit_P1.movement_bomb_squigs"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "AUDIT P1: the Orks' Bomb Squigs reactive must have a human UI. The MovementPhase set _bomb_squigs_pending_unit and emitted bomb_squigs_available, but only AIPlayer listened, so a human could never use it. Here the prompt is raised for a human-owned Ork unit; the dialog must appear with a target button per eligible enemy + Decline, and declining must clear the pending state.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    {
+      "act": "execute_script",
+      "script": "GameState.set_active_player(2)\nPhaseManager.transition_to_phase(7)\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 6 },
+    {
+      "act": "execute_script",
+      "script": "return GameState.state[\"meta\"][\"phase\"]",
+      "multiline": true,
+      "equals": 7
+    },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nfp._bomb_squigs_pending_unit = \"U_BOYZ_E\"\nfp.emit_signal(\"bomb_squigs_available\", \"U_BOYZ_E\", 2, [{\"target_unit_id\": \"U_BLADE_CHAMPION_A\"}])\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"BombSquigsDialog\")\nreturn d != null and d.visible",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"BombSquigsDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nvar btns = d.find_children(\"*\", \"Button\", true, false)\nvar has_target = false\nvar has_decline = false\nfor b in btns:\n\tvar t = String(b.text)\n\tif t.contains(\"Bomb Squigs\"):\n\t\thas_target = true\n\tif t.contains(\"Decline\"):\n\t\thas_decline = true\nreturn has_target and has_decline",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "bomb_squigs_dialog_shown" },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"BombSquigsDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nd._on_decline_pressed()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "return PhaseManager.get_current_phase_instance()._bomb_squigs_pending_unit",
+      "multiline": true,
+      "equals": ""
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node_or_null(\"BombSquigsDialog\") == null",
+      "multiline": true,
+      "equals": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First fix from the audit's **P1 tier** ("abilities the game models but only the AI can trigger"). `MovementPhase` set `_bomb_squigs_pending_unit` and emitted `bomb_squigs_available` after a Normal move, but only `AIPlayer` listened (guarded by `is_ai_player`) — so a human player could never use Bomb Squigs.

## Fix (same recipe as the P0 reactive-dialog fixes)

- **MovementController**: connect `bomb_squigs_available` in `set_phase` and show the dialog to the local human, skipping AI defenders (AIPlayer resolves those) and non-owning multiplayer seats — no double-submit. Dispatch `USE_BOMB_SQUIGS` (`actor_unit_id` + `target_unit_id`) / `DECLINE_BOMB_SQUIGS`.
- **New `BombSquigsDialog`**: one "Bomb Squigs → &lt;target&gt;" button per eligible enemy unit (D3 mortal wounds), plus Decline.

## Validation

New windowed scenario `movement_bomb_squigs_ui.json` raises the prompt for a human-owned Ork unit in the live Movement phase and asserts the dialog renders with a target button + Decline, and that declining clears `_bomb_squigs_pending_unit`. Result: **13/13 pass**, with a screenshot of the rendered dialog. Movement regression set still green.

This addresses **one** of the audit's "movement abilities are AI-only" items; the others (Da Jump, Deff From Above, Grot Oiler, Mekaniak, Sawbonez, Quicksilver, Surge) remain follow-ups.

Player-facing, so `version_history.json` → 0.92.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_