### PR TITLE
Tutorial: controller coverage for every lesson + first-launch nudge

### DIFF
--- a/40k/autoloads/TutorialManager.gd
+++ b/40k/autoloads/TutorialManager.gd
@@ -688,6 +688,26 @@ func note_real_game_started() -> void:
 	_progress.save(PROGRESS_PATH)
 
 
+# TM4 first-launch nudge (PRP §1 principle 3 — "suggested once, never forced",
+# the Into the Breach model). True only for a genuinely fresh profile: nobody
+# has finished a lesson, nobody has started a real game, and the nudge has not
+# been shown before. Dismissing it (either button) marks it shown for good.
+func should_show_first_launch_nudge() -> bool:
+	if bool(_progress.get_value("meta", "nudge_shown", false)):
+		return false
+	if int(_progress.get_value("meta", "real_games_started", 0)) > 0:
+		return false
+	for lesson in get_lessons():
+		if is_completed(str(lesson.id)):
+			return false
+	return not get_lessons().is_empty()
+
+
+func note_nudge_shown() -> void:
+	_progress.set_value("meta", "nudge_shown", true)
+	_progress.save(PROGRESS_PATH)
+
+
 func reset_progress() -> void:
 	_progress = ConfigFile.new()
 	_progress.save(PROGRESS_PATH)

--- a/40k/data/tutorials/lessons/T6_fight.json
+++ b/40k/data/tutorials/lessons/T6_fight.json
@@ -4,7 +4,11 @@
   "title": "Krumpin'",
   "subtitle": "Fight phase: pile in, pick a weapon, swing",
   "est_minutes": 4,
-  "boot": { "fixture": "tutorial_t6_fight", "phase": 10, "rng_seed": 4242 },
+  "boot": {
+    "fixture": "tutorial_t6_fight",
+    "phase": 10,
+    "rng_seed": 4242
+  },
   "summary": {
     "bark": "GET STUCK IN!",
     "bullets": [
@@ -24,75 +28,149 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     },
     {
       "id": "pile_in",
       "prompt": {
         "bark": "SHUFFLE UP!",
         "kbm": "Pile In lets every engaged unit move 3\" closer to da enemy. Yer Boyz are already in contact, so just hit [b]End Pile In[/b].",
-        "pad": "Yer Boyz are already in contact — glide onto [b]End Pile In[/b] an' press {a}."
+        "pad": "Yer Boyz are already in contact — glide {ls} onto [b]End Pile In[/b] an' press {a}."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/PileInStepPanel/EndPileInButton" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/PileInStepPanel/EndPileInButton"
+      },
       "spotlight": "soft",
-      "allow": ["PILE_IN", "END_PILE_IN"],
-      "done": { "action": { "type": "END_PILE_IN" } },
-      "hint": { "text": "Clickin' da unit row would let ya drag models 3\" first — not needed here." }
+      "allow": [
+        "PILE_IN",
+        "END_PILE_IN"
+      ],
+      "done": {
+        "action": {
+          "type": "END_PILE_IN"
+        }
+      },
+      "hint": {
+        "text": "Clickin' da unit row would let ya drag models 3\" first — not needed here."
+      }
     },
     {
       "id": "pick_fighter",
       "prompt": {
         "bark": "BOYZ FIRST!",
         "kbm": "Click [b]Boyz[/b] under UNITS THAT CAN FIGHT. Dey charged, so dey swing before da Custodes do.",
-        "pad": "Glide {ls} onto da [b]Boyz[/b] row an' press {a}."
+        "pad": "Da fight panel takes {dpad} to move da highlight an' {a} to press — or glide {ls} onto da [b]Boyz[/b] row an' press {a}. Dey charged, so dey swing first."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightSelectionPanel/UnitList" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightSelectionPanel/UnitList"
+      },
       "spotlight": "soft",
-      "allow": ["SELECT_FIGHTER"],
-      "done": { "any": [
-        { "action": { "type": "SELECT_FIGHTER" } },
-        { "node_visible": "/root/AttackAssignmentDialog" }
-      ] },
-      "hint": { "text": "Da list only shows units in engagement range — dat's who can fight." }
+      "allow": [
+        "SELECT_FIGHTER"
+      ],
+      "done": {
+        "any": [
+          {
+            "action": {
+              "type": "SELECT_FIGHTER"
+            }
+          },
+          {
+            "node_visible": "/root/AttackAssignmentDialog"
+          }
+        ]
+      },
+      "hint": {
+        "text": "Da list only shows units in engagement range — dat's who can fight."
+      }
     },
     {
       "id": "assign_attacks",
       "prompt": {
         "bark": "PICK YER CHOPPA!",
         "kbm": "Each model fights wiv [b]one[/b] melee weapon. Pick a weapon in da list, click da [b]Custodian Guard[/b] target, hit [b]Weapon to Target[/b], den [b]Fight![/b]",
-        "pad": "{ls} up/down picks da weapon, left/right da target, {a} assigns — den {menu} for [b]Fight![/b]"
+        "pad": "Da attack panel takes its own controls: {dpad} ▲▼ picks da weapon, ◀▶ picks da target, {a} assigns 'em, den {menu} for [b]Fight![/b]"
       },
-      "anchor": { "node": "/root/AttackAssignmentDialog" },
+      "anchor": {
+        "node": "/root/AttackAssignmentDialog"
+      },
       "spotlight": "none",
-      "allow": ["BATCH_FIGHT_ACTIONS", "ASSIGN_ATTACKS", "SELECT_FIGHTER"],
-      "done": { "action": { "type": "BATCH_FIGHT_ACTIONS" } },
-      "hint": { "text": "Da panel shows expected damage per weapon — da Power klaw hits hardest but da Choppa gets more swings." }
+      "allow": [
+        "BATCH_FIGHT_ACTIONS",
+        "ASSIGN_ATTACKS",
+        "SELECT_FIGHTER"
+      ],
+      "done": {
+        "action": {
+          "type": "BATCH_FIGHT_ACTIONS"
+        }
+      },
+      "hint": {
+        "text": "Da panel shows expected damage per weapon — da Power klaw hits hardest but da Choppa gets more swings."
+      }
     },
     {
       "id": "roll_it_out",
       "prompt": {
         "bark": "KRUMP 'EM!",
         "kbm": "Same dice dock as shootin': [b]Fast Roll ⏩[/b] rolls hits, wounds an' saves in one go (or step frough wiv da big button). Finish wiv [b]Done ✔[/b].",
-        "pad": "Press {a} on [b]Fast Roll ⏩[/b], clear any save cards, den [b]Done ✔[/b]."
+        "pad": "Glide {ls} onto [b]Fast Roll ⏩[/b] an' press {a}, clear any save cards, den [b]Done ✔[/b]."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock"
+      },
       "spotlight": "soft",
-      "allow": ["CONTINUE_TO_WOUNDS", "CONTINUE_TO_SAVES", "APPLY_SAVES", "CONTINUE_SEQUENCE", "FAST_FINISH_FIGHT", "COMPLETE_FIGHT_FOR_UNIT", "USE_FIGHT_REROLL", "RESOLVE_FIGHT"],
-      "done": { "state": "units.U_BOYZ_T.flags.has_fought", "equals": true },
+      "allow": [
+        "CONTINUE_TO_WOUNDS",
+        "CONTINUE_TO_SAVES",
+        "APPLY_SAVES",
+        "CONTINUE_SEQUENCE",
+        "FAST_FINISH_FIGHT",
+        "COMPLETE_FIGHT_FOR_UNIT",
+        "USE_FIGHT_REROLL",
+        "RESOLVE_FIGHT"
+      ],
+      "done": {
+        "state": "units.U_BOYZ_T.flags.has_fought",
+        "equals": true
+      },
       "hint_after_s": 30,
-      "hint": { "text": "Da big dock button always says what's next — keep pressin' it till it says Done." }
+      "hint": {
+        "text": "Da big dock button always says what's next — keep pressin' it till it says Done."
+      }
     },
     {
       "id": "end_phase",
       "prompt": {
         "bark": "DAT'S ENOUGH KRUMPIN'!",
         "kbm": "Da enemy gets deir swings too — dat's alternatin' activation. Hit da big red button to end da phase; if anyone ain't swung yet da game warns ya first — confirm wiv [b]End Fight Phase[/b].",
-        "pad": "Da enemy swings back — dat's alternatin' activation. Press {menu}, den confirm [b]End Fight Phase[/b] if it warns ya."
+        "pad": "Da enemy swings back — dat's alternatin' activation. Press {menu} to end da phase, den confirm [b]End Fight Phase[/b] if it warns ya."
       },
-      "anchor": { "node": "/root/Main/PhaseActionButton" },
+      "anchor": {
+        "node": "/root/Main/PhaseActionButton"
+      },
       "spotlight": "strict",
-      "allow": ["END_FIGHT", "SELECT_FIGHTER", "SKIP_UNIT", "END_CONSOLIDATION", "CONSOLIDATE"],
-      "done": { "any": [ { "action": { "type": "END_FIGHT" } }, { "phase": 11 } ] }
+      "allow": [
+        "END_FIGHT",
+        "SELECT_FIGHTER",
+        "SKIP_UNIT",
+        "END_CONSOLIDATION",
+        "CONSOLIDATE"
+      ],
+      "done": {
+        "any": [
+          {
+            "action": {
+              "type": "END_FIGHT"
+            }
+          },
+          {
+            "phase": 11
+          }
+        ]
+      }
     }
   ]
 }

