### PR TITLE
Smoothly glide the camera when switching units with LB/RB

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -1931,35 +1931,57 @@ func _center_camera_on_unit(unit_id: String) -> void:
 	# Zoomed far out (e.g. right after loading a save): frame the cycled unit
 	# properly — fit_view_to_selection centers AND zooms to its bounding box —
 	# so bumper-cycling is usable without ever touching the zoom triggers. At
-	# normal zoom keep the player's chosen zoom and just pan (as before).
+	# normal zoom keep the player's chosen zoom and just pan. Either way the
+	# move now GLIDES (animate:true / smooth pan) instead of hard-cutting — the
+	# "it jumps the camera between the units" report.
 	var m := get_tree().current_scene
 	if m != null and ("view_zoom" in m) and float(m.view_zoom) < CYCLE_FRAME_MIN_ZOOM \
 			and m.has_method("fit_view_to_selection"):
-		if m.fit_view_to_selection(unit_id):
+		if m.fit_view_to_selection(unit_id, true):
 			return
 	for model in unit.get("models", []):
 		if not model.get("alive", true):
 			continue
 		var pos = model.get("position", null)
 		if pos is Dictionary and pos.has("x"):
-			_center_camera_on_world(Vector2(float(pos.x), float(pos.y)))
+			_smooth_center_camera_on_world(Vector2(float(pos.x), float(pos.y)))
 			return
 		elif pos is Vector2:
-			_center_camera_on_world(pos)
+			_smooth_center_camera_on_world(pos)
 			return
 
 
 func _center_camera_on_world(world_pos: Vector2) -> void:
-	# Same duck-typed camera model as VirtualCursor._edge_pan. Exact when the
-	# board isn't rotated; with view_rotation it lands near enough to see the
-	# unit (rotation-aware framing is an M5 polish item).
+	# INSTANT framing (carry pickup, model hop): the caller projects world→screen
+	# the same frame, so this must land immediately AND cancel any in-flight
+	# LB/RB unit-switch glide (snap_center_on_world) so a still-running tween
+	# can't overwrite view_offset underneath the projection. Same duck-typed
+	# camera model as VirtualCursor._edge_pan; exact when the board isn't rotated
+	# (rotation-aware framing is an M5 polish item). Falls back to a direct
+	# view_offset set on scenes without the tweened camera (test stubs).
 	var m := get_tree().current_scene
 	if m == null or not ("view_offset" in m) or not m.has_method("update_view_transform"):
+		return
+	if m.has_method("snap_center_on_world"):
+		m.snap_center_on_world(world_pos)
 		return
 	var vp: Vector2 = m.get_viewport().get_visible_rect().size
 	var zoom: float = m.view_zoom if "view_zoom" in m else 1.0
 	m.view_offset = world_pos - vp / (2.0 * zoom)
 	m.update_view_transform()
