### PR TITLE
feat(shooting): human UI + AI resolver for Shooty Power Trip (audit P1)

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -857,6 +857,13 @@ func _connect_phase_stratagem_signals() -> void:
 		phase.distraction_grot_available.connect(callable_dg)
 		_connected_phase_signals.append({"signal_name": "distraction_grot_available", "callable": callable_dg})
 		print("AIPlayer: Connected to ShootingPhase.distraction_grot_available")
+	# audit P1: Shooty Power Trip previously had NO listener (controller or AI),
+	# so the phase blocked the AI too. Auto-resolve it here (free beneficial roll).
+	if phase.has_signal("shooty_power_trip_available"):
+		var callable_spt = Callable(self, "_on_shooty_power_trip_available")
+		phase.shooty_power_trip_available.connect(callable_spt)
+		_connected_phase_signals.append({"signal_name": "shooty_power_trip_available", "callable": callable_spt})
+		print("AIPlayer: Connected to ShootingPhase.shooty_power_trip_available")
 
 	# --- MovementPhase signals ---
 	if phase.has_signal("fire_overwatch_opportunity"):
@@ -1019,6 +1026,20 @@ func _on_distraction_grot_available(unit_id: String, player: int) -> void:
 		"actor_unit_id": unit_id,
 		"player": player,
 		"_ai_description": "AI activates Distraction Grot (5+ invuln, free ability)"
