### PR TITLE
Smooth LB/RB unit-switch camera: eased glide, no pause-then-jump

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
 	"_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
 	"releases": [
 		{
+			"version": "0.93.12",
+			"date": "2026-07-24",
+			"summary": "Switching units with the controller bumpers (LB/RB) now glides the camera smoothly instead of pausing and then jumping. The camera eases slow-to-fast-to-slow to the newly selected unit, and the brief work the game does when you pick a unit can no longer make the move lurch.",
+			"changes": [
+				"Controller: the LB/RB unit-switch camera move is now a proper eased glide (slow → fast → slow) with a slightly longer, more readable duration.",
+				"Fixed the 'pause then jump' when cycling units: the camera pan is driven with a capped per-frame step, so the heavier frame that happens when a unit is selected can no longer fast-forward the animation to its destination.",
+				"Grabbing the camera yourself (pan/zoom) mid-glide instantly hands control back to you."
+			]
+		},
+		{
 			"version": "0.93.11",
 			"date": "2026-07-23",
 			"summary": "The Fight phase now uses the melee weapons models actually carry, the same way shooting was fixed. Datasheets list every close-combat OPTION per model, which made a mob report all of them at once; when the army list pins the melee loadout (Kommandos with Choppas, Burna Boyz with Cuttin' flames, Beast Snagga with Choppas + a Power snappa) each model now fights with its real weapon instead of the whole menu.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -6250,7 +6250,14 @@ func _process(delta: float) -> void:
 	
 	
 	if view_changed:
+		# A manual pan/zoom means the player grabbed the camera themselves —
+		# abandon any in-flight LB/RB unit-switch glide so the two don't fight.
+		_cam_glide_active = false
 		update_view_transform()
+
+	# Drive the LB/RB unit-switch camera glide (clamped-delta, hitch-proof — see
+	# _update_cycle_camera_glide). No-op unless a glide is active.
+	_update_cycle_camera_glide(delta)
 
 	# T5-MP8: Update phase timer HUD and waiting overlay timer (runs every frame, labels only change on integer second)
 	_update_phase_timer_hud()
@@ -6452,7 +6459,7 @@ func fit_view_to_selection(unit_id: String, animate: bool = false) -> bool:
 		# unit's bounding box instead of hard-cutting (the "it jumps the camera
 		# between the units" report). _sync_camera_node_to_view restores the
 		# camera.position/zoom the instant path sets once the glide settles.
-		_run_cycle_camera_tween(target_offset, z)
+		_start_cycle_camera_glide(target_offset, z)
 		return true
 	camera.position = center
 	camera.zoom = Vector2(z, z)
@@ -6611,53 +6618,90 @@ func _tween_update_view(_progress: float) -> void:
 
 # ── LB/RB unit-switch camera glide ──────────────────────────────────────────
 # Controller unit-cycling (PadRouter LB/RB, and the shooting/charge target
-# walk) frames each unit with a short glide instead of a hard cut — the "it
-# jumps the camera between the units" report. Uses the same view_offset /
-# view_zoom + update_view_transform model as the instant pans, driven by a
-# tween so rapid presses smoothly chase the newest unit (each press kills the
-# in-flight glide and restarts from wherever the camera currently is).
-var _cycle_camera_tween: Tween = null
+# walk) frames each unit with a short eased glide instead of a hard cut — the
+# "it jumps the camera between the units" report.
+#
+# Driven MANUALLY from _process with a CLAMPED per-frame delta, NOT a Tween.
+# Why: the unit-selection handler that fires on the same button press is heavy
+# (BEGIN_NORMAL_MOVE rebuilds the move ghosts / range overlays), so the press
+# frame runs long. A Tween created inside that frame swallows the whole slow
+# frame's delta on its very first tick — with EASE_OUT it lurched ~60% of the
+# way in one step (measured), which read as "pause, then jump" rather than a
+# glide. Clamping the per-frame advance means any slow frame (the press frame,
+# or a later GC hitch) can move the glide by at most one small increment, so the
+# motion stays smooth slow→fast→slow no matter how the frames land. Each press
+# retargets from the current position, so rapid cycling chases smoothly.
+var _cam_glide_active: bool = false
+var _cam_glide_from_offset: Vector2 = Vector2.ZERO
+var _cam_glide_to_offset: Vector2 = Vector2.ZERO
+var _cam_glide_from_zoom: float = 1.0
+var _cam_glide_to_zoom: float = 1.0
+var _cam_glide_elapsed: float = 0.0
 
-# Duration of the unit-switch glide: long enough to read as motion, short
-# enough to stay responsive when cycling quickly.
-const CYCLE_CAMERA_PAN_TIME := 0.28
+# Glide duration. Long enough to read as a deliberate slow-fast-slow move,
+# short enough to stay responsive when cycling quickly.
+const CYCLE_CAMERA_PAN_TIME := 0.42
+
+# Hitch guard: never advance the glide by more than this much wall-time in one
+# frame (~2 frames at 60fps). Caps the long press/selection frame (or any GC
+# hitch) to a single small step instead of teleporting the camera.
+const CYCLE_CAMERA_MAX_STEP := 1.0 / 30.0
+
+# Test/coverage seam: true while a unit-switch glide is animating.
+func is_cycle_glide_active() -> bool:
+	return _cam_glide_active
 
 # Smoothly pan (keeping the current zoom) so world_pos sits at viewport centre.
 # The pad's LB/RB unit-cycle camera-follow at normal zoom.
 func smooth_center_on_world(world_pos: Vector2) -> void:
 	var vp_size: Vector2 = get_viewport().get_visible_rect().size
 	var target_offset: Vector2 = world_pos - vp_size / (2.0 * view_zoom)
-	_run_cycle_camera_tween(target_offset, view_zoom)
+	_start_cycle_camera_glide(target_offset, view_zoom)
 
 # Instant camera framing that also cancels any in-flight unit-switch glide.
 # Carry pickup / model-hop paths call this and then project world→screen the
-# SAME frame, so a still-running cycle tween must not overwrite view_offset
+# SAME frame, so a still-running glide must not overwrite view_offset
 # underneath them.
 func snap_center_on_world(world_pos: Vector2) -> void:
-	if _cycle_camera_tween and _cycle_camera_tween.is_valid():
-		_cycle_camera_tween.kill()
+	_cam_glide_active = false
 	var vp_size: Vector2 = get_viewport().get_visible_rect().size
 	view_offset = world_pos - vp_size / (2.0 * view_zoom)
 	update_view_transform()
 
-# Shared tween driver for the unit-switch glide: kill any prior glide, then
-# animate view_offset (+ view_zoom — unchanged for a plain pan, retargeted by
-# the fit path) to the target, calling update_view_transform every frame. Syncs
-# the Camera2D node to the settled view on completion so it matches the
-# instant-pan end state.
-func _run_cycle_camera_tween(target_offset: Vector2, target_zoom: float) -> void:
-	if _cycle_camera_tween and _cycle_camera_tween.is_valid():
-		_cycle_camera_tween.kill()
+# Begin (or retarget) the unit-switch glide from wherever the camera is right
+# now. view_zoom is unchanged for a plain pan, retargeted by the fit path.
+func _start_cycle_camera_glide(target_offset: Vector2, target_zoom: float) -> void:
 	if view_offset.is_equal_approx(target_offset) and is_equal_approx(view_zoom, target_zoom):
+		_cam_glide_active = false
 		return  # already framed — no glide needed
-	_cycle_camera_tween = create_tween()
-	_cycle_camera_tween.set_parallel(true)
-	_cycle_camera_tween.set_ease(Tween.EASE_OUT)
-	_cycle_camera_tween.set_trans(Tween.TRANS_CUBIC)
-	_cycle_camera_tween.tween_property(self, "view_offset", target_offset, CYCLE_CAMERA_PAN_TIME)
-	_cycle_camera_tween.tween_property(self, "view_zoom", target_zoom, CYCLE_CAMERA_PAN_TIME)
-	_cycle_camera_tween.tween_method(_tween_update_view, 0.0, 1.0, CYCLE_CAMERA_PAN_TIME)
-	_cycle_camera_tween.finished.connect(_sync_camera_node_to_view)
+	_cam_glide_from_offset = view_offset
+	_cam_glide_to_offset = target_offset
+	_cam_glide_from_zoom = view_zoom
+	_cam_glide_to_zoom = target_zoom
+	_cam_glide_elapsed = 0.0
+	_cam_glide_active = true
+
+# Advance the unit-switch glide one frame. Called every frame from _process
+# with the frame delta, CLAMPED so a heavy frame can't fast-forward the motion.
+func _update_cycle_camera_glide(delta: float) -> void:
+	if not _cam_glide_active:
+		return
+	_cam_glide_elapsed += min(delta, CYCLE_CAMERA_MAX_STEP)
+	var t: float = clampf(_cam_glide_elapsed / CYCLE_CAMERA_PAN_TIME, 0.0, 1.0)
+	var e: float = _ease_in_out_cubic(t)
+	view_offset = _cam_glide_from_offset.lerp(_cam_glide_to_offset, e)
+	view_zoom = lerpf(_cam_glide_from_zoom, _cam_glide_to_zoom, e)
+	update_view_transform()
+	if t >= 1.0:
+		_cam_glide_active = false
+		_sync_camera_node_to_view()
+
+# Cubic ease-in-out (slow → fast → slow): the standard camera-glide feel.
+func _ease_in_out_cubic(t: float) -> float:
+	if t < 0.5:
+		return 4.0 * t * t * t
+	var f: float = -2.0 * t + 2.0
+	return 1.0 - (f * f * f) / 2.0
 
 # Keep the Camera2D node's position/zoom in step with the view_offset/view_zoom
 # rendering source of truth after a glide settles (the fit path and the direct

--- a/40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json
+++ b/40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json
@@ -5,13 +5,15 @@
     "controller.smooth_camera_unit_switch",
     "controller.bumper_only_unit_cycling",
     "PadRouter",
-    "Main.smooth_center_on_world"
+    "Main.smooth_center_on_world",
+    "Main.is_cycle_glide_active",
+    "Main._update_cycle_camera_glide"
   ],
   "fixture": "audit_baseline_postdeploy",
   "transition_to_phase": 7,
   "disable_ai": true,
   "rng_seed": 42,
-  "description": "LB/RB unit switching GLIDES the camera to the newly-selected unit instead of instantly jumping. At normal zoom a bumper press starts a short view_offset tween (Main._cycle_camera_tween) that is still running immediately after the press; once it settles the camera is centered on the new unit's first alive model, and the settled position differs from where the camera started — proving it animated over time rather than hard-cutting. (Model carry / L3 hop still snap instantly; that is covered by the carry scenarios.)",
+  "description": "LB/RB unit switching GLIDES the camera to the newly-selected unit with an eased slow-fast-slow move instead of hard-cutting or lurching. At normal zoom a bumper press starts Main's manual clamped-delta glide (is_cycle_glide_active() true right after the press). Crucially the camera does NOT jump: immediately after the press it is still far nearer where it started than the destination — proving the heavy same-frame unit-selection work no longer fast-forwards the motion (the old 'pause then jump' report). Once the glide settles the camera is centered on the new unit's first alive model, and the settled position differs from where it started. (Model carry / L3 hop still snap instantly; that is covered by the carry scenarios.)",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
@@ -20,17 +22,19 @@
     { "act": "execute_script", "script": "main.update_view_transform()" },
 
     { "act": "simulate_joy_button", "button_index": 10 },
-    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "wait_seconds", "seconds": 0.7 },
     { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != \"\"", "equals": true },
     { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"ua\", str(main.movement_controller.active_unit_id))" },
     { "act": "execute_script", "script": "main.set_meta(\"off_a\", main.view_offset)" },
     { "act": "screenshot", "label": "01_first_unit_framed" },
 
     { "act": "simulate_joy_button", "button_index": 10 },