+
+
+# SMOOTH framing (LB/RB unit-switch, shooting/charge target walk): glide the
+# camera so world_pos is centered instead of hard-cutting — the "camera jumps
+# between units" report. Unlike _center_camera_on_world this is NOT followed by
+# a world→screen projection, so a mid-tween camera is fine. Falls back to the
+# instant pan on scenes without the tweened path (test stubs).
+func _smooth_center_camera_on_world(world_pos: Vector2) -> void:
+	var m := get_tree().current_scene
+	if m != null and m.has_method("smooth_center_on_world"):
+		m.smooth_center_on_world(world_pos)
+	else:
+		_center_camera_on_world(world_pos)
 
 
 # Frame `world_pos` at a chosen vertical screen fraction (0 = top, 0.5 = center)

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.13",
+			"date": "2026-07-22",
+			"summary": "Controller: switching units with the left/right bumpers now glides the camera smoothly to the next unit instead of instantly jumping to it. Rapid cycling chases the newest unit fluidly, and the reframe from a zoomed-out overview (e.g. just after loading) animates too.",
+			"changes": [
+				"LB/RB unit cycling now pans the camera with a short eased tween instead of a hard cut. The same smooth transition applies when the bumpers reframe a unit from a zoomed-out overview and when the shooting/charge target walk follows a target.",
+				"Model carry pickup and the L3/paddle model-hop still snap instantly (they immediately project the model to a screen position), and they now also cancel any in-flight glide so the pickup can't be knocked off by a still-running pan."
+			]
+		},
+		{
 			"version": "0.92.12",
 			"date": "2026-07-22",
 			"summary": "Orks can now use Bomb Squigs by hand. After an eligible unit makes a Normal move, a dialog lets you pick which enemy unit takes D3 mortal wounds (or Decline) — previously only the AI could trigger this, so a human player never got the option.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6386,7 +6386,7 @@ func fit_view_to_decision(unit_ids: Array) -> bool:
 # T14: zoom + center the camera on a unit's bounding box (all its models).
 # Returns true on success, false if the unit can't be resolved or has no
 # models. Sets last_camera_fit_action = "selection" on success.
-func fit_view_to_selection(unit_id: String) -> bool:
+func fit_view_to_selection(unit_id: String, animate: bool = false) -> bool:
 	if unit_id == "":
 		return false
 	var unit = GameState.get_unit(unit_id)
@@ -6425,11 +6425,19 @@ func fit_view_to_selection(unit_id: String) -> bool:
 	var zy: float = vp_size.y / (box_h + PAD_PX * 2.0)
 	var z: float = min(min(zx, zy), MAX_ZOOM)
 	var center := (min_pt + max_pt) * 0.5
+	last_camera_fit_action = "selection"
+	var target_offset: Vector2 = center - vp_size / (2.0 * z)
+	if animate:
+		# Controller LB/RB reframing from a zoomed-out overview: glide to the
+		# unit's bounding box instead of hard-cutting (the "it jumps the camera
+		# between the units" report). _sync_camera_node_to_view restores the
+		# camera.position/zoom the instant path sets once the glide settles.
+		_run_cycle_camera_tween(target_offset, z)
+		return true
 	camera.position = center
 	camera.zoom = Vector2(z, z)
 	view_zoom = z
-	view_offset = center - vp_size / (2.0 * z)
-	last_camera_fit_action = "selection"
+	view_offset = target_offset
 	update_view_transform()
 	return true
 
@@ -6580,6 +6588,64 @@ func focus_on_deployment_zone(player: int, animate: bool = true) -> void:
 
 func _tween_update_view(_progress: float) -> void:
 	update_view_transform()
+
+# ── LB/RB unit-switch camera glide ──────────────────────────────────────────
+# Controller unit-cycling (PadRouter LB/RB, and the shooting/charge target
+# walk) frames each unit with a short glide instead of a hard cut — the "it
+# jumps the camera between the units" report. Uses the same view_offset /
+# view_zoom + update_view_transform model as the instant pans, driven by a
+# tween so rapid presses smoothly chase the newest unit (each press kills the
+# in-flight glide and restarts from wherever the camera currently is).
+var _cycle_camera_tween: Tween = null
+
+# Duration of the unit-switch glide: long enough to read as motion, short
+# enough to stay responsive when cycling quickly.
+const CYCLE_CAMERA_PAN_TIME := 0.28
+
+# Smoothly pan (keeping the current zoom) so world_pos sits at viewport centre.
+# The pad's LB/RB unit-cycle camera-follow at normal zoom.
+func smooth_center_on_world(world_pos: Vector2) -> void:
+	var vp_size: Vector2 = get_viewport().get_visible_rect().size
+	var target_offset: Vector2 = world_pos - vp_size / (2.0 * view_zoom)
+	_run_cycle_camera_tween(target_offset, view_zoom)
+
+# Instant camera framing that also cancels any in-flight unit-switch glide.
+# Carry pickup / model-hop paths call this and then project world→screen the
+# SAME frame, so a still-running cycle tween must not overwrite view_offset
+# underneath them.
+func snap_center_on_world(world_pos: Vector2) -> void:
+	if _cycle_camera_tween and _cycle_camera_tween.is_valid():
+		_cycle_camera_tween.kill()
+	var vp_size: Vector2 = get_viewport().get_visible_rect().size
+	view_offset = world_pos - vp_size / (2.0 * view_zoom)
+	update_view_transform()
+
+# Shared tween driver for the unit-switch glide: kill any prior glide, then
+# animate view_offset (+ view_zoom — unchanged for a plain pan, retargeted by
+# the fit path) to the target, calling update_view_transform every frame. Syncs
+# the Camera2D node to the settled view on completion so it matches the
+# instant-pan end state.
+func _run_cycle_camera_tween(target_offset: Vector2, target_zoom: float) -> void:
+	if _cycle_camera_tween and _cycle_camera_tween.is_valid():
+		_cycle_camera_tween.kill()
+	if view_offset.is_equal_approx(target_offset) and is_equal_approx(view_zoom, target_zoom):
+		return  # already framed — no glide needed
+	_cycle_camera_tween = create_tween()
+	_cycle_camera_tween.set_parallel(true)
+	_cycle_camera_tween.set_ease(Tween.EASE_OUT)
+	_cycle_camera_tween.set_trans(Tween.TRANS_CUBIC)
+	_cycle_camera_tween.tween_property(self, "view_offset", target_offset, CYCLE_CAMERA_PAN_TIME)
+	_cycle_camera_tween.tween_property(self, "view_zoom", target_zoom, CYCLE_CAMERA_PAN_TIME)
+	_cycle_camera_tween.tween_method(_tween_update_view, 0.0, 1.0, CYCLE_CAMERA_PAN_TIME)
+	_cycle_camera_tween.finished.connect(_sync_camera_node_to_view)
+
+# Keep the Camera2D node's position/zoom in step with the view_offset/view_zoom
+# rendering source of truth after a glide settles (the fit path and the direct
+# pans set camera.* themselves; a tweened pan only touches view_*).
+func _sync_camera_node_to_view() -> void:
+	var vp_size: Vector2 = get_viewport().get_visible_rect().size
+	camera.position = view_offset + vp_size / (2.0 * view_zoom)
+	camera.zoom = Vector2(view_zoom, view_zoom)
 
 # P2-40: Briefly pan camera to a world position, then return after a delay
 func focus_on_position_briefly(world_pos: Vector2, hold_duration: float = 1.5, pan_duration: float = 0.5) -> void:

--- a/40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json
+++ b/40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json
@@ -1,0 +1,38 @@
+{
+  "id": "pad_smooth_camera_unit_switch",
+  "covers": [
+    "controller.m2.unit_cycling",
+    "controller.smooth_camera_unit_switch",
+    "controller.bumper_only_unit_cycling",
+    "PadRouter",
+    "Main.smooth_center_on_world"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "LB/RB unit switching GLIDES the camera to the newly-selected unit instead of instantly jumping. At normal zoom a bumper press starts a short view_offset tween (Main._cycle_camera_tween) that is still running immediately after the press; once it settles the camera is centered on the new unit's first alive model, and the settled position differs from where the camera started — proving it animated over time rather than hard-cutting. (Model carry / L3 hop still snap instantly; that is covered by the carry scenarios.)",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "main.set(\"view_zoom\", 0.8)" },
+    { "act": "execute_script", "script": "main.update_view_transform()" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != \"\"", "equals": true },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"ua\", str(main.movement_controller.active_unit_id))" },
+    { "act": "execute_script", "script": "main.set_meta(\"off_a\", main.view_offset)" },
+    { "act": "screenshot", "label": "01_first_unit_framed" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "execute_script", "multiline": true, "script": "var tw = tree.current_scene._cycle_camera_tween\nif tw == null:\n\treturn false\nreturn tw.is_valid() and tw.is_running()", "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
+
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "multiline": true, "script": "var mn = tree.current_scene\nvar uid = str(mn.movement_controller.active_unit_id)\nvar u = GameState.get_unit(uid)\nvar p = null\nfor mdl in u.get(\"models\", []):\n\tif mdl.get(\"alive\", true):\n\t\tvar pos = mdl.get(\"position\", null)\n\t\tif pos is Dictionary and pos.has(\"x\"):\n\t\t\tp = Vector2(float(pos.x), float(pos.y))\n\t\t\tbreak\n\t\telif pos is Vector2:\n\t\t\tp = pos\n\t\t\tbreak\nif p == null:\n\treturn false\nvar vp = mn.get_viewport().get_visible_rect().size\nvar expected = p - vp / (2.0 * mn.view_zoom)\nreturn mn.view_offset.distance_to(expected) < 2.0", "equals": true },
+    { "act": "execute_script", "script": "main.view_offset.distance_to(main.get_meta(\"off_a\"))", "expect_min": 1.0 },
+    { "act": "screenshot", "label": "02_glide_settled_on_new_unit" }
+  ]
+}