+	}
+	_submit_reactive_action(player, decision)
+
+func _on_shooty_power_trip_available(unit_id: String, player: int) -> void:
+	"""audit P1: the AI auto-activates Shooty Power Trip (free once-per-battle
+	D6 bonus). Without a listener the phase blocked awaiting a decision."""
+	if not is_ai_player(player):
+		return
+	print("AIPlayer: Shooty Power Trip available for AI player %d, unit %s — auto-activating" % [player, unit_id])
+	var decision = {
+		"type": "USE_SHOOTY_POWER_TRIP",
+		"actor_unit_id": unit_id,
+		"player": player,
+		"_ai_description": "AI activates Shooty Power Trip (free D6 bonus)"
 	}
 	_submit_reactive_action(player, decision)
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.14",
+			"date": "2026-07-22",
+			"summary": "Orks can now use Shooty Power Trip by hand. When an eligible Warboss unit is about to shoot, a dialog lets you Activate it (roll a D6 for a bonus) or Decline — previously nothing responded to this ability, so the Shooting phase could stall for both players.",
+			"changes": [
+				"Shooting phase: added the Shooty Power Trip prompt. A human gets an Activate / Decline dialog; the AI now auto-activates it. Previously neither the controller nor the AI listened for the ability, so it blocked the phase awaiting a decision that never came."
+			]
+		},
+		{
 			"version": "0.92.13",
 			"date": "2026-07-22",
 			"summary": "Controller: switching units with the left/right bumpers now glides the camera smoothly to the next unit instead of instantly jumping to it. Rapid cycling chases the newest unit fluidly, and the reframe from a zoomed-out overview (e.g. just after loading) animates too.",

--- a/40k/dialogs/ShootyPowerTripDialog.gd
+++ b/40k/dialogs/ShootyPowerTripDialog.gd
@@ -1,0 +1,110 @@
+extends AcceptDialog
+
+# ShootyPowerTripDialog - UI for the Orks' Shooty Power Trip reactive ability.
+#
+# SHOOTY POWER TRIP (Orks — Warboss, once per battle)
+# WHEN: Shooting phase, when the bearer's unit is selected to shoot.
+# EFFECT: Roll a D6 for a bonus effect on this unit's shooting this phase.
+#
+# Before this dialog existed the choice had NO handler at all — the phase set
+# awaiting_shooty_power_trip and emitted shooty_power_trip_available, but
+# neither the ShootingController nor AIPlayer listened, so the phase blocked
+# both players (audit P1). This dialog is the missing human UI (a matching AI
+# auto-resolver is added in AIPlayer).
+
+signal shooty_power_trip_chosen(unit_id: String, use_ability: bool)
+
+var unit_id: String = ""
+var player: int = 0
+var unit_name: String = ""
+
+func setup(p_unit_id: String, p_player: int) -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	unit_id = p_unit_id
+	player = p_player
+
+	var unit = GameState.get_unit(unit_id)
+	var _sptd_meta = unit.get("meta", {})
+	unit_name = _sptd_meta.get("display_name", _sptd_meta.get("name", unit_id))
+
+	title = "Shooty Power Trip — %s" % unit_name
+	min_size = DialogConstants.SMALL
+
+	get_ok_button().visible = false
+	_build_ui()
+
+func _build_ui() -> void:
+	var main_container = VBoxContainer.new()
+	main_container.custom_minimum_size = Vector2(DialogConstants.SMALL.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "SHOOTY POWER TRIP"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", Color.GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(header)
+
+	var subheader = Label.new()
+	subheader.text = "Orks — Warboss (once per battle)"
+	subheader.add_theme_font_size_override("font_size", 12)
+	subheader.add_theme_color_override("font_color", Color.GRAY)
+	subheader.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(subheader)
+
+	main_container.add_child(HSeparator.new())
+
+	var desc_label = Label.new()
+	desc_label.text = "Roll a D6 for a bonus effect on this unit's shooting this phase."
+	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc_label.add_theme_font_size_override("font_size", 13)
+	desc_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(desc_label)
+
+	var spacer = Control.new()
+	spacer.custom_minimum_size = Vector2(0, 10)
+	main_container.add_child(spacer)
+
+	var unit_label = Label.new()
+	unit_label.text = "%s is about to shoot. Activate Shooty Power Trip?" % unit_name
+	unit_label.add_theme_font_size_override("font_size", 14)
+	unit_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	unit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(unit_label)
+
+	main_container.add_child(HSeparator.new())
+
+	var button_container = HBoxContainer.new()
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
+
+	var use_button = Button.new()
+	use_button.name = "UseButton"
+	use_button.text = "Activate Shooty Power Trip"
+	use_button.custom_minimum_size = Vector2(240, 50)
+	use_button.pressed.connect(_on_use_pressed)
+	button_container.add_child(use_button)
+
+	var btn_spacer = Control.new()
+	btn_spacer.custom_minimum_size = Vector2(20, 0)
+	button_container.add_child(btn_spacer)
+
+	var decline_button = Button.new()
+	decline_button.name = "DeclineButton"
+	decline_button.text = "Decline"
+	decline_button.custom_minimum_size = Vector2(150, 50)
+	decline_button.pressed.connect(_on_decline_pressed)
+	button_container.add_child(decline_button)
+
+	main_container.add_child(button_container)
+	add_child(main_container)
+
+func _on_use_pressed() -> void:
+	print("ShootyPowerTripDialog: Player %d activates Shooty Power Trip for %s" % [player, unit_name])
+	emit_signal("shooty_power_trip_chosen", unit_id, true)
+	hide()
+	queue_free()
+
+func _on_decline_pressed() -> void:
+	print("ShootyPowerTripDialog: Player %d declines Shooty Power Trip for %s" % [player, unit_name])
+	emit_signal("shooty_power_trip_chosen", unit_id, false)
+	hide()
+	queue_free()

--- a/40k/dialogs/ShootyPowerTripDialog.gd.uid
+++ b/40k/dialogs/ShootyPowerTripDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://03ryop2mub72

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -832,6 +832,7 @@ func phase_signal_map() -> Dictionary:
 		"sentinel_storm_available": _on_sentinel_storm_available,  # P1-10
 		"throat_slittas_available": _on_throat_slittas_available,  # P1-12
 		"distraction_grot_available": _on_distraction_grot_available,  # audit P0: human defender UI
+		"shooty_power_trip_available": _on_shooty_power_trip_available,  # audit P1: human UI
 	}
 
 func set_phase(phase: BasePhase) -> void:
@@ -3745,6 +3746,51 @@ func _on_distraction_grot_chosen(unit_id: String, use_ability: bool) -> void:
 		print("[ShootingController] Player declines Distraction Grot for %s" % unit_id)
 		emit_signal("shoot_action_requested", {
 			"type": "DECLINE_DISTRACTION_GROT",
+			"actor_unit_id": unit_id
+		})
+
+# ============================================================================
+# AUDIT P1: SHOOTY POWER TRIP — WARBOSS D6 BONUS
+# ============================================================================
+
+func _on_shooty_power_trip_available(unit_id: String, player: int) -> void:
+	"""Show the Shooty Power Trip prompt to a HUMAN. The phase pauses awaiting
+	USE/DECLINE; previously neither the controller NOR AIPlayer listened, so the
+	phase blocked both players. AIPlayer now auto-resolves the AI (its own
+	is_ai_player guard), so skip AI here to avoid a double-submit."""
+	print("[ShootingController] Shooty Power Trip available for %s (player %d)" % [unit_id, player])
+
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(player):
+		print("[ShootingController] Shooty Power Trip belongs to AI player %d — AIPlayer handles it" % player)
+		return
+
+	if NetworkManager and NetworkManager.is_networked() \
+			and NetworkManager.get_local_player() != player:
+		print("[ShootingController] Shooty Power Trip is P%d's choice — local seat waits" % player)
+		return
+
+	var dialog = preload("res://dialogs/ShootyPowerTripDialog.gd").new()
+	dialog.name = "ShootyPowerTripDialog"
+	dialog.setup(unit_id, player)
+	dialog.shooty_power_trip_chosen.connect(_on_shooty_power_trip_chosen)
+	get_tree().root.add_child(dialog)
+	DialogUtils.popup_at_bottom(dialog)
+
+func _on_shooty_power_trip_chosen(unit_id: String, use_ability: bool) -> void:
+	"""Dispatch the Shooty Power Trip decision."""
+	if use_ability:
+		print("[ShootingController] Player activates Shooty Power Trip for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "USE_SHOOTY_POWER_TRIP",
+			"actor_unit_id": unit_id
+		})
+		if dice_log_display:
+			dice_log_display.append_text("[b][color=gold]SHOOTY POWER TRIP! Rolling D6…[/color][/b]\n")
+	else:
+		print("[ShootingController] Player declines Shooty Power Trip for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "DECLINE_SHOOTY_POWER_TRIP",
 			"actor_unit_id": unit_id
 		})
 

