### PR TITLE
Special-weapon marker: dashed base ring instead of a top-left badge

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.13",
+			"date": "2026-07-24",
+			"summary": "The special-weapon model marker now sits on the model's own base. Instead of an amber badge at the top-left of the token (which could look like it hovered over a neighbouring model), the model carrying the squad's special/heavy weapon now shows a dashed base ring — four amber dashes at the north/south/east/west of its base rim — so it's unmistakable which model it belongs to.",
+			"changes": [
+				"Board: the special-weapon indicator is now drawn as four amber dashes on the model's base ring (N/E/S/W) rather than a corner badge, removing the ambiguity about which model was flagged.",
+				"The dashes are screen-aligned so the pattern reads the same regardless of which way the model faces, with a dark backing so they stay visible on any base colour."
+			]
+		},
+		{
 			"version": "0.93.12",
 			"date": "2026-07-23",
 			"summary": "Firing Deck weapon assignment now groups identical guns. When several embarked models fire the same weapon through a transport's firing deck (e.g. 10 Boyz with Sluggas), they show up as a single 'Slugga ×10' row instead of ten separate weapons — and you can split that fire across multiple targets exactly like a normal squad.",

--- a/40k/scripts/TokenVisual.gd
+++ b/40k/scripts/TokenVisual.gd
@@ -1174,12 +1174,13 @@ func _has_beacon_flag() -> bool:
 	return not unit.is_empty() and unit.get("flags", {}).get("beacon", false)
 
 func _draw_special_weapon_indicator(radius: float) -> void:
-	# MA-LOADOUT Phase 3 (Task B): draw an amber 4-point "spark" badge at the
-	# token's top-left when this model carries the special/heavy weapon (its
-	# resolved ranged loadout differs from the mob's bulk gun). Distinct in colour
-	# and position from the leader chevron (top-centre) and the Marked-for-Death /
-	# Beacon rings (top-right). Nothing is drawn for unresolved units or uniform
-	# mobs where no model stands out. Result cached — see set_model_data.
+	# MA-LOADOUT Phase 3 (Task B): mark the model carrying the special/heavy weapon
+	# (its resolved ranged loadout differs from the mob's bulk gun) by breaking its
+	# base ring into four amber dashes at screen N / E / S / W. Drawing ON the
+	# model's OWN base rim makes it unmistakable which model it belongs to — the
+	# earlier top-left badge could look like it hovered over a neighbouring model.
+	# Nothing is drawn for unresolved units or uniform mobs where no model stands
+	# out. Result cached — see set_model_data.
 	if not has_meta("unit_id"):
 		return
 	if not _special_checked:
@@ -1192,22 +1193,19 @@ func _draw_special_weapon_indicator(radius: float) -> void:
 	if not _is_special_weapon:
 		return
 
-	var center = Vector2(-radius * 0.62, -radius - 6.0)
-	var outer = max(4.0, radius * 0.34)
-	var inner = outer * 0.42
-	var star = PackedVector2Array()
-	for i in range(8):
-		var ang = -PI / 2.0 + TAU * i / 8.0
-		var r = outer if (i % 2 == 0) else inner
-		star.append(center + Vector2(cos(ang), sin(ang)) * r)
-	# Dark outline (scaled-up copy) behind an amber fill so it reads at board zoom.
-	var outline = PackedVector2Array()
-	for p in star:
-		outline.append(center + (p - center) * 1.3)
-	draw_colored_polygon(outline, Color(0.12, 0.08, 0.0, 0.92))
-	draw_colored_polygon(star, Color(1.0, 0.72, 0.12, 1.0))
-	# Small dark core keeps the star shape legible when the token is tiny.
-	draw_circle(center, max(1.0, inner * 0.35), Color(0.2, 0.12, 0.0, 0.92))
+	# Four short arcs on the base rim at screen N/E/S/W (screen-aligned so the
+	# pattern reads the same regardless of which way the model faces). A darker,
+	# slightly wider backing arc sits under each amber dash so it stays legible on
+	# any base/border colour.
+	var amber := Color(1.0, 0.72, 0.12, 1.0)
+	var dark := Color(0.12, 0.08, 0.0, 0.92)
+	var dash_w: float = max(3.0, radius * 0.13)
+	var half_span := deg_to_rad(20.0)  # each dash spans ~40°, with ~50° gaps
+	var cardinals := [-PI / 2.0, 0.0, PI / 2.0, PI]
+	for a in cardinals:
+		draw_arc(Vector2.ZERO, radius, a - half_span, a + half_span, 12, dark, dash_w + 2.0)
+	for a in cardinals:
+		draw_arc(Vector2.ZERO, radius, a - half_span, a + half_span, 12, amber, dash_w)
 
 func _draw_selection_ring(radius: float) -> void:
 	var pulse = (sin(_pulse_time * 4.0) + 1.0) / 2.0


### PR DESCRIPTION
Follow-up to the per-model loadout work (#763). The special/heavy-weapon marker was an amber "spark" badge drawn at the token's **top-left**, which could look like it hovered over a neighbouring model. This moves it onto the model's **own base rim** as four amber dashes at screen N/E/S/W, so it's unmistakable which model carries the special weapon.

## Change
- `TokenVisual._draw_special_weapon_indicator`: replaced the corner badge with four short arcs on the base ring (screen-aligned N/E/S/W, each with a darker wider backing so they read on any base/border colour).
- Detection is unchanged — still `RulesEngine.get_special_weapon_model_ids`; only the drawing changed, so the same models are flagged.

## Validation
- Windowed scenario `iss_loadout_special_marker_taskb_11e` passes **9/0**; the screenshot shows the leftmost Burna model (the Big Shoota) with the dashed base ring while its four squadmates keep solid rings.
- No `SCRIPT ERROR` in the debug log.
- `test_iss020_public_api.gd` (public-API lint) passes 5/0 — no new private access introduced.
- Changelog entry `0.93.13` added.

Note: the pre-existing red "Windowed scenarios (Xvfb)" / multi-peer jobs on `scenarios.yml` are unaffected by this change (they fail on the same pre-existing broken scenarios that are red on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeE1hM9DLxhVxpzG5F73ue

---
_Generated by [Claude Code](https://claude.ai/code/session_01UeE1hM9DLxhVxpzG5F73ue)_