### PR DESCRIPTION
## Summary

When cycling units with the left/right bumpers, `PadRouter._center_camera_on_unit()` set the camera position instantly — a hard cut between units. This makes that transition **glide** instead.

Each bumper press now runs a short eased tween (0.28s `EASE_OUT` cubic over `view_offset`/`view_zoom` + `update_view_transform`), reusing the same pan pattern the deployment auto-zoom already uses. Rapid cycling kills the in-flight glide and smoothly chases the newest unit.

## Changes

- **`40k/scripts/Main.gd`**
  - `smooth_center_on_world()` / `_run_cycle_camera_tween()` — the eased unit-switch glide (kills any prior glide, tweens `view_offset`/`view_zoom`, calls `update_view_transform` each frame).
  - `snap_center_on_world()` — instant framing that also cancels any in-flight glide, for paths that must project world→screen the same frame.
  - `fit_view_to_selection(unit_id, animate := false)` — opt-in `animate` flag so the zoomed-out reframe (e.g. just after loading a save) glides too. Default stays instant, so the direct-call path is unchanged.
  - `_sync_camera_node_to_view()` — keeps the `Camera2D` node in step with the settled view.
- **`40k/autoloads/PadRouter.gd`**
  - `_center_camera_on_unit()` now glides (animated fit + smooth pan). This also makes the shooting/charge target-walk camera-follow glide (shared helper).
  - Model carry-pickup and the L3/paddle model-hop keep snapping instantly (they project world→screen the same frame) and now cancel any running glide first via `snap_center_on_world`.