--- a/40k/tests/scenarios/sp/shooting_shooty_power_trip_ui.json
+++ b/40k/tests/scenarios/sp/shooting_shooty_power_trip_ui.json
@@ -1,0 +1,57 @@
+{
+  "id": "shooting_shooty_power_trip_ui",
+  "covers": [
+    "scripts.ShootingController.shooty_power_trip_ui",
+    "phases.ShootingPhase.shooty_power_trip",
+    "audit_P1.shooting_shooty_power_trip"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "AUDIT P1: the Orks' Shooty Power Trip reactive must have a human UI. The phase set awaiting_shooty_power_trip and emitted shooty_power_trip_available, but neither the controller NOR AIPlayer listened — so it blocked both players. Here the prompt is raised for a human-owned Ork unit; the dialog must appear with Activate/Decline, and declining must clear the pending state (unblocking the phase).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nfp.awaiting_shooty_power_trip = true\nfp.shooty_power_trip_pending_unit = \"U_BOYZ_E\"\nfp.emit_signal(\"shooty_power_trip_available\", \"U_BOYZ_E\", 2)\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"ShootyPowerTripDialog\")\nreturn d != null and d.visible",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"ShootyPowerTripDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nvar btns = d.find_children(\"*\", \"Button\", true, false)\nvar has_use = false\nvar has_decline = false\nfor b in btns:\n\tvar t = String(b.text)\n\tif t.contains(\"Shooty Power Trip\"):\n\t\thas_use = true\n\tif t.contains(\"Decline\"):\n\t\thas_decline = true\nreturn has_use and has_decline",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "shooty_power_trip_dialog_shown" },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"ShootyPowerTripDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nd._on_decline_pressed()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "return PhaseManager.get_current_phase_instance().awaiting_shooty_power_trip",
+      "multiline": true,
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node_or_null(\"ShootyPowerTripDialog\") == null",
+      "multiline": true,
+      "equals": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Next P1 item. `ShootingPhase` set `awaiting_shooty_power_trip` and emitted `shooty_power_trip_available`, but **neither the ShootingController nor AIPlayer listened** — so the phase blocked **both** players awaiting a decision that never came. (Unlike Distraction Grot / Bomb Squigs, which the AI already handled, this ability had no handler on either side.)

## Fix

- **ShootingController**: add `shooty_power_trip_available` to `phase_signal_map` and show `ShootyPowerTripDialog` to the local human (skip AI + non-owning MP seats).
- **AIPlayer**: connect the signal and **auto-activate for the AI** (free D6 bonus), mirroring the Distraction Grot handler — so the AI no longer blocks either.
- **New `ShootyPowerTripDialog`**: Activate / Decline.

This establishes the recipe for the remaining "blocking + unhandled-by-both" reactive abilities (Pulsa Rokkit, Ammo Runt, Deff From Above, Grot Oiler, …): human dialog + AI auto-resolver.

## Validation

New windowed scenario `shooting_shooty_power_trip_ui.json` raises the prompt for a human-owned Ork unit in the live Shooting phase and asserts the dialog renders with Activate/Decline, and that declining clears `awaiting_shooty_power_trip`. Result: **11/11 pass**, with a screenshot of the rendered dialog. Shooting regression green.

Player-facing, so `version_history.json` → 0.92.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_