### PR TITLE
feat(shooting): human UI + AI resolver for Pulsa Rokkit (audit P1)

### DIFF
--- a/40k/autoloads/AIPlayer.gd
+++ b/40k/autoloads/AIPlayer.gd
@@ -864,6 +864,12 @@ func _connect_phase_stratagem_signals() -> void:
 		phase.shooty_power_trip_available.connect(callable_spt)
 		_connected_phase_signals.append({"signal_name": "shooty_power_trip_available", "callable": callable_spt})
 		print("AIPlayer: Connected to ShootingPhase.shooty_power_trip_available")
+	# audit P1: Pulsa Rokkit had no listener either — auto-resolve for the AI.
+	if phase.has_signal("pulsa_rokkit_available"):
+		var callable_pr = Callable(self, "_on_pulsa_rokkit_available")
+		phase.pulsa_rokkit_available.connect(callable_pr)
+		_connected_phase_signals.append({"signal_name": "pulsa_rokkit_available", "callable": callable_pr})
+		print("AIPlayer: Connected to ShootingPhase.pulsa_rokkit_available")
 
 	# --- MovementPhase signals ---
 	if phase.has_signal("fire_overwatch_opportunity"):
@@ -1040,6 +1046,20 @@ func _on_shooty_power_trip_available(unit_id: String, player: int) -> void:
 		"actor_unit_id": unit_id,
 		"player": player,
 		"_ai_description": "AI activates Shooty Power Trip (free D6 bonus)"