-    { "act": "execute_script", "multiline": true, "script": "var tw = tree.current_scene._cycle_camera_tween\nif tw == null:\n\treturn false\nreturn tw.is_valid() and tw.is_running()", "equals": true },
+    { "act": "execute_script", "script": "tree.current_scene.is_cycle_glide_active()", "equals": true },
     { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != str(InputDeviceManager.get_meta(\"ua\"))", "equals": true },
 
-    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "multiline": true, "script": "var mn = tree.current_scene\nvar uid = str(mn.movement_controller.active_unit_id)\nvar u = GameState.get_unit(uid)\nvar p = null\nfor mdl in u.get(\"models\", []):\n\tif mdl.get(\"alive\", true):\n\t\tvar pos = mdl.get(\"position\", null)\n\t\tif pos is Dictionary and pos.has(\"x\"):\n\t\t\tp = Vector2(float(pos.x), float(pos.y))\n\t\t\tbreak\n\t\telif pos is Vector2:\n\t\t\tp = pos\n\t\t\tbreak\nif p == null:\n\treturn false\nvar vp = mn.get_viewport().get_visible_rect().size\nvar expected = p - vp / (2.0 * mn.view_zoom)\nvar off_a = mn.get_meta(\"off_a\")\nvar total = off_a.distance_to(expected)\nif total < 1.0:\n\treturn true\nreturn mn.view_offset.distance_to(off_a) < 0.4 * total", "equals": true },
+
+    { "act": "wait_seconds", "seconds": 0.9 },
     { "act": "execute_script", "multiline": true, "script": "var mn = tree.current_scene\nvar uid = str(mn.movement_controller.active_unit_id)\nvar u = GameState.get_unit(uid)\nvar p = null\nfor mdl in u.get(\"models\", []):\n\tif mdl.get(\"alive\", true):\n\t\tvar pos = mdl.get(\"position\", null)\n\t\tif pos is Dictionary and pos.has(\"x\"):\n\t\t\tp = Vector2(float(pos.x), float(pos.y))\n\t\t\tbreak\n\t\telif pos is Vector2:\n\t\t\tp = pos\n\t\t\tbreak\nif p == null:\n\treturn false\nvar vp = mn.get_viewport().get_visible_rect().size\nvar expected = p - vp / (2.0 * mn.view_zoom)\nreturn mn.view_offset.distance_to(expected) < 2.0", "equals": true },
     { "act": "execute_script", "script": "main.view_offset.distance_to(main.get_meta(\"off_a\"))", "expect_min": 1.0 },
     { "act": "screenshot", "label": "02_glide_settled_on_new_unit" }


### PR DESCRIPTION
## Summary

Cycling units with the controller bumpers (LB/RB) paused for a fraction of a second and then **jumped** to the next unit instead of gliding smoothly. This makes it a proper eased camera glide.

## Root cause (measured, not assumed)

The unit-switch camera used a `Tween` created inside the **same frame** as the LB/RB press. That press frame is heavy — the selection handler fires `BEGIN_NORMAL_MOVE`, which rebuilds the move ghosts / range overlays (~32 ms CPU, measured live). A Godot `Tween`'s first tick then swallows that whole slow frame's `delta`, and with the old `EASE_OUT` (front-loaded) curve the camera **lurched ~59 % of the way in a single tick** (measured: first tick `prog = 0.59`). That reads as "frozen frame, then jump", not a glide.

## Fix

Drive the glide **manually from `_process` with a clamped per-frame delta** instead of a `Tween`:

- **Hitch-proof:** a slow frame (the press frame, or any later GC hitch) can advance the animation by at most one small step (1/30 s), so it can never fast-forward to the destination. Measured after the fix: first tick `prog = 0.002` (0.2 %), smooth ramp to a mid-move peak, easing to a stop.
- **Ease-in-out cubic** (slow → fast → slow) instead of ease-out — the standard camera-glide feel.
- **Slightly longer** duration (0.28 s → 0.42 s) so the motion reads.
- Manual pan/zoom mid-glide cancels the glide (the player takes over).

Carry pickup / L3 model-hop still snap instantly (`snap_center_on_world`), which now just clears the glide flag.

## Validation (windowed)

- Reproduced and measured the original "59 % first tick" jump live via the MCP bridge, then confirmed the post-fix smooth ramp tick-by-tick.
- Updated the windowed scenario `pad_smooth_camera_unit_switch` to assert the new `is_cycle_glide_active()` seam **plus an explicit anti-jump check** (right after the press the camera is still far nearer where it started than the destination).
- 7 pad/camera scenarios pass, 0 script errors, 0 errors in the debug log; screenshots show the camera settling on the newly-selected unit (Blade Champion → Contemptor-Achillus Dreadnought).

## Files changed

- `40k/scripts/Main.gd` — replace the cycle-camera tween with the clamped-delta manual glide + ease-in-out.
- `40k/tests/scenarios/sp/pad_smooth_camera_unit_switch.json` — new API + anti-jump assertion.
- `40k/data/version_history.json` — new player-facing entry (0.93.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KwLdDXpkcNZuRb6qBmoP4

---
_Generated by [Claude Code](https://claude.ai/code/session_016KwLdDXpkcNZuRb6qBmoP4)_