### PR TITLE
Firing Deck: auto-fire embarked models' basic guns (no dialog)

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.6",
+			"date": "2026-07-23",
+			"summary": "Firing Deck transports now shoot their embarked models' guns automatically — no more model-selection dialog. When you select a transport (e.g. a Battlewagon) with embarked units, their weapons are added straight onto the transport as its own guns, so a wagon full of Boyz just fires its Shootas and you go straight to choosing targets.",
+			"changes": [
+				"Shooting phase: selecting a Firing Deck transport no longer opens the per-model selection dialog. Each embarked model's basic ranged gun is loaned onto the transport automatically (up to the Firing Deck limit) and treated as the transport's own weapon.",
+				"The 'basic gun' is a model's plain rank-and-file weapon (the lowest-damage, lowest-strength non-Pistol option), so a Boyz mob fires Shootas rather than a special weapon on every model. [ONE SHOT] and [HAZARDOUS] weapons are never auto-fired, and Mega Armour / Jump Pack models correctly count as two toward the Firing Deck limit.",
+				"Note: datasheets list every wargear option per model, so the game can't tell which exact gun a model is built with and fires the most basic option — e.g. Lootas will fire Big Shootas rather than Deffguns."
+			]
+		},
+		{
 			"version": "0.93.5",
 			"date": "2026-07-23",
 			"summary": "Controller: you can now 'Take to the skies' with a FLY unit using the pad. When you open the move menu for an eligible flying unit, a 'Take to the skies: Off/On' entry lets you declare the fly-over before choosing Move or Advance — previously the toggle was mouse-only and unreachable on a controller.",

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -5330,75 +5330,106 @@ func validate_loaded_state() -> bool:
 
 # Transport Firing Deck support
 
-# 24.14: decide whether the firing-deck selection needs the player or can be
-# auto-resolved. Returns {"mode":"dialog"} when a genuine choice exists, or
-# {"mode":"auto","loans":[...]} when every eligible model has exactly one
-# non-[ONE SHOT] ranged weapon, they all fit under Firing Deck X, and none are
-# [HAZARDOUS]. `loans` may be empty (the embarked units carry no deck-eligible
-# weapon at all) — the caller then just shoots the transport's own guns.
+# 24.14: choose the firing-deck weapons automatically so the transport shoots
+# with its embarked models' guns without a per-model dialog. Datasheets list
+# every wargear OPTION on each model (the loadout isn't pinned per model), so a
+# model typically reports several ranged weapons; we pick each model's BASIC
+# ranged gun (the plain rank-and-file weapon, not a one-off special upgrade) so a
+# mob of Boyz fires ~Shootas rather than, say, a Big Shoota on every model —
+# which would over-count a weapon the mob only carries one of. Returns
+# {"mode":"auto","loans":[...]}; `loans` may be empty (no deck-eligible weapon),
+# in which case the caller just shoots the transport's own guns.
 func _compute_firing_deck_plan(transport_id: String, eligible_embarked: Array) -> Dictionary:
 	var transport = get_unit(transport_id)
 	var t_data = transport.get("transport_data", {})
 	var capacity = int(t_data.get("firing_deck", 0))
-	# [EMBARKING]: some models count as more than one model for capacity/Firing
-	# Deck (e.g. MEGA ARMOUR / JUMP PACK). The transport's capacity_multipliers
-	# is the data-driven source of which keywords double-count; MEGA ARMOUR /
-	# JUMP PACK are a safety fallback when it's absent.
+	# [EMBARKING]: MEGA ARMOUR / JUMP PACK models (and any keyword the transport
+	# declares with a capacity_multiplier > 1) count as two for Firing Deck, so
+	# each of their weapons consumes 2 of the X slots.
 	var multi_keywords := ["MEGA ARMOUR", "JUMP PACK"]
 	for mk in t_data.get("capacity_multipliers", {}):
 		if int(t_data["capacity_multipliers"][mk]) > 1 and not (mk in multi_keywords):
 			multi_keywords.append(mk)
 	var board = game_state_snapshot
-	var loans := []
+	# One candidate loan per eligible model, tagged with its Firing Deck slot cost.
+	var candidates := []
 	for embarked_id in eligible_embarked:
 		var embarked = get_unit(embarked_id)
 		if embarked.is_empty():
 			continue
-		# A double-counting model's weapons consume more than one Firing Deck
-		# slot. That slot arithmetic isn't modelled here, so defer to the manual
-		# dialog rather than risk auto-loaning more weapons than the cap allows.
 		var kws = embarked.get("meta", {}).get("keywords", [])
-		var is_multi := false
+		var slot_cost := 1
 		for mk in multi_keywords:
 			if mk in kws:
-				is_multi = true
+				slot_cost = 2
 				break
-		if is_multi:
-			return {"mode": "dialog"}
 		var model_weapons = RulesEngine.get_unit_weapons(embarked_id, board)
 		for model in embarked.get("models", []):
 			if not model.get("alive", true):
 				continue
 			var mid = str(model.get("id", ""))
-			var eligible_ids := []
-			for wid in model_weapons.get(mid, []):
-				if RulesEngine.is_one_shot_weapon(wid, board):
-					continue  # 24.14 step 2 excludes [ONE SHOT]
-				eligible_ids.append(wid)
-			if eligible_ids.is_empty():
-				continue
-			# More than one ranged option → the player must pick which one fires.
-			if eligible_ids.size() > 1:
-				return {"mode": "dialog"}
-			var chosen = str(eligible_ids[0])
-			# [HAZARDOUS] (24.15): firing it risks the transport — let the player
-			# decide rather than auto-committing them to the hazard roll.
-			if RulesEngine.is_hazardous_weapon(chosen, board):
-				return {"mode": "dialog"}
-			loans.append({"unit_id": embarked_id, "model_id": mid, "weapon_id": chosen})
-	# More eligible weapons than the deck can carry.
-	if loans.size() > capacity:
-		# If every eligible weapon is identical, any capacity-sized subset fires
-		# exactly the same — the shots come from the TRANSPORT, so which donor
-		# model contributes is irrelevant. Auto-pick the first X and skip the
-		# dialog (e.g. a full wagon of identical-loadout Boyz). When the eligible
-		# weapons differ, WHICH ones fire is a real choice → ask the player.
-		var first_wid = str(loans[0].get("weapon_id", ""))
-		for loan in loans:
-			if str(loan.get("weapon_id", "")) != first_wid:
-				return {"mode": "dialog"}
-		return {"mode": "auto", "loans": loans.slice(0, capacity)}
+			var chosen = _pick_firing_deck_weapon(model_weapons.get(mid, []), board)
+			if chosen == "":
+				continue  # no auto-eligible (non-[ONE SHOT], non-[HAZARDOUS]) gun
+			candidates.append({
+				"loan": {"unit_id": embarked_id, "model_id": mid, "weapon_id": chosen},
+				"cost": slot_cost
+			})
+	# Fit the candidates under Firing Deck X (double-counting models cost 2). All
+	# models of a unit share the same basic gun, so an over-capacity mob just
+	# fires the first X — any subset of identical guns is equivalent.
+	var loans := []
+	var used := 0
+	for c in candidates:
+		if used + int(c["cost"]) <= capacity:
+			loans.append(c["loan"])
+			used += int(c["cost"])
 	return {"mode": "auto", "loans": loans}
+
+
+# Pick a model's BASIC ranged gun for the firing deck from its weapon ids.
+# Excludes [ONE SHOT] (24.14 step 2) and [HAZARDOUS] (24.15 — never auto-commit
+# the transport to a hazard roll), prefers a non-Pistol, and among what remains
+# picks the plainest gun (lowest Damage, then lowest Strength) so a mob fires its
+# rank-and-file weapon rather than a special upgrade only one model really has.
+# Returns "" when the model has no auto-eligible ranged weapon.
+func _pick_firing_deck_weapon(weapon_ids: Array, board: Dictionary) -> String:
+	var eligible := []
+	for wid in weapon_ids:
+		if RulesEngine.is_one_shot_weapon(wid, board):
+			continue
+		if RulesEngine.is_hazardous_weapon(wid, board):
+			continue
+		eligible.append(str(wid))
+	if eligible.is_empty():
+		return ""
+	# Prefer non-Pistol guns when the model has any (a Pistol is a fallback gun).
+	var pool := []
+	for wid in eligible:
+		if not RulesEngine.is_pistol_weapon(wid, board):
+			pool.append(wid)
+	if pool.is_empty():
+		pool = eligible
+	# Plainest gun wins: lowest Damage, then lowest Strength; ties keep order.
+	var best := ""
+	var best_dmg := 1 << 30
+	var best_str := 1 << 30
+	for wid in pool:
+		var prof = RulesEngine.get_weapon_profile(wid, board)
+		var dmg := _fd_numeric_rank(str(prof.get("damage", "1")))
+		var stg := _fd_numeric_rank(str(prof.get("strength", "1")))
+		if best == "" or dmg < best_dmg or (dmg == best_dmg and stg < best_str):
+			best = wid
+			best_dmg = dmg
+			best_str = stg
+	return best
+
+
+# Rank a weapon stat string numerically: a plain integer sorts by value; anything
+# variable/special (e.g. "D6", "D3", "2D6") sorts high, so a random-damage upgrade
+# is never mistaken for the basic gun.
+func _fd_numeric_rank(s: String) -> int:
+	return int(s) if s.is_valid_int() else (1 << 20)
 
 
 # 24.14: loan `loans` (each {unit_id, model_id, weapon_id}) onto the transport so

--- a/40k/tests/scenarios/sp/iss_firing_deck_autoresolve_11e.json
+++ b/40k/tests/scenarios/sp/iss_firing_deck_autoresolve_11e.json
@@ -2,14 +2,14 @@
   "id": "iss_firing_deck_autoresolve_11e",
   "covers": [
     "shooting.firing_deck.auto_resolve_11e",
-    "shooting.firing_deck.dialog_when_choice",
+    "shooting.firing_deck.basic_gun_pick",
     "phases.ShootingPhase._compute_firing_deck_plan"
   ],
   "fixture": "audit_baseline_postdeploy",
   "edition": 11,
   "disable_ai": true,
   "transition_to_phase": 8,
-  "description": "24.14 Firing Deck friction reduction: when every eligible embarked model has a single non-[ONE SHOT] ranged weapon that fits under Firing Deck X and isn't [HAZARDOUS], SELECT_SHOOTER auto-loans the weapons onto the transport (no dialog) and they appear as the transport's own guns. When a model carries more than one ranged weapon (a real choice), the selection dialog still shows.",
+  "description": "24.14 Firing Deck: selecting a transport with embarked models resolves the firing deck automatically with NO dialog. Real Ork datasheets list several ranged options per model, so the transport is loaned each model's BASIC gun (a 10-model Boyz mob -> ~Shootas, not a special weapon on every model). Burna Boyz -> Burnas. The loaned guns appear as the transport's own weapons.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -23,65 +23,19 @@
     {
       "act": "execute_script",
       "multiline": true,
-      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_FD_TANK\": {\"id\": \"U_FD_TANK\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Test Wagon\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 11, \"capacity\": 22, \"embarked_units\": [\"U_FD_MOB\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 400}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_MOB\": {\"id\": \"U_FD_MOB\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK\", \"meta\": {\"name\": \"FD Boyz\", \"keywords\": [\"INFANTRY\"], \"weapons\": [{\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"models\": [{\"id\": \"m0\", \"alive\": true, \"position\": {\"x\": 150, \"y\": 350}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}, {\"id\": \"m1\", \"alive\": true, \"position\": {\"x\": 170, \"y\": 350}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TARGET\": {\"id\": \"U_FD_TARGET\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Target\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 400}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TANK2\": {\"id\": \"U_FD_TANK2\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Choice Wagon\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 11, \"capacity\": 22, \"embarked_units\": [\"U_FD_MOB2\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 900}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_MOB2\": {\"id\": \"U_FD_MOB2\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK2\", \"meta\": {\"name\": \"FD Nob\", \"keywords\": [\"INFANTRY\"], \"weapons\": [{\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}, {\"name\": \"Kombi-weapon\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"models\": [{\"id\": \"m0\", \"alive\": true, \"position\": {\"x\": 150, \"y\": 850}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TARGET2\": {\"id\": \"U_FD_TARGET2\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Target 2\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 900}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TANK3\": {\"id\": \"U_FD_TANK3\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Full Wagon\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 2, \"capacity\": 22, \"embarked_units\": [\"U_FD_MOB3\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 1400}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_MOB3\": {\"id\": \"U_FD_MOB3\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK3\", \"meta\": {\"name\": \"FD Shoota Boyz\", \"keywords\": [\"INFANTRY\"], \"weapons\": [{\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"models\": [{\"id\": \"m0\", \"alive\": true, \"position\": {\"x\": 150, \"y\": 1350}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}, {\"id\": \"m1\", \"alive\": true, \"position\": {\"x\": 170, \"y\": 1350}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}, {\"id\": \"m2\", \"alive\": true, \"position\": {\"x\": 190, \"y\": 1350}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TARGET3\": {\"id\": \"U_FD_TARGET3\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Target 3\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 1400}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TANK4\": {\"id\": \"U_FD_TANK4\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Mixed Wagon\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 2, \"capacity\": 22, \"embarked_units\": [\"U_FD_MOB4A\", \"U_FD_MOB4B\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 1900}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_MOB4A\": {\"id\": \"U_FD_MOB4A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK4\", \"meta\": {\"name\": \"FD Shoota Pair\", \"keywords\": [\"INFANTRY\"], \"weapons\": [{\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"models\": [{\"id\": \"m0\", \"alive\": true, \"position\": {\"x\": 150, \"y\": 1850}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}, {\"id\": \"m1\", \"alive\": true, \"position\": {\"x\": 170, \"y\": 1850}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_MOB4B\": {\"id\": \"U_FD_MOB4B\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK4\", \"meta\": {\"name\": \"FD Rokkit Boy\", \"keywords\": [\"INFANTRY\"], \"weapons\": [{\"name\": \"Rokkit launcha\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"8\", \"ap\": \"2\", \"damage\": \"3\", \"special_rules\": \"\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"models\": [{\"id\": \"m0\", \"alive\": true, \"position\": {\"x\": 230, \"y\": 1850}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TARGET4\": {\"id\": \"U_FD_TARGET4\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Target 4\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 1900}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}}, true)\nreturn U.has(\"U_FD_TANK\") and U.has(\"U_FD_TANK2\")",
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_FD_TANK_A\": {\"id\": \"U_FD_TANK_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Wagon A\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 11, \"capacity\": 22, \"capacity_multipliers\": {\"MEGA ARMOUR\": 2, \"JUMP PACK\": 2}, \"embarked_units\": [\"U_FD_BOYZ\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 400}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_BOYZ\": {\"id\": \"U_FD_BOYZ\", \"squad_id\": \"U_BOYZ_K\", \"owner\": 1, \"status\": 2, \"meta\": {\"name\": \"Boyz\", \"keywords\": [\"BATTLELINE\", \"BOYZ\", \"GRENADES\", \"INFANTRY\", \"MOB\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 2}, \"points\": 75, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"9x Slugga\", \"1x Slugga\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Kombi-weapon\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"anti-infantry 4+, devastating wounds, rapid fire 1\", \"abilities\": [{\"id\": \"anti\", \"keyword\": \"INFANTRY\", \"threshold\": 4}, {\"id\": \"devastating_wounds\"}, {\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Rokkit launcha\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"D3\", \"ballistic_skill\": \"5\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"3\", \"special_rules\": \"blast\", \"abilities\": [{\"id\": \"blast\"}]}, {\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 1\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Slugga\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"pistol\", \"abilities\": [{\"id\": \"pistol\"}]}, {\"name\": \"Big choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"7\", \"ap\": \"-1\", \"damage\": \"2\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"-1\", \"damage\": \"1\"}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Power klaw\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"4\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"2\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Bodyguard\", \"type\": \"Datasheet\", \"description\": \"This model gains the Extra Leader Attachment ability.\"}, {\"name\": \"Get Da Good Bitz\", \"type\": \"Datasheet\", \"description\": \"The unit retains control of objective markers even after no models remain in range, until the enemy retakes them (sticky objectives).\"}], \"unit_composition\": [{\"description\": \"1 Boss Nob\", \"line\": 1}, {\"description\": \"9-19 Boy\", \"line\": 2}], \"model_profiles\": {\"boss_nob\": {\"label\": \"Boss Nob\", \"short_label\": \"N\", \"weapons\": [\"Big choppa\", \"Choppa\", \"Power klaw\", \"Slugga\", \"Kombi-weapon\"], \"stats_override\": {\"save\": 4, \"weapon_skill\": 3}, \"transport_slots\": 1}, \"boy\": {\"label\": \"Boy\", \"short_label\": \"B\", \"weapons\": [\"Choppa\", \"Close combat weapon\", \"Shoota\", \"Slugga\", \"Big shoota\", \"Rokkit launcha\"], \"stats_override\": {\"weapon_skill\": 4}, \"transport_slots\": 1}}}, \"models\": [{\"id\": \"m1\", \"wounds\": 2, \"current_wounds\": 2, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boss_nob\"}, {\"id\": \"m2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m5\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m6\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m7\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m8\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m9\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"m10\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}], \"flags\": {}, \"embarked_in\": \"U_FD_TANK_A\"}, \"U_FD_TARGET_A\": {\"id\": \"U_FD_TARGET_A\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"U_FD_TARGET_A\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 400}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TANK_B\": {\"id\": \"U_FD_TANK_B\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Wagon B\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 11, \"capacity\": 22, \"capacity_multipliers\": {\"MEGA ARMOUR\": 2, \"JUMP PACK\": 2}, \"embarked_units\": [\"U_FD_BURNA\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 900}, \"base_mm\": 170, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_BURNA\": {\"id\": \"U_FD_BURNA\", \"squad_id\": \"U_BURNA_BOYZ_A\", \"owner\": 1, \"status\": 2, \"meta\": {\"name\": \"Burna Boyz\", \"keywords\": [\"BURNA BOYZ\", \"INFANTRY\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 1}, \"points\": 60, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"1x Spanner\", \"1x Big shoota\", \"1x Close combat weapon\", \"4x Burna Boy\", \"4x Burna\", \"4x Cuttin' flames\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Burna\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"D6\", \"ballistic_skill\": \"N/A\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"ignores cover, torrent\", \"abilities\": [{\"id\": \"ignores_cover\"}, {\"id\": \"torrent\"}]}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Cuttin' flames\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"4\", \"strength\": \"4\", \"ap\": \"-2\", \"damage\": \"1\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Pyromaniaks\", \"type\": \"Datasheet\", \"description\": \"During the Shooting phase, you can re-roll a Wound roll of 1.\"}], \"unit_composition\": [{\"description\": \"1-2 Spanner\", \"line\": 1}, {\"description\": \"4-8 Burna Boy\", \"line\": 2}]}, \"models\": [{\"id\": \"m1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []}, {\"id\": \"m2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []}, {\"id\": \"m3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []}, {\"id\": \"m4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []}, {\"id\": \"m5\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []}], \"flags\": {}, \"embarked_in\": \"U_FD_TANK_B\"}, \"U_FD_TARGET_B\": {\"id\": \"U_FD_TARGET_B\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"U_FD_TARGET_B\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 900}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}}, true)\nreturn U.has(\"U_FD_TANK_A\") and U.has(\"U_FD_BOYZ\")",
       "equals": true
     },
     {
       "act": "execute_script",
-      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK\", GameState.state).size() > 0",
-      "equals": true
-    },
-    {
-      "act": "dispatch_action",
-      "action": {
-        "type": "SELECT_SHOOTER",
-        "actor_unit_id": "U_FD_TANK"
-      }
-    },
-    {
-      "act": "expect_action_result",
-      "path": "success",
-      "equals": true
-    },
-    {
-      "act": "wait_frames",
-      "frames": 2
-    },
-    {
-      "act": "execute_script",
-      "multiline": true,
-      "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\treturn true\nreturn false",
-      "equals": false
-    },
-    {
-      "act": "execute_script",
-      "script": "GameState.get_unit(\"U_FD_TANK\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
-      "equals": 2
-    },
-    {
-      "act": "execute_script",
-      "script": "str(RulesEngine.get_unit_weapons(\"U_FD_TANK\", GameState.state)).contains(\"__fd\")",
-      "equals": true
-    },
-    {
-      "act": "execute_script",
-      "script": "GameState.get_unit(\"U_FD_MOB\").get(\"flags\", {}).get(\"has_shot\", false)",
-      "equals": true
-    },
-    {
-      "act": "screenshot",
-      "label": "01_auto_resolved_no_dialog_loan_on_tank"
-    },
-    {
-      "act": "execute_script",
-      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK2\", GameState.state).size() > 0",
+      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK_A\", GameState.state).size() > 0",
       "equals": true
     },
     {
       "act": "dispatch_action",
       "action": {
         "type": "SELECT_SHOOTER",
-        "actor_unit_id": "U_FD_TANK2"
+        "actor_unit_id": "U_FD_TANK_A"
       }
     },
     {
@@ -97,98 +51,38 @@
       "act": "execute_script",
       "multiline": true,
       "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\treturn true\nreturn false",
-      "equals": true
-    },
-    {
-      "act": "screenshot",
-      "label": "02_dialog_shown_when_real_choice"
-    },
-    {
-      "act": "execute_script",
-      "multiline": true,
-      "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\tif c.checkboxes.has(\"U_FD_MOB2_0_Shoota\"):\n\t\t\tc.checkboxes[\"U_FD_MOB2_0_Shoota\"].set_pressed(true)\n\t\t\treturn c.selected_weapons.size()\nreturn -1",
-      "equals": 1
-    },
-    {
-      "act": "wait_frames",
-      "frames": 2
-    },
-    {
-      "act": "execute_script",
-      "multiline": true,
-      "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\tc._on_confirm_pressed()\n\t\treturn true\nreturn false",
-      "equals": true
-    },
-    {
-      "act": "wait_frames",
-      "frames": 3
-    },
-    {
-      "act": "execute_script",
-      "multiline": true,
-      "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\treturn true\nreturn false",
       "equals": false
     },
     {
       "act": "execute_script",
-      "script": "GameState.get_unit(\"U_FD_TANK2\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
-      "equals": 1
+      "script": "GameState.get_unit(\"U_FD_TANK_A\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
+      "equals": 10
     },
     {
       "act": "execute_script",
-      "script": "str(RulesEngine.get_unit_weapons(\"U_FD_TANK2\", GameState.state)).contains(\"__fd\")",
+      "multiline": true,
+      "script": "var n = 0\nfor l in GameState.get_unit(\"U_FD_TANK_A\").get(\"flags\", {}).get(\"firing_deck_weapons\", []):\n\tif str(l.get(\"weapon_id\", \"\")).begins_with(\"shoota\"):\n\t\tn += 1\nreturn n",
+      "equals": 9
+    },
+    {
+      "act": "execute_script",
+      "script": "str(RulesEngine.get_unit_weapons(\"U_FD_TANK_A\", GameState.state)).contains(\"__fd\")",
       "equals": true
     },
     {
       "act": "screenshot",
-      "label": "03_dialog_confirmed_loan_applied"
+      "label": "01_boyz_autoloaded_shootas_no_dialog"
     },
     {
       "act": "execute_script",
-      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK3\", GameState.state).size() > 0",
+      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK_B\", GameState.state).size() > 0",
       "equals": true
     },
     {
       "act": "dispatch_action",
       "action": {
         "type": "SELECT_SHOOTER",
-        "actor_unit_id": "U_FD_TANK3"
-      }
-    },
-    {
-      "act": "expect_action_result",
-      "path": "success",
-      "equals": true
-    },
-    {
-      "act": "wait_frames",
-      "frames": 2
-    },
-    {
-      "act": "execute_script",
-      "multiline": true,
-      "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\treturn true\nreturn false",
-      "equals": false
-    },
-    {
-      "act": "execute_script",
-      "script": "GameState.get_unit(\"U_FD_TANK3\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
-      "equals": 2
-    },
-    {
-      "act": "screenshot",
-      "label": "04_over_cap_identical_autopicks_cap"
-    },
-    {
-      "act": "execute_script",
-      "script": "RulesEngine.get_eligible_targets(\"U_FD_TANK4\", GameState.state).size() > 0",
-      "equals": true
-    },
-    {
-      "act": "dispatch_action",
-      "action": {
-        "type": "SELECT_SHOOTER",
-        "actor_unit_id": "U_FD_TANK4"
+        "actor_unit_id": "U_FD_TANK_B"
       }
     },
     {
@@ -204,11 +98,22 @@
       "act": "execute_script",
       "multiline": true,
       "script": "for c in tree.root.get_children():\n\tvar sc = c.get_script()\n\tif sc != null and str(sc.resource_path).ends_with(\"FiringDeckDialog.gd\"):\n\t\treturn true\nreturn false",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.get_unit(\"U_FD_TANK_B\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
+      "equals": 5
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var loans = GameState.get_unit(\"U_FD_TANK_B\").get(\"flags\", {}).get(\"firing_deck_weapons\", [])\nif loans.is_empty():\n\treturn false\nfor l in loans:\n\tif not str(l.get(\"weapon_id\", \"\")).begins_with(\"burna\"):\n\t\treturn false\nreturn true",
       "equals": true
     },
     {
       "act": "screenshot",
-      "label": "05_over_cap_mixed_shows_dialog"
+      "label": "02_burnaboyz_autoloaded_burnas_no_dialog"
     }
   ]
 }