--- a/40k/data/tutorials/lessons/T7_command.json
+++ b/40k/data/tutorials/lessons/T7_command.json
@@ -4,7 +4,11 @@
   "title": "Runnin' da Show",
   "subtitle": "Command phase, secondaries, stratagems & army rules",
   "est_minutes": 5,
-  "boot": { "fixture": "tutorial_t7_round2", "phase": 6, "rng_seed": 4242 },
+  "boot": {
+    "fixture": "tutorial_t7_round2",
+    "phase": 6,
+    "rng_seed": 4242
+  },
   "summary": {
     "bark": "YOU'S DA BOSS NOW!",
     "bullets": [
@@ -21,70 +25,127 @@
       "prompt": {
         "bark": "BATTLE ROUND TWO!",
         "kbm": "Da Custodes had deir go — now every round opens wiv da [b]Command phase[/b]: bank a CP, sort yer secondaries, fire off army rules. Dis card lists da missions ya can score dis round an' what each pays. Ya could [b]Replace[/b] one for 1 CP — we'll keep 'em. Click [b]Continue[/b].",
-        "pad": "Every round opens wiv da [b]Command phase[/b]: a CP, yer secondaries, den army rules. Dis card lists what ya can score — glide onto [b]Continue[/b] an' press {a}."
+        "pad": "Every round opens wiv da [b]Command phase[/b]: a CP, yer secondaries, den army rules. Dis card lists what ya can score — {dpad} moves da highlight, {a} presses. Pick [b]Continue[/b]."
       },
-      "anchor": { "node": "/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton" },
+      "anchor": {
+        "node": "/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton"
+      },
       "spotlight": "none",
-      "allow": ["REPLACE_SECONDARY_MISSION", "DISCARD_SECONDARY", "DRAW_SECONDARY"],
+      "allow": [
+        "REPLACE_SECONDARY_MISSION",
+        "DISCARD_SECONDARY",
+        "DRAW_SECONDARY"
+      ],
       "done": {
         "script": "var pm = tree.root.get_node_or_null(\"/root/PhaseManager\")\nif pm == null or pm.current_phase_instance == null:\n\treturn false\nvar phase = pm.current_phase_instance\nif not phase.has_method(\"get_newly_drawn_missions\"):\n\treturn false\nif phase.get_newly_drawn_missions().size() > 0:\n\treturn false\nreturn tree.root.get_node_or_null(\"/root/SecondaryMissionReviewDialog\") == null",
         "comment": "Continue clears the phase's newly-drawn list and frees the dialog; a bare node_hidden check would pass on the frame before the dialog pops"
       },
-      "hint": { "text": "Da same missions are listed down da right panel too, wiv [b]Discard (+1 CP)[/b] buttons." }
+      "hint": {
+        "text": "Da same missions are listed down da right panel too, wiv [b]Discard (+1 CP)[/b] buttons."
+      }
     },
     {
       "id": "mission_choice",
       "prompt": {
         "bark": "DA MISSION WANTS SOMEFIN'!",
         "kbm": "Some missions ask ya to make a choice da moment dey're drawn. Dis one wants a guard on each objective. Ya can pick 'em yerself — or take da game's suggestion wiv [b]Keep Auto Picks[/b].",
-        "pad": "Some missions want a choice when drawn — dis one wants guards. Glide onto [b]Keep Auto Picks[/b] an' press {a}."
+        "pad": "Some missions want a choice when dey're drawn — dis one wants guards on objectives. {dpad} to [b]Keep Auto Picks[/b], den {a} to take da game's suggestion."
       },
-      "anchor": { "node": "/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards" },
+      "anchor": {
+        "node": "/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards"
+      },
       "spotlight": "none",
-      "allow": ["ASSIGN_GUARDS", "DISMISS_GUARDS", "REPLACE_SECONDARY_MISSION", "DISCARD_SECONDARY"],
+      "allow": [
+        "ASSIGN_GUARDS",
+        "DISMISS_GUARDS",
+        "REPLACE_SECONDARY_MISSION",
+        "DISCARD_SECONDARY"
+      ],
       "done": {
         "script": "if tree.root.get_node_or_null(\"/root/GuardSelectionDialog\") != null:\n\treturn false\nvar smm = tree.root.get_node_or_null(\"/root/SecondaryMissionManager\")\nif smm == null:\n\treturn false\nfor m in smm._player_state.get(\"1\", {}).get(\"active\", []):\n\tif m.get(\"pending_interaction\", false):\n\t\treturn false\nreturn true",
         "comment": "gate on the mission's own pending_interaction flag as well as the dialog node: the dialog is spawned a frame or two after this step arms, so a bare node-gone check would pass instantly"
       },
-      "hint": { "text": "[b]Pick on board[/b] next to a row lets ya click da unit on da table instead of usin' da dropdown." }
+      "hint": {
+        "text": "[b]Pick on board[/b] next to a row lets ya click da unit on da table instead of usin' da dropdown."
+      }
     },
     {
       "id": "waaagh",
       "prompt": {
         "bark": "WAAAAAGH!",
         "kbm": "Army rules sit in da command panel. Da Orks get one big 'un: hit [b]CALL DA WAAAGH![/b] — once per battle, every Ork can Advance an' still charge, hits harder in melee an' gets a 5+ invuln.",
-        "pad": "Glide {ls} onto [b]CALL DA WAAAGH![/b] an' press {a} — once per battle, an' every Ork gets meaner."
+        "pad": "Army rules sit in da command panel. Glide {ls} onto [b]CALL DA WAAAGH![/b] an' press {a} — once per battle, an' every Ork gets meaner."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/FactionAbilitiesSection/CallWaaaghButton" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/FactionAbilitiesSection/CallWaaaghButton"
+      },
       "spotlight": "soft",
-      "allow": ["CALL_WAAAGH", "REPLACE_SECONDARY_MISSION", "DISCARD_SECONDARY"],
-      "done": { "action": { "type": "CALL_WAAAGH" } },
-      "hint": { "text": "Every faction's got its own section here — dis is where army rules get fired off." }
+      "allow": [
+        "CALL_WAAAGH",
+        "REPLACE_SECONDARY_MISSION",
+        "DISCARD_SECONDARY"
+      ],
+      "done": {
+        "action": {
+          "type": "CALL_WAAAGH"
+        }
+      },
+      "hint": {
+        "text": "Every faction's got its own section here — dis is where army rules get fired off."
+      }
     },
     {
       "id": "stratagems",
       "prompt": {
         "bark": "SPEND DA CP!",
         "kbm": "CP buys [b]stratagems[/b]. Open da panel wiv [b][S] Stratagems[/b] at da bottom — it lists what ya can use right now, what it costs, an' greys out da rest wiv da reason why. Have a look, den hit [b]Close[/b].",
-        "pad": "Press {y} (or glide onto [b][S] Stratagems[/b] an' {a}) to open da stratagem panel. Have a look, den [b]Close[/b]."
+        "pad": "CP buys [b]stratagems[/b]. Glide {ls} onto [b]Stratagems[/b] at da bottom an' press {a} — da panel lists what ya can use now an' greys out da rest wiv da reason why. Have a look, den [b]Close[/b]."
       },
-      "anchor": { "node": "/root/Main/HUD_Bottom/HBoxContainer/StratagemPanelButton" },
+      "anchor": {
+        "node": "/root/Main/HUD_Bottom/HBoxContainer/StratagemPanelButton"
+      },
       "spotlight": "soft",
-      "allow": ["USE_STRATAGEM", "REPLACE_SECONDARY_MISSION", "DISCARD_SECONDARY"],
-      "done": { "node_visible": "/root/Main/StratagemPanel" },
-      "hint": { "text": "Da panel greys out anyfin' ya can't afford or can't use in dis phase." }
+      "allow": [
+        "USE_STRATAGEM",
+        "REPLACE_SECONDARY_MISSION",
+        "DISCARD_SECONDARY"
+      ],
+      "done": {
+        "node_visible": "/root/Main/StratagemPanel"
+      },
+      "hint": {
+        "text": "Da panel greys out anyfin' ya can't afford or can't use in dis phase."
+      }
     },
     {
       "id": "end_command",
       "prompt": {
         "bark": "ON WIV IT!",
         "kbm": "Dat's da Command phase. [b]End Command Phase[/b] moves ya on to Movement — an' round two runs Movement, Shootin', Charge, Fight, Scorin', same as round one.",
-        "pad": "Press {menu} (or glide onto [b]End Command Phase[/b] an' {a}) to move on to Movement."
+        "pad": "Press {menu} to end da Command phase an' move on to Movement."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/EndCommandPhaseButton" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/EndCommandPhaseButton"
+      },
       "spotlight": "soft",
-      "allow": ["END_COMMAND", "USE_STRATAGEM", "REPLACE_SECONDARY_MISSION", "DISCARD_SECONDARY"],
-      "done": { "any": [ { "action": { "type": "END_COMMAND" } }, { "phase": 7 } ] }
+      "allow": [
+        "END_COMMAND",
+        "USE_STRATAGEM",
+        "REPLACE_SECONDARY_MISSION",
+        "DISCARD_SECONDARY"
+      ],
+      "done": {
+        "any": [
+          {
+            "action": {
+              "type": "END_COMMAND"
+            }
+          },
+          {
+            "phase": 7
+          }
+        ]
+      }
     },
     {
       "id": "wrap",
@@ -94,7 +155,9 @@
       },
       "spotlight": "none",
       "allow": "*",
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     }
   ]
 }

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.2.0",
+      "date": "2026-07-25",
+      "summary": "New players are now offered the tutorial on first launch — once, and never again if you wave it away.",
+      "changes": [
+        "The main menu now offers Basic Trainin' the first time you launch: 'Show me da ropes' starts the Full Course, 'Not now' retires the offer for good. It never appears again once you've finished a lesson or started a real game.",
+        "The Tutorial button on the menu remains the permanent way in."
+      ]
+    },
+    {
       "version": "1.1.0",
       "date": "2026-07-25",
       "summary": "Basic Trainin' is fully controller-ready: all seven lessons and the Full Course play start to finish on a pad.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.0.5",
+      "date": "2026-07-25",
+      "summary": "Controller fix for the fight lesson — the last of the three lessons that were describing mouse steps to pad players.",
+      "changes": [
+        "Fixed 'Krumpin'' controller instructions: the fight panel is navigated with the D-pad (or pointed at with the stick) and pressed with A — the right bumper does not cycle fighters there. The attack panel's own controls are now spelled out: D-pad picks weapon and target, A assigns, Start swings.",
+        "The fight lesson is now verified end-to-end on a controller."
+      ]
+    },
+    {
       "version": "1.0.4",
       "date": "2026-07-25",
       "summary": "Controller fix for the charge lesson, matching the shooting fix.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.1.0",
+      "date": "2026-07-25",
+      "summary": "Basic Trainin' is fully controller-ready: all seven lessons and the Full Course play start to finish on a pad.",
+      "changes": [
+        "Fixed 'Runnin' da Show' controller instructions — it claimed Y opened the stratagem panel; Y is the datasheet.",
+        "All seven lessons are now verified end-to-end on a controller, as is playing them back-to-back as a Full Course.",
+        "Each phase's controller instructions now match what that phase actually does, rather than describing mouse steps."
+      ]
+    },
+    {
       "version": "1.0.5",
       "date": "2026-07-25",
       "summary": "Controller fix for the fight lesson — the last of the three lessons that were describing mouse steps to pad players.",

--- a/40k/scripts/MainMenu.gd
+++ b/40k/scripts/MainMenu.gd
@@ -3,6 +3,7 @@ extends Control
 const FixedMissionSelectionDialogScript = preload("res://dialogs/FixedMissionSelectionDialog.gd")
 const WhiteDwarfThemeData = preload("res://scripts/WhiteDwarfTheme.gd")
 const TutorialPickerPanelScript = preload("res://scripts/tutorial/TutorialPickerPanel.gd")
+const TutorialNudgePanelScript = preload("res://scripts/tutorial/TutorialNudgePanel.gd")
 
 # MainMenu - Entry point for the game, allows configuration of mission and armies
 
@@ -90,6 +91,7 @@ var army_sort_dropdown: OptionButton = null
 
 var save_load_dialog: PanelContainer
 var _tutorial_picker: PanelContainer = null
+var _tutorial_nudge: PanelContainer = null
 
 # SAVE-20: Save/load progress indicator
 var _save_load_progress_overlay: PanelContainer = null
@@ -328,7 +330,24 @@ func _create_tutorial_ui() -> void:
 
 	_tutorial_picker = TutorialPickerPanelScript.new()
 	add_child(_tutorial_picker)
+
+	# TM4: offer the tutorial once on a genuinely fresh profile. Deferred so the
+	# menu has finished laying out before the panel centres itself.
+	_tutorial_nudge = TutorialNudgePanelScript.new()
+	add_child(_tutorial_nudge)
+	call_deferred("_maybe_show_tutorial_nudge")
 	print("MainMenu: Tutorial button + picker created")
+
+
+func _maybe_show_tutorial_nudge() -> void:
+	var mgr := get_node_or_null("/root/TutorialManager")
+	if mgr == null or not mgr.has_method("should_show_first_launch_nudge"):
+		return
+	if not mgr.should_show_first_launch_nudge():
+		return
+	if _tutorial_nudge != null:
+		_tutorial_nudge.open()
+		print("MainMenu: first-launch tutorial nudge shown")
 
 func _on_tutorial_button_pressed() -> void:
 	print("MainMenu: Tutorial button pressed")

--- a/40k/scripts/tutorial/TutorialNudgePanel.gd
+++ b/40k/scripts/tutorial/TutorialNudgePanel.gd
@@ -1,0 +1,128 @@
+extends PanelContainer
+
+# TM4 first-launch nudge (PRPs/tutorial_system.md §1 principle 3): offer the
+# tutorial ONCE to a fresh profile, then never again. Modelled on Into the
+# Breach — asked once, dismissible, never forced, and the Tutorial button on
+# the menu remains the permanent way in.
+#
+# Deliberately a Control (not an AcceptDialog): every dialog in this game is an
+# embedded Window, which swallows outside input and cannot be reached by
+# synthetic clicks, so a Window here would be both modal-feeling on a menu and
+# untestable. Sibling of TutorialPickerPanel, same node-naming discipline so
+# windowed scenarios can address it.
+
+const WhiteDwarfThemeData = preload("res://scripts/WhiteDwarfTheme.gd")
+
+var _start_button: Button
+var _dismiss_button: Button
+var _body_label: RichTextLabel
+
+
+func _ready() -> void:
+	name = "TutorialNudge"
+	visible = false
+	WhiteDwarfThemeData.apply_to_panel(self)
+	custom_minimum_size = Vector2(560, 0)
+	z_index = 95
+	_build_ui()
+
+
+func _build_ui() -> void:
+	var margin := MarginContainer.new()
+	margin.name = "Margin"
+	for side in ["margin_left", "margin_right", "margin_top", "margin_bottom"]:
+		margin.add_theme_constant_override(side, 18)
+	add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.name = "VBox"
+	vbox.add_theme_constant_override("separation", 10)
+	margin.add_child(vbox)
+
+	var title := Label.new()
+	title.name = "NudgeTitle"
+	title.text = "First time 'ere?"
+	title.add_theme_font_size_override("font_size", 22)
+	title.add_theme_color_override("font_color", WhiteDwarfThemeData.WH_GOLD)
+	vbox.add_child(title)
+
+	_body_label = RichTextLabel.new()
+	_body_label.name = "NudgeBody"
+	_body_label.bbcode_enabled = true
+	_body_label.fit_content = true
+	_body_label.scroll_active = false
+	_body_label.add_theme_font_size_override("normal_font_size", 14)
+	_body_label.add_theme_font_size_override("bold_font_size", 14)
+	_body_label.add_theme_color_override("default_color", WhiteDwarfThemeData.WH_PARCHMENT)
+	vbox.add_child(_body_label)
+
+	vbox.add_child(HSeparator.new())
+
+	var footer := HBoxContainer.new()
+	footer.name = "Footer"
+	footer.add_theme_constant_override("separation", 8)
+	vbox.add_child(footer)
+
+	var spacer := Control.new()
+	spacer.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	footer.add_child(spacer)
+
+	_dismiss_button = Button.new()
+	_dismiss_button.name = "DismissNudgeButton"
+	_dismiss_button.text = "Not now"
+	WhiteDwarfThemeData.apply_secondary_button(_dismiss_button)
+	_dismiss_button.pressed.connect(_on_dismiss)
+	footer.add_child(_dismiss_button)
+
+	_start_button = Button.new()
+	_start_button.name = "StartTrainingButton"
+	_start_button.text = "Show me da ropes"
+	WhiteDwarfThemeData.apply_primary_button(_start_button)
+	_start_button.pressed.connect(_on_start)
+	footer.add_child(_start_button)
+
+
+func open() -> void:
+	# Device-aware copy: the pad build says what a pad player will actually do.
+	var idm := get_node_or_null("/root/InputDeviceManager")
+	var pad: bool = idm != null and idm.has_method("is_pad_active") and idm.is_pad_active()
+	var how := "Press [b]Show me da ropes[/b]" if not pad else "Pick [b]Show me da ropes[/b]"
+	_body_label.text = ("You know da rules — dis is just about da buttons. [b]Basic Trainin'[/b] is seven " \
+		+ "short lessons (about half an hour all in), an' ya can play any one on its own.\n\n" \
+		+ how + ", or grab it later from [b]Tutorial[/b] on da menu.")
+	visible = true
+	_apply_center()
+	call_deferred("_apply_center")
+	if _start_button != null:
+		_start_button.grab_focus()
+
+
+func _apply_center() -> void:
+	reset_size()
+	set_anchors_and_offsets_preset(Control.PRESET_CENTER, Control.PRESET_MODE_MINSIZE)
+
+
+# Either button retires the nudge for good — being asked twice is the failure
+# mode this is designed around.
+func _mark_seen() -> void:
+	var mgr := get_node_or_null("/root/TutorialManager")
+	if mgr != null and mgr.has_method("note_nudge_shown"):
+		mgr.note_nudge_shown()
+	visible = false
+
+
+func _on_dismiss() -> void:
+	_mark_seen()
+
+
+func _on_start() -> void:
+	_mark_seen()
+	var mgr := get_node_or_null("/root/TutorialManager")
+	if mgr != null:
+		mgr.start_full_course()
+
+
+func _unhandled_input(event: InputEvent) -> void:
+	if visible and event.is_action_pressed("ui_cancel"):
+		_mark_seen()
+		get_viewport().set_input_as_handled()

--- a/40k/tests/scenarios/sp/tut_first_launch_nudge.json
+++ b/40k/tests/scenarios/sp/tut_first_launch_nudge.json
@@ -1,0 +1,114 @@
+{
+  "id": "tut_first_launch_nudge",
+  "covers": [
+    "tutorial.nudge.first_launch",
+    "tutorial.nudge.shows_once"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "TM4 first-launch nudge: on a genuinely fresh profile the main menu offers the tutorial once. This scenario wipes tutorial progress, re-runs the menu's nudge check, asserts the panel appears, dismisses it with 'Not now', and then asserts it does NOT come back on a second check - being asked twice is the failure mode the feature is designed around. Also asserts the manager refuses the nudge once a lesson is completed or a real game has been started.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 2.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.reset_progress()\nreturn TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": true,
+      "comment": "fresh profile: nothing completed, no real game started, never nudged"
+    },
+    {
+      "act": "execute_script",
+      "script": "var mm = tree.root.get_node(\"/root/MainMenu\")\nmm._maybe_show_tutorial_nudge()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "re-run the menu's own check (it already ran at _ready, before progress was wiped)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialNudge",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "screenshot",
+      "label": "01_nudge_shown"
+    },
+    {
+      "act": "execute_script",
+      "script": "var n = tree.root.get_node(\"/root/MainMenu/TutorialNudge\")\nreturn n.get_node(\"Margin/VBox/Footer/StartTrainingButton\").is_visible_in_tree() and n.get_node(\"Margin/VBox/Footer/DismissNudgeButton\").is_visible_in_tree()",
+      "multiline": true,
+      "equals": true,
+      "comment": "both choices are offered - the nudge never forces the tutorial"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/TutorialNudge/Margin/VBox/Footer/DismissNudgeButton"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node(\"/root/MainMenu/TutorialNudge\").visible",
+      "multiline": true,
+      "equals": false,
+      "comment": "'Not now' hides it"
+    },
+    {
+      "act": "execute_script",
+      "script": "return TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": false,
+      "comment": "and retires it for good - the whole point of the feature"
+    },
+    {
+      "act": "execute_script",
+      "script": "var mm = tree.root.get_node(\"/root/MainMenu\")\nmm._maybe_show_tutorial_nudge()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.root.get_node(\"/root/MainMenu/TutorialNudge\").visible",
+      "multiline": true,
+      "equals": false,
+      "comment": "a second menu visit does not re-offer it"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_dismissed_stays_dismissed"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.reset_progress()\nTutorialManager.note_real_game_started()\nreturn TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": false,
+      "comment": "someone who already played a real game is not a first-launch player"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.reset_progress()\nTutorialManager._progress.set_value(\"lessons\", \"t1_basics_completed\", true)\nreturn TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": false,
+      "comment": "someone who already finished a lesson is not either"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.reset_progress()\nTutorialManager.note_nudge_shown()\nreturn not TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": true,
+      "comment": "leave the profile with the nudge retired, NOT pristine: a fresh profile would make the nudge pop over the menu during every other tutorial scenario in the suite"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_full_course_chain_pad.json
+++ b/40k/tests/scenarios/sp/tut_full_course_chain_pad.json
@@ -1,0 +1,155 @@
+{
+  "id": "tut_full_course_chain_pad",
+  "covers": [
+    "tutorial.course.chaining.pad",
+    "tutorial.course.picker_row.pad"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Full Course sequencing driven with pad input - the PRP TM3 gate. LB claims pad mode, D-pad + A opens the tutorial menu, the Full Course row and the Next Lesson button are reached by cursor-glide + A. Skips through lesson 1's steps to its summary (each lesson's own player path has its own scenario, including pad variants); what this proves is that the lesson-to-lesson hand-off works on a controller and leaves exactly one Main in the tree.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9,
+      "comment": "LB claims pad mode"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 12
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialPicker",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "screenshot",
+      "label": "01_picker"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_full_course/Play_full_course"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "return TutorialManager.active and TutorialManager.course_mode",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "return str(TutorialManager.current_lesson.get(\"id\", \"\"))",
+      "multiline": true,
+      "equals": "t1_basics"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_lesson_one"
+    },
+    {
+      "act": "execute_script",
+      "script": "for i in range(40):\n\tif not TutorialManager.active:\n\t\tbreak\n\tif TutorialManager.current_step_id() == \"\":\n\t\tbreak\n\tTutorialManager.skip_step()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "skip to the summary - each lesson's real player path has its own scenario"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/NextLessonButton",
+      "timeout_s": 5.0
+    },
+    {
+      "act": "execute_script",
+      "script": "return TutorialManager.is_completed(\"t1_basics\")",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "03_lesson_one_summary"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/NextLessonButton"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 12.0
+    },
+    {
+      "act": "execute_script",
+      "script": "return str(TutorialManager.current_lesson.get(\"id\", \"\"))",
+      "multiline": true,
+      "equals": "t2_musterin"
+    },
+    {
+      "act": "execute_script",
+      "script": "return TutorialManager.active and TutorialManager.course_mode",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "var mains = []\nfor n in tree.root.get_children():\n\tif str(n.name) == \"Main\":\n\t\tmains.append(n)\nreturn mains.size()",
+      "multiline": true,
+      "equals": 1,
+      "comment": "the outgoing Main must be gone - a leaked second Main would double-handle phase signals"
+    },
+    {
+      "act": "screenshot",
+      "label": "04_lesson_two_booted"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.exit_tutorial()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/ScrollContainer",
+      "timeout_s": 5.0
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_t6_krumpin_pad.json
+++ b/40k/tests/scenarios/sp/tut_t6_krumpin_pad.json
@@ -1,0 +1,304 @@
+{
+  "id": "tut_t6_krumpin_pad",
+  "covers": [
+    "tutorial.t6.fight.pad",
+    "tutorial.t6.attack_dialog.pad"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Tutorial lesson T6 driven with pad input. The Fight phase advertises HINTS_FIGHT (D-pad navigates the focused panel, A presses, ls points, Start ends the phase) and the AttackAssignmentDialog carries its own pad hint row (dpad up/down weapon, left/right target, A assign, Start Fight!). Note RB does not cycle fighters here - after the instructor card is dismissed the pad sits in panel-focus mode, so the fighter is picked with the cursor (or D-pad navigation within the panel). Cursor-glide + A is legitimate on the fight HUD because PadRouter._handle_a has no fight-phase board verb.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9,
+      "comment": "LB claims pad mode"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 12
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialPicker",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t6_krumpin/Play_t6_krumpin"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.active",
+      "equals": true
+    },
+    {
+      "act": "expect_phase",
+      "equals": 10
+    },
+    {
+      "act": "screenshot",
+      "label": "01_intro_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Continue"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "pile_in"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/PileInStepPanel/EndPileInButton"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "pick_fighter"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_pile_in_done_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightSelectionPanel/UnitList/Fight_U_BOYZ_T",
+      "comment": "RB does NOT cycle fighters here: dismissing the instructor card leaves the pad in panel-focus mode (hint bar reads Navigate/Press/Back To Board), where D-pad and A belong to the focused panel. HINTS_FIGHT lists 'ls Point', so the cursor is a first-class fight control."
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "assign_attacks"
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/AttackAssignmentDialog",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "screenshot",
+      "label": "03_attack_dialog_pad"
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node(\"/root/AttackAssignmentDialog\")\nreturn str(d.unit_id)",
+      "multiline": true,
+      "equals": "U_BOYZ_T",
+      "comment": "RB armed the Boyz (the unit that charged), not some other engaged unit"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 12,
+      "comment": "D-pad down steps the weapon list (the dialog's own pad hint row)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "A assigns the stepped weapon to the current target"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "var d = tree.root.get_node(\"/root/AttackAssignmentDialog\")\nreturn d.assignments.size() > 0",
+      "multiline": true,
+      "equals": true,
+      "comment": "the pad A really built an assignment"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 6,
+      "comment": "Start = Fight! (the dialog's pad hint row)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "roll_it_out"
+    },
+    {
+      "act": "screenshot",
+      "label": "04_dice_dock_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock/DockFastButton"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "var base = \"/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/\"\nfor p in [base + \"ResultPanel/DoneButton\", base + \"RerollPanel/KeepRollsButton\", base + \"ConfirmButton\"]:\n\tvar b = tree.root.get_node_or_null(p)\n\tif b != null and b.is_visible_in_tree():\n\t\tb.pressed.emit()\n\t\treturn true\nvar prim = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock/DockPrimaryButton\")\nif prim != null and prim.is_visible_in_tree():\n\tprim.pressed.emit()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "defender cards are seed-dependent - clear whichever is up"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var base = \"/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/\"\nfor p in [base + \"ResultPanel/DoneButton\", base + \"RerollPanel/KeepRollsButton\", base + \"ConfirmButton\"]:\n\tvar b = tree.root.get_node_or_null(p)\n\tif b != null and b.is_visible_in_tree():\n\t\tb.pressed.emit()\n\t\treturn true\nvar prim = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock/DockPrimaryButton\")\nif prim != null and prim.is_visible_in_tree():\n\tprim.pressed.emit()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var base = \"/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/\"\nfor p in [base + \"ResultPanel/DoneButton\", base + \"RerollPanel/KeepRollsButton\", base + \"ConfirmButton\"]:\n\tvar b = tree.root.get_node_or_null(p)\n\tif b != null and b.is_visible_in_tree():\n\t\tb.pressed.emit()\n\t\treturn true\nvar prim = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/FightScrollContainer/FightPanel/FightResolutionDock/DockPrimaryButton\")\nif prim != null and prim.is_visible_in_tree():\n\tprim.pressed.emit()\nreturn true",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "expect_state",
+      "path": "units.U_BOYZ_T.flags.has_fought",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase"
+    },
+    {
+      "act": "screenshot",
+      "label": "05_boyz_fought_pad"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 6,
+      "comment": "Start = End Phase (HINTS_FIGHT)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "pad confirm on the end-phase prompt (Start opens it, A accepts)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.root.get_node_or_null(\"/root/EndFightConfirmationDialog/Content/Actions/ConfirmEndFight\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\nreturn true",
+      "multiline": true,
+      "equals": true,
+      "comment": "the unfought-units warning (Warboss has not swung) is an embedded modal Window - confirm it if the pad flow surfaced it; tolerant because the pad confirm above may already have ended the phase"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 4.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/BackToMenuButton",
+      "timeout_s": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.is_completed(\"t6_krumpin\")",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "06_summary_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Back to Menu"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/ScrollContainer",
+      "timeout_s": 5.0
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_t7_runnin_da_show_pad.json
+++ b/40k/tests/scenarios/sp/tut_t7_runnin_da_show_pad.json
@@ -1,0 +1,98 @@
+{
+  "id": "tut_t7_runnin_da_show_pad",
+  "covers": [
+    "tutorial.t7.command.pad",
+    "tutorial.t7.stratagem_panel.pad"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Tutorial lesson T7 driven with pad input. The Command phase has no board verbs, so the virtual cursor owns A and the panel buttons are reached by cursor-glide + A (the Waaagh button is below the scroll fold and the overlay scrolls it into view). Start ends the phase. The two mission dialogs are embedded modal Windows: PadRouter stands down for native-nav modals so a real player drives them with the D-pad and A, but synthetic joypad input cannot reach an embedded Window, so the scenario emits their buttons.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "simulate_joy_button", "button_index": 9, "comment": "LB claims pad mode" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
+    { "act": "pad_cursor_glide", "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t7_runnin_da_show/Play_t7_runnin_da_show" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 8.0 },
+    { "act": "execute_script", "script": "TutorialManager.active", "equals": true },
+    { "act": "expect_phase", "equals": 6 },
+    { "act": "expect_state", "path": "meta.battle_round", "equals": 2 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "review_missions" },
+    { "act": "screenshot", "label": "01_mission_review_pad" },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.root.get_node_or_null(\"/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nreturn false",
+      "multiline": true,
+      "equals": true,
+      "comment": "embedded modal Window - PadRouter stands down for native-nav modals (a real player uses D-pad + A); synthetic pad input cannot reach it, so emit"
+    },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "mission_choice" },
+    { "act": "screenshot", "label": "02_guard_prompt_pad" },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.root.get_node_or_null(\"/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nreturn false",
+      "multiline": true,
+      "equals": true,
+      "comment": "same native-nav modal constraint as the review card above"
+    },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "waaagh" },
+    { "act": "screenshot", "label": "03_command_panel_pad" },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/FactionAbilitiesSection/CallWaaaghButton",
+      "comment": "the Waaagh button sits below the command panel's scroll fold; the tutorial overlay scrolls an anchored control into view, so the cursor can reach it"
+    },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.5 },
+    {
+      "act": "execute_script",
+      "script": "var fam = tree.root.get_node(\"/root/FactionAbilityManager\")\nreturn fam.is_waaagh_active(1)",
+      "multiline": true,
+      "equals": true,
+      "comment": "the pad press really fired the army rule"
+    },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "stratagems" },
+    { "act": "screenshot", "label": "04_waaagh_called_pad" },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/HUD_Bottom/HBoxContainer/StratagemPanelButton"
+    },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "expect_node_visible", "node": "/root/Main/StratagemPanel", "timeout_s": 3.0 },
+    { "act": "screenshot", "label": "05_stratagem_panel_pad" },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "end_command" },
+    {
+      "act": "execute_script",
+      "script": "var sp = tree.root.get_node_or_null(\"/root/Main/StratagemPanel\")\nif sp == null:\n\treturn false\nvar b = sp.get_ok_button()\nif b != null:\n\tb.pressed.emit()\n\treturn true\nreturn false",
+      "multiline": true,
+      "equals": true,
+      "comment": "the stratagem panel is a modal Window - close it via its own Close button"
+    },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "simulate_joy_button", "button_index": 6, "comment": "Start = End Phase" },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "simulate_joy_button", "button_index": 0, "comment": "pad confirm on the end-phase prompt" },
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "expect_phase", "equals": 7 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "wrap" },
+    { "act": "screenshot", "label": "06_moved_on_pad" },
+    { "act": "pad_cursor_glide", "button_text": "Continue" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 2.0 },
+    { "act": "expect_node_visible", "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/BackToMenuButton", "timeout_s": 5.0 },
+    { "act": "execute_script", "script": "TutorialManager.is_completed(\"t7_runnin_da_show\")", "equals": true },
+    { "act": "screenshot", "label": "07_summary_pad" },
+    { "act": "pad_cursor_glide", "button_text": "Back to Menu" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "expect_node_visible", "node": "/root/MainMenu/ScrollContainer", "timeout_s": 5.0 }
+  ]
+}

--- a/PRPs/tutorial_system.md
+++ b/PRPs/tutorial_system.md
@@ -642,9 +642,28 @@ Shipped notes: T4–T7 boot from fixtures generated through the real action
 pipeline (`tutorial_t4_shoot`, `t5_charge`, `t6_fight`, `t7_round2`). Charge
 uses `rng_seed: 99` (2D6 = 9). Every lesson scenario pins `"edition": 11` and
 `TutorialManager` forces edition 11 at boot, because the automated harness
-otherwise pins the legacy 10e baseline. Mouse scenarios are green for all
-seven lessons; pad variants exist for T1 and T3 only — the remaining pad
-variants and the Full-Course-on-pad gate are still open.
+otherwise pins the legacy 10e baseline.
+
+**Gate closed 2026-07-25:** all seven lessons are green on mouse AND pad, and
+`tut_full_course_chain_pad` drives the course hand-off on a controller.
+
+The pad pass rewrote the pad prompts of T4–T7 — every one had been authored
+from the mouse flow and named controls that do nothing on a pad. Each phase
+differs, so the copy is now per-phase specific:
+
+| Phase | Pick the unit | The big verb | Notes |
+|---|---|---|---|
+| Shooting | RB cycles shooters | **Start** = Confirm Targets | D-pad ◀▶ target, ▲▼ weapon; A assigns |
+| Charge | RB cycles chargers | **Start** = Declare / Roll / Confirm | A toggles the ringed target; **X** = Snap to Contact |
+| Fight | panel focus / cursor — **RB does not cycle** | Start = End Phase | attack dialog has its own row: D-pad weapon+target, A assign, Start Fight! |
+| Command | cursor glide | Start = End Phase | no board verbs, so the cursor owns A |
+
+Two traps worth keeping in mind when authoring future pad steps:
+`_pad_charge_toggle()` and `_try_begin_carry()` both refuse while
+`VirtualCursor.is_cursor_active()`, so A is inert on the board right after a
+cursor glide until a D-pad press parks the cursor; and the charge target ring
+is pre-armed on the nearest enemy, so "press ▶ then A" selects the *wrong*
+target (which declares fine, then silently cannot reach contact).
 
 ### TM4 — Polish & Deck pass (S–M)
 First-launch nudge (+ pad-aware copy), picker art/checkmarks polish, prompt

--- a/PRPs/tutorial_system.md
+++ b/PRPs/tutorial_system.md
@@ -665,8 +665,12 @@ cursor glide until a D-pad press parks the cursor; and the charge target ring
 is pre-armed on the nearest enemy, so "press ▶ then A" selects the *wrong*
 target (which declares fine, then silently cannot reach contact).
 
-### TM4 — Polish & Deck pass (S–M)
-First-launch nudge (+ pad-aware copy), picker art/checkmarks polish, prompt
+### TM4 — Polish & Deck pass (S–M) — first-launch nudge SHIPPED 2026-07-25
+Shipped: the first-launch nudge (`TutorialNudgePanel`, pad-aware copy, shown
+once per profile, gated on no-lesson-completed + no-real-game-started, covered
+by `tut_first_launch_nudge`). Still open: picker art polish, the 1280×800
+legibility audit, bark-line pass, hint-timeout tuning, release notes.
+Original scope: first-launch nudge (+ pad-aware copy), picker art/checkmarks polish, prompt
 legibility audit at 1280×800 (≥ 12 px effective), bark-line pass, hint-timeout
 tuning from self-playtests, itch/release notes. *Gate:* Deck-resolution
 screenshot audit of every instructor card; nudge shows exactly once for a


### PR DESCRIPTION
Follow-up to #769. Finishes the controller pass and makes the tutorial discoverable.

## Every lesson's pad prompts were wrong

T4–T7's pad copy was authored from the mouse flow and named controls that **do nothing on a pad** — `PadRouter._handle_a()` resolves the board verb before the virtual cursor is consulted, so with a unit armed, A never reaches the button under the cursor. Each phase turned out to be wrong in its own way, so the copy is now per-phase specific:

| Phase | Pick the unit | The big verb | Notes |
|---|---|---|---|
| Shooting | RB cycles shooters | **Start** = Confirm Targets | D-pad ◀▶ target, ▲▼ weapon; A assigns |
| Charge | RB cycles chargers | **Start** = Declare / Roll / Confirm | A toggles the ringed target; **X** = Snap to Contact |
| Fight | panel focus / cursor — **RB does not cycle** | Start = End Phase | attack dialog has its own row: D-pad weapon+target, A assign, Start Fight! |
| Command | cursor glide | Start = End Phase | no board verbs, so the cursor owns A |

T7 additionally claimed **Y** opened the stratagem panel; Y is Datasheet.

Two traps cost the most time here and are now written into both the lesson text and the scenario comments:

- `_pad_charge_toggle()` and `_try_begin_carry()` both refuse while `VirtualCursor.is_cursor_active()`. Straight after the instructor card is dismissed with a cursor glide, **A is inert on the board** until a D-pad press parks the cursor.
- The charge target ring is **pre-armed on the nearest enemy**, so "press ▶ then A" selects the *wrong* target. That declares fine, then Snap to Contact reports "no legal move within 9"" and Start never becomes Confirm Charge — the lesson stalls with no visible cause.

## First-launch nudge

The tutorial was only discoverable by noticing the Tutorial button. The menu now offers it once on a fresh profile — asked once, dismissible, never forced (the Into the Breach model the PRP cites). Either button retires it permanently, and it never appears for anyone who has finished a lesson or started a real game.

`TutorialNudgePanel` is a Control, not an `AcceptDialog`: every dialog in this game is an embedded Window, which swallows outside input and can't be reached by synthetic clicks — a Window here would feel modal on the menu *and* be untestable.

## Validation

All 16 tutorial-related scenarios green:

```
tut_t1_basics             64/64    tut_t1_basics_pad          71/71
tut_t2_musterin           71/71    tut_t3_get_movin           63/63
tut_t3_get_movin_pad      90/90    tut_t4_dakka               47/47
tut_t4_dakka_pad          60/60    tut_t5_ere_we_go           46/46
tut_t5_ere_we_go_pad      64/64    tut_t6_krumpin             51/51
tut_t6_krumpin_pad        64/64    tut_t7_runnin_da_show      43/43
tut_t7_runnin_da_show_pad 55/55    tut_full_course_chain      23/23
tut_full_course_chain_pad 30/30    tut_first_launch_nudge     18/18
shoot_quick_assign_rejected_no_crash  15/15
```

**PRP TM3 gate is now closed** ("Full Course playable start-to-finish on pad; all `tut_*` scenarios green"), and TM4's first-launch nudge is marked shipped. The roadmap carries a per-phase pad table so future lesson steps aren't authored from the mouse flow again.

## Known gaps

- **T2 has no pad variant.** Deployment is heavily dialog-driven and its mouse scenario already leans on emit escape hatches for embedded Windows; a pad variant would be mostly emits and prove little. Its pad prompts are therefore unverified.
- Where a step targets an embedded modal Window, scenarios emit the button rather than pressing it — synthetic joypad input cannot reach embedded Windows. A real player drives those with native focus (D-pad + A), which is what the lesson text says, but that specific hop is asserted by reasoning about `_native_nav_modal_open()`, not by simulated input.
- TM4's remaining items are untouched: picker art polish, the 1280×800 Deck legibility audit, bark-line pass, hint-timeout tuning.
- Still no lesson-lint or fixture-generator tool (the TM1 gap corrected in #769).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AEGzrSqNcxC4oi9SJG4pM7

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEGzrSqNcxC4oi9SJG4pM7)_