### PR TITLE
Per-model weapon loadout — roadmap Tasks A–D (hover/inspect, board marker, wider coverage, melee)

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6296,7 +6296,9 @@ static func _get_model_weapon_ids(unit: Dictionary, model: Dictionary, weapon_ty
 	return weapon_ids
 
 
-# MA-LOADOUT: resolve which RANGED gun each model actually carries.
+# MA-LOADOUT: resolve which weapon(s) each model of a multi-model unit actually
+# carries, from the unit's `wargear` counts, stamping them onto the models
+# (`ranged_loadout` — and, once Task D lands, `melee_loadout`).
 #
 # Datasheets store, per model_type, the full MENU of wargear options. When the
 # importer already narrowed that to one weapon (e.g. Lootas' loota_deffgun ->
@@ -6304,47 +6306,77 @@ static func _get_model_weapon_ids(unit: Dictionary, model: Dictionary, weapon_ty
 # generic "boy" type) — or gave no model_profiles at all — every model reports
 # EVERY option, so a 10-model mob reports ~4x its real guns.
 #
-# The unit's `wargear` records the actual loadout with counts ("8x Deffgun",
-# "2x Kustom mega-blasta"). When that unambiguously pins the ranged loadout —
-# every model gets exactly one gun and the counts sum to the model count — stamp
-# each model with its real gun in `ranged_loadout`. This is deliberately
-# conservative: anything it can't parse cleanly (incomplete/oversized wargear,
-# no counts, dual-gun models) is left exactly as-is (the pre-existing behavior),
-# so it only ever REDUCES over-counting, never changes an already-correct unit.
+# Resolution is deliberately conservative: it only ever REDUCES over-counting and
+# every assignment is cross-checked against model_profiles, so it never hands a
+# model a weapon its type can't take and never changes an already-correct unit.
+# Anything it can't pin cleanly is left exactly as-is (the safe fallback) and
+# logged. See _resolve_type_loadout for the cases handled (A/B/C).
 static func _ensure_loadout_resolved(unit: Dictionary) -> void:
 	if unit.get("_loadout_checked", false):
 		return
 	unit["_loadout_checked"] = true
 
-	var meta = unit.get("meta", {})
-	var models = unit.get("models", [])
 	# Multi-model units only. A single-model unit (VEHICLE / MONSTER / character)
 	# legitimately fires ALL of its weapons, so we must never collapse it to one
 	# gun — its "menu" is its real arsenal, not a per-model choice.
-	if models.size() < 2:
+	if unit.get("models", []).size() < 2:
 		return
 
-	# Ranged weapon names this datasheet actually lists.
-	var ranged_names := {}
+	_resolve_type_loadout(unit, "Ranged", "ranged_loadout")
+
+
+# MA-LOADOUT: cross-check guard — may this model's type actually take
+# `weapon_name`? True when the unit has no model_profiles constraint for this
+# model (its menu is already limited to meta.weapons), otherwise the name must be
+# in the model_type's allowed weapon list. This is the guard against inventing a
+# weapon a model_type can't have (the #1 risk when widening coverage).
+static func _model_allows_weapon(unit: Dictionary, model: Dictionary, weapon_name: String) -> bool:
+	var model_profiles = unit.get("meta", {}).get("model_profiles", {})
+	var model_type = model.get("model_type", "")
+	if model_profiles.is_empty() or model_type == "" or not model_profiles.has(model_type):
+		return true
+	return weapon_name in model_profiles[model_type].get("weapons", [])
+
+
+# MA-LOADOUT: shared resolver for one weapon type ("Ranged" / "Melee"). Parses
+# the unit's `wargear` counts for that type's weapons and, when they unambiguously
+# pin the per-model loadout, stamps `loadout_key` on each model. Leaves the unit
+# untouched (safe fallback) and logs why otherwise.
+#
+# Cases handled:
+#   A) one gun per model, counts sum to the model count (original Phase 1) — the
+#      special (lowest-count) guns go on the first models that may take them.
+#   B) uniform multi-gun models: every distinct gun appears exactly once per
+#      model (each count == model_count), so each model carries the same set
+#      (Deffkopta -> [Kopta rokkits, Slugga]). Guards out oversized/broken
+#      wargear (a 2-model unit carrying 10-model counts fails this cleanly).
+#   C) incomplete-but-consistent: fewer counts than models but all the SAME gun
+#      (a 20-Boy mob recorded with only "10x Slugga") -> that gun on every model.
+static func _resolve_type_loadout(unit: Dictionary, weapon_type_filter: String, loadout_key: String) -> void:
+	var meta = unit.get("meta", {})
+	var models = unit.get("models", [])
+
+	# Weapon names of this type the datasheet actually lists.
+	var type_names := {}
 	for w in meta.get("weapons", []):
-		if str(w.get("type", "")).to_lower() == "ranged":
-			ranged_names[str(w.get("name", ""))] = true
-	if ranged_names.is_empty():
+		if str(w.get("type", "")).to_lower() == weapon_type_filter.to_lower():
+			type_names[str(w.get("name", ""))] = true
+	if type_names.is_empty():
 		return
 
-	# Only act when a model currently over-reports ranged weapons. Units already
+	# Only act when a model currently over-reports this weapon type. Units already
 	# resolved per model_type (loota_deffgun, etc.) are left untouched.
 	var over_reports := false
 	for model in models:
-		if _get_model_weapon_ids(unit, model, "Ranged").size() > 1:
+		if _get_model_weapon_ids(unit, model, weapon_type_filter).size() > 1:
 			over_reports = true
 			break
 	if not over_reports:
 		return
 
-	# Parse wargear into ranged {name: count}, summing duplicate lines and
-	# ignoring entries that aren't this unit's ranged weapons (roles, melee, and
-	# count-less entries we can't size).
+	# Parse wargear into {name: count} for this type, summing duplicate lines and
+	# ignoring entries that aren't this unit's weapons of this type (roles, the
+	# other weapon type, and count-less entries we can't size).
 	var counts := {}
 	var total := 0
 	for entry in meta.get("wargear", []):
@@ -6360,26 +6392,77 @@ static func _ensure_loadout_resolved(unit: Dictionary) -> void:
 			if not num_str.is_valid_int():
 				continue
 			var name = txt.substr(space + 1).strip_edges()
-			if ranged_names.has(name):
+			if type_names.has(name):
 				var n = int(num_str)
 				counts[name] = int(counts.get(name, 0)) + n
 				total += n
 
-	# Confidence gate: exactly one ranged gun per model, summing to the model
-	# count. Otherwise leave the unit as-is (safe fallback).
-	if counts.is_empty() or total != models.size():
+	var model_count = models.size()
+	var uname = str(meta.get("name", ""))
+	var tlow = weapon_type_filter.to_lower()
+	if counts.is_empty():
+		print("[MA-LOADOUT] %s (%s): left unresolved — no parseable %s wargear counts" % [uname, weapon_type_filter, tlow])
 		return
 
-	# Assign one ranged weapon per model. Lowest-count (special) weapons go to the
-	# first models so they're identifiable; the bulk basic gun fills the rest.
-	var ordered = counts.keys()
-	ordered.sort_custom(func(a, b): return int(counts[a]) < int(counts[b]))
-	var idx := 0
-	for name in ordered:
-		for _i in range(int(counts[name])):
-			if idx < models.size():
-				models[idx]["ranged_loadout"] = [name]
-				idx += 1
+	var distinct = counts.keys()
+
+	# CASE A — exactly one gun per model. Assign lowest-count (special) weapons to
+	# the earliest model that may take them so they're identifiable; the bulk gun
+	# fills the rest. Falls back if a gun can't be placed within model_profiles.
+	if total == model_count:
+		var ordered = distinct.duplicate()
+		ordered.sort_custom(func(a, b): return int(counts[a]) < int(counts[b]))
+		var assigned := {}   # model index -> gun name
+		var used := {}       # model index -> true
+		for name in ordered:
+			for _i in range(int(counts[name])):
+				var placed := false
+				for mi in range(model_count):
+					if used.has(mi):
+						continue
+					if _model_allows_weapon(unit, models[mi], name):
+						used[mi] = true
+						assigned[mi] = name
+						placed = true
+						break
+				if not placed:
+					print("[MA-LOADOUT] %s (%s): left unresolved — could not place '%s' within model_profiles" % [uname, weapon_type_filter, name])
+					return
+		for mi in range(model_count):
+			models[mi][loadout_key] = [assigned[mi]]
+		return
+
+	# CASE B — uniform multi-gun models (each distinct gun appears once per model).
+	var uniform := true
+	for name in distinct:
+		if int(counts[name]) != model_count:
+			uniform = false
+			break
+	if uniform and total == distinct.size() * model_count:
+		var gun_set := []
+		for name in distinct:
+			gun_set.append(name)
+		for model in models:
+			for name in gun_set:
+				if not _model_allows_weapon(unit, model, name):
+					print("[MA-LOADOUT] %s (%s): left unresolved — set gun '%s' not allowed for model_type '%s'" % [uname, weapon_type_filter, name, str(model.get("model_type", ""))])
+					return
+		for model in models:
+			model[loadout_key] = gun_set.duplicate()
+		return
+
+	# CASE C — incomplete-but-consistent: fewer counts than models, all one gun.
+	if distinct.size() == 1 and total < model_count:
+		var name = str(distinct[0])
+		for model in models:
+			if not _model_allows_weapon(unit, model, name):
+				print("[MA-LOADOUT] %s (%s): left unresolved — consistent gun '%s' not allowed for model_type '%s'" % [uname, weapon_type_filter, name, str(model.get("model_type", ""))])
+				return
+		for model in models:
+			model[loadout_key] = [name]
+		return
+
+	print("[MA-LOADOUT] %s (%s): left unresolved — counts inconclusive (total=%d models=%d distinct=%d)" % [uname, weapon_type_filter, total, model_count, distinct.size()])
 
 # Get weapons for a unit
 static func get_unit_weapons(unit_id: String, board: Dictionary = {}) -> Dictionary:

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6464,6 +6464,52 @@ static func _resolve_type_loadout(unit: Dictionary, weapon_type_filter: String, 
 
 	print("[MA-LOADOUT] %s (%s): left unresolved — counts inconclusive (total=%d models=%d distinct=%d)" % [uname, weapon_type_filter, total, model_count, distinct.size()])
 
+# MA-LOADOUT Phase 3 (Task B): the model IDs in this unit that carry a
+# NON-majority ranged loadout — i.e. the special/heavy-weapon models that should
+# look distinct on the board. Uses each model's ACTUALLY-reported ranged guns
+# (the same resolved data get_unit_weapons uses — covers both wargear-resolved
+# loadouts and model_type-resolved mobs like Lootas), so an over-reporting
+# unresolved unit (every model shows the same menu) yields [] and gets no marker.
+# Returns [] when every model carries the same guns (nobody stands out). Single
+# source of truth shared by TokenVisual (draws the marker) and the tests.
+static func get_special_weapon_model_ids(unit: Dictionary) -> Array:
+	var models = unit.get("models", [])
+	if models.size() < 2:
+		return []
+	_ensure_loadout_resolved(unit)
+	var sig_of := {}       # model_id -> ranged-loadout signature
+	var sig_counts := {}   # signature -> count
+	for m in models:
+		if not m.get("alive", true):
+			continue
+		var ids = _get_model_weapon_ids(unit, m, "Ranged")
+		var sig = _loadout_signature(ids)
+		sig_of[str(m.get("id", ""))] = sig
+		sig_counts[sig] = int(sig_counts.get(sig, 0)) + 1
+	if sig_counts.size() <= 1:
+		return []  # every model reports the same guns -> nobody is "special"
+	# Majority signature = the bulk/basic gun the rank-and-file carry.
+	var majority_sig := ""
+	var majority_n := -1
+	for s in sig_counts:
+		if int(sig_counts[s]) > majority_n:
+			majority_n = int(sig_counts[s])
+			majority_sig = s
+	var out := []
+	for mid in sig_of:
+		if sig_of[mid] != majority_sig:
+			out.append(mid)
+	return out
+
+# Stable order-independent signature for a per-model loadout (the sorted weapon
+# names joined), so [A,B] and [B,A] compare equal.
+static func _loadout_signature(loadout: Array) -> String:
+	var names := []
+	for n in loadout:
+		names.append(str(n))
+	names.sort()
+	return "|".join(names)
+
 # Get weapons for a unit
 static func get_unit_weapons(unit_id: String, board: Dictionary = {}) -> Dictionary:
 	# First try legacy format for backward compatibility

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6269,22 +6269,28 @@ static func _get_model_weapon_ids(unit: Dictionary, model: Dictionary, weapon_ty
 	if use_profile:
 		allowed_weapon_names = model_profiles[model_type].get("weapons", [])
 
-	# MA-LOADOUT: a resolved per-model RANGED loadout (derived from the unit's
-	# wargear by _ensure_loadout_resolved) overrides the model_profiles menu for
-	# ranged weapons only — so a model reports the gun it actually carries rather
-	# than every wargear option. Melee/other filters are unchanged.
+	# MA-LOADOUT: a resolved per-model loadout (derived from the unit's wargear by
+	# _ensure_loadout_resolved) overrides the model_profiles menu — so a model
+	# reports the weapon it actually carries rather than every wargear option.
+	# Ranged (Phase 1/Task C) and melee (Phase 1b/Task D) are symmetric.
+	var tf = weapon_type_filter.to_lower()
 	var resolved_ranged = model.get("ranged_loadout", null)
-	var use_resolved_ranged = weapon_type_filter.to_lower() == "ranged" and resolved_ranged is Array
+	var resolved_melee = model.get("melee_loadout", null)
+	var use_resolved_ranged = tf == "ranged" and resolved_ranged is Array
+	var use_resolved_melee = tf == "melee" and resolved_melee is Array
 
 	var weapon_ids = []
 	for weapon in weapons_data:
 		var wtype = weapon.get("type", "")
-		if wtype.to_lower() != weapon_type_filter.to_lower():
+		if wtype.to_lower() != tf:
 			continue
 
 		var wname = weapon.get("name", "")
 		if use_resolved_ranged:
 			if wname not in resolved_ranged:
+				continue
+		elif use_resolved_melee:
+			if wname not in resolved_melee:
 				continue
 		elif use_profile and wname not in allowed_weapon_names:
 			continue
@@ -6323,6 +6329,12 @@ static func _ensure_loadout_resolved(unit: Dictionary) -> void:
 		return
 
 	_resolve_type_loadout(unit, "Ranged", "ranged_loadout")
+	# MA-LOADOUT Phase 1b (Task D): resolve melee the same way, so the Fight phase
+	# stops over-counting a model's melee options (a Boy's Choppa AND Close combat
+	# weapon, a Nob's several melee profiles). Melee wargear is spottier than
+	# ranged, so most units fall back to the menu; those that pin it cleanly
+	# (Kommandos -> Choppa, Burna Boyz -> Cuttin' flames + CCW) are resolved.
+	_resolve_type_loadout(unit, "Melee", "melee_loadout")
 
 
 # MA-LOADOUT: cross-check guard — may this model's type actually take
@@ -12735,6 +12747,11 @@ static func get_unit_melee_weapons(unit_id: String, board: Dictionary = {}) -> D
 	if unit.is_empty():
 		return unit_weapons
 
+	# MA-LOADOUT Phase 1b (Task D): resolve per-model melee loadouts (once) so a
+	# model reports the melee weapon(s) it actually fights with rather than every
+	# datasheet option. Idempotent — a no-op once the unit is resolved.
+	_ensure_loadout_resolved(unit)
+
 	var models = unit.get("models", [])
 	var weapons_data = unit.get("meta", {}).get("weapons", [])
 	var model_profiles = unit.get("meta", {}).get("model_profiles", {})
@@ -12755,10 +12772,18 @@ static func get_unit_melee_weapons(unit_id: String, board: Dictionary = {}) -> D
 		var model_id = "m" + str(model_index)
 		var model_weapons = []
 
-		# Per-model profile branch: if model_profiles exist and model has a model_type,
-		# only assign melee weapons listed in that model's profile
+		# Prefer the resolved per-model melee loadout when present (the weapons the
+		# model actually fights with); else fall back to the profile menu, else all.
+		var resolved_melee = model.get("melee_loadout", null)
 		var model_type = model.get("model_type", "")
-		if not model_profiles.is_empty() and model_type != "" and model_profiles.has(model_type):
+		if resolved_melee is Array:
+			for weapon in weapons_data:
+				if weapon.get("type", "").to_lower() == "melee" and weapon.get("name", "") in resolved_melee:
+					var wname = weapon.get("name", "Unknown Weapon")
+					if wname not in model_weapons:
+						model_weapons.append(wname)
+		elif not model_profiles.is_empty() and model_type != "" and model_profiles.has(model_type):
+			# Per-model profile branch: only melee weapons listed in this model's profile
 			var profile = model_profiles[model_type]
 			var profile_weapon_names = profile.get("weapons", [])
 			for weapon in weapons_data:

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -14929,6 +14929,12 @@ static func check_units_in_engagement_range(unit1: Dictionary, unit2: Dictionary
 static func generate_weapon_id(weapon_name: String, weapon_type: String = "") -> String:
 	return _generate_weapon_id(weapon_name, weapon_type)
 
+## MA-LOADOUT: force per-model loadout resolution (ranged + melee) on a unit so
+## UI/read paths can then read model.ranged_loadout / model.melee_loadout.
+## Idempotent — a no-op once the unit has been resolved.
+static func ensure_loadout_resolved(unit: Dictionary) -> void:
+	_ensure_loadout_resolved(unit)
+
 ## Staged fight: re-roll Hold Still (OA-19) mortal wounds for a melee
 ## hit_context after a Command Re-roll changed the critical-wound tally.
 static func roll_hold_still_mortal_wounds(hit_context: Dictionary, all_critical_wound_count: int, rng_service: RNGService = null) -> int:

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.9",
+			"date": "2026-07-23",
+			"summary": "Inspecting or hovering a model now shows the gun it ACTUALLY carries instead of every wargear option on its datasheet. A Slugga Boy reads 'Slugga', not the whole Shoota/Big Shoota/Rokkit menu; in a mixed mob the special-weapon model shows its own gun. The unit panel's ranged weapon table is labelled '(as equipped)' and lists only carried guns with a per-gun model count.",
+			"changes": [
+				"Board hover: the per-model tooltip now lists the model's resolved ranged weapon (its real gun) rather than the full datasheet menu, so hovering different models in a mixed mob shows their different weapons. Also works for units without per-model profiles (e.g. Burna Boyz, Deffkoptas).",
+				"Unit inspect panel: the 'RANGED WEAPONS' table now shows a weapon-name column and, for resolved units, is titled 'RANGED WEAPONS (as equipped)' and lists only the guns models actually carry, each tagged with how many carry it (e.g. 'Slugga ×10').",
+				"Unit inspect panel: the model-composition breakdown's per-type 'Weapons:' line shows the resolved loadout (e.g. '9x Slugga') instead of the option menu.",
+				"Melee weapons now show their names too; unresolved units and single-model units are unchanged and still list their full weapon set."
+			]
+		},
+		{
 			"version": "0.93.8",
 			"date": "2026-07-23",
 			"summary": "More units now report the guns they actually carry. Widened the per-model loadout resolver so it also handles units the first pass had to leave alone: mobs whose army-list only records some of the guns (a 20-model Boyz mob listed with just '10x Slugga' now shows 20 Sluggas), and models that legitimately carry two guns (Deffkoptas keep both their Kopta rokkits and Slugga). Eight more multi-model units are now resolved, with no risk of ever handing a model a weapon it can't take.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.11",
+			"date": "2026-07-23",
+			"summary": "The Fight phase now uses the melee weapons models actually carry, the same way shooting was fixed. Datasheets list every close-combat OPTION per model, which made a mob report all of them at once; when the army list pins the melee loadout (Kommandos with Choppas, Burna Boyz with Cuttin' flames, Beast Snagga with Choppas + a Power snappa) each model now fights with its real weapon instead of the whole menu.",
+			"changes": [
+				"Fight phase: multi-model units whose datasheet lists several melee options per model are resolved from their wargear — each model reports the melee weapon it actually fights with, so a Burna Boyz mob shows 4 Cuttin' flames + 1 Close combat weapon rather than both on every model.",
+				"Unit inspect panel: the MELEE WEAPONS table is titled '(as equipped)' for resolved units and lists only the weapons carried, each with a model count — matching the ranged table.",
+				"Conservative and safe: melee wargear is spottier than ranged, so units that can't be pinned cleanly keep their full melee menu; single-model units are untouched; and the resolver never assigns a melee weapon a model's datasheet doesn't allow (e.g. a Kommando Boss that can only take a Big Choppa is left alone rather than forced to a Choppa)."
+			]
+		},
+		{
 			"version": "0.93.10",
 			"date": "2026-07-23",
 			"summary": "The model carrying a mob's special/heavy weapon now stands out on the board. An amber spark badge is drawn on the token of any model whose gun differs from the rank-and-file (the Big Shoota Boy in a Burna mob, the Kustom Mega-blasta Lootas, a mob's odd-model-out), so you can see at a glance who has what without opening a menu.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.8",
+			"date": "2026-07-23",
+			"summary": "More units now report the guns they actually carry. Widened the per-model loadout resolver so it also handles units the first pass had to leave alone: mobs whose army-list only records some of the guns (a 20-model Boyz mob listed with just '10x Slugga' now shows 20 Sluggas), and models that legitimately carry two guns (Deffkoptas keep both their Kopta rokkits and Slugga). Eight more multi-model units are now resolved, with no risk of ever handing a model a weapon it can't take.",
+			"changes": [
+				"Shooting: a mob whose wargear lists fewer guns than it has models, all of the same type, is now resolved to that gun on every model (20-model Boyz mob -> 20 Sluggas instead of the whole 5-option menu).",
+				"Shooting: models that carry a fixed set of two guns (e.g. Deffkoptas with Kopta rokkits + Slugga) are recognised and each reports exactly that pair, instead of an ambiguous menu.",
+				"Every assignment is cross-checked against the model's own datasheet options, so the resolver never invents a weapon a model can't actually take.",
+				"Units that still can't be resolved (no wargear detail, or army-list counts that don't match the model count) are left exactly as before and logged, so it's clear which ones fall back."
+			]
+		},
+		{
 			"version": "0.93.7",
 			"date": "2026-07-23",
 			"summary": "Units now shoot with the guns they actually carry. Datasheets list every wargear OPTION per model, which made a mob report ALL of them at once — a 10-model Ork Boyz mob showed ~38 ranged weapons instead of 10. When a unit's army-list wargear pins the loadout, each model is now assigned its real gun, so shooting (and the Firing Deck) uses the correct weapons.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.10",
+			"date": "2026-07-23",
+			"summary": "The model carrying a mob's special/heavy weapon now stands out on the board. An amber spark badge is drawn on the token of any model whose gun differs from the rank-and-file (the Big Shoota Boy in a Burna mob, the Kustom Mega-blasta Lootas, a mob's odd-model-out), so you can see at a glance who has what without opening a menu.",
+			"changes": [
+				"Board: models that carry a non-standard ranged weapon (a minority gun within their unit) get a small amber 4-point badge at the top-left of their token.",
+				"The badge is only drawn when a model genuinely stands out — uniform mobs (every model the same gun) and single-model units get nothing new, and unresolved units are unchanged.",
+				"Works with both wargear-resolved loadouts and model-type mobs like Lootas; the marked count always matches the mob's actual special-weapon models."
+			]
+		},
+		{
 			"version": "0.93.9",
 			"date": "2026-07-23",
 			"summary": "Inspecting or hovering a model now shows the gun it ACTUALLY carries instead of every wargear option on its datasheet. A Slugga Boy reads 'Slugga', not the whole Shoota/Big Shoota/Rokkit menu; in a mixed mob the special-weapon model shows its own gun. The unit panel's ranged weapon table is labelled '(as equipped)' and lists only carried guns with a per-gun model count.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7544,14 +7544,12 @@ func _show_token_hover(unit_id: String, screen_pos: Vector2, model_id: String = 
 	_position_token_hover(screen_pos)
 
 func _build_model_profile_hover_text(unit: Dictionary, model_id: String) -> String:
-	# Returns a BBCode block describing the hovered model's profile + weapons, or
-	# "" when the unit has no per-model profiles (legacy squads — nothing to add).
+	# Returns a BBCode block describing the hovered model's profile + the weapons
+	# it ACTUALLY carries, or "" when there is nothing model-specific to add.
 	if model_id == "":
 		return ""
 	var meta = unit.get("meta", {})
 	var profiles = meta.get("model_profiles", {})
-	if profiles.is_empty():
-		return ""
 	var model = {}
 	for m in unit.get("models", []):
 		if m.get("id", "") == model_id:
@@ -7559,27 +7557,57 @@ func _build_model_profile_hover_text(unit: Dictionary, model_id: String) -> Stri
 			break
 	if model.is_empty():
 		return ""
+	# MA-LOADOUT Phase 2 (Task A): make sure the per-model ranged loadout is
+	# resolved so hover shows the model's REAL gun rather than the whole datasheet
+	# menu. Idempotent — a no-op once the unit has been resolved.
+	RulesEngine._ensure_loadout_resolved(unit)
+	var resolved_ranged = model.get("ranged_loadout", null)  # Array of names, or null
+	var has_resolved_ranged: bool = resolved_ranged is Array and not (resolved_ranged as Array).is_empty()
 	var model_type = model.get("model_type", "")
-	if model_type == "" or not profiles.has(model_type):
+	var has_profile: bool = not profiles.is_empty() and model_type != "" and profiles.has(model_type)
+	# Legacy squad with neither a profile nor a resolved loadout: nothing to add.
+	if not has_profile and not has_resolved_ranged:
 		return ""
-	var profile = profiles[model_type]
-	var label = profile.get("label", model_type)
+	var profile = profiles.get(model_type, {}) if has_profile else {}
+	var label = str(profile.get("label", ""))
+	if label == "":
+		label = model_type if model_type != "" else str(meta.get("name", "Model"))
 	# Weapon name -> full profile lookup from the unit weapon list.
 	var weapon_index := {}
 	for w in meta.get("weapons", []):
 		weapon_index[w.get("name", "")] = w
-	var profile_weapons = profile.get("weapons", [])
+	# RANGED: the resolved loadout (real gun) when we have it; otherwise the
+	# profile's ranged menu (unresolved fallback — never hide a model's guns).
+	var ranged_names: Array = []
+	if has_resolved_ranged:
+		ranged_names = resolved_ranged
+	elif has_profile:
+		for wname in profile.get("weapons", []):
+			var w = weapon_index.get(wname, {})
+			if w.get("type", "") == "Ranged":
+				ranged_names.append(wname)
+	# MELEE: the profile's menu (melee resolution is a later task); a legacy
+	# non-profiled model has none to enumerate here.
+	var melee_names: Array = []
+	if has_profile:
+		for wname in profile.get("weapons", []):
+			var w = weapon_index.get(wname, {})
+			if w.is_empty() or w.get("type", "") != "Ranged":
+				melee_names.append(wname)
 	var ranged_lines: Array = []
-	var melee_lines: Array = []
-	for wname in profile_weapons:
+	for wname in ranged_names:
 		var w = weapon_index.get(wname, {})
 		if w.is_empty():
-			melee_lines.append("• %s" % wname)
-			continue
-		if w.get("type", "") == "Ranged":
+			ranged_lines.append("• %s" % wname)
+		else:
 			ranged_lines.append("• %s [color=#888888]%s\"  A%s BS%s S%s AP%s D%s[/color]" % [
 				w.get("name", wname), w.get("range", "-"), w.get("attacks", "-"),
 				w.get("ballistic_skill", "-"), w.get("strength", "-"), w.get("ap", "0"), w.get("damage", "-")])
+	var melee_lines: Array = []
+	for wname in melee_names:
+		var w = weapon_index.get(wname, {})
+		if w.is_empty():
+			melee_lines.append("• %s" % wname)
 		else:
 			melee_lines.append("• %s [color=#888888]A%s WS%s S%s AP%s D%s[/color]" % [
 				w.get("name", wname), w.get("attacks", "-"), w.get("weapon_skill", "-"),

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -7560,7 +7560,7 @@ func _build_model_profile_hover_text(unit: Dictionary, model_id: String) -> Stri
 	# MA-LOADOUT Phase 2 (Task A): make sure the per-model ranged loadout is
 	# resolved so hover shows the model's REAL gun rather than the whole datasheet
 	# menu. Idempotent — a no-op once the unit has been resolved.
-	RulesEngine._ensure_loadout_resolved(unit)
+	RulesEngine.ensure_loadout_resolved(unit)
 	var resolved_ranged = model.get("ranged_loadout", null)  # Array of names, or null
 	var has_resolved_ranged: bool = resolved_ranged is Array and not (resolved_ranged as Array).is_empty()
 	var model_type = model.get("model_type", "")

--- a/40k/scripts/TokenVisual.gd
+++ b/40k/scripts/TokenVisual.gd
@@ -13,6 +13,12 @@ var is_selected: bool = false
 var is_hovered: bool = false
 var _pulse_time: float = 0.0
 
+# MA-LOADOUT Phase 3 (Task B): cached "carries the special/heavy weapon" flag so
+# the per-frame redraw doesn't recompute the unit-wide majority every time.
+# Invalidated whenever model_data changes (set_model_data).
+var _special_checked: bool = false
+var _is_special_weapon: bool = false
+
 # Sprite overlay (Phase 2 - static)
 var _sprite_resolved: bool = false
 var _sprite_texture: Texture2D = null
@@ -485,6 +491,8 @@ func _draw() -> void:
 		_draw_letter_mode()
 		_draw_battle_shock_indicator()  # T-096: also show in letter mode
 		_draw_colorblind_shape_badge()  # T-097: colorblind-friendly shape badge
+		var lm_bounds = base_shape.get_bounds()
+		_draw_special_weapon_indicator(min(lm_bounds.size.x, lm_bounds.size.y) / 2.0)
 		return
 
 	if use_retro and not debug_mode:
@@ -521,6 +529,12 @@ func _draw() -> void:
 
 	# Draw model number with shadow for readability (all styles)
 	_draw_model_number()
+
+	# MA-LOADOUT Phase 3 (Task B): mark the special/heavy-weapon model so a player
+	# can see at a glance which model carries the non-standard gun.
+	if not debug_mode:
+		var sw_bounds = base_shape.get_bounds()
+		_draw_special_weapon_indicator(min(sw_bounds.size.x, sw_bounds.size.y) / 2.0)
 
 	# Draw unit name label beneath the token base
 	_draw_unit_name_label()
@@ -1158,6 +1172,42 @@ func _has_beacon_flag() -> bool:
 		return false
 	var unit = GameState.get_unit(get_meta("unit_id"))
 	return not unit.is_empty() and unit.get("flags", {}).get("beacon", false)
+
+func _draw_special_weapon_indicator(radius: float) -> void:
+	# MA-LOADOUT Phase 3 (Task B): draw an amber 4-point "spark" badge at the
+	# token's top-left when this model carries the special/heavy weapon (its
+	# resolved ranged loadout differs from the mob's bulk gun). Distinct in colour
+	# and position from the leader chevron (top-centre) and the Marked-for-Death /
+	# Beacon rings (top-right). Nothing is drawn for unresolved units or uniform
+	# mobs where no model stands out. Result cached — see set_model_data.
+	if not has_meta("unit_id"):
+		return
+	if not _special_checked:
+		_special_checked = true
+		_is_special_weapon = false
+		var unit = GameState.get_unit(get_meta("unit_id"))
+		if not unit.is_empty():
+			var special_ids = RulesEngine.get_special_weapon_model_ids(unit)
+			_is_special_weapon = str(model_data.get("id", "")) in special_ids
+	if not _is_special_weapon:
+		return
+
+	var center = Vector2(-radius * 0.62, -radius - 6.0)
+	var outer = max(4.0, radius * 0.34)
+	var inner = outer * 0.42
+	var star = PackedVector2Array()
+	for i in range(8):
+		var ang = -PI / 2.0 + TAU * i / 8.0
+		var r = outer if (i % 2 == 0) else inner
+		star.append(center + Vector2(cos(ang), sin(ang)) * r)
+	# Dark outline (scaled-up copy) behind an amber fill so it reads at board zoom.
+	var outline = PackedVector2Array()
+	for p in star:
+		outline.append(center + (p - center) * 1.3)
+	draw_colored_polygon(outline, Color(0.12, 0.08, 0.0, 0.92))
+	draw_colored_polygon(star, Color(1.0, 0.72, 0.12, 1.0))
+	# Small dark core keeps the star shape legible when the token is tiny.
+	draw_circle(center, max(1.0, inner * 0.35), Color(0.2, 0.12, 0.0, 0.92))
 
 func _draw_selection_ring(radius: float) -> void:
 	var pulse = (sin(_pulse_time * 4.0) + 1.0) / 2.0
@@ -1817,6 +1867,7 @@ func set_model_data(data: Dictionary) -> void:
 	model_data = data
 	base_shape = Measurement.create_base_shape(data)
 	_faction_font = null  # Reset font cache on model change
+	_special_checked = false  # Task B: recompute special-weapon flag on data change
 	queue_redraw()
 
 	# Set model number if available

--- a/40k/scripts/UnitStatsPanel.gd
+++ b/40k/scripts/UnitStatsPanel.gd
@@ -458,10 +458,13 @@ func _create_weapons_tables(unit_data: Dictionary, weapons_container: VBoxContai
 		spacer.custom_minimum_size = Vector2(0, 10)
 		weapons_container.add_child(spacer)
 
-	# Create melee weapons table
+	# Create melee weapons table (Task D: resolved melee loadout, symmetric w/ ranged)
 	if not melee_weapons.is_empty():
+		var carried_melee = _carried_melee_counts(unit_data)
+		var melee_resolved = not carried_melee.is_empty()
+
 		var melee_label = Label.new()
-		melee_label.text = "MELEE WEAPONS"
+		melee_label.text = "MELEE WEAPONS (as equipped)" if melee_resolved else "MELEE WEAPONS"
 		melee_label.add_theme_font_size_override("font_size", 14)
 		melee_label.add_theme_color_override("font_color", Color(0.9, 0.4, 0.35))  # Lightened WH red
 		weapons_container.add_child(melee_label)
@@ -479,9 +482,18 @@ func _create_weapons_tables(unit_data: Dictionary, weapons_container: VBoxContai
 			label.modulate = Color(0.9, 0.4, 0.35)  # Lightened WH red for melee headers
 			melee_grid.add_child(label)
 
-		# Data rows (melee stays the full menu until melee resolution lands)
+		# Data rows — when resolved, show only carried melee weapons with a model
+		# count; otherwise show every datasheet option.
 		for weapon in melee_weapons:
-			_add_weapon_row(melee_grid, weapon, "melee", str(weapon.get("name", "")))
+			var wname = str(weapon.get("name", ""))
+			if melee_resolved and not carried_melee.has(wname):
+				continue
+			var name_cell = wname
+			if melee_resolved:
+				var c = int(carried_melee.get(wname, 0))
+				if c > 1:
+					name_cell = "%s ×%d" % [wname, c]
+			_add_weapon_row(melee_grid, weapon, "melee", name_cell)
 
 		weapons_container.add_child(melee_grid)
 
@@ -500,6 +512,26 @@ func _carried_ranged_counts(unit_data: Dictionary) -> Dictionary:
 		if not m.get("alive", true):
 			continue
 		var lo = m.get("ranged_loadout", null)
+		if lo is Array:
+			any_resolved = true
+			for nm in lo:
+				counts[str(nm)] = int(counts.get(str(nm), 0)) + 1
+	return counts if any_resolved else {}
+
+# Task D (MA-LOADOUT Phase 1b): melee counterpart of _carried_ranged_counts.
+# {melee weapon name: model count} actually carried, or empty when the unit's
+# melee isn't resolved / it's a single-model unit.
+func _carried_melee_counts(unit_data: Dictionary) -> Dictionary:
+	var models = unit_data.get("models", [])
+	if models.size() < 2:
+		return {}
+	RulesEngine._ensure_loadout_resolved(unit_data)
+	var counts := {}
+	var any_resolved := false
+	for m in models:
+		if not m.get("alive", true):
+			continue
+		var lo = m.get("melee_loadout", null)
 		if lo is Array:
 			any_resolved = true
 			for nm in lo:
@@ -882,34 +914,53 @@ func _format_profile_weapons(models: Array, profile_key: String, profile_weapons
 	var name_type := {}
 	for w in meta.get("weapons", []):
 		name_type[str(w.get("name", ""))] = str(w.get("type", ""))
-	# Count resolved ranged guns carried by alive models of THIS type.
-	var carried := {}   # name -> model count
-	var any_resolved := false
+	# Count resolved ranged AND melee weapons carried by alive models of THIS type.
+	var carried_r := {}
+	var carried_m := {}
+	var any_r := false
+	var any_m := false
 	for m in models:
 		if not m.get("alive", true):
 			continue
 		if str(m.get("model_type", "")) != profile_key:
 			continue
-		var lo = m.get("ranged_loadout", null)
-		if lo is Array:
-			any_resolved = true
-			for nm in lo:
-				carried[str(nm)] = int(carried.get(str(nm), 0)) + 1
-	if not any_resolved:
-		# Unresolved -> keep the full menu exactly as before.
+		var lor = m.get("ranged_loadout", null)
+		if lor is Array:
+			any_r = true
+			for nm in lor:
+				carried_r[str(nm)] = int(carried_r.get(str(nm), 0)) + 1
+		var lom = m.get("melee_loadout", null)
+		if lom is Array:
+			any_m = true
+			for nm in lom:
+				carried_m[str(nm)] = int(carried_m.get(str(nm), 0)) + 1
+	if not any_r and not any_m:
+		# Nothing resolved -> keep the full menu exactly as before.
 		return ", ".join(profile_weapons)
-	# Resolved -> real ranged guns (with counts), then the non-ranged menu options.
-	var ranged_parts: Array = []
-	var ordered = carried.keys()
-	ordered.sort()
-	for nm in ordered:
-		var c = int(carried[nm])
-		ranged_parts.append(("%dx %s" % [c, nm]) if c > 1 else str(nm))
-	var other_parts: Array = []
-	for wname in profile_weapons:
-		if name_type.get(str(wname), "") != "Ranged":
-			other_parts.append(str(wname))
-	return ", ".join(ranged_parts + other_parts)
+	var parts: Array = []
+	# Ranged: resolved guns (with counts) when known, else the ranged menu options.
+	if any_r:
+		var ro = carried_r.keys()
+		ro.sort()
+		for nm in ro:
+			var c = int(carried_r[nm])
+			parts.append(("%dx %s" % [c, nm]) if c > 1 else str(nm))
+	else:
+		for wname in profile_weapons:
+			if name_type.get(str(wname), "") == "Ranged":
+				parts.append(str(wname))
+	# Melee: resolved weapons (with counts) when known, else the melee menu options.
+	if any_m:
+		var mo = carried_m.keys()
+		mo.sort()
+		for nm in mo:
+			var c = int(carried_m[nm])
+			parts.append(("%dx %s" % [c, nm]) if c > 1 else str(nm))
+	else:
+		for wname in profile_weapons:
+			if name_type.get(str(wname), "") != "Ranged":
+				parts.append(str(wname))
+	return ", ".join(parts)
 
 # Stat name abbreviations matching Warhammer 40k conventions
 const STAT_ABBREVIATIONS = {

--- a/40k/scripts/UnitStatsPanel.gd
+++ b/40k/scripts/UnitStatsPanel.gd
@@ -505,7 +505,7 @@ func _carried_ranged_counts(unit_data: Dictionary) -> Dictionary:
 	var models = unit_data.get("models", [])
 	if models.size() < 2:
 		return {}
-	RulesEngine._ensure_loadout_resolved(unit_data)
+	RulesEngine.ensure_loadout_resolved(unit_data)
 	var counts := {}
 	var any_resolved := false
 	for m in models:
@@ -525,7 +525,7 @@ func _carried_melee_counts(unit_data: Dictionary) -> Dictionary:
 	var models = unit_data.get("models", [])
 	if models.size() < 2:
 		return {}
-	RulesEngine._ensure_loadout_resolved(unit_data)
+	RulesEngine.ensure_loadout_resolved(unit_data)
 	var counts := {}
 	var any_resolved := false
 	for m in models:
@@ -763,7 +763,7 @@ func _create_composition_list(unit_data: Dictionary, composition_container: VBox
 	# so the composition breakdown can show the guns models ACTUALLY carry rather
 	# than the whole datasheet menu.
 	if models.size() >= 2:
-		RulesEngine._ensure_loadout_resolved(unit_data)
+		RulesEngine.ensure_loadout_resolved(unit_data)
 
 	# If model_profiles exist, show detailed per-type breakdown
 	if not model_profiles.is_empty() and not models.is_empty():

--- a/40k/scripts/UnitStatsPanel.gd
+++ b/40k/scripts/UnitStatsPanel.gd
@@ -400,49 +400,64 @@ func _create_weapons_tables(unit_data: Dictionary, weapons_container: VBoxContai
 	var weapons = unit_data["meta"]["weapons"]
 	if weapons.is_empty():
 		return
-	
+
+	# MA-LOADOUT Phase 2 (Task A): which ranged guns the unit's models ACTUALLY
+	# carry (empty = unresolved / single-model -> show the whole datasheet menu).
+	var carried_ranged = _carried_ranged_counts(unit_data)
+	var ranged_resolved = not carried_ranged.is_empty()
+
 	# Separate weapons by type
 	var ranged_weapons = []
 	var melee_weapons = []
-	
+
 	for weapon in weapons:
 		if weapon.get("type", "") == "Ranged":
 			ranged_weapons.append(weapon)
 		elif weapon.get("type", "") == "Melee":
 			melee_weapons.append(weapon)
-	
+
 	# Create ranged weapons table
 	if not ranged_weapons.is_empty():
 		var ranged_label = Label.new()
-		ranged_label.text = "RANGED WEAPONS"
+		# Signal when the list is the resolved loadout rather than the full menu.
+		ranged_label.text = "RANGED WEAPONS (as equipped)" if ranged_resolved else "RANGED WEAPONS"
 		ranged_label.add_theme_font_size_override("font_size", 14)
 		ranged_label.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_GOLD)
 		weapons_container.add_child(ranged_label)
-		
+
 		var ranged_grid = GridContainer.new()
-		ranged_grid.columns = 7
+		ranged_grid.columns = 8
 		ranged_grid.add_theme_constant_override("h_separation", 10)
 		ranged_grid.add_theme_constant_override("v_separation", 5)
-		
+
 		# Headers
-		for header in ["Range", "A", "BS", "S", "AP", "D", "Abilities"]:
+		for header in ["Weapon", "Range", "A", "BS", "S", "AP", "D", "Abilities"]:
 			var label = Label.new()
 			label.text = header
 			label.add_theme_font_size_override("font_size", 12)
 			label.modulate = _WhiteDwarfTheme.WH_GOLD  # Gold tint for ranged headers
 			ranged_grid.add_child(label)
-		
-		# Data rows
+
+		# Data rows — when resolved, show only carried guns, tagged with how many
+		# models carry each; otherwise show every datasheet option (unchanged).
 		for weapon in ranged_weapons:
-			_add_weapon_row(ranged_grid, weapon, "ranged")
-		
+			var wname = str(weapon.get("name", ""))
+			if ranged_resolved and not carried_ranged.has(wname):
+				continue
+			var name_cell = wname
+			if ranged_resolved:
+				var c = int(carried_ranged.get(wname, 0))
+				if c > 1:
+					name_cell = "%s ×%d" % [wname, c]
+			_add_weapon_row(ranged_grid, weapon, "ranged", name_cell)
+
 		weapons_container.add_child(ranged_grid)
-		
+
 		# Add spacing
 		var spacer = Control.new()
 		spacer.custom_minimum_size = Vector2(0, 10)
 		weapons_container.add_child(spacer)
-	
+
 	# Create melee weapons table
 	if not melee_weapons.is_empty():
 		var melee_label = Label.new()
@@ -450,31 +465,53 @@ func _create_weapons_tables(unit_data: Dictionary, weapons_container: VBoxContai
 		melee_label.add_theme_font_size_override("font_size", 14)
 		melee_label.add_theme_color_override("font_color", Color(0.9, 0.4, 0.35))  # Lightened WH red
 		weapons_container.add_child(melee_label)
-		
+
 		var melee_grid = GridContainer.new()
-		melee_grid.columns = 7
+		melee_grid.columns = 8
 		melee_grid.add_theme_constant_override("h_separation", 10)
 		melee_grid.add_theme_constant_override("v_separation", 5)
-		
+
 		# Headers
-		for header in ["Range", "A", "WS", "S", "AP", "D", "Abilities"]:
+		for header in ["Weapon", "Range", "A", "WS", "S", "AP", "D", "Abilities"]:
 			var label = Label.new()
 			label.text = header
 			label.add_theme_font_size_override("font_size", 12)
 			label.modulate = Color(0.9, 0.4, 0.35)  # Lightened WH red for melee headers
 			melee_grid.add_child(label)
-		
-		# Data rows
+
+		# Data rows (melee stays the full menu until melee resolution lands)
 		for weapon in melee_weapons:
-			_add_weapon_row(melee_grid, weapon, "melee")
-		
+			_add_weapon_row(melee_grid, weapon, "melee", str(weapon.get("name", "")))
+
 		weapons_container.add_child(melee_grid)
 
-func _add_weapon_row(grid: GridContainer, weapon: Dictionary, type: String) -> void:
+# Task A (MA-LOADOUT Phase 2): {ranged weapon name: model count} that the unit's
+# models actually carry, using the resolved per-model loadout. Empty when the
+# unit isn't resolved (caller falls back to the full menu) or is a single-model
+# unit (which fires all its weapons and must never be filtered).
+func _carried_ranged_counts(unit_data: Dictionary) -> Dictionary:
+	var models = unit_data.get("models", [])
+	if models.size() < 2:
+		return {}
+	RulesEngine._ensure_loadout_resolved(unit_data)
+	var counts := {}
+	var any_resolved := false
+	for m in models:
+		if not m.get("alive", true):
+			continue
+		var lo = m.get("ranged_loadout", null)
+		if lo is Array:
+			any_resolved = true
+			for nm in lo:
+				counts[str(nm)] = int(counts.get(str(nm), 0)) + 1
+	return counts if any_resolved else {}
+
+func _add_weapon_row(grid: GridContainer, weapon: Dictionary, type: String, name_cell: String = "") -> void:
 	var cells = []
-	
+
 	if type == "ranged":
 		cells = [
+			name_cell,
 			str(weapon.get("range", "")) + "\"" if weapon.get("range", "") != "" else "",
 			str(weapon.get("attacks", "")),
 			str(weapon.get("ballistic_skill", "")) + "+" if weapon.get("ballistic_skill", "") != "" else "",
@@ -485,6 +522,7 @@ func _add_weapon_row(grid: GridContainer, weapon: Dictionary, type: String) -> v
 		]
 	else:  # melee
 		cells = [
+			name_cell,
 			"Melee",
 			str(weapon.get("attacks", "")),
 			str(weapon.get("weapon_skill", "")) + "+" if weapon.get("weapon_skill", "") != "" else "",
@@ -493,11 +531,13 @@ func _add_weapon_row(grid: GridContainer, weapon: Dictionary, type: String) -> v
 			str(weapon.get("damage", "")),
 			weapon.get("special_rules", "")
 		]
-	
-	for cell_text in cells:
+
+	for i in range(cells.size()):
 		var label = Label.new()
-		label.text = str(cell_text)
+		label.text = str(cells[i])
 		label.add_theme_font_size_override("font_size", 11)
+		if i == 0:
+			label.add_theme_color_override("font_color", _WhiteDwarfTheme.WH_PARCHMENT)
 		grid.add_child(label)
 
 func _create_abilities_list(unit_data: Dictionary, abilities_container: VBoxContainer) -> void:
@@ -687,6 +727,12 @@ func _create_composition_list(unit_data: Dictionary, composition_container: VBox
 	var model_profiles = meta.get("model_profiles", {})
 	var models = unit_data.get("models", [])
 
+	# MA-LOADOUT Phase 2 (Task A): resolve the per-model ranged loadout (idempotent)
+	# so the composition breakdown can show the guns models ACTUALLY carry rather
+	# than the whole datasheet menu.
+	if models.size() >= 2:
+		RulesEngine._ensure_loadout_resolved(unit_data)
+
 	# If model_profiles exist, show detailed per-type breakdown
 	if not model_profiles.is_empty() and not models.is_empty():
 		_create_model_profiles_breakdown(composition_container, model_profiles, models, meta)
@@ -783,11 +829,15 @@ func _create_model_profiles_breakdown(container: VBoxContainer, model_profiles: 
 			override_label.modulate = Color(0.9, 0.85, 0.7)  # Slightly gold tint
 			container.add_child(override_label)
 
-		# Show weapons for this profile
+		# Show weapons for this profile. When the per-model ranged loadout has been
+		# resolved (MA-LOADOUT Phase 2 / Task A) show the guns this type ACTUALLY
+		# carries, grouped with counts, instead of the full datasheet menu; the
+		# melee menu is kept until melee resolution lands. Falls back to the menu
+		# when the unit is unresolved.
 		var profile_weapons = profile.get("weapons", [])
 		if not profile_weapons.is_empty():
 			var weapons_label = Label.new()
-			weapons_label.text = "  Weapons: " + ", ".join(profile_weapons)
+			weapons_label.text = "  Weapons: " + _format_profile_weapons(models, profile_key, profile_weapons, meta)
 			weapons_label.add_theme_font_size_override("font_size", 10)
 			weapons_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 			container.add_child(weapons_label)
@@ -821,6 +871,45 @@ func _create_model_profiles_breakdown(container: VBoxContainer, model_profiles: 
 	total_label.add_theme_font_size_override("font_size", 11)
 	total_label.modulate = Color(0.8, 1.0, 0.8) if total_alive == total_count else Color(1.0, 0.8, 0.8)
 	container.add_child(total_label)
+
+# Task A (MA-LOADOUT Phase 2): format the "Weapons:" line for one model_type
+# group. Prefers the resolved per-model RANGED loadout (grouped with counts) over
+# the full datasheet menu, so a Slugga Boyz mob reads "9x Slugga" instead of the
+# 6-option boy menu; melee/other options are kept from the menu (melee resolution
+# is a later task). Falls back to the whole menu when the type isn't resolved.
+func _format_profile_weapons(models: Array, profile_key: String, profile_weapons: Array, meta: Dictionary) -> String:
+	# Weapon name -> datasheet type (Ranged/Melee/...).
+	var name_type := {}
+	for w in meta.get("weapons", []):
+		name_type[str(w.get("name", ""))] = str(w.get("type", ""))
+	# Count resolved ranged guns carried by alive models of THIS type.
+	var carried := {}   # name -> model count
+	var any_resolved := false
+	for m in models:
+		if not m.get("alive", true):
+			continue
+		if str(m.get("model_type", "")) != profile_key:
+			continue
+		var lo = m.get("ranged_loadout", null)
+		if lo is Array:
+			any_resolved = true
+			for nm in lo:
+				carried[str(nm)] = int(carried.get(str(nm), 0)) + 1
+	if not any_resolved:
+		# Unresolved -> keep the full menu exactly as before.
+		return ", ".join(profile_weapons)
+	# Resolved -> real ranged guns (with counts), then the non-ranged menu options.
+	var ranged_parts: Array = []
+	var ordered = carried.keys()
+	ordered.sort()
+	for nm in ordered:
+		var c = int(carried[nm])
+		ranged_parts.append(("%dx %s" % [c, nm]) if c > 1 else str(nm))
+	var other_parts: Array = []
+	for wname in profile_weapons:
+		if name_type.get(str(wname), "") != "Ranged":
+			other_parts.append(str(wname))
+	return ", ".join(ranged_parts + other_parts)
 
 # Stat name abbreviations matching Warhammer 40k conventions
 const STAT_ABBREVIATIONS = {

--- a/40k/tests/scenarios/sp/iss_loadout_coverage_taskc_11e.json
+++ b/40k/tests/scenarios/sp/iss_loadout_coverage_taskc_11e.json
@@ -1,0 +1,73 @@
+{
+  "id": "iss_loadout_coverage_taskc_11e",
+  "covers": [
+    "shooting.loadout_resolution.widen_coverage",
+    "autoloads.RulesEngine._resolve_type_loadout"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "transition_to_phase": 8,
+  "description": "Task C: widen loadout resolution. A 20-model Boyz mob recorded with only '10x Slugga' (incomplete-but-consistent) now resolves to 20 Sluggas with no menu ghosts; a Deffkoptas unit (Kopta rokkits + Slugga per model) resolves to a uniform 2-gun set. The Deffkoptas' shooting weapon panel shows the real resolved loadout.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 8
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_TC_BOYZ\": {\"id\": \"U_TC_BOYZ\", \"squad_id\": \"U_BOYZ_E\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Boyz\", \"keywords\": [\"BATTLELINE\", \"BOYZ\", \"GRENADES\", \"INFANTRY\", \"MOB\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 2}, \"points\": 150, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"9x Slugga\", \"1x Slugga\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Kombi-weapon\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"anti-infantry 4+, devastating wounds, rapid fire 1\", \"abilities\": [{\"id\": \"anti\", \"keyword\": \"INFANTRY\", \"threshold\": 4}, {\"id\": \"devastating_wounds\"}, {\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Rokkit launcha\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"D3\", \"ballistic_skill\": \"5\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"3\", \"special_rules\": \"blast\", \"abilities\": [{\"id\": \"blast\"}]}, {\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 1\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Slugga\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"pistol\", \"abilities\": [{\"id\": \"pistol\"}]}, {\"name\": \"Big choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"7\", \"ap\": \"-1\", \"damage\": \"2\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"-1\", \"damage\": \"1\"}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Power klaw\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"4\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"2\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Bodyguard\", \"type\": \"Datasheet\", \"description\": \"This model gains the Extra Leader Attachment ability.\"}, {\"name\": \"Get Da Good Bitz\", \"type\": \"Datasheet\", \"description\": \"The unit retains control of objective markers even after no models remain in range, until the enemy retakes them (sticky objectives).\"}], \"unit_composition\": [{\"description\": \"1 Boss Nob\", \"line\": 1}, {\"description\": \"9-19 Boy\", \"line\": 2}]}, \"models\": [{\"id\": \"b0\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 200, \"y\": 200}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 255, \"y\": 200}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 310, \"y\": 200}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 365, \"y\": 200}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 420, \"y\": 200}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b5\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 200, \"y\": 255}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b6\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 255, \"y\": 255}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b7\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 310, \"y\": 255}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b8\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 365, \"y\": 255}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b9\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 420, \"y\": 255}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b10\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 200, \"y\": 310}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b11\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 255, \"y\": 310}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b12\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 310, \"y\": 310}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b13\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 365, \"y\": 310}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b14\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 420, \"y\": 310}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b15\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 200, \"y\": 365}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b16\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 255, \"y\": 365}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b17\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 310, \"y\": 365}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b18\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 365, \"y\": 365}, \"alive\": true, \"status_effects\": []}, {\"id\": \"b19\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 420, \"y\": 365}, \"alive\": true, \"status_effects\": []}]}, \"U_TC_DEFF\": {\"id\": \"U_TC_DEFF\", \"squad_id\": \"U_DEFFKOPTAS_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Deffkoptas\", \"keywords\": [\"DEFFKOPTAS\", \"FLY\", \"GRENADES\", \"ORKS\", \"SPEED FREEKS\", \"VEHICLE\"], \"stats\": {\"move\": 12, \"toughness\": 6, \"save\": 4, \"wounds\": 4, \"leadership\": 7, \"objective_control\": 2, \"invuln\": 6}, \"points\": 75, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"3x Kopta rokkits\", \"3x Slugga\", \"3x Spinnin' blades\"], \"weapons\": [{\"name\": \"Kopta rokkits\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"D3\", \"ballistic_skill\": \"5\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"3\", \"special_rules\": \"blast, twin linked\", \"abilities\": [{\"id\": \"blast\"}, {\"id\": \"twin_linked\"}]}, {\"name\": \"Slugga\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"pistol\", \"abilities\": [{\"id\": \"pistol\"}]}, {\"name\": \"Spinnin' blades\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"6\", \"weapon_skill\": \"3\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Deep Strike\", \"type\": \"Core\", \"description\": \"The unit has the Deep Strike ability.\"}, {\"name\": \"Deff from Above\", \"type\": \"Datasheet\", \"description\": \"Roll one D6 for each model in this unit: for each 4+, the target suffers 1 mortal wound.\"}], \"unit_composition\": [{\"description\": \"3-6 Deffkopta\", \"line\": 1}]}, \"models\": [{\"id\": \"k0\", \"wounds\": 4, \"current_wounds\": 4, \"base_mm\": 75, \"base_type\": \"oval\", \"base_dimensions\": {\"length\": 42, \"width\": 75}, \"position\": {\"x\": 400, \"y\": 1000}, \"alive\": true, \"status_effects\": []}, {\"id\": \"k1\", \"wounds\": 4, \"current_wounds\": 4, \"base_mm\": 75, \"base_type\": \"oval\", \"base_dimensions\": {\"length\": 42, \"width\": 75}, \"position\": {\"x\": 600, \"y\": 1000}, \"alive\": true, \"status_effects\": []}, {\"id\": \"k2\", \"wounds\": 4, \"current_wounds\": 4, \"base_mm\": 75, \"base_type\": \"oval\", \"base_dimensions\": {\"length\": 42, \"width\": 75}, \"position\": {\"x\": 800, \"y\": 1000}, \"alive\": true, \"status_effects\": []}]}, \"U_TC_TARGET\": {\"id\": \"U_TC_TARGET\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"TC Target\", \"keywords\": [\"INFANTRY\"], \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 600, \"y\": 1280}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}}, true)\nreturn U.has(\"U_TC_BOYZ\") and U.has(\"U_TC_DEFF\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "equals": "20_slugga_0_ghost",
+      "script": "var mw = RulesEngine.get_unit_weapons(\"U_TC_BOYZ\", GameState.state)\nvar sl = 0\nvar ghost = 0\nfor mid in mw:\n\tfor w in mw[mid]:\n\t\tif str(w).begins_with(\"slugga\"): sl += 1\n\t\telif str(w).begins_with(\"big_shoota\") or str(w).begins_with(\"rokkit\") or str(w).begins_with(\"shoota\") or str(w).begins_with(\"kombi\"): ghost += 1\nreturn \"%d_slugga_%d_ghost\" % [sl, ghost]"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "equals": 20,
+      "script": "var mw = RulesEngine.get_unit_weapons(\"U_TC_BOYZ\", GameState.state)\nvar t = 0\nfor mid in mw:\n\tt += mw[mid].size()\nreturn t"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "equals": "3_kopta_3_slugga_6_total",
+      "script": "var mw = RulesEngine.get_unit_weapons(\"U_TC_DEFF\", GameState.state)\nvar kr = 0\nvar sl = 0\nvar t = 0\nfor mid in mw:\n\tt += mw[mid].size()\n\tfor w in mw[mid]:\n\t\tif str(w).begins_with(\"kopta_rokkits\"): kr += 1\n\t\telif str(w).begins_with(\"slugga\"): sl += 1\nreturn \"%d_kopta_%d_slugga_%d_total\" % [kr, sl, t]"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "equals": true,
+      "script": "return RulesEngine.get_eligible_targets(\"U_TC_DEFF\", GameState.state).size() > 0"
+    },
+    {
+      "act": "dispatch_action",
+      "action": {
+        "type": "SELECT_SHOOTER",
+        "actor_unit_id": "U_TC_DEFF"
+      }
+    },
+    {
+      "act": "expect_action_result",
+      "path": "success",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "screenshot",
+      "label": "01_deffkoptas_resolved_weapon_panel"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss_loadout_hover_taska_11e.json
+++ b/40k/tests/scenarios/sp/iss_loadout_hover_taska_11e.json
@@ -1,0 +1,74 @@
+{
+  "id": "iss_loadout_hover_taska_11e",
+  "covers": [
+    "ui.loadout.hover_real_weapon",
+    "scripts.Main._build_model_profile_hover_text",
+    "scripts.UnitStatsPanel._format_profile_weapons"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "transition_to_phase": 8,
+  "description": "Task A: hovering/inspecting a model shows the gun it ACTUALLY carries. A Slugga Boyz mob's boy reads 'Slugga' (no Big shoota/Rokkit/Kombi menu ghosts); in a mixed Burna Boyz mob the Big-shoota model reads 'Big shoota' and a Burna model reads 'Burna'. The unit inspect panel's model-composition weapons line shows the resolved loadout.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 8
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_TA_BOYZ\": {\"id\": \"U_TA_BOYZ\", \"squad_id\": \"U_BOYZ_K\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Boyz\", \"keywords\": [\"BATTLELINE\", \"BOYZ\", \"GRENADES\", \"INFANTRY\", \"MOB\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 2}, \"points\": 75, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"9x Slugga\", \"1x Slugga\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Kombi-weapon\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"anti-infantry 4+, devastating wounds, rapid fire 1\", \"abilities\": [{\"id\": \"anti\", \"keyword\": \"INFANTRY\", \"threshold\": 4}, {\"id\": \"devastating_wounds\"}, {\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Rokkit launcha\", \"type\": \"Ranged\", \"range\": \"24\", \"attacks\": \"D3\", \"ballistic_skill\": \"5\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"3\", \"special_rules\": \"blast\", \"abilities\": [{\"id\": \"blast\"}]}, {\"name\": \"Shoota\", \"type\": \"Ranged\", \"range\": \"18\", \"attacks\": \"2\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 1\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 1}]}, {\"name\": \"Slugga\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"pistol\", \"abilities\": [{\"id\": \"pistol\"}]}, {\"name\": \"Big choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"7\", \"ap\": \"-1\", \"damage\": \"2\"}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"-1\", \"damage\": \"1\"}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Power klaw\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"4\", \"strength\": \"9\", \"ap\": \"-2\", \"damage\": \"2\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Bodyguard\", \"type\": \"Datasheet\", \"description\": \"This model gains the Extra Leader Attachment ability.\"}, {\"name\": \"Get Da Good Bitz\", \"type\": \"Datasheet\", \"description\": \"The unit retains control of objective markers even after no models remain in range, until the enemy retakes them (sticky objectives).\"}], \"unit_composition\": [{\"description\": \"1 Boss Nob\", \"line\": 1}, {\"description\": \"9-19 Boy\", \"line\": 2}], \"model_profiles\": {\"boss_nob\": {\"label\": \"Boss Nob\", \"short_label\": \"N\", \"weapons\": [\"Big choppa\", \"Choppa\", \"Power klaw\", \"Slugga\", \"Kombi-weapon\"], \"stats_override\": {\"save\": 4, \"weapon_skill\": 3}, \"transport_slots\": 1}, \"boy\": {\"label\": \"Boy\", \"short_label\": \"B\", \"weapons\": [\"Choppa\", \"Close combat weapon\", \"Shoota\", \"Slugga\", \"Big shoota\", \"Rokkit launcha\"], \"stats_override\": {\"weapon_skill\": 4}, \"transport_slots\": 1}}}, \"models\": [{\"id\": \"U_TA_BOYZ_m0\", \"wounds\": 2, \"current_wounds\": 2, \"base_mm\": 32, \"position\": {\"x\": 250, \"y\": 250}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boss_nob\"}, {\"id\": \"U_TA_BOYZ_m1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 295, \"y\": 250}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 340, \"y\": 250}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 385, \"y\": 250}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 430, \"y\": 250}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m5\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 250, \"y\": 295}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m6\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 295, \"y\": 295}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m7\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 340, \"y\": 295}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m8\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 385, \"y\": 295}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}, {\"id\": \"U_TA_BOYZ_m9\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 430, \"y\": 295}, \"alive\": true, \"status_effects\": [], \"model_type\": \"boy\"}]}, \"U_TA_BURNA\": {\"id\": \"U_TA_BURNA\", \"squad_id\": \"U_BURNA_BOYZ_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Burna Boyz\", \"keywords\": [\"BURNA BOYZ\", \"INFANTRY\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 1}, \"points\": 60, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"1x Spanner\", \"1x Big shoota\", \"1x Close combat weapon\", \"4x Burna Boy\", \"4x Burna\", \"4x Cuttin' flames\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Burna\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"D6\", \"ballistic_skill\": \"N/A\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"ignores cover, torrent\", \"abilities\": [{\"id\": \"ignores_cover\"}, {\"id\": \"torrent\"}]}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Cuttin' flames\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"4\", \"strength\": \"4\", \"ap\": \"-2\", \"damage\": \"1\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Pyromaniaks\", \"type\": \"Datasheet\", \"description\": \"During the Shooting phase, you can re-roll a Wound roll of 1.\"}], \"unit_composition\": [{\"description\": \"1-2 Spanner\", \"line\": 1}, {\"description\": \"4-8 Burna Boy\", \"line\": 2}]}, \"models\": [{\"id\": \"U_TA_BURNA_m0\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 250, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"U_TA_BURNA_m1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 295, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"U_TA_BURNA_m2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 340, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"U_TA_BURNA_m3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 385, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"U_TA_BURNA_m4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 430, \"y\": 700}, \"alive\": true, \"status_effects\": []}]}}, true)\nreturn U.has(\"U_TA_BOYZ\") and U.has(\"U_TA_BURNA\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar unit = GameState.state[\"units\"][\"U_TA_BOYZ\"]\nvar mid = \"\"\nfor m in unit[\"models\"]:\n\tif str(m.get(\"model_type\",\"\")) == \"boy\":\n\t\tmid = str(m[\"id\"])\n\t\tbreak\nvar txt = str(main._build_model_profile_hover_text(unit, mid))\nreturn (\"Slugga\" in txt) and not (\"hoota\" in txt) and not (\"Rokkit\" in txt) and not (\"Kombi\" in txt)",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nRulesEngine.get_unit_weapons(\"U_TA_BURNA\", GameState.state)\nvar unit = GameState.state[\"units\"][\"U_TA_BURNA\"]\nvar mid = \"\"\nfor m in unit[\"models\"]:\n\tvar lo = m.get(\"ranged_loadout\", [])\n\tif lo is Array and lo.has(\"Big shoota\"):\n\t\tmid = str(m[\"id\"])\n\t\tbreak\nvar txt = str(main._build_model_profile_hover_text(unit, mid))\nreturn (mid != \"\") and (\"Big shoota\" in txt) and not (\"Burna\" in txt.replace(\"Burna Boyz\",\"\"))",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nRulesEngine.get_unit_weapons(\"U_TA_BURNA\", GameState.state)\nvar unit = GameState.state[\"units\"][\"U_TA_BURNA\"]\nvar mid = \"\"\nfor m in unit[\"models\"]:\n\tvar lo = m.get(\"ranged_loadout\", [])\n\tif lo is Array and lo.has(\"Burna\"):\n\t\tmid = str(m[\"id\"])\n\t\tbreak\nvar txt = str(main._build_model_profile_hover_text(unit, mid))\nreturn (mid != \"\") and (\"Burna\" in txt) and not (\"Big shoota\" in txt)",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar panel = main.get_node_or_null(\"UnitStatsPanel\")\nif panel == null: return \"NO_PANEL\"\nvar unit = GameState.state[\"units\"][\"U_TA_BOYZ\"]\npanel.set_collapsed(false)\npanel.display_unit(unit)\nvar parts = []\nvar stack = [panel.player_composition_container]\nwhile stack.size() > 0:\n\tvar n = stack.pop_back()\n\tif n == null: continue\n\tif n is Label: parts.append(str(n.text))\n\tfor c in n.get_children(): stack.append(c)\nvar txt = \" || \".join(parts)\nvar ok = (\"Slugga\" in txt) and not (\"Big shoota\" in txt) and not (\"Rokkit\" in txt) and not (\"Kombi\" in txt)\nreturn \"OK\" if ok else (\"BAD: \" + txt)",
+      "equals": "OK"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar panel = main.get_node_or_null(\"UnitStatsPanel\")\nif panel == null: return \"NO_PANEL\"\nvar unit = GameState.state[\"units\"][\"U_TA_BOYZ\"]\npanel.set_collapsed(false)\npanel.display_unit(unit)\nvar parts = []\nvar stack = [panel.player_weapons_container]\nwhile stack.size() > 0:\n\tvar n = stack.pop_back()\n\tif n == null: continue\n\tif n is Label: parts.append(str(n.text))\n\tfor c in n.get_children(): stack.append(c)\nvar txt = \" || \".join(parts)\nvar ok = (\"Slugga\" in txt) and (\"as equipped\" in txt) and not (\"Big shoota\" in txt) and not (\"Rokkit\" in txt) and not (\"Kombi\" in txt)\nreturn \"OK\" if ok else (\"BAD: \" + txt)",
+      "equals": "OK"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar panel = main.get_node_or_null(\"UnitStatsPanel\")\nif panel == null: return false\npanel.set_collapsed(false)\npanel.show_panel(true)\npanel.display_unit(GameState.state[\"units\"][\"U_TA_BOYZ\"])\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "screenshot",
+      "label": "01_boyz_inspect_panel_resolved_loadout"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss_loadout_melee_taskd_11e.json
+++ b/40k/tests/scenarios/sp/iss_loadout_melee_taskd_11e.json
@@ -1,0 +1,56 @@
+{
+  "id": "iss_loadout_melee_taskd_11e",
+  "covers": [
+    "fight.loadout_resolution.melee",
+    "autoloads.RulesEngine.get_unit_melee_weapons",
+    "scripts.UnitStatsPanel._carried_melee_counts"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "transition_to_phase": 10,
+  "description": "Task D: melee loadout resolution. In the Fight phase a Burna Boyz mob (datasheet lists Cuttin' flames AND Close combat weapon on every model) reports its RESOLVED melee via get_unit_melee_weapons \u2014 4 Cuttin' flames + 1 CCW, one weapon per model (5 instances, not the 10 the menu would give). The unit panel's MELEE WEAPONS table shows the resolved loadout '(as equipped)'.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 10
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_TD_BURNA\": {\"id\": \"U_TD_BURNA\", \"squad_id\": \"U_BURNA_BOYZ_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Burna Boyz\", \"keywords\": [\"BURNA BOYZ\", \"INFANTRY\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 1}, \"points\": 60, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"1x Spanner\", \"1x Big shoota\", \"1x Close combat weapon\", \"4x Burna Boy\", \"4x Burna\", \"4x Cuttin' flames\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Burna\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"D6\", \"ballistic_skill\": \"N/A\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"ignores cover, torrent\", \"abilities\": [{\"id\": \"ignores_cover\"}, {\"id\": \"torrent\"}]}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Cuttin' flames\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"4\", \"strength\": \"4\", \"ap\": \"-2\", \"damage\": \"1\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Pyromaniaks\", \"type\": \"Datasheet\", \"description\": \"During the Shooting phase, you can re-roll a Wound roll of 1.\"}], \"unit_composition\": [{\"description\": \"1-2 Spanner\", \"line\": 1}, {\"description\": \"4-8 Burna Boy\", \"line\": 2}]}, \"models\": [{\"id\": \"td0\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 700, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"td1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 770, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"td2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 840, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"td3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 910, \"y\": 700}, \"alive\": true, \"status_effects\": []}, {\"id\": \"td4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 980, \"y\": 700}, \"alive\": true, \"status_effects\": []}]}}, true)\nreturn U.has(\"U_TD_BURNA\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar mm = RulesEngine.get_unit_melee_weapons(\"U_TD_BURNA\", GameState.state)\nvar total = 0\nvar cf = 0\nvar ccw = 0\nvar worst = 0\nfor mid in mm:\n\tworst = max(worst, mm[mid].size())\n\tfor wn in mm[mid]:\n\t\ttotal += 1\n\t\tif str(wn) == \"Cuttin' flames\": cf += 1\n\t\telif str(wn) == \"Close combat weapon\": ccw += 1\nreturn \"%d|%d|%d|%d\" % [total, cf, ccw, worst]",
+      "equals": "5|4|1|1"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar unit = GameState.state[\"units\"][\"U_TD_BURNA\"]\nvar melee_menu = 0\nfor w in unit[\"meta\"][\"weapons\"]:\n\tif str(w.get(\"type\",\"\")).to_lower() == \"melee\": melee_menu += 1\nreturn melee_menu * unit[\"models\"].size()",
+      "equals": 10
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar panel = main.get_node_or_null(\"UnitStatsPanel\")\nif panel == null: return \"NO_PANEL\"\npanel.set_collapsed(false)\npanel.show_panel(true)\npanel.display_unit(GameState.state[\"units\"][\"U_TD_BURNA\"])\nvar parts = []\nvar stack = [panel.player_weapons_container]\nwhile stack.size() > 0:\n\tvar n = stack.pop_back()\n\tif n == null: continue\n\tif n is Label: parts.append(str(n.text))\n\tfor c in n.get_children(): stack.append(c)\nvar txt = \" || \".join(parts)\nvar ok = (\"MELEE WEAPONS (as equipped)\" in txt) and (\"Cuttin' flames \u00d74\" in txt) and (\"Close combat weapon\" in txt)\nreturn \"OK\" if ok else (\"BAD: \" + txt)",
+      "equals": "OK"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "screenshot",
+      "label": "01_burna_fight_resolved_melee_panel"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss_loadout_special_marker_taskb_11e.json
+++ b/40k/tests/scenarios/sp/iss_loadout_special_marker_taskb_11e.json
@@ -1,0 +1,60 @@
+{
+  "id": "iss_loadout_special_marker_taskb_11e",
+  "covers": [
+    "ui.loadout.special_weapon_marker",
+    "scripts.TokenVisual._draw_special_weapon_indicator",
+    "autoloads.RulesEngine.get_special_weapon_model_ids"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "transition_to_phase": 8,
+  "description": "Task B: the special/heavy-weapon model looks distinct on the board. A 5-model Burna Boyz mob (4 Burna + 1 Big shoota) flags exactly one model (the Big shoota, model tb0) as special; an amber spark badge is drawn on that token. Camera zooms in for the screenshot.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 8
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nU.merge({\"U_TB_BURNA\": {\"id\": \"U_TB_BURNA\", \"squad_id\": \"U_BURNA_BOYZ_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Burna Boyz\", \"keywords\": [\"BURNA BOYZ\", \"INFANTRY\", \"ORKS\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 1}, \"points\": 60, \"is_warlord\": false, \"enhancements\": [], \"wargear\": [\"1x Spanner\", \"1x Big shoota\", \"1x Close combat weapon\", \"4x Burna Boy\", \"4x Burna\", \"4x Cuttin' flames\"], \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"rapid fire 2\", \"abilities\": [{\"id\": \"rapid_fire\", \"x\": 2}]}, {\"name\": \"Burna\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"D6\", \"ballistic_skill\": \"N/A\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"ignores cover, torrent\", \"abilities\": [{\"id\": \"ignores_cover\"}, {\"id\": \"torrent\"}]}, {\"name\": \"Close combat weapon\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\"}, {\"name\": \"Cuttin' flames\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"2\", \"weapon_skill\": \"4\", \"strength\": \"4\", \"ap\": \"-2\", \"damage\": \"1\"}], \"abilities\": [{\"name\": \"Waaagh!\", \"type\": \"Faction\", \"description\": \"Once per battle, until your next Command phase:\\n  -> The unit gains the Advance & Charge ability.\\n  -> Add 1 to the unit's Strength characteristic (melee).\\n  -> Add 1 to the unit's Attacks characteristic (melee).\\n  -> The unit has a 5+ invulnerable save.\"}, {\"name\": \"Pyromaniaks\", \"type\": \"Datasheet\", \"description\": \"During the Shooting phase, you can re-roll a Wound roll of 1.\"}], \"unit_composition\": [{\"description\": \"1-2 Spanner\", \"line\": 1}, {\"description\": \"4-8 Burna Boy\", \"line\": 2}]}, \"models\": [{\"id\": \"tb0\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 760, \"y\": 720}, \"alive\": true, \"status_effects\": []}, {\"id\": \"tb1\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 835, \"y\": 720}, \"alive\": true, \"status_effects\": []}, {\"id\": \"tb2\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 910, \"y\": 720}, \"alive\": true, \"status_effects\": []}, {\"id\": \"tb3\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 985, \"y\": 720}, \"alive\": true, \"status_effects\": []}, {\"id\": \"tb4\", \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": {\"x\": 1060, \"y\": 720}, \"alive\": true, \"status_effects\": []}]}}, true)\nreturn U.has(\"U_TB_BURNA\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar unit = GameState.state[\"units\"][\"U_TB_BURNA\"]\nvar sp = RulesEngine.get_special_weapon_model_ids(unit)\nreturn \"%d:%s\" % [sp.size(), (\"tb0\" if sp.has(\"tb0\") else \"?\")]",
+      "equals": "1:tb0"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nmain._recreate_unit_visuals()\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var main = tree.get_root().get_node_or_null(\"Main\")\nif main == null: main = tree.current_scene\nvar vp = main.get_viewport().get_visible_rect().size\nvar z = 1.7\nmain.view_rotation = 0.0\nmain.view_zoom = z\nmain.view_offset = Vector2(910, 720) - vp / (2.0 * z)\nmain.update_view_transform()\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "screenshot",
+      "label": "01_burna_special_weapon_marker"
+    }
+  ]
+}

--- a/40k/tests/test_loadout_resolution.gd
+++ b/40k/tests/test_loadout_resolution.gd
@@ -81,6 +81,7 @@ func _run():
 		return
 	var resolved_units := 0
 	var unresolved_multimodel := []
+	var special_units := []  # Task B: units with special-weapon model(s) flagged
 	for path in _list_army_files():
 		var data = _load_json(path)
 		if typeof(data) != TYPE_DICTIONARY:
@@ -163,12 +164,26 @@ func _run():
 			elif models.size() >= 2 and worst > 1:
 				unresolved_multimodel.append("%s/%s(%s)" % [fname, uid, str(unit.get("meta", {}).get("name", ""))])
 
+			# Task B: collect special-weapon models (minority resolved gun). Also
+			# assert the marked models are a strict subset of alive models (never
+			# mark every model — that would defeat "stands out").
+			var special = RE.get_special_weapon_model_ids(unit)
+			if special.size() > 0:
+				var alive_now := 0
+				for m in models:
+					if m.get("alive", true):
+						alive_now += 1
+				_check("special-subset %s/%s" % [fname, uid], special.size() < alive_now,
+					"special=%d alive=%d" % [special.size(), alive_now])
+				special_units.append("%s/%s(%s): %d special" % [fname, uid, str(unit.get("meta", {}).get("name", "")), special.size()])
+
 	# -------- Targeted spot-checks --------
 	_spot_check_boyz()
 	_spot_check_orks_lootas_unchanged()
 	_spot_check_burna()
 	_spot_check_boyz_incomplete()   # Task C: incomplete-but-consistent (20-Boy mob, 10x Slugga)
 	_spot_check_deffkopta()         # Task C: uniform dual-gun (kopta rokkits + slugga)
+	_spot_check_special_weapons()   # Task B: minority-gun model detection
 
 	# Task C: widening coverage must RESOLVE MORE units than the Phase-1 baseline
 	# (16) and leave fewer over-counters. Lower/upper bounds so future additions
@@ -181,6 +196,10 @@ func _run():
 	print("")
 	print("Resolved units (loadout pinned from wargear): %d" % resolved_units)
 	print("Unresolved multi-model over-counters left as-is (data-limited): %d" % unresolved_multimodel.size())
+	print("")
+	print("Units with special-weapon model(s) flagged (Task B): %d" % special_units.size())
+	for u in special_units:
+		print("   * %s" % u)
 	for u in unresolved_multimodel:
 		print("   - %s" % u)
 	print("")
@@ -262,3 +281,38 @@ func _spot_check_deffkopta():
 	# Each model is stamped resolved with a 2-gun set (not left as the raw menu).
 	var m0 = u.get("models", [])[0]
 	_check("Deffkoptas -> model stamped 2-gun set", m0.get("ranged_loadout", []).size() == 2, str(m0.get("ranged_loadout", [])))
+	# Task B: a uniform 2-gun mob has no stand-out model.
+	_check("Deffkoptas -> 0 special (uniform)", RE.get_special_weapon_model_ids(u).size() == 0, str(RE.get_special_weapon_model_ids(u)))
+
+func _spot_check_special_weapons():
+	# Task B: minority-gun model detection (the special/heavy-weapon models).
+	# Burna Boyz (battlewagons): 4 Burna + 1 Big shoota -> exactly 1 special.
+	var bw = _load_json("res://armies/battlewagons.json")
+	if typeof(bw) == TYPE_DICTIONARY:
+		var u = bw["units"].get("U_BURNA_BOYZ_A", {})
+		if not u.is_empty():
+			var sp = RE.get_special_weapon_model_ids(u)
+			_check("Burna Boyz -> 1 special-weapon model", sp.size() == 1, "special=%s" % str(sp))
+	var ork = _load_json("res://armies/orks.json")
+	if typeof(ork) == TYPE_DICTIONARY:
+		# orks Lootas: 8 Deffgun + 3 KMB (model_type resolved) -> 3 special (KMB minority).
+		var lu = ork["units"].get("U_LOOTAS_A", {})
+		if not lu.is_empty():
+			var sp2 = RE.get_special_weapon_model_ids(lu)
+			_check("orks Lootas -> 3 special (KMB minority)", sp2.size() == 3, "special=%s" % str(sp2))
+		# Boyz K: all Slugga -> 0 special (uniform).
+		var bk = ork["units"].get("U_BOYZ_K", {})
+		if not bk.is_empty():
+			_check("Boyz K (all Slugga) -> 0 special", RE.get_special_weapon_model_ids(bk).size() == 0, str(RE.get_special_weapon_model_ids(bk)))
+		# Boyz E: Task-C resolved to all Slugga -> 0 special.
+		var be = ork["units"].get("U_BOYZ_E", {})
+		if not be.is_empty():
+			_check("Boyz E (all Slugga) -> 0 special", RE.get_special_weapon_model_ids(be).size() == 0, str(RE.get_special_weapon_model_ids(be)))
+	# Single-model units never get a special marker (guarded on models.size()).
+	var sm = _load_json("res://armies/space_marines.json")
+	if typeof(sm) == TYPE_DICTIONARY:
+		for uid in sm.get("units", {}):
+			var su = sm["units"][uid]
+			if typeof(su) == TYPE_DICTIONARY and su.get("models", []).size() == 1:
+				_check("single-model %s -> 0 special" % uid, RE.get_special_weapon_model_ids(su).size() == 0, "")
+				break

--- a/40k/tests/test_loadout_resolution.gd
+++ b/40k/tests/test_loadout_resolution.gd
@@ -124,16 +124,42 @@ func _run():
 					"resolved=%s raw=%d new=%d" % [str(got_resolved), raw_total, new_total])
 			if got_resolved:
 				resolved_units += 1
-				# INVARIANT 2: a resolved model reports exactly ONE ranged gun.
-				_check("resolved-1gun %s/%s" % [fname, uid], worst <= 1,
-					"worst=%d" % worst)
-				# INVARIANT 3: total ranged == number of alive models (one each).
+				# INVARIANT 2 (generalized for Task C): every resolved model reports
+				# the SAME number k of ranged guns (k>=1) — a uniform loadout size.
+				# This still catches over-counting but allows legit multi-gun models
+				# (Deffkopta k=2) alongside one-gun mobs (k=1).
+				var kmin := 999999
+				var kmax := 0
+				for mid in mw:
+					var c = mw[mid].size()
+					kmin = min(kmin, c)
+					kmax = max(kmax, c)
+				_check("resolved-uniform-k %s/%s" % [fname, uid], kmin == kmax and kmin >= 1,
+					"kmin=%d kmax=%d" % [kmin, kmax])
+				# INVARIANT 3 (generalized): total ranged == k × alive models.
 				var alive := 0
 				for m in models:
 					if m.get("alive", true):
 						alive += 1
-				_check("resolved-total==models %s/%s" % [fname, uid], new_total == alive,
-					"total=%d alive=%d" % [new_total, alive])
+				_check("resolved-total==k*alive %s/%s" % [fname, uid], new_total == kmax * alive,
+					"total=%d k=%d alive=%d" % [new_total, kmax, alive])
+				# INVARIANT 5 (Task C): every stamped gun is one the model_type may
+				# actually take — never invent a weapon a model can't have.
+				var mp2 = unit.get("meta", {}).get("model_profiles", {})
+				var meta_ranged := {}
+				for w in unit.get("meta", {}).get("weapons", []):
+					if str(w.get("type", "")).to_lower() == "ranged":
+						meta_ranged[str(w.get("name", ""))] = true
+				for m in models:
+					if not m.has("ranged_loadout"):
+						continue
+					var mt2 = str(m.get("model_type", ""))
+					var use_prof = not mp2.is_empty() and mt2 != "" and mp2.has(mt2)
+					var allowed2 = mp2[mt2].get("weapons", []) if use_prof else []
+					for wname in m["ranged_loadout"]:
+						var ok2 = (str(wname) in allowed2) if use_prof else meta_ranged.has(str(wname))
+						_check("resolved-gun-allowed %s/%s" % [fname, uid], ok2,
+							"'%s' not allowed for model_type '%s'" % [str(wname), mt2])
 			elif models.size() >= 2 and worst > 1:
 				unresolved_multimodel.append("%s/%s(%s)" % [fname, uid, str(unit.get("meta", {}).get("name", ""))])
 
@@ -141,6 +167,16 @@ func _run():
 	_spot_check_boyz()
 	_spot_check_orks_lootas_unchanged()
 	_spot_check_burna()
+	_spot_check_boyz_incomplete()   # Task C: incomplete-but-consistent (20-Boy mob, 10x Slugga)
+	_spot_check_deffkopta()         # Task C: uniform dual-gun (kopta rokkits + slugga)
+
+	# Task C: widening coverage must RESOLVE MORE units than the Phase-1 baseline
+	# (16) and leave fewer over-counters. Lower/upper bounds so future additions
+	# only make this stronger.
+	_check("Task C: resolved count increased vs Phase-1 baseline (16)", resolved_units >= 24,
+		"resolved=%d (expected >=24)" % resolved_units)
+	_check("Task C: unresolved over-counters decreased vs baseline (24)", unresolved_multimodel.size() <= 16,
+		"unresolved=%d (expected <=16)" % unresolved_multimodel.size())
 
 	print("")
 	print("Resolved units (loadout pinned from wargear): %d" % resolved_units)
@@ -192,3 +228,37 @@ func _spot_check_burna():
 	# wargear = 4x Burna + 1x Big shoota
 	_check("Burna Boyz -> 4 Burna", hist.get("burna_ranged", 0) == 4, str(hist))
 	_check("Burna Boyz -> 1 Big shoota", hist.get("big_shoota_ranged", 0) == 1, str(hist))
+
+func _spot_check_boyz_incomplete():
+	# Task C CASE C: a 20-model Boyz mob whose wargear records only "9x Slugga,
+	# 1x Slugga" (10 Slugga < 20 models, one consistent gun) -> every model Slugga.
+	var data = _load_json("res://armies/orks.json")
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	for uid in ["U_BOYZ_E", "U_BOYZ_F"]:
+		var u = data["units"].get(uid, {})
+		if u.is_empty():
+			continue
+		var n = u.get("models", []).size()
+		var hist = _weapon_hist(uid, u)
+		_check("Boyz %s -> %d Slugga (incomplete-consistent)" % [uid, n], hist.get("slugga_ranged", 0) == n, str(hist))
+		_check("Boyz %s -> no Big shoota" % uid, not hist.has("big_shoota_ranged"), str(hist))
+		_check("Boyz %s -> no Rokkit" % uid, not hist.has("rokkit_launcha_ranged"), str(hist))
+		_check("Boyz %s -> no Shoota" % uid, not hist.has("shoota_ranged"), str(hist))
+
+func _spot_check_deffkopta():
+	# Task C CASE B: Deffkoptas carry a Kopta rokkits AND a Slugga (2 ranged each);
+	# wargear "3x Kopta rokkits, 3x Slugga" over 3 models -> uniform 2-gun set.
+	var data = _load_json("res://armies/battlewagons.json")
+	if typeof(data) != TYPE_DICTIONARY:
+		return
+	var u = data["units"].get("U_DEFFKOPTAS_A", {})
+	if u.is_empty():
+		return
+	var n = u.get("models", []).size()
+	var hist = _weapon_hist("U_DEFFKOPTAS_A", u)
+	_check("Deffkoptas -> %d Kopta rokkits" % n, hist.get("kopta_rokkits_ranged", 0) == n, str(hist))
+	_check("Deffkoptas -> %d Slugga" % n, hist.get("slugga_ranged", 0) == n, str(hist))
+	# Each model is stamped resolved with a 2-gun set (not left as the raw menu).
+	var m0 = u.get("models", [])[0]
+	_check("Deffkoptas -> model stamped 2-gun set", m0.get("ranged_loadout", []).size() == 2, str(m0.get("ranged_loadout", [])))

--- a/40k/tests/test_loadout_resolution.gd
+++ b/40k/tests/test_loadout_resolution.gd
@@ -82,6 +82,7 @@ func _run():
 	var resolved_units := 0
 	var unresolved_multimodel := []
 	var special_units := []  # Task B: units with special-weapon model(s) flagged
+	var melee_resolved_units := 0  # Task D: units with resolved melee loadout
 	for path in _list_army_files():
 		var data = _load_json(path)
 		if typeof(data) != TYPE_DICTIONARY:
@@ -177,6 +178,37 @@ func _run():
 					"special=%d alive=%d" % [special.size(), alive_now])
 				special_units.append("%s/%s(%s): %d special" % [fname, uid, str(unit.get("meta", {}).get("name", "")), special.size()])
 
+			# ---- Task D: melee resolution invariants (mirror of ranged) ----
+			var raw_melee = _raw_melee_total(unit)
+			var mm = RE.get_unit_melee_weapons(uid, board)  # resolves melee
+			var new_melee := 0
+			var worst_melee := 0
+			for mid in mm:
+				var c = mm[mid].size()
+				new_melee += c
+				worst_melee = max(worst_melee, c)
+			# INVARIANT: melee resolution never ADDS melee instances.
+			_check("melee-no-increase %s/%s" % [fname, uid], new_melee <= raw_melee,
+				"raw=%d new=%d" % [raw_melee, new_melee])
+			var got_melee_resolved := false
+			for m in models:
+				if m.has("melee_loadout"):
+					got_melee_resolved = true
+					break
+			# INVARIANT: single-model units never get a resolved melee loadout.
+			if models.size() < 2:
+				_check("single-model-melee-untouched %s/%s" % [fname, uid], not got_melee_resolved, "")
+			if got_melee_resolved:
+				melee_resolved_units += 1
+				var kmin_m := 999999
+				var kmax_m := 0
+				for mid in mm:
+					kmin_m = min(kmin_m, mm[mid].size())
+					kmax_m = max(kmax_m, mm[mid].size())
+				# INVARIANT: resolved melee is uniform (all models same count k>=1).
+				_check("melee-uniform-k %s/%s" % [fname, uid], kmin_m == kmax_m and kmin_m >= 1,
+					"kmin=%d kmax=%d" % [kmin_m, kmax_m])
+
 	# -------- Targeted spot-checks --------
 	_spot_check_boyz()
 	_spot_check_orks_lootas_unchanged()
@@ -184,6 +216,7 @@ func _run():
 	_spot_check_boyz_incomplete()   # Task C: incomplete-but-consistent (20-Boy mob, 10x Slugga)
 	_spot_check_deffkopta()         # Task C: uniform dual-gun (kopta rokkits + slugga)
 	_spot_check_special_weapons()   # Task B: minority-gun model detection
+	_spot_check_melee()             # Task D: melee loadout resolution
 
 	# Task C: widening coverage must RESOLVE MORE units than the Phase-1 baseline
 	# (16) and leave fewer over-counters. Lower/upper bounds so future additions
@@ -200,6 +233,8 @@ func _run():
 	print("Units with special-weapon model(s) flagged (Task B): %d" % special_units.size())
 	for u in special_units:
 		print("   * %s" % u)
+	print("")
+	print("Units with resolved MELEE loadout (Task D): %d" % melee_resolved_units)
 	for u in unresolved_multimodel:
 		print("   - %s" % u)
 	print("")
@@ -316,3 +351,85 @@ func _spot_check_special_weapons():
 			if typeof(su) == TYPE_DICTIONARY and su.get("models", []).size() == 1:
 				_check("single-model %s -> 0 special" % uid, RE.get_special_weapon_model_ids(su).size() == 0, "")
 				break
+
+# Count melee instances a unit reports WITHOUT resolution (menu-based), mirroring
+# the pre-change get_unit_melee_weapons so we can prove melee totals only go down.
+func _raw_melee_total(unit: Dictionary) -> int:
+	var meta = unit.get("meta", {})
+	var mp = meta.get("model_profiles", {})
+	var all_melee := []
+	for w in meta.get("weapons", []):
+		if str(w.get("type", "")).to_lower() == "melee":
+			var wn = w.get("name", "")
+			if wn not in all_melee:
+				all_melee.append(wn)
+	var total := 0
+	for model in unit.get("models", []):
+		if not model.get("alive", true):
+			continue
+		var mt = model.get("model_type", "")
+		if not mp.is_empty() and mt != "" and mp.has(mt):
+			var allowed = mp[mt].get("weapons", [])
+			for wn in all_melee:
+				if wn in allowed:
+					total += 1
+		else:
+			total += all_melee.size()
+	return total
+
+func _melee_hist(uid: String, unit: Dictionary) -> Dictionary:
+	var board = {"units": {uid: unit}}
+	var mm = RE.get_unit_melee_weapons(uid, board)
+	var hist := {}
+	for mid in mm:
+		for wn in mm[mid]:
+			hist[str(wn)] = int(hist.get(str(wn), 0)) + 1
+	return hist
+
+func _spot_check_melee():
+	# Task D: melee loadout resolution (mirror of the ranged spot-checks).
+	# Beast Snagga Boyz (Orks_2000): wargear 9x Choppa + 1x Power snappa over 10
+	# models -> 9 Choppa + 1 Power snappa, dropping the Close combat weapon ghost.
+	var o = _load_json("res://armies/Orks_2000.json")
+	if typeof(o) == TYPE_DICTIONARY:
+		var bs = o["units"].get("U_BEAST_SNAGGA_BOYZ_A", {})
+		if not bs.is_empty():
+			var mmh = _melee_hist("U_BEAST_SNAGGA_BOYZ_A", bs)
+			_check("Beast Snagga melee -> 9 Choppa", mmh.get("Choppa", 0) == 9, str(mmh))
+			_check("Beast Snagga melee -> 1 Power snappa", mmh.get("Power snappa", 0) == 1, str(mmh))
+			_check("Beast Snagga melee -> no Close combat weapon", not mmh.has("Close combat weapon"), str(mmh))
+		# Kommandos: wargear says 10x Choppa but the Boss Nob's profile only allows
+		# Big choppa — so the cross-check SAFELY declines (never invent a weapon a
+		# model can't take) and melee falls back to the menu rather than resolving.
+		var k = o["units"].get("U_KOMMANDOS_A", {})
+		if not k.is_empty():
+			var board_k = {"units": {"U_KOMMANDOS_A": k}}
+			RE.get_unit_melee_weapons("U_KOMMANDOS_A", board_k)
+			var kommandos_resolved := false
+			for m in k.get("models", []):
+				if m.has("melee_loadout"):
+					kommandos_resolved = true
+					break
+			_check("Kommandos melee -> fallback (boss can't take Choppa)", not kommandos_resolved, "")
+	# Burna Boyz (battlewagons): 4x Cuttin' flames + 1x Close combat weapon.
+	var bw = _load_json("res://armies/battlewagons.json")
+	if typeof(bw) == TYPE_DICTIONARY:
+		var b = bw["units"].get("U_BURNA_BOYZ_A", {})
+		if not b.is_empty():
+			var mmh2 = _melee_hist("U_BURNA_BOYZ_A", b)
+			_check("Burna melee -> 4 Cuttin' flames", mmh2.get("Cuttin' flames", 0) == 4, str(mmh2))
+			_check("Burna melee -> 1 Close combat weapon", mmh2.get("Close combat weapon", 0) == 1, str(mmh2))
+	# A melee menu that can't be pinned falls back (keeps the menu) — Boyz have no
+	# melee wargear, so melee stays unresolved (no melee_loadout), NOT collapsed.
+	var ork = _load_json("res://armies/orks.json")
+	if typeof(ork) == TYPE_DICTIONARY:
+		var bk = ork["units"].get("U_BOYZ_K", {})
+		if not bk.is_empty():
+			var board = {"units": {"U_BOYZ_K": bk}}
+			RE.get_unit_melee_weapons("U_BOYZ_K", board)  # trigger resolution attempt
+			var any_melee_lo := false
+			for m in bk.get("models", []):
+				if m.has("melee_loadout"):
+					any_melee_lo = true
+					break
+			_check("Boyz K melee unresolved (no wargear) -> fallback", not any_melee_lo, "")

--- a/40k/tests/test_loadout_resolution.gd.uid
+++ b/40k/tests/test_loadout_resolution.gd.uid
@@ -1,0 +1,1 @@
+uid://bpdf4p4i0l6gg


### PR DESCRIPTION
Completes all four remaining tasks in `docs/PER_MODEL_LOADOUT_ROADMAP.md`. Each is a separate commit, validated with the extended headless invariant test **and** a windowed scenario driving the real UI (with a screenshot of the effect and no `SCRIPT ERROR`).

## Task C — Widen resolution coverage (`0591015`)
Extends the ranged resolver so it also handles units Phase 1 left alone, taking resolved multi-model units from **16 → 24**:
- **CASE C (incomplete-but-consistent):** wargear records fewer guns than models but all the same weapon (a 20-Boy mob listed with only `10x Slugga` → 20 Sluggas).
- **CASE B (uniform multi-gun):** every distinct gun appears once per model (Deffkoptas keep both Kopta rokkits + Slugga); cleanly rejects oversized/broken wargear.
- Every assignment is cross-checked against `model_profiles`, so the resolver never hands a model a weapon its type can't take. Unresolvable units fall back to the menu and are logged.
- Refactored the shared parse/assign logic into `_resolve_type_loadout` (reused by Task D).

## Task A — Hover/inspect shows a model's real weapon (`4658ac4`)
- Board hover (`Main._build_model_profile_hover_text`) lists the model's resolved gun; works for non-profiled units too.
- Unit panel: `RANGED WEAPONS` gains a name column and, when resolved, is titled `(as equipped)` and lists only carried guns with a model count (`Slugga ×10`). Model-composition line shows the resolved loadout.

## Task B — On-board marker for special-weapon models (`45c21a3`)
- `RulesEngine.get_special_weapon_model_ids` (single source of truth for token + tests) flags models whose reported ranged guns differ from the mob's majority — covers wargear-resolved and `model_type`-resolved mobs (Lootas' KMB), and returns `[]` for uniform/single-model/unresolved units.
- `TokenVisual._draw_special_weapon_indicator` draws an amber spark badge top-left in all render modes; per-token result cached.

## Task D — Resolve melee loadouts (`142f8dc`)
- `_ensure_loadout_resolved` now resolves melee too (symmetric with ranged). 7 units resolve melee (Burna Boyz, Beast Snagga Boyz…); spottier melee wargear falls back safely (e.g. Kommandos, whose Boss can't take a Choppa, is left alone).
- `_get_model_weapon_ids` and `get_unit_melee_weapons` (the function the Fight weapon tree reads) prefer `melee_loadout`.
- Unit panel `MELEE WEAPONS` table gets the same `(as equipped)` treatment.

## Validation
- **Headless:** `tests/test_loadout_resolution.gd` extended with uniform-k, profile-subset, special-weapon and melee invariants + spot-checks — **905 passed, 0 failed** across all army files. Resolved 16→24, special-weapon units 27, melee-resolved 7; single-model units never touched.
- **Windowed scenarios (new):** `iss_loadout_coverage_taskc_11e` (11/11), `iss_loadout_hover_taska_11e` (11/11), `iss_loadout_special_marker_taskb_11e` (9/9), `iss_loadout_melee_taskd_11e` (8/8) — each drives the real UI and screenshots the effect.
- **Regressions:** shooting/fight/firing-deck scenarios stay green (`iss_loadout_resolution_11e`, `iss050_fight_11e`, `fight_one_weapon_per_model_11e`, firing-deck, …). Pre-existing failures (`374_supa_cybork_fnp`, `iss048_shooting_types_11e`, `stompa_gets_to_fight_11e`, `click_select_shooter_shooting`) were each confirmed identical on a clean checkout — not introduced here.
- Changelog entries `0.93.8`–`0.93.11` added.

## Note on Task D's screenshot
Task D's suggested "screenshot the assign-attacks UI" shows the unit panel's `MELEE WEAPONS (as equipped)` table instead of the FightController weapon tree: that tree's `attack_tree` only instantiates once an engaged fighter is selected, and the post-deploy fixture has no active combat. Task D is instead validated via the exact function the tree renders from — `get_unit_melee_weapons`, asserted live in the Fight phase to return the resolved 4 Cuttin' flames + 1 CCW (one weapon per model, not the 10 the menu gives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeE1hM9DLxhVxpzG5F73ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeE1hM9DLxhVxpzG5F73ue)_