### PR DESCRIPTION
## What & why

Selecting a Firing Deck transport (rule 24.14 — e.g. a Battlewagon with Boyz aboard) **no longer opens the per-model selection dialog**. The embarked models' guns are loaned straight onto the transport as its own weapons, so the wagon just fires its Shootas and you go straight to picking targets — the behaviour requested in the follow-up feedback.

### Why the previous auto-resolve wasn't enough
Real datasheets list *every wargear option* on each model (the loadout isn't pinned per model), so a single `boy` model reports **four** ranged weapons (`Big shoota, Rokkit launcha, Shoota, Slugga`) and a Burna Boy reports two. The prior "auto-resolve only when a model has exactly one gun" therefore fell back to the dialog for essentially every real Ork mob.

## Behaviour

For each eligible embarked model, the transport is loaned that model's **basic gun** — the plain rank-and-file weapon (lowest Damage, then lowest Strength, preferring a non-Pistol). This deliberately avoids the naive "best gun" pick, which would fire, e.g., a **Big Shoota on all 10 Boyz** — an illegal over-count of a weapon the mob carries one of. Verified against real data:
- Boyz (10) → **9 Shootas + 1 Kombi** (the nob)
- Burna Boyz (5) → **5 Burnas**
- Meganobz (5, Mega Armour) → 5 Kustom Shootas at **2 Firing-Deck slots each**

Guardrails kept: `[ONE SHOT]` and `[HAZARDOUS]` weapons are never auto-fired; `MEGA ARMOUR` / `JUMP PACK` models count as two slots; an over-capacity mob fires the first X.

**Known limitation:** because loadouts aren't resolved per model, the pick is a best-effort *basic* gun — e.g. Lootas fire Big Shootas rather than Deffguns. Documented in the changelog.

## Validation
- Rewrote the windowed scenario `iss_firing_deck_autoresolve_11e` to drive **real** multi-option Ork mobs (Boyz, Burna Boyz): asserts no dialog appears, the correct basic guns are loaned (9 Shootas + nob Kombi; all Burnas), and they show up as the transport's own weapons. 20/20 steps pass; screenshot captured of the wagon with 11 weapons (own + loaned) and no dialog.
- Regressions green: `test_iss071_firing_deck_11e` (headless), `iss071_firing_deck_11e` + `370_bgnt_vehicle_shoots_in_engagement` (windowed). The `FiringDeckDialog` is unchanged and still validated in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PkGyXEdZiBNCiC1zFVprYC

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkGyXEdZiBNCiC1zFVprYC)_