### PR TITLE
Firing Deck: group identical embarked weapons into one split-fireable row

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6137,6 +6137,13 @@ static func _is_target_within_engagement_range(actor_unit_id: String, target_uni
 	return false
 
 static func _get_model_by_id(unit: Dictionary, model_id: String) -> Dictionary:
+	# FIRING DECK (24.14): synthetic bearer ids "<hull_id>@fd<i>" (produced by
+	# get_unit_weapons for loaned embarked weapons) resolve to the transport's
+	# hull model so BS / position / LoS use the transport. Real model ids never
+	# contain "@fd", so this strip is a no-op for every normal lookup.
+	var fd_idx = model_id.find("@fd")
+	if fd_idx > 0:
+		model_id = model_id.substr(0, fd_idx)
 	for model in unit.get("models", []):
 		if model.get("id", "") == model_id:
 			return model
@@ -6431,9 +6438,15 @@ static func get_unit_weapons(unit_id: String, board: Dictionary = {}) -> Diction
 				result[composite_id] = _get_model_weapon_ids(char_unit, char_model, "Ranged")
 
 	# FIRING DECK (24.14): weapons selected from embarked models are treated as
-	# being equipped by the TRANSPORT model for this activation. Each loan gets a
-	# distinct "__fd<i>" alias so identical guns from different embarked models
-	# each contribute their own attacks; get_weapon_profile strips the alias.
+	# being equipped by the TRANSPORT model for this activation. Each loan becomes
+	# a distinct SYNTHETIC BEARER model id "<hull_id>@fd<i>" that carries the
+	# loaned weapon's BASE id (not a per-weapon "__fd" alias). Modelling each loan
+	# as one more bearer of the SAME base weapon lets identical guns collapse into
+	# a single "<weapon> ×N" row and split-fire exactly like a squad's shared
+	# weapon — while still contributing N models' worth of attacks (resolution
+	# counts one attack-set per bearer). _get_model_by_id maps the synthetic id
+	# back to the transport hull model, so BS / position / LoS use the transport
+	# (identical to the previous alias, which also bound to the hull).
 	var fd_loans = unit.get("flags", {}).get("firing_deck_weapons", [])
 	if fd_loans is Array and not fd_loans.is_empty():
 		var hull_model_id := ""
@@ -6442,14 +6455,13 @@ static func get_unit_weapons(unit_id: String, board: Dictionary = {}) -> Diction
 				hull_model_id = model.get("id", "")
 				break
 		if hull_model_id != "":
-			if not result.has(hull_model_id):
-				result[hull_model_id] = []
 			for i in range(fd_loans.size()):
 				var loan = fd_loans[i]
 				var base_weapon_id = str(loan.get("weapon_id", ""))
 				if base_weapon_id == "":
 					continue
-				result[hull_model_id].append("%s__fd%d" % [base_weapon_id, i])
+				var bearer_id = "%s@fd%d" % [hull_model_id, i]
+				result[bearer_id] = [base_weapon_id]
 
 	return result
 

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.8",
+			"date": "2026-07-23",
+			"summary": "Firing Deck weapon assignment now groups identical guns. When several embarked models fire the same weapon through a transport's firing deck (e.g. 10 Boyz with Sluggas), they show up as a single 'Slugga ×10' row instead of ten separate weapons — and you can split that fire across multiple targets exactly like a normal squad.",
+			"changes": [
+				"Shooting phase: firing-deck weapons of the same type are now collapsed into one grouped row (e.g. 'Slugga ×10') in the weapon-assignment list, instead of cluttering it with one row per model.",
+				"Split fire: the grouped firing-deck weapon can be split across targets just like a squad's shared weapon — assign it to a target to send all of them, then click another eligible target to peel off however many you want.",
+				"Rules unchanged: this is purely a UI convenience. The same number of shots are fired with the same profiles; only how the weapons are listed and targeted has changed."
+			]
+		},
+		{
 			"version": "0.93.7",
 			"date": "2026-07-23",
 			"summary": "Units now shoot with the guns they actually carry. Datasheets list every wargear OPTION per model, which made a mob report ALL of them at once — a 10-model Ork Boyz mob showed ~38 ranged weapons instead of 10. When a unit's army-list wargear pins the loadout, each model is now assigned its real gun, so shooting (and the Firing Deck) uses the correct weapons.",

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -5486,9 +5486,9 @@ func _on_firing_deck_models_selected(selected_weapons: Array, transport_id: Stri
 
 	# 24.14: the selected weapons are treated as being equipped by the TRANSPORT
 	# model for this activation (RulesEngine.get_unit_weapons offers them as
-	# __fd<i> aliases alongside the transport's own guns). The loan is cleared
-	# when the transport finishes shooting (_clear_firing_deck_loan) and at end
-	# of phase.
+	# synthetic hull bearers alongside the transport's own guns). The loan is
+	# cleared when the transport finishes shooting (_clear_firing_deck_loan) and
+	# at end of phase.
 	var loans = []
 	for weapon_data in selected_weapons:
 		loans.append({

--- a/40k/tests/scenarios/sp/firing_deck_weapon_grouping_11e.json
+++ b/40k/tests/scenarios/sp/firing_deck_weapon_grouping_11e.json
@@ -1,0 +1,177 @@
+{
+  "id": "firing_deck_weapon_grouping_11e",
+  "covers": [
+    "shooting.firing_deck.weapon_grouping",
+    "shooting.firing_deck.split_fire",
+    "autoloads.RulesEngine.get_unit_weapons",
+    "autoloads.RulesEngine._get_model_by_id",
+    "scripts.ShootingController._refresh_weapon_tree"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "edition": 11,
+  "disable_ai": true,
+  "transition_to_phase": 8,
+  "description": "24.14 Firing Deck UI grouping: a transport carrying 10 embarked Boyz who all fire Sluggas through the firing deck must show ONE grouped 'Slugga xN' weapon row (plus the transport's own Big shoota) instead of 10 separate one-off weapons. Because each loan is now modelled as another bearer of the SAME base weapon (synthetic hull bearers), the grouped row split-fires exactly like a squad's shared weapon: assigning it to Target A commits all 10, then clicking Target C opens the Move picker so the player can peel off 4 - leaving Slugga 6->A / 4->C. The fixture's pre-deployed units are relocated far away first so only the injected transport + two targets matter.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 8
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.set_edition(11)\nvar U = GameState.state[\"units\"]\nvar mine = {\"U_FD_TANK_A\": true, \"U_FD_BOYZ\": true, \"U_FD_TARGET_A\": true, \"U_FD_TARGET_C\": true}\nfor uid in U.keys():\n\tif mine.has(uid):\n\t\tcontinue\n\tfor m in U[uid].get(\"models\", []):\n\t\tif m.get(\"position\") != null:\n\t\t\tm[\"position\"] = {\"x\": 12000.0, \"y\": 12000.0}\nvar boyz_models = []\nfor i in range(10):\n\tboyz_models.append({\"id\": \"m%d\" % (i + 1), \"wounds\": 1, \"current_wounds\": 1, \"base_mm\": 32, \"position\": null, \"alive\": true, \"status_effects\": []})\nU.merge({\"U_FD_TANK_A\": {\"id\": \"U_FD_TANK_A\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"FD Wagon A\", \"keywords\": [\"VEHICLE\", \"TRANSPORT\"], \"stats\": {\"move\": 10, \"toughness\": 10, \"save\": 3, \"wounds\": 16, \"leadership\": 6, \"objective_control\": 5}, \"weapons\": [{\"name\": \"Big shoota\", \"type\": \"Ranged\", \"range\": \"36\", \"attacks\": \"3\", \"ballistic_skill\": \"5\", \"strength\": \"5\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"\"}]}, \"transport_data\": {\"firing_deck\": 11, \"capacity\": 22, \"capacity_multipliers\": {\"MEGA ARMOUR\": 2, \"JUMP PACK\": 2}, \"embarked_units\": [\"U_FD_BOYZ\"]}, \"models\": [{\"id\": \"t0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 400}, \"base_mm\": 170, \"wounds\": 16, \"current_wounds\": 16}]}, \"U_FD_BOYZ\": {\"id\": \"U_FD_BOYZ\", \"owner\": 1, \"status\": 2, \"flags\": {}, \"embarked_in\": \"U_FD_TANK_A\", \"meta\": {\"name\": \"Boyz\", \"keywords\": [\"INFANTRY\", \"ORKS\", \"MOB\"], \"stats\": {\"move\": 6, \"toughness\": 5, \"save\": 5, \"wounds\": 1, \"leadership\": 7, \"objective_control\": 2}, \"weapons\": [{\"name\": \"Slugga\", \"type\": \"Ranged\", \"range\": \"12\", \"attacks\": \"1\", \"ballistic_skill\": \"5\", \"strength\": \"4\", \"ap\": \"0\", \"damage\": \"1\", \"special_rules\": \"pistol\", \"abilities\": [{\"id\": \"pistol\"}]}, {\"name\": \"Choppa\", \"type\": \"Melee\", \"range\": \"Melee\", \"attacks\": \"3\", \"weapon_skill\": \"3\", \"strength\": \"4\", \"ap\": \"-1\", \"damage\": \"1\"}]}, \"models\": boyz_models}, \"U_FD_TARGET_A\": {\"id\": \"U_FD_TARGET_A\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Target A\", \"keywords\": [\"INFANTRY\"], \"stats\": {\"move\": 6, \"toughness\": 4, \"save\": 4, \"wounds\": 2, \"leadership\": 6, \"objective_control\": 2}, \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 650, \"y\": 400}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}, \"U_FD_TARGET_C\": {\"id\": \"U_FD_TARGET_C\", \"owner\": 2, \"status\": 2, \"flags\": {}, \"meta\": {\"name\": \"Target C\", \"keywords\": [\"INFANTRY\"], \"stats\": {\"move\": 6, \"toughness\": 4, \"save\": 4, \"wounds\": 2, \"leadership\": 6, \"objective_control\": 2}, \"weapons\": []}, \"models\": [{\"id\": \"e0\", \"alive\": true, \"position\": {\"x\": 200, \"y\": 800}, \"base_mm\": 32, \"wounds\": 2, \"current_wounds\": 2}]}}, true)\nreturn U.has(\"U_FD_TANK_A\") and U.has(\"U_FD_BOYZ\") and U.has(\"U_FD_TARGET_A\") and U.has(\"U_FD_TARGET_C\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var et = RulesEngine.get_eligible_targets(\"U_FD_TANK_A\", GameState.state)\nreturn et.has(\"U_FD_TARGET_A\") and et.has(\"U_FD_TARGET_C\") and et.size() == 2",
+      "equals": true
+    },
+    {
+      "act": "dispatch_action",
+      "action": {
+        "type": "SELECT_SHOOTER",
+        "actor_unit_id": "U_FD_TANK_A"
+      }
+    },
+    {
+      "act": "expect_action_result",
+      "path": "success",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.get_unit(\"U_FD_TANK_A\").get(\"flags\", {}).get(\"firing_deck_weapons\", []).size()",
+      "equals": 10
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var root = tree.current_scene.get_node(\"ShootingController\").weapon_tree.get_root()\nvar n = 0\nvar c = root.get_first_child()\nwhile c:\n\tn += 1\n\tc = c.get_next()\nreturn n",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var root = tree.current_scene.get_node(\"ShootingController\").weapon_tree.get_root()\nvar slug_rows = 0\nvar c = root.get_first_child()\nwhile c:\n\tif str(c.get_metadata(0)).begins_with(\"slugga\"):\n\t\tslug_rows += 1\n\tc = c.get_next()\nreturn slug_rows",
+      "equals": 1
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var root = tree.current_scene.get_node(\"ShootingController\").weapon_tree.get_root()\nvar c = root.get_first_child()\nwhile c:\n\tif str(c.get_metadata(0)).begins_with(\"slugga\"):\n\t\treturn c.get_text(0).contains(\"10\")\n\tc = c.get_next()\nreturn false",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "01_slugga_grouped_x10"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nwhile c:\n\tif str(c.get_metadata(0)).begins_with(\"slugga\"):\n\t\tc.select(0)\n\t\tbreak\n\tc = c.get_next()\nreturn wt.get_selected() != null and str(wt.get_selected().get_metadata(0)).begins_with(\"slugga\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.emit_signal(\"item_selected\")"
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._select_target_for_current_weapon(\"U_FD_TARGET_A\")"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var pa = tree.current_scene.get_node(\"ShootingController\").current_phase.pending_assignments\nvar t = 0\nfor x in pa:\n\tif str(x.get(\"weapon_id\", \"\")).begins_with(\"slugga\"):\n\t\tt += x.get(\"model_ids\", []).size()\nreturn t",
+      "equals": 10
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var pa = tree.current_scene.get_node(\"ShootingController\").current_phase.pending_assignments\nfor x in pa:\n\tif str(x.get(\"weapon_id\", \"\")).begins_with(\"slugga\"):\n\t\treturn str(x.get(\"target_unit_id\", \"\"))\nreturn \"none\"",
+      "equals": "U_FD_TARGET_A"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_all_10_to_target_a"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nwhile c:\n\tif str(c.get_metadata(0)).begins_with(\"slugga\"):\n\t\tc.select(0)\n\t\tbreak\n\tc = c.get_next()\nreturn true"
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").weapon_tree.emit_signal(\"item_selected\")"
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\")._select_target_for_current_weapon(\"U_FD_TARGET_C\")"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFirePicker\", true, false) != null",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "03_move_picker_open"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var picker = tree.current_scene.get_node(\"ShootingController\").find_child(\"SplitFirePicker\", true, false)\nvar spin = picker.find_child(\"SplitFireSpin\", true, false)\nspin.value = 4\nreturn int(spin.value)",
+      "equals": 4
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"ShootingController\").find_child(\"SplitFirePicker\", true, false).get_ok_button().emit_signal(\"pressed\")"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var pa = tree.current_scene.get_node(\"ShootingController\").current_phase.pending_assignments\nvar n = 0\nfor x in pa:\n\tif str(x.get(\"weapon_id\", \"\")).begins_with(\"slugga\"):\n\t\tn += 1\nreturn n",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var pa = tree.current_scene.get_node(\"ShootingController\").current_phase.pending_assignments\nvar a = 0\nfor x in pa:\n\tif str(x.get(\"weapon_id\", \"\")).begins_with(\"slugga\") and x.get(\"target_unit_id\", \"\") == \"U_FD_TARGET_A\":\n\t\ta = x.get(\"model_ids\", []).size()\nreturn a",
+      "equals": 6
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var pa = tree.current_scene.get_node(\"ShootingController\").current_phase.pending_assignments\nvar b = 0\nfor x in pa:\n\tif str(x.get(\"weapon_id\", \"\")).begins_with(\"slugga\") and x.get(\"target_unit_id\", \"\") == \"U_FD_TARGET_C\":\n\t\tb = x.get(\"model_ids\", []).size()\nreturn b",
+      "equals": 4
+    },
+    {
+      "act": "screenshot",
+      "label": "04_split_slugga_6_to_a_4_to_c"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss_firing_deck_autoresolve_11e.json
+++ b/40k/tests/scenarios/sp/iss_firing_deck_autoresolve_11e.json
@@ -72,7 +72,7 @@
     },
     {
       "act": "execute_script",
-      "script": "str(RulesEngine.get_unit_weapons(\"U_FD_TANK_A\", GameState.state)).contains(\"__fd\")",
+      "script": "str(RulesEngine.get_unit_weapons(\"U_FD_TANK_A\", GameState.state)).contains(\"@fd\")",
       "equals": true
     },
     {

--- a/40k/tests/test_loadout_resolution.gd.uid
+++ b/40k/tests/test_loadout_resolution.gd.uid
@@ -1,0 +1,1 @@
+uid://bfcbp4d6c8che

--- a/40k/tests/test_transport_audit_2026_07.gd
+++ b/40k/tests/test_transport_audit_2026_07.gd
@@ -14,8 +14,9 @@ extends SceneTree
 #      charge-eligible).
 #   5. RulesEngine.get_eligible_targets never offers an embarked unit.
 #   6. CONFIRM_DISEMBARK rejects placements overlapping other models.
-#   7. FIRING DECK loans: get_unit_weapons offers __fd aliases from
-#      flags.firing_deck_weapons and get_weapon_profile resolves them.
+#   7. FIRING DECK loans: get_unit_weapons offers each loaned embarked weapon
+#      as a synthetic hull bearer "<hull>@fd<i>" carrying the base weapon id
+#      (so identical guns group into one row and split-fire like a squad).
 #
 # Usage: godot --headless --path . -s tests/test_transport_audit_2026_07.gd
 
@@ -227,12 +228,23 @@ func _test_firing_deck_loan() -> void:
 	}
 	var rules = root.get_node("RulesEngine")
 	var weapons = rules.get_unit_weapons("U_WAGON", board)
+	# FIRING DECK grouping: the two loaned Shootas are exposed as synthetic hull
+	# bearers "m1@fd0" / "m1@fd1", each carrying the BASE weapon id (not a
+	# per-weapon "__fd" alias), so identical guns collapse into one "×N" row and
+	# split-fire like a squad. The hull model itself keeps only its own guns.
 	var hull = weapons.get("m1", [])
-	_check("hull model exposes both loaned aliases",
-		"shoota_ranged__fd0" in hull and "shoota_ranged__fd1" in hull, str(hull))
-	var profile = rules.get_weapon_profile("shoota_ranged__fd0", board)
-	_check("__fd alias resolves to the Shoota profile", profile.get("name", "") == "Shoota", str(profile.get("name")))
-	_check("alias keeps base attacks", int(profile.get("attacks", 0)) == 2, str(profile.get("attacks")))
+	_check("hull model keeps its own gun (Big shoota), not the loaned Shootas",
+		"big_shoota_ranged" in hull and not ("shoota_ranged" in hull), str(hull))
+	var bearer0 = weapons.get("m1@fd0", [])
+	var bearer1 = weapons.get("m1@fd1", [])
+	_check("both loans become synthetic hull bearers carrying the base weapon",
+		"shoota_ranged" in bearer0 and "shoota_ranged" in bearer1, str([bearer0, bearer1]))
+	# The synthetic bearer id resolves to the transport hull model (BS/position).
+	var resolved = rules.get_model_by_id(board.units.U_WAGON, "m1@fd0")
+	_check("synthetic bearer id resolves to the hull model", resolved.get("id", "") == "m1", str(resolved.get("id")))
+	var profile = rules.get_weapon_profile("shoota_ranged", board)
+	_check("loaned base weapon resolves to the Shoota profile", profile.get("name", "") == "Shoota", str(profile.get("name")))
+	_check("loaned weapon keeps base attacks", int(profile.get("attacks", 0)) == 2, str(profile.get("attacks")))
 
 	# Embarked unit still cannot shoot on its own (weapons come via the loan).
 	var boyz_weapons = rules.get_unit_weapons("U_BOYZ", board)


### PR DESCRIPTION
## What & why

When several embarked models fire the **same** weapon through a transport's firing deck (e.g. 10 Boyz with Sluggas), the weapon-assignment list showed **one row per model** — ten "Slugga ×1" rows that were tedious to target. This groups them into a single **"Slugga ×10"** row that split-fires exactly like a normal squad's shared weapon.

This is a pure UI/ergonomics change — the same shots fire with the same profiles.

## Root cause

Firing-deck loans were exposed by `get_unit_weapons` as distinct per-weapon aliases (`<weapon>__fd<i>`), all bound to the transport hull. Because each alias was a different `weapon_id`, the weapon tree's group-by-`weapon_id` + `×N` counting could never collapse them → N separate rows.

## Fix

Model each loan as one more **bearer of the same base weapon** instead of a weapon alias:
- `get_unit_weapons` now emits a synthetic hull-bearer model id `<hull_id>@fd<i>` carrying the loaned weapon's **base** id.
- `_get_model_by_id` maps that synthetic id back to the transport hull model, so BS / position / LoS are identical to the old alias (which also bound to the hull).

Identical guns now collapse into a single `<weapon> ×N` row and split-fire through the **exact same path a squad's shared weapon uses** (concentrate on first assign, Move picker to peel off a slice) — no new UI or split-fire code. Resolution still counts one attack-set per bearer, matching the previous one-alias-per-loan behaviour.

## Changes

- `autoloads/RulesEngine.gd` — `get_unit_weapons` emits synthetic hull bearers; `_get_model_by_id` resolves `@fd` ids to the hull.
- `phases/ShootingPhase.gd` — comment accuracy only.
- `data/version_history.json` — new `0.93.8` player-facing entry.
- `tests/test_transport_audit_2026_07.gd` — updated to assert the synthetic-bearer representation.
- `tests/scenarios/sp/iss_firing_deck_autoresolve_11e.json` — `__fd` → `@fd` marker check.
- `tests/scenarios/sp/firing_deck_weapon_grouping_11e.json` — **new** windowed scenario.
- `tests/test_loadout_resolution.gd.uid` — track a `.uid` the repo convention expects (unrelated hygiene).

## Validation

- **New windowed scenario `firing_deck_weapon_grouping_11e` (32/32)**: 10 Sluggas render as one "Slugga ×10" row (2 total weapon rows), assign all 10 to Target A, then the Move picker splits 4 off to Target C → 6 A / 4 C. Screenshots captured of the grouped row and the split in Current Targets.
- `test_transport_audit_2026_07` (23/23), `iss071_firing_deck_11e`, and `iss_firing_deck_autoresolve_11e` all pass.
- `split_fire_move_picker` (normal squad split fire) unaffected.
- No `SCRIPT ERROR` lines in the debug log during the run.

> Note: the pre-existing `split_fire_spinbox_commit` scenario fails in this environment with or without these changes (verified by stashing) — unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhjgSrHbwPbqzDXRVEopqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhjgSrHbwPbqzDXRVEopqr)_