+	}
+	_submit_reactive_action(player, decision)
+
+func _on_pulsa_rokkit_available(unit_id: String, player: int) -> void:
+	"""audit P1: the AI auto-fires Pulsa Rokkit (free once-per-battle +1 S/+1 AP
+	on ranged weapons). Without a listener the phase blocked awaiting a decision."""
+	if not is_ai_player(player):
+		return
+	print("AIPlayer: Pulsa Rokkit available for AI player %d, unit %s — auto-firing" % [player, unit_id])
+	var decision = {
+		"type": "USE_PULSA_ROKKIT",
+		"actor_unit_id": unit_id,
+		"player": player,
+		"_ai_description": "AI fires Pulsa Rokkit (+1 S / +1 AP ranged)"
 	}
 	_submit_reactive_action(player, decision)
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.92.15",
+			"date": "2026-07-22",
+			"summary": "Orks can now fire the Pulsa Rokkit by hand. When an eligible unit is about to shoot, a dialog lets you Fire it (+1 Strength and +1 AP on its ranged weapons this phase) or Decline — previously nothing responded to this ability, so the Shooting phase could stall for both players.",
+			"changes": [
+				"Shooting phase: added the Pulsa Rokkit prompt. A human gets a Fire / Decline dialog; the AI now auto-fires it. Previously neither the controller nor the AI listened, so it blocked the phase awaiting a decision that never came."
+			]
+		},
+		{
 			"version": "0.92.14",
 			"date": "2026-07-22",
 			"summary": "Orks can now use Shooty Power Trip by hand. When an eligible Warboss unit is about to shoot, a dialog lets you Activate it (roll a D6 for a bonus) or Decline — previously nothing responded to this ability, so the Shooting phase could stall for both players.",

--- a/40k/dialogs/PulsaRokkitDialog.gd
+++ b/40k/dialogs/PulsaRokkitDialog.gd
@@ -1,0 +1,110 @@
+extends AcceptDialog
+
+# PulsaRokkitDialog - UI for the Orks' Pulsa Rokkit reactive ability.
+#
+# PULSA ROKKIT (Orks — once per battle)
+# WHEN: Shooting phase, when the bearer's unit is selected to shoot.
+# EFFECT: This unit's ranged weapons gain +1 Strength and +1 AP this phase.
+#
+# Before this dialog existed the choice had NO handler at all — the phase set
+# awaiting_pulsa_rokkit and emitted pulsa_rokkit_available, but neither the
+# ShootingController nor AIPlayer listened, so it blocked both players (audit
+# P1). This dialog is the missing human UI (a matching AI auto-resolver is
+# added in AIPlayer).
+
+signal pulsa_rokkit_chosen(unit_id: String, use_ability: bool)
+
+var unit_id: String = ""
+var player: int = 0
+var unit_name: String = ""
+
+func setup(p_unit_id: String, p_player: int) -> void:
+	WhiteDwarfTheme.apply_to_dialog(self)
+	unit_id = p_unit_id
+	player = p_player
+
+	var unit = GameState.get_unit(unit_id)
+	var _prd_meta = unit.get("meta", {})
+	unit_name = _prd_meta.get("display_name", _prd_meta.get("name", unit_id))
+
+	title = "Pulsa Rokkit — %s" % unit_name
+	min_size = DialogConstants.SMALL
+
+	get_ok_button().visible = false
+	_build_ui()
+
+func _build_ui() -> void:
+	var main_container = VBoxContainer.new()
+	main_container.custom_minimum_size = Vector2(DialogConstants.SMALL.x - 20, 0)
+
+	var header = Label.new()
+	header.text = "PULSA ROKKIT"
+	header.add_theme_font_size_override("font_size", 20)
+	header.add_theme_color_override("font_color", Color.GOLD)
+	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(header)
+
+	var subheader = Label.new()
+	subheader.text = "Orks — once per battle"
+	subheader.add_theme_font_size_override("font_size", 12)
+	subheader.add_theme_color_override("font_color", Color.GRAY)
+	subheader.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(subheader)
+
+	main_container.add_child(HSeparator.new())
+
+	var desc_label = Label.new()
+	desc_label.text = "This unit's ranged weapons gain +1 Strength and +1 AP this phase."
+	desc_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc_label.add_theme_font_size_override("font_size", 13)
+	desc_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(desc_label)
+
+	var spacer = Control.new()
+	spacer.custom_minimum_size = Vector2(0, 10)
+	main_container.add_child(spacer)
+
+	var unit_label = Label.new()
+	unit_label.text = "%s is about to shoot. Fire the Pulsa Rokkit?" % unit_name
+	unit_label.add_theme_font_size_override("font_size", 14)
+	unit_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	unit_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	main_container.add_child(unit_label)
+
+	main_container.add_child(HSeparator.new())
+
+	var button_container = HBoxContainer.new()
+	button_container.alignment = BoxContainer.ALIGNMENT_CENTER
+
+	var use_button = Button.new()
+	use_button.name = "UseButton"
+	use_button.text = "Fire Pulsa Rokkit"
+	use_button.custom_minimum_size = Vector2(220, 50)
+	use_button.pressed.connect(_on_use_pressed)
+	button_container.add_child(use_button)
+
+	var btn_spacer = Control.new()
+	btn_spacer.custom_minimum_size = Vector2(20, 0)
+	button_container.add_child(btn_spacer)
+
+	var decline_button = Button.new()
+	decline_button.name = "DeclineButton"
+	decline_button.text = "Decline"
+	decline_button.custom_minimum_size = Vector2(150, 50)
+	decline_button.pressed.connect(_on_decline_pressed)
+	button_container.add_child(decline_button)
+
+	main_container.add_child(button_container)
+	add_child(main_container)
+
+func _on_use_pressed() -> void:
+	print("PulsaRokkitDialog: Player %d fires Pulsa Rokkit for %s" % [player, unit_name])
+	emit_signal("pulsa_rokkit_chosen", unit_id, true)
+	hide()
+	queue_free()
+
+func _on_decline_pressed() -> void:
+	print("PulsaRokkitDialog: Player %d declines Pulsa Rokkit for %s" % [player, unit_name])
+	emit_signal("pulsa_rokkit_chosen", unit_id, false)
+	hide()
+	queue_free()

--- a/40k/dialogs/PulsaRokkitDialog.gd.uid
+++ b/40k/dialogs/PulsaRokkitDialog.gd.uid
@@ -1,0 +1,1 @@
+uid://hri3ty4ydwag

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -833,6 +833,7 @@ func phase_signal_map() -> Dictionary:
 		"throat_slittas_available": _on_throat_slittas_available,  # P1-12
 		"distraction_grot_available": _on_distraction_grot_available,  # audit P0: human defender UI
 		"shooty_power_trip_available": _on_shooty_power_trip_available,  # audit P1: human UI
+		"pulsa_rokkit_available": _on_pulsa_rokkit_available,  # audit P1: human UI
 	}
 
 func set_phase(phase: BasePhase) -> void:
@@ -3791,6 +3792,50 @@ func _on_shooty_power_trip_chosen(unit_id: String, use_ability: bool) -> void:
 		print("[ShootingController] Player declines Shooty Power Trip for %s" % unit_id)
 		emit_signal("shoot_action_requested", {
 			"type": "DECLINE_SHOOTY_POWER_TRIP",
+			"actor_unit_id": unit_id
+		})
+
+# ============================================================================
+# AUDIT P1: PULSA ROKKIT — +1 STRENGTH / +1 AP RANGED
+# ============================================================================
+
+func _on_pulsa_rokkit_available(unit_id: String, player: int) -> void:
+	"""Show the Pulsa Rokkit prompt to a HUMAN. The phase pauses awaiting
+	USE/DECLINE; previously neither the controller NOR AIPlayer listened, so the
+	phase blocked both players. AIPlayer now auto-resolves the AI, so skip AI."""
+	print("[ShootingController] Pulsa Rokkit available for %s (player %d)" % [unit_id, player])
+
+	var ai_player_node = get_node_or_null("/root/AIPlayer")
+	if ai_player_node and ai_player_node.is_ai_player(player):
+		print("[ShootingController] Pulsa Rokkit belongs to AI player %d — AIPlayer handles it" % player)
+		return
+
+	if NetworkManager and NetworkManager.is_networked() \
+			and NetworkManager.get_local_player() != player:
+		print("[ShootingController] Pulsa Rokkit is P%d's choice — local seat waits" % player)
+		return
+
+	var dialog = preload("res://dialogs/PulsaRokkitDialog.gd").new()
+	dialog.name = "PulsaRokkitDialog"
+	dialog.setup(unit_id, player)
+	dialog.pulsa_rokkit_chosen.connect(_on_pulsa_rokkit_chosen)
+	get_tree().root.add_child(dialog)
+	DialogUtils.popup_at_bottom(dialog)
+
+func _on_pulsa_rokkit_chosen(unit_id: String, use_ability: bool) -> void:
+	"""Dispatch the Pulsa Rokkit decision."""
+	if use_ability:
+		print("[ShootingController] Player fires Pulsa Rokkit for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "USE_PULSA_ROKKIT",
+			"actor_unit_id": unit_id
+		})
+		if dice_log_display:
+			dice_log_display.append_text("[b][color=gold]PULSA ROKKIT! +1 Strength, +1 AP.[/color][/b]\n")
+	else:
+		print("[ShootingController] Player declines Pulsa Rokkit for %s" % unit_id)
+		emit_signal("shoot_action_requested", {
+			"type": "DECLINE_PULSA_ROKKIT",
 			"actor_unit_id": unit_id
 		})
 

--- a/40k/tests/scenarios/sp/shooting_pulsa_rokkit_ui.json
+++ b/40k/tests/scenarios/sp/shooting_pulsa_rokkit_ui.json
@@ -1,0 +1,57 @@
+{
+  "id": "shooting_pulsa_rokkit_ui",
+  "covers": [
+    "scripts.ShootingController.pulsa_rokkit_ui",
+    "phases.ShootingPhase.pulsa_rokkit",
+    "audit_P1.shooting_pulsa_rokkit"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "disable_ai": true,
+  "description": "AUDIT P1: the Orks' Pulsa Rokkit reactive must have a human UI. The phase set awaiting_pulsa_rokkit and emitted pulsa_rokkit_available, but neither the controller NOR AIPlayer listened — so it blocked both players. Here the prompt is raised for a human-owned Ork unit; the dialog must appear with Fire/Decline, and declining must clear the pending state.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+    {
+      "act": "execute_script",
+      "script": "var fp = PhaseManager.get_current_phase_instance()\nfp.awaiting_pulsa_rokkit = true\nfp.pulsa_rokkit_pending_unit = \"U_BOYZ_E\"\nfp.emit_signal(\"pulsa_rokkit_available\", \"U_BOYZ_E\", 2)\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"PulsaRokkitDialog\")\nreturn d != null and d.visible",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"PulsaRokkitDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nvar btns = d.find_children(\"*\", \"Button\", true, false)\nvar has_use = false\nvar has_decline = false\nfor b in btns:\n\tvar t = String(b.text)\n\tif t.contains(\"Pulsa Rokkit\"):\n\t\thas_use = true\n\tif t.contains(\"Decline\"):\n\t\thas_decline = true\nreturn has_use and has_decline",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "screenshot", "label": "pulsa_rokkit_dialog_shown" },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node_or_null(\"PulsaRokkitDialog\")\nif d == null:\n\treturn \"NO_DIALOG\"\nd._on_decline_pressed()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 8 },
+    {
+      "act": "execute_script",
+      "script": "return PhaseManager.get_current_phase_instance().awaiting_pulsa_rokkit",
+      "multiline": true,
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node_or_null(\"PulsaRokkitDialog\") == null",
+      "multiline": true,
+      "equals": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Same class of bug as Shooty Power Trip (#751): `ShootingPhase` set `awaiting_pulsa_rokkit` and emitted `pulsa_rokkit_available`, but **neither the ShootingController nor AIPlayer listened** — so the phase blocked **both** players.

## Fix (blocking-unhandled recipe: human dialog + AI auto-resolver)

- **ShootingController**: add `pulsa_rokkit_available` to `phase_signal_map` and show `PulsaRokkitDialog` to the local human (skip AI + non-owning MP seats).
- **AIPlayer**: connect the signal and auto-fire for the AI (free +1 Strength / +1 AP on ranged weapons).
- **New `PulsaRokkitDialog`**: Fire / Decline.

## Validation

New windowed scenario `shooting_pulsa_rokkit_ui.json` raises the prompt for a human-owned Ork unit in the live Shooting phase and asserts the dialog renders with Fire/Decline and that declining clears `awaiting_pulsa_rokkit`. Result: **11/11 pass** (running the full project also confirms clean parse). Structure is identical to the screenshot-confirmed Shooty Power Trip dialog.

Player-facing, so `version_history.json` → 0.92.15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVMqk5VwjN9btcQxdm8B9Y)_