- **`40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json`** — new windowed scenario.
- **`40k/data/version_history.json`** — version bump to 0.92.13.

## Validation

Ran the real game windowed (xvfb + software GL) and drove the player path via the MCP scenario harness:

- **New scenario `pad_smooth_camera_unit_switch`** — 17/17. Presses the actual bumper, asserts a glide tween is *running* immediately after the press (an instant jump never creates one), then that it settles centered on the new unit and the camera actually relocated. Before/after screenshots show two different units framed.
- **Regression scenarios (0 failures):** `pad_bumper_only_unit_cycling`, `pad_m2_unit_cycle`, `pad_load_zoom_focus` (animated fit-on-load), `pad_m3_carry_move` (carry pickup), `pad_move_l3_cycle_model` (L3 hop), `pad_deploy_unit_cycling`, `pad_fight_selection_bumper`.
- **`T14_fit_selection`** — 17/17, confirming the default instant fit path (with its immediate camera-position assertion) is untouched.
- No script/runtime errors in any run.

## Notes

- Glide duration is a single constant (`CYCLE_CAMERA_PAN_TIME = 0.28`), easy to tune.
- The shooting/charge target-walk follow now glides too (same shared helper) — consistent, but slightly wider than bumpers alone.
- Like the pre-existing pan code, framing isn't rotation-aware (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GX9fNxdvoLjRWTKrTC9xL1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GX9fNxdvoLjRWTKrTC9xL1)_