### PR TITLE
Tutorial: wait for every suggested camera control before advancing

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -804,6 +804,11 @@ func _do_simulate_key(step: Dictionary) -> Dictionary:
 	# the built-in ui_* actions (ui_cancel = dialog close-on-escape, ui_accept,
 	# focus navigation) are bound to PHYSICAL keys, so an event carrying only
 	# `keycode` never matches them and e.g. ESC silently fails to close dialogs.
+	# Optional `hold_s`: keep the key down for that long before releasing. Needed
+	# for the POLLED consumers (camera pan/zoom read KeybindingManager
+	# .is_action_pressed() from _process, not from an event) — a press/release
+	# straddling a single process_frame await is not reliably observed by them.
+	var hold_s: float = float(step.get("hold_s", 0.0))
 	var press := InputEventKey.new()
 	press.keycode = kc
 	press.physical_keycode = kc
@@ -811,6 +816,8 @@ func _do_simulate_key(step: Dictionary) -> Dictionary:
 	press.pressed = true
 	Input.parse_input_event(press)
 	await get_tree().process_frame
+	if hold_s > 0.0:
+		await get_tree().create_timer(hold_s).timeout
 	var release := InputEventKey.new()
 	release.keycode = kc
 	release.physical_keycode = kc
@@ -818,7 +825,7 @@ func _do_simulate_key(step: Dictionary) -> Dictionary:
 	release.pressed = false
 	Input.parse_input_event(release)
 	await get_tree().process_frame
-	return {"pass": true}
+	return {"pass": true, "hold_s": hold_s}
 
 
 func _do_simulate_wheel(step: Dictionary) -> Dictionary:

--- a/40k/autoloads/TutorialManager.gd
+++ b/40k/autoloads/TutorialManager.gd
@@ -15,7 +15,15 @@ extends Node
 # scenario assert vocabulary (tests/scenarios/_schema.md): state paths with
 # equals/exists/expect_min/expect_max, node_visible/node_hidden, phase,
 # action (matched against phase_action_taken payloads), multiline script
-# predicates, and ack (explicit Continue). Combinators: any / all.
+# predicates, ack (explicit Continue), and checklist (every item of the step's
+# checklist ticked). Combinators: any / all.
+#
+# A step that teaches SEVERAL inputs declares a "checklist": each item latches
+# independently the moment its predicate first goes true, the overlay renders
+# the live tick list, and `done: {"checklist": true}` fires only when every item
+# is ticked. Without it a step advances on whichever control the player happens
+# to try first and the rest are never discovered — the "look around" step used
+# to jump ahead on a single arrow-key tap.
 
 signal lesson_started(lesson_id: String)
 signal step_changed(step_index: int)
@@ -45,6 +53,8 @@ var _steps: Array = []
 var _captured: Dictionary = {}
 var _ack_done: bool = false
 var _action_hits: Dictionary = {}   # done-tree path ("0.1") -> true once seen
+var _checklist: Array = []          # device-resolved checklist items for the step
+var _checklist_done: Dictionary = {}  # checklist item id -> true once ticked
 var _step_script: GDScript = null   # compiled per-step script predicate cache
 var _script_cache: Dictionary = {}  # code -> GDScript for capture snippets
 var _bypass_gate: bool = false
@@ -120,6 +130,8 @@ func _teardown(emit_exit: bool) -> void:
 	_poll_timer.stop()
 	_hint_timer.stop()
 	_step_script = null
+	_checklist = []
+	_checklist_done = {}
 	if GameState.state.has("meta"):
 		GameState.state.meta.erase("tutorial")
 		GameState.state.meta.erase("tutorial_lesson")
@@ -320,6 +332,13 @@ func _enter_step(index: int) -> void:
 		var spec = capture[key]
 		if typeof(spec) == TYPE_DICTIONARY and spec.has("script"):
 			_captured[key] = _run_snippet(str(spec.script))
+	# on_enter runs BEFORE the checklist is built so a step can clear whatever
+	# latch its items read (e.g. camera gestures the player made during an
+	# earlier step) and start the player on a clean, all-unticked list.
+	var on_enter = step.get("on_enter", {})
+	if typeof(on_enter) == TYPE_DICTIONARY and on_enter.has("script"):
+		_run_snippet(str(on_enter.script))
+	_build_checklist(step)
 	var done: Dictionary = step.get("done", {})
 	if done.has("script"):
 		_step_script = _compile_snippet(str(done.script))
@@ -349,16 +368,109 @@ func _show_current_step() -> void:
 		"ack": _is_ack_step(step),
 		"anchor": step.get("anchor", {}),
 		"spotlight": str(step.get("spotlight", "soft" if step.has("anchor") else "none")),
+		"checklist_label": str(step.get("checklist", {}).get("label", "")),
+		"checklist": _checklist_view(),
 	})
 
 
 func refresh_prompt() -> void:
-	if active:
-		_show_current_step()
+	if not active:
+		return
+	# Item labels (and which items apply at all) are device-dependent, so a
+	# pad<->keyboard swap mid-step has to rebuild the list — carrying the
+	# already-ticked ids across so the player never loses progress.
+	if current_step_index >= 0 and current_step_index < _steps.size():
+		_build_checklist(_steps[current_step_index], _checklist_done)
+	_show_current_step()
 
 
 func _is_ack_step(step: Dictionary) -> bool:
 	return bool(step.get("done", {}).get("ack", false))
+
+
+# --------------------------------------------------------------- checklist ---
+
+# Resolve the step's checklist for the ACTIVE device. Items carry the same
+# device filter as steps do ("any"/"pad"/"kbm") and an optional pad_label, so a
+# single item can read "Pan up [W]" on keyboard and "Pan up [RS]" on a pad.
+# `preserve` re-applies ticks across a rebuild (device swap).
+func _build_checklist(step: Dictionary, preserve: Dictionary = {}) -> void:
+	_checklist = []
+	_checklist_done = {}
+	var spec = step.get("checklist", {})
+	if typeof(spec) != TYPE_DICTIONARY:
+		return
+	var items = spec.get("items", [])
+	if typeof(items) != TYPE_ARRAY:
+		return
+	var pad := InputDeviceManager.is_pad_active()
+	for raw in items:
+		if typeof(raw) != TYPE_DICTIONARY:
+			continue
+		var iid := str(raw.get("id", ""))
+		if iid == "":
+			continue
+		var dev := str(raw.get("device", "any"))
+		if (dev == "pad" and not pad) or (dev == "kbm" and pad):
+			continue
+		var label := str(raw.get("label", ""))
+		if pad and raw.has("pad_label"):
+			label = str(raw.pad_label)
+		_checklist.append({"id": iid, "label": label, "script": str(raw.get("script", ""))})
+		_checklist_done[iid] = bool(preserve.get(iid, false))
+
+
+# Evaluate every not-yet-ticked item. Returns true if anything newly ticked, so
+# the caller only repaints the overlay when the list actually changed (this runs
+# on the 0.1s poll timer).
+func _poll_checklist() -> bool:
+	var changed := false
+	for item in _checklist:
+		var iid: String = str(item.get("id", ""))
+		if bool(_checklist_done.get(iid, false)):
+			continue
+		var code: String = str(item.get("script", ""))
+		if code == "":
+			continue
+		var s := _compile_snippet(code)
+		if s == null:
+			continue
+		if bool(_call_snippet(s)):
+			_checklist_done[iid] = true
+			changed = true
+			print("TutorialManager: checklist item '%s' ticked (%d/%d)" % [
+				iid, _checklist_ticked_count(), _checklist.size()])
+	return changed
+
+
+func _checklist_ticked_count() -> int:
+	var n := 0
+	for item in _checklist:
+		if bool(_checklist_done.get(str(item.get("id", "")), false)):
+			n += 1
+	return n
+
+
+func _checklist_complete() -> bool:
+	return _checklist_ticked_count() == _checklist.size()
+
+
+func _checklist_view() -> Array:
+	var pad := InputDeviceManager.is_pad_active()
+	var out: Array = []
+	for item in _checklist:
+		var iid: String = str(item.get("id", ""))
+		out.append({
+			"id": iid,
+			"label": TutorialScriptLib.render_text(str(item.get("label", "")), pad),
+			"done": bool(_checklist_done.get(iid, false)),
+		})
+	return out
+
+
+# Exposed for windowed scenarios / the MCP bridge: which items are ticked.
+func checklist_state() -> Dictionary:
+	return _checklist_done.duplicate()
 
 
 func ack() -> void:
@@ -460,6 +572,10 @@ func _on_poll() -> void:
 func _check_done() -> void:
 	if not active or current_step_index < 0 or current_step_index >= _steps.size():
 		return
+	if not _checklist.is_empty() and _poll_checklist():
+		var overlay := get_node_or_null("/root/TutorialOverlay")
+		if overlay:
+			overlay.update_checklist(_checklist_view())
 	var done: Dictionary = _steps[current_step_index].get("done", {})
 	if _eval_condition(done, "0"):
 		_complete_step()
@@ -480,6 +596,11 @@ func _eval_condition(cond: Dictionary, path: String) -> bool:
 		return true
 	if cond.has("ack"):
 		return _ack_done
+	if cond.has("checklist"):
+		# A step declaring `done: {"checklist": true}` with no checklist items
+		# would otherwise complete instantly — treat the empty list as done, the
+		# validator flags the authoring mistake.
+		return _checklist_complete() == bool(cond.checklist)
 	if cond.has("action"):
 		return _action_hits.get(path, false)
 	if cond.has("phase"):

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -4,7 +4,11 @@
   "title": "Scoutin' da Field",
   "subtitle": "Camera, selection & reading the table",
   "est_minutes": 4,
-  "boot": { "fixture": "tutorial_postdeploy", "phase": 7, "rng_seed": 4242 },
+  "boot": {
+    "fixture": "tutorial_postdeploy",
+    "phase": 7,
+    "rng_seed": 4242
+  },
   "summary": {
     "bark": "PROPPA JOB, YA GIT!",
     "bullets": [
@@ -24,25 +28,70 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     },
     {
       "id": "camera",
       "prompt": {
         "bark": "EYES ON DA FIELD!",
-        "kbm": "Move da camera wiv {key:camera_pan_up} {key:camera_pan_left} {key:camera_pan_down} {key:camera_pan_right} or da arrow keys. Zoom wiv da mouse wheel. Go on — 'ave a look around.",
-        "pad": "Pan da camera wiv {rs}. Zoom wiv {lt} an' {rt}. Go on — 'ave a look around."
+        "kbm": "Look over da whole table: pan wiv da arrow keys (or {key:camera_pan_up} {key:camera_pan_left} {key:camera_pan_down} {key:camera_pan_right}), an' zoom in an' out wiv da mouse wheel. Try 'em all.",
+        "pad": "Look over da whole table: shove {rs} every way to pan, den zoom in wiv {rt} an' out wiv {lt}. Try 'em all."
       },
       "spotlight": "none",
       "allow": [],
-      "capture": {
-        "off": { "script": "return str(main.view_offset)" },
-        "zoom": { "script": "return main.view_zoom" }
+      "on_enter": {
+        "script": "if main != null and main.has_method(\"reset_camera_gestures\"):\n\tmain.reset_camera_gestures()"
+      },
+      "checklist": {
+        "label": "Try each:",
+        "items": [
+          {
+            "id": "pan_up",
+            "label": "Up",
+            "pad_label": "Up {rs}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"pan_up\")"
+          },
+          {
+            "id": "pan_down",
+            "label": "Down",
+            "pad_label": "Down {rs}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"pan_down\")"
+          },
+          {
+            "id": "pan_left",
+            "label": "Left",
+            "pad_label": "Left {rs}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"pan_left\")"
+          },
+          {
+            "id": "pan_right",
+            "label": "Right",
+            "pad_label": "Right {rs}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"pan_right\")"
+          },
+          {
+            "id": "zoom_in",
+            "label": "Zoom in",
+            "pad_label": "Zoom in {rt}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"zoom_in\")"
+          },
+          {
+            "id": "zoom_out",
+            "label": "Zoom out",
+            "pad_label": "Zoom out {lt}",
+            "script": "return main != null and main.has_method(\"camera_gesture_used\") and main.camera_gesture_used(\"zoom_out\")"
+          }
+        ]
       },
       "done": {
-        "script": "return str(main.view_offset) != str(captured[\"off\"]) or abs(main.view_zoom - captured[\"zoom\"]) > 0.01"
+        "checklist": true
       },
-      "hint": { "text": "Any pan or zoom counts — just nudge da view." }
+      "hint": {
+        "kbm": "Tick every box: pan all four ways wiv da arrow keys, den roll da wheel forward an' back. Stuck on one? [i]Skip Step[/i] up 'ere moves on.",
+        "pad": "Tick every box: push {rs} all four ways, den squeeze {rt} an' {lt}. Stuck on one? [i]Skip Step[/i] up 'ere moves on."
+      }
     },
     {
       "id": "select_wagon",
@@ -51,13 +100,19 @@
         "kbm": "Click [b]Battlewagon[/b] in da unit list on da right — or click its token up in your deployment zone.",
         "pad": "Tap {rb} to cycle units until da [b]Battlewagon[/b] is picked — or point {ls} at its token on da board an' press {a}."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList"
+      },
       "spotlight": "soft",
-      "allow": ["BEGIN_NORMAL_MOVE"],
+      "allow": [
+        "BEGIN_NORMAL_MOVE"
+      ],
       "done": {
         "script": "var mc = main.get(\"movement_controller\")\nreturn mc != null and str(mc.active_unit_id) == \"U_BATTLEWAGON_T\""
       },
-      "hint": { "text": "Da unit list is top-right — da Battlewagon row. If dat list looks empty, point at da wagon on da board an' pick it dere instead." }
+      "hint": {
+        "text": "Da unit list is top-right — da Battlewagon row. If dat list looks empty, point at da wagon on da board an' pick it dere instead."
+      }
     },
     {
       "id": "open_datasheet",
@@ -68,7 +123,9 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "node_visible": "/root/Main/DatasheetModal" }
+      "done": {
+        "node_visible": "/root/Main/DatasheetModal"
+      }
     },
     {
       "id": "close_datasheet",
@@ -79,7 +136,9 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "node_hidden": "/root/Main/DatasheetModal" }
+      "done": {
+        "node_hidden": "/root/Main/DatasheetModal"
+      }
     },
     {
       "id": "dice_log",
@@ -88,7 +147,9 @@
         "kbm": "Da left panel logs everyfing wot 'appens. Click da [b]Dice Log[/b] tab — every roll ends up dere.",
         "pad": "Da left panel logs everyfing. Glide {ls} onto da [b]Dice Log[/b] tab an' press {a}."
       },
-      "anchor": { "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog" },
+      "anchor": {
+        "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog"
+      },
       "spotlight": "soft",
       "allow": [],
       "done": {
@@ -102,10 +163,14 @@
         "bark": "READ DA BAR!",
         "pad": "Dat strip at da bottom always shows wot each button does [i]right now[/i]. It changes wiv da situation — when in doubt, read da bar."
       },
-      "anchor": { "node": "/root/PadHintBar" },
+      "anchor": {
+        "node": "/root/PadHintBar"
+      },
       "spotlight": "soft",
       "allow": [],
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     },
     {
       "id": "hotkey_help_open",
@@ -116,7 +181,9 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "node_visible": "/root/Main/HotkeyHelpOverlay" }
+      "done": {
+        "node_visible": "/root/Main/HotkeyHelpOverlay"
+      }
     },
     {
       "id": "hotkey_help_close",
@@ -127,7 +194,9 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "node_hidden": "/root/Main/HotkeyHelpOverlay" }
+      "done": {
+        "node_hidden": "/root/Main/HotkeyHelpOverlay"
+      }
     },
     {
       "id": "end_phase_intro",
@@ -135,10 +204,14 @@
         "bark": "SEE DAT BUTTON?",
         "text": "Dat big red button ends da current phase for good. [b]Don't[/b] press it yet — first, a bit of movin'."
       },
-      "anchor": { "node": "/root/Main/PhaseActionButton" },
+      "anchor": {
+        "node": "/root/Main/PhaseActionButton"
+      },
       "spotlight": "soft",
       "allow": [],
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     },
     {
       "id": "move_grots",
@@ -147,11 +220,25 @@
         "kbm": "Click [b]Gretchin[/b] in da unit list, den [b]drag[/b] one grot a short way forward an' drop it.",
         "pad": "Tap {rb} until da [b]Gretchin[/b] are picked, glide {ls} onto a grot, press {a} to grab it, walk it forward an' press {a} to drop it."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList"
+      },
       "spotlight": "soft",
-      "allow": ["BEGIN_NORMAL_MOVE", "STAGE_MODEL_MOVE", "SET_MODEL_DEST", "LOCK_MOVEMENT_MODE", "UNDO_LAST_MODEL_MOVE"],
-      "done": { "action": { "type": "STAGE_MODEL_MOVE" } },
-      "hint": { "text": "Pick da Gretchin row first — den drag any single grot base. Keep 'im near his mates (wivin 2\") an' don't drop him on top of anyone." }
+      "allow": [
+        "BEGIN_NORMAL_MOVE",
+        "STAGE_MODEL_MOVE",
+        "SET_MODEL_DEST",
+        "LOCK_MOVEMENT_MODE",
+        "UNDO_LAST_MODEL_MOVE"
+      ],
+      "done": {
+        "action": {
+          "type": "STAGE_MODEL_MOVE"
+        }
+      },
+      "hint": {
+        "text": "Pick da Gretchin row first — den drag any single grot base. Keep 'im near his mates (wivin 2\") an' don't drop him on top of anyone."
+      }
     },
     {
       "id": "confirm_grots",
@@ -160,10 +247,23 @@
         "kbm": "Press [b]End This Unit's Move[/b] on da right to lock da move in.",
         "pad": "Check da hint bar — confirm da move to lock it in."
       },
-      "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton" },
+      "anchor": {
+        "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton"
+      },
       "spotlight": "soft",
-      "allow": ["BEGIN_NORMAL_MOVE", "STAGE_MODEL_MOVE", "SET_MODEL_DEST", "LOCK_MOVEMENT_MODE", "UNDO_LAST_MODEL_MOVE", "CONFIRM_UNIT_MOVE"],
-      "done": { "action": { "type": "CONFIRM_UNIT_MOVE" } }
+      "allow": [
+        "BEGIN_NORMAL_MOVE",
+        "STAGE_MODEL_MOVE",
+        "SET_MODEL_DEST",
+        "LOCK_MOVEMENT_MODE",
+        "UNDO_LAST_MODEL_MOVE",
+        "CONFIRM_UNIT_MOVE"
+      ],
+      "done": {
+        "action": {
+          "type": "CONFIRM_UNIT_MOVE"
+        }
+      }
     },
     {
       "id": "wrap",
@@ -173,7 +273,9 @@
       },
       "spotlight": "none",
       "allow": [],
-      "done": { "ack": true }
+      "done": {
+        "ack": true
+      }
     }
   ]
 }

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.0",
+      "date": "2026-07-27",
+      "summary": "Basic Trainin's 'ave a look around' step now waits until you've tried every camera control instead of jumping ahead on the first button you press.",
+      "changes": [
+        "The first camera step of Basic Trainin' used to skip to the next step the moment you nudged the view even once — so if you tapped one key you never found out about panning the other three ways, or about zooming. It now waits until you have used all of them at least once. Same on Steam Deck and in the browser version.",
+        "That step now shows a live tick list — Up, Down, Left, Right, Zoom in, Zoom out — so you can see at a glance which controls you have not tried yet. Each one goes green as you use it.",
+        "The tick list shows the right prompts for whatever you are playing on: keyboard directions on mouse+keyboard, right-stick and trigger glyphs on a controller — and it swaps live if you put the pad down mid-step.",
+        "The keyboard version of the step now points at the arrow keys first, which pan the camera without also opening the Stratagems panel.",
+        "Stuck on one control? The Skip Step button still moves you on — no lesson can trap you."
+      ]
+    },
+    {
       "version": "1.4.1",
       "date": "2026-07-26",
       "summary": "Fixed Basic Trainin' starting with an empty army, plus the first-launch offer and the blank movement unit list.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -92,6 +92,18 @@ var view_rotation: float = 0.0  # Board rotation in radians (multiples of PI/2)
 # "selection" = Shift+F, "decision" = auto-zoom on side panel open.
 var last_camera_fit_action: String = ""
 
+# Which camera gestures the player has actually used, keyed by screen-space id:
+# "pan_up" / "pan_down" / "pan_left" / "pan_right" / "zoom_in" / "zoom_out".
+# The tutorial's "'ave a look around" step used to advance on the FIRST nudge of
+# the view, so a player who only tapped one key never found out the other three
+# directions (or the zoom) existed. It now waits on this latch set instead, so
+# it needs to know WHICH inputs were used, not merely that the view moved.
+#
+# Latched from the INPUT, not from the resulting view change: zoom clamps at
+# 0.1x/3.0x and a pan can be a no-op at the board edge, and a player sitting at
+# a limit must still be able to tick the box off.
+var camera_gestures_used: Dictionary = {}
+
 # T32: LoS debug is now a held-key power-user mode rather than a persistent
 # top-bar toggle. los_debug_active mirrors the debug state for scenarios.
 var los_debug_active: bool = false
@@ -6187,6 +6199,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	if deployment_controller and deployment_controller.has_method("is_placing") and deployment_controller.is_placing():
 		return
 	var factor: float = WHEEL_ZOOM_FACTOR if mb.button_index == MOUSE_BUTTON_WHEEL_UP else 1.0 / WHEEL_ZOOM_FACTOR
+	note_camera_gesture("zoom_in" if mb.button_index == MOUSE_BUTTON_WHEEL_UP else "zoom_out")
 	if _zoom_about(view_zoom * factor, get_viewport().get_mouse_position()):
 		update_view_transform()
 	# We acted on the scroll — stop it here so nothing else treats the same
@@ -6212,6 +6225,7 @@ func _process(delta: float) -> void:
 	if not _text_focused and KeybindingManager.is_action_pressed("camera_pan_right"):
 		pan_dir.x += 1.0
 	if pan_dir != Vector2.ZERO:
+		note_camera_pan_gesture(pan_dir)
 		# Counter-rotate the pan direction so WASD always maps to screen directions
 		view_offset += pan_dir.rotated(-view_rotation) * pan_speed
 		view_changed = true
@@ -6220,9 +6234,11 @@ func _process(delta: float) -> void:
 	# cursor stays put while zooming (instead of the view drifting toward the
 	# viewport's top-left corner).
 	if not _text_focused and KeybindingManager.is_action_pressed("zoom_in"):
+		note_camera_gesture("zoom_in")
 		if _zoom_about(view_zoom * 1.03, get_viewport().get_mouse_position()):
 			view_changed = true
 	if not _text_focused and KeybindingManager.is_action_pressed("zoom_out"):
+		note_camera_gesture("zoom_out")
 		if _zoom_about(view_zoom * 0.97, get_viewport().get_mouse_position()):
 			view_changed = true
 
@@ -6239,8 +6255,17 @@ func _process(delta: float) -> void:
 		if SettingsService.pad_invert_camera_y:
 			pad_pan.y = -pad_pan.y
 		if pad_pan != Vector2.ZERO:
+			# Latched AFTER the invert-Y fix-up so the tick list matches the
+			# direction the player sees the view travel, not the raw stick axis.
+			note_camera_pan_gesture(pad_pan)
 			view_offset += pad_pan.rotated(-view_rotation) * pan_speed * SettingsService.pad_camera_sensitivity
 			view_changed = true
+		# Latched per trigger rather than from the combined delta: squeezing both
+		# triggers together cancels out to zero, but the player has still used both.
+		if Input.get_action_strength("pad_zoom_in") > 0.0:
+			note_camera_gesture("zoom_in")
+		if Input.get_action_strength("pad_zoom_out") > 0.0:
+			note_camera_gesture("zoom_out")
 		var pad_zoom = Input.get_action_strength("pad_zoom_in") - Input.get_action_strength("pad_zoom_out")
 		if pad_zoom != 0.0:
 			# Same per-frame multiplicative step as the keyboard zoom above,
@@ -6554,6 +6579,38 @@ func _zoom_about(new_zoom: float, screen_anchor: Vector2) -> bool:
 	view_offset += screen_anchor * (1.0 / view_zoom - 1.0 / new_zoom)
 	view_zoom = new_zoom
 	return true
+
+# ---------------------------------------------------------- camera gestures --
+# Used by the tutorial (TutorialManager step checklists) to tell a player who
+# has genuinely tried every camera control from one who nudged the view once.
+# Programmatic camera moves (focus_on_*, camera fit, the LB/RB unit glide) do
+# NOT latch anything — only real player input runs through the callers below.
+
+func note_camera_gesture(id: String) -> void:
+	if not camera_gestures_used.has(id):
+		camera_gestures_used[id] = true
+
+
+# Screen-space pan vector -> the direction ids it covers. A diagonal (mouse-free
+# stick push, or W+D held together) legitimately ticks two boxes at once.
+func note_camera_pan_gesture(dir: Vector2) -> void:
+	if dir.y < 0.0:
+		note_camera_gesture("pan_up")
+	if dir.y > 0.0:
+		note_camera_gesture("pan_down")
+	if dir.x < 0.0:
+		note_camera_gesture("pan_left")
+	if dir.x > 0.0:
+		note_camera_gesture("pan_right")
+
+
+func camera_gesture_used(id: String) -> bool:
+	return bool(camera_gestures_used.get(id, false))
+
+
+func reset_camera_gestures() -> void:
+	camera_gestures_used.clear()
+
 
 func focus_on_player2_zone() -> void:
 	var zone2 = BoardState.get_deployment_zone_for_player(2)

--- a/40k/scripts/tutorial/TutorialOverlay.gd
+++ b/40k/scripts/tutorial/TutorialOverlay.gd
@@ -22,6 +22,7 @@ var _card: PanelContainer
 var _instructor_chip: Label
 var _bark_label: Label
 var _body_text: RichTextLabel
+var _checklist_text: RichTextLabel
 var _hint_label: Label
 var _progress_label: Label
 var _continue_button: Button
@@ -30,6 +31,7 @@ var _exit_button: Button
 var _next_button: Button
 var _menu_button: Button
 
+var _checklist_label: String = ""
 var _anchor_spec: Dictionary = {}
 var _anchor_node: Node = null
 var _anchor_rect: Rect2 = Rect2()
@@ -145,6 +147,25 @@ func _build() -> void:
 	_body_text.add_theme_color_override("default_color", WhiteDwarfThemeData.WH_PARCHMENT)
 	_body_text.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	vbox.add_child(_body_text)
+
+	# Live tick list for multi-input steps ("try every camera control"). Hidden
+	# on steps with no checklist. One RichTextLabel rather than a row of child
+	# controls so the chip BBCode from the prompt vocabulary ({key:...}, {rs})
+	# renders the same way here as in the body, and so scenarios can assert the
+	# whole list with a single node read.
+	_checklist_text = RichTextLabel.new()
+	_checklist_text.name = "ChecklistText"
+	_checklist_text.bbcode_enabled = true
+	_checklist_text.fit_content = true
+	_checklist_text.scroll_active = false
+	_checklist_text.custom_minimum_size = Vector2(560, 0)
+	_checklist_text.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	_checklist_text.add_theme_font_size_override("normal_font_size", 14)
+	_checklist_text.add_theme_font_size_override("bold_font_size", 14)
+	_checklist_text.add_theme_color_override("default_color", WhiteDwarfThemeData.WH_PARCHMENT)
+	_checklist_text.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_checklist_text.visible = false
+	vbox.add_child(_checklist_text)
 
 	_hint_label = Label.new()
 	_hint_label.name = "HintLabel"
@@ -265,6 +286,8 @@ func show_step(view: Dictionary) -> void:
 	set_process(true)
 	_bark_label.text = str(view.get("bark", ""))
 	_body_text.text = str(view.get("body", ""))
+	_checklist_label = str(view.get("checklist_label", ""))
+	update_checklist(view.get("checklist", []))
 	_hint_label.visible = false
 	_hint_label.text = ""
 	_progress_label.text = str(view.get("progress", ""))
@@ -291,11 +314,37 @@ func show_hint(text: String) -> void:
 	_hint_label.visible = true
 
 
+# Repaint the multi-input tick list. `items` is [{id, label (BBCode), done}];
+# an empty array hides the row. Ticked entries go green, outstanding ones stay
+# dim — the whole point of the row is that the player can see, at a glance,
+# which controls they have NOT tried yet.
+func update_checklist(items) -> void:
+	if typeof(items) != TYPE_ARRAY or (items as Array).is_empty():
+		_checklist_text.visible = false
+		_checklist_text.text = ""
+		return
+	var parts: Array = []
+	for it in items:
+		if typeof(it) != TYPE_DICTIONARY:
+			continue
+		var done: bool = bool(it.get("done", false))
+		var color: Color = UIConstantsData.CONFIRMED_GREEN if done else Color(WhiteDwarfThemeData.WH_PARCHMENT, 0.55)
+		parts.append("[color=#%s]%s %s[/color]" % [
+			color.to_html(false), "[b]✔[/b]" if done else "○", str(it.get("label", ""))])
+	var prefix := ""
+	if _checklist_label != "":
+		prefix = "%s  " % _checklist_label
+	_checklist_text.text = prefix + "    ".join(parts)
+	_checklist_text.visible = true
+
+
 func show_summary(view: Dictionary) -> void:
 	visible = true
 	set_process(true)
 	_bark_label.text = str(view.get("bark", "PROPPA JOB!"))
 	_body_text.text = str(view.get("body", ""))
+	_checklist_label = ""
+	update_checklist([])
 	_hint_label.visible = false
 	_progress_label.text = str(view.get("progress", ""))
 	_continue_button.visible = false
@@ -347,6 +396,10 @@ func current_body_text() -> String:
 
 func current_progress_text() -> String:
 	return _progress_label.text
+
+
+func current_checklist_text() -> String:
+	return _checklist_text.text if _checklist_text.visible else ""
 
 
 # --------------------------------------------------------------- process ----

--- a/40k/scripts/tutorial/TutorialScript.gd
+++ b/40k/scripts/tutorial/TutorialScript.gd
@@ -86,6 +86,7 @@ static func validate(lesson: Dictionary) -> Array:
 		var allow = step.get("allow", [])
 		if typeof(allow) != TYPE_ARRAY and str(allow) != "*":
 			errors.append("%s (%s): 'allow' must be an array or \"*\"" % [tag, sid])
+		errors.append_array(_validate_checklist(step, tag, sid))
 		# Soft guidance: keep instructions short (warning only, never fatal).
 		var prompt = step.get("prompt", {})
 		if typeof(prompt) == TYPE_DICTIONARY:
@@ -93,6 +94,48 @@ static func validate(lesson: Dictionary) -> Array:
 				if prompt.has(k) and str(prompt[k]).length() > BODY_LENGTH_WARN:
 					print("TutorialScript: WARNING %s (%s) '%s' body is %d chars (> %d guideline)" % [
 						tag, sid, k, str(prompt[k]).length(), BODY_LENGTH_WARN])
+	return errors
+
+
+# Multi-input steps: `checklist.items` is a list of {id, label, script} the
+# player must satisfy one by one before the step advances. A `done.checklist`
+# with no items would complete the step instantly, and an item with no predicate
+# could never tick, so both are hard errors — a mis-authored checklist soft-locks
+# or trivialises the lesson rather than failing loudly at runtime.
+static func _validate_checklist(step: Dictionary, tag: String, sid: String) -> Array:
+	var errors: Array = []
+	var has_done_checklist: bool = bool(step.get("done", {}).get("checklist", false))
+	if not step.has("checklist"):
+		if has_done_checklist:
+			errors.append("%s (%s): done.checklist set but step has no 'checklist'" % [tag, sid])
+		return errors
+	var spec = step.get("checklist")
+	if typeof(spec) != TYPE_DICTIONARY:
+		errors.append("%s (%s): 'checklist' must be an object" % [tag, sid])
+		return errors
+	var items = spec.get("items", [])
+	if typeof(items) != TYPE_ARRAY or (items as Array).is_empty():
+		errors.append("%s (%s): 'checklist.items' must be a non-empty array" % [tag, sid])
+		return errors
+	var seen := {}
+	for j in range((items as Array).size()):
+		var item = items[j]
+		if typeof(item) != TYPE_DICTIONARY:
+			errors.append("%s (%s): checklist item %d is not an object" % [tag, sid, j])
+			continue
+		var iid := str(item.get("id", ""))
+		if iid == "":
+			errors.append("%s (%s): checklist item %d missing 'id'" % [tag, sid, j])
+		elif seen.has(iid):
+			errors.append("%s (%s): duplicate checklist item id '%s'" % [tag, sid, iid])
+		seen[iid] = true
+		if str(item.get("script", "")) == "":
+			errors.append("%s (%s): checklist item '%s' missing 'script'" % [tag, sid, iid])
+		if str(item.get("label", "")) == "":
+			errors.append("%s (%s): checklist item '%s' missing 'label'" % [tag, sid, iid])
+		var idev := str(item.get("device", "any"))
+		if not idev in VALID_DEVICE:
+			errors.append("%s (%s): checklist item '%s' bad device '%s'" % [tag, sid, iid, idev])
 	return errors
 
 

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Runs the audit-suite of headless GDScript regression tests:
+#   - tutorial multi-input checklist ("'ave a look around" waits for every
+#     suggested camera control instead of the first one pressed)
 #   - 3 pretrigger fixture tests (deferred-action stratagems CO/HI/RI)
 #   - audit-fix verification (#329, #336, #338, #356, #359)
 #   - T2.M6 base-touching regression (#321/#327)
@@ -39,6 +41,7 @@ cp -n tests/saves/*.w40ksave saves/ 2>/dev/null || true
 cp -n tests/saves/*.meta saves/ 2>/dev/null || true
 
 TESTS=(
+    "tests/test_tutorial_checklist.gd"
     "tests/test_controller_controls_doc_sync.gd"
     "tests/test_hi_pretrigger.gd"
     "tests/test_ai_reactive_window_guard.gd"

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -186,8 +186,12 @@ Each step is a dict with an `act` field plus act-specific keys.
   `OS.find_keycode_from_string`, so use the human-readable key name
   (`"Escape"`, `"Equal"`, `"2"`), NOT the `KEY_*` enum constant name —
   `"KEY_ESCAPE"` does not resolve and fails the step.
+  Optional `hold_s` keeps the key down for that long before releasing — needed
+  for POLLED consumers (camera pan/zoom read `is_action_pressed()` from
+  `_process`), which a press/release straddling one frame may miss.
   ```json
   { "act": "simulate_key", "keycode": "Escape" }
+  { "act": "simulate_key", "keycode": "W", "hold_s": 0.25 }
   ```
 
 - `simulate_joy_button`: dispatch a joypad button press+release through the

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -116,7 +116,75 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "select_wagon"
+      "equals": "camera",
+      "comment": "reported bug: the camera step advanced on the FIRST input, so a player who only rolled the wheel never learned pan exists. One gesture must NOT complete the step."
+    },
+    {
+      "act": "execute_script",
+      "script": "var s = TutorialManager.checklist_state()\nreturn bool(s.get(\"zoom_in\", false)) and not bool(s.get(\"pan_up\", false)) and s.size() == 6",
+      "multiline": true,
+      "equals": true,
+      "comment": "the wheel ticked zoom_in only; the other five are still outstanding"
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_checklist_text().contains(\"Zoom in\") and o.current_checklist_text().contains(\"Up\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "and the player can SEE what is left — the tick list is on the instructor card"
+    },
+    {
+      "act": "screenshot",
+      "label": "02b_camera_checklist_partial"
+    },
+    {
+      "act": "simulate_wheel",
+      "direction": "down",
+      "count": 2
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "Up",
+      "hold_s": 0.25,
+      "comment": "arrow keys, not WASD: S also toggles the Stratagems panel and A the aura rings (pre-existing default-keybind collision with camera_pan_down/left), which swallows the next click"
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "Down",
+      "hold_s": 0.25,
+      "comment": "arrow keys, not WASD: S also toggles the Stratagems panel and A the aura rings (pre-existing default-keybind collision with camera_pan_down/left), which swallows the next click"
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "Left",
+      "hold_s": 0.25,
+      "comment": "arrow keys, not WASD: S also toggles the Stratagems panel and A the aura rings (pre-existing default-keybind collision with camera_pan_down/left), which swallows the next click"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "camera",
+      "comment": "five of six ticked — still waiting on Pan Right"
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "Right",
+      "hold_s": 0.25,
+      "comment": "arrow keys, not WASD: S also toggles the Stratagems panel and A the aura rings (pre-existing default-keybind collision with camera_pan_down/left), which swallows the next click"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "select_wagon",
+      "comment": "all six suggested camera controls used -> and only now does the step advance"
     },
     {
       "act": "execute_script",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -89,7 +89,8 @@
       "act": "simulate_joy_axis",
       "axis": 2,
       "value": 1.0,
-      "hold_s": 0.6
+      "hold_s": 0.4,
+      "comment": "right stick right -> Pan Right"
     },
     {
       "act": "wait_frames",
@@ -98,7 +99,81 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "select_wagon"
+      "equals": "camera",
+      "comment": "reported bug (Steam Deck + itch.io alike): the camera step advanced on the FIRST input, so a player who only nudged the stick one way never learned about the other directions or the trigger zoom. One gesture must NOT complete the step."
+    },
+    {
+      "act": "execute_script",
+      "script": "var s = TutorialManager.checklist_state()\nreturn bool(s.get(\"pan_right\", false)) and not bool(s.get(\"zoom_in\", false)) and s.size() == 6",
+      "multiline": true,
+      "equals": true,
+      "comment": "one stick push ticks one box; five are still outstanding"
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_checklist_text().contains(\"Zoom in\") and o.current_checklist_text().contains(\"Right\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "and the pad player can SEE what is left on the instructor card"
+    },
+    {
+      "act": "screenshot",
+      "label": "02b_camera_checklist_partial_pad"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": -1.0,
+      "hold_s": 0.4,
+      "comment": "right stick left -> Pan Left"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": -1.0,
+      "hold_s": 0.4,
+      "comment": "right stick up -> Pan Up"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": 1.0,
+      "hold_s": 0.4,
+      "comment": "right stick down -> Pan Down"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 5,
+      "value": 1.0,
+      "hold_s": 0.4,
+      "comment": "right trigger -> Zoom In"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "camera",
+      "comment": "five of six ticked - still waiting on the left trigger (Zoom Out)"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 4,
+      "value": 1.0,
+      "hold_s": 0.4,
+      "comment": "left trigger -> Zoom Out"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "select_wagon",
+      "comment": "all six suggested pad camera controls used -> and only now does the step advance"
     },
     {
       "act": "execute_script",

--- a/40k/tests/test_tutorial_checklist.gd
+++ b/40k/tests/test_tutorial_checklist.gd
@@ -1,0 +1,224 @@
+extends SceneTree
+
+# Tutorial multi-input checklist (the "'ave a look around" progression fix).
+#
+# The T1 camera step used to advance on the FIRST camera input the player
+# happened to try, so anyone who tapped one key never discovered the other
+# three pan directions or the zoom — the reported confusion on both Steam Deck
+# and the itch.io build. The step now declares a `checklist`: each item latches
+# independently and `done: {"checklist": true}` only fires once every item is
+# ticked, with the outstanding ones rendered live on the instructor card.
+#
+# Checks:
+#   A) TutorialScript.validate rejects mis-authored checklists (a `done
+#      .checklist` with no items would complete the step instantly; an item
+#      with no predicate could never tick).
+#   B) The shipped T1 lesson gates its camera step on a checklist covering all
+#      six suggested controls, and no longer on a single view-changed predicate.
+#   C) TutorialManager latches each item once, refuses to complete until every
+#      one is ticked, keeps ticks after the input stops, and preserves them
+#      across a device-swap rebuild.
+#   D) Main.gd latches real camera input per direction (and from the input, not
+#      from the resulting view change — zoom clamps and board edges must not be
+#      able to strand a player on an un-tickable box).
+#
+# The live player path is covered by the windowed scenarios
+# tests/scenarios/sp/tut_t1_basics(.pad).json; this is the fast net underneath.
+#
+# Usage: godot --headless --path . -s tests/test_tutorial_checklist.gd
+
+const TutorialScriptLib = preload("res://scripts/tutorial/TutorialScript.gd")
+
+var passed := 0
+var failed := 0
+
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+
+# Predicates read a Dictionary parked in TutorialManager._captured, which the
+# snippet host exposes to step scripts as `captured` — no live camera needed.
+func _fake_step(flag_names: Array) -> Dictionary:
+	var items: Array = []
+	for name in flag_names:
+		items.append({
+			"id": name,
+			"label": name,
+			"script": "return bool(captured[\"flags\"].get(\"%s\", false))" % name,
+		})
+	return {"id": "cl", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"label": "Try each:", "items": items}}
+
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_tutorial_checklist ===\n")
+
+	_test_validation()
+	_test_shipped_t1_lesson()
+	_test_latching()
+	_test_main_gesture_latch()
+
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)
+
+
+# A: authoring mistakes fail loudly instead of soft-locking or trivialising ----
+
+func _test_validation():
+	var base := {"id": "x", "title": "x", "boot": {"fixture": "f"}}
+
+	var empty_items := base.duplicate(true)
+	empty_items["steps"] = [{"id": "a", "prompt": {"text": "t"},
+		"done": {"checklist": true}, "checklist": {"items": []}}]
+	_check("validate rejects an empty checklist",
+		" ".join(TutorialScriptLib.validate(empty_items)).contains("non-empty"))
+
+	var no_checklist := base.duplicate(true)
+	no_checklist["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true}}]
+	_check("validate rejects done.checklist with no checklist block",
+		" ".join(TutorialScriptLib.validate(no_checklist)).contains("no 'checklist'"))
+
+	var no_script := base.duplicate(true)
+	no_script["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"items": [{"id": "i", "label": "l"}]}}]
+	_check("validate rejects a checklist item with no predicate",
+		" ".join(TutorialScriptLib.validate(no_script)).contains("missing 'script'"))
+
+	var dupe := base.duplicate(true)
+	dupe["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"items": [
+			{"id": "i", "label": "l", "script": "return true"},
+			{"id": "i", "label": "l", "script": "return true"}]}}]
+	_check("validate rejects duplicate checklist item ids",
+		" ".join(TutorialScriptLib.validate(dupe)).contains("duplicate checklist"))
+
+	var good := base.duplicate(true)
+	good["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"items": [{"id": "i", "label": "l", "script": "return true"}]}}]
+	_check("validate accepts a well-formed checklist",
+		TutorialScriptLib.validate(good).is_empty(),
+		str(TutorialScriptLib.validate(good)))
+
+
+# B: the shipped lesson actually uses it ---------------------------------------
+
+func _test_shipped_t1_lesson():
+	var out: Dictionary = TutorialScriptLib.load_lesson("res://data/tutorials/lessons/T1_basics.json")
+	_check("shipped T1 lesson validates", out.ok, str(out.errors))
+	if not out.ok:
+		return
+	var camera := {}
+	for step in out.lesson.get("steps", []):
+		if str(step.get("id", "")) == "camera":
+			camera = step
+	_check("T1 still has a 'camera' step", not camera.is_empty())
+	if camera.is_empty():
+		return
+	_check("camera step gates on the checklist, not on any single nudge",
+		bool(camera.get("done", {}).get("checklist", false)))
+	var ids: Array = []
+	for item in camera.get("checklist", {}).get("items", []):
+		ids.append(str(item.get("id", "")))
+	for wanted in ["pan_up", "pan_down", "pan_left", "pan_right", "zoom_in", "zoom_out"]:
+		_check("camera checklist covers '%s'" % wanted, ids.has(wanted), str(ids))
+	# Entering the step must clear whatever the player did during an earlier
+	# step, or a wanderer arrives with boxes pre-ticked and skips the lesson.
+	_check("camera step resets the gesture latch on entry",
+		str(camera.get("on_enter", {}).get("script", "")).contains("reset_camera_gestures"))
+
+
+# C: the engine waits for every item ------------------------------------------
+
+func _test_latching():
+	var tm = root.get_node_or_null("/root/TutorialManager")
+	if tm == null:
+		_check("TutorialManager autoload present", false)
+		return
+	var saved_captured: Dictionary = tm._captured
+	var saved_list: Array = tm._checklist
+	var saved_done: Dictionary = tm._checklist_done
+
+	var flags := {"pan_up": false, "pan_down": false}
+	var step := _fake_step(["pan_up", "pan_down"])
+	tm._captured = {"flags": flags}
+	tm._build_checklist(step)
+	_check("checklist builds one entry per item", tm._checklist.size() == 2, str(tm._checklist.size()))
+	_check("nothing ticked before any input", not tm._checklist_complete())
+
+	flags["pan_up"] = true
+	tm._poll_checklist()
+	_check("using one control ticks exactly that box",
+		tm.checklist_state().get("pan_up", false) and not tm.checklist_state().get("pan_down", true))
+	_check("one input does NOT complete the step (the reported bug)",
+		not tm._checklist_complete())
+	_check("done.checklist stays false while items are outstanding",
+		not tm._eval_condition({"checklist": true}, "0"))
+
+	# A pan is momentary — the tick must survive the key coming back up.
+	flags["pan_up"] = false
+	tm._poll_checklist()
+	_check("a ticked item never un-ticks", tm.checklist_state().get("pan_up", false))
+
+	# Device swap mid-step rebuilds the (differently labelled) list.
+	tm._build_checklist(step, tm._checklist_done)
+	_check("rebuild preserves ticks across a device swap",
+		tm.checklist_state().get("pan_up", false) and not tm.checklist_state().get("pan_down", true))
+
+	flags["pan_down"] = true
+	tm._poll_checklist()
+	_check("step completes once every item is ticked", tm._checklist_complete())
+	_check("done.checklist fires only then", tm._eval_condition({"checklist": true}, "0"))
+
+	tm._captured = saved_captured
+	tm._checklist = saved_list
+	tm._checklist_done = saved_done
+
+
+# D: Main latches real camera input per direction ------------------------------
+
+func _test_main_gesture_latch():
+	var main_script = load("res://scripts/Main.gd")
+	var main = main_script.new()
+	_check("Main exposes the gesture latch API",
+		main.has_method("camera_gesture_used") and main.has_method("note_camera_pan_gesture")
+			and main.has_method("reset_camera_gestures"))
+
+	main.note_camera_pan_gesture(Vector2(0, -1))
+	_check("pan up latches pan_up only",
+		main.camera_gesture_used("pan_up") and not main.camera_gesture_used("pan_down"))
+	main.note_camera_pan_gesture(Vector2(1, 1))
+	_check("a diagonal legitimately ticks both axes",
+		main.camera_gesture_used("pan_right") and main.camera_gesture_used("pan_down"))
+	_check("untouched directions stay untouched", not main.camera_gesture_used("pan_left"))
+	main.note_camera_gesture("zoom_in")
+	_check("zoom latches independently of pan", main.camera_gesture_used("zoom_in"))
+
+	main.reset_camera_gestures()
+	_check("reset clears every latch",
+		not main.camera_gesture_used("pan_up") and not main.camera_gesture_used("zoom_in"))
+
+	# Latched from the INPUT, not from the resulting view change: zoom clamps at
+	# 0.1x/3.0x, and a player sitting at a limit must still be able to tick the
+	# box off rather than be stranded on the step.
+	var src: String = FileAccess.get_file_as_string("res://scripts/Main.gd")
+	var zoom_in_at: int = src.find("is_action_pressed(\"zoom_in\")")
+	var zoom_call_at: int = src.find("_zoom_about", zoom_in_at)
+	var note_at: int = src.find("note_camera_gesture(\"zoom_in\")", zoom_in_at)
+	_check("keyboard zoom_in latches before (and independently of) the clamped _zoom_about",
+		zoom_in_at != -1 and note_at != -1 and note_at < zoom_call_at,
+		"pressed=%d note=%d zoom_about=%d" % [zoom_in_at, note_at, zoom_call_at])
+
+	main.free()

--- a/40k/tests/unit/test_tutorial_engine.gd
+++ b/40k/tests/unit/test_tutorial_engine.gd
@@ -12,6 +12,9 @@ var _saved_active: bool
 var _saved_lesson: Dictionary
 var _saved_steps: Array
 var _saved_index: int
+var _saved_captured: Dictionary
+var _saved_checklist: Array
+var _saved_checklist_done: Dictionary
 
 
 func before_each():
@@ -19,6 +22,9 @@ func before_each():
 	_saved_lesson = TutorialManager.current_lesson
 	_saved_steps = TutorialManager._steps
 	_saved_index = TutorialManager.current_step_index
+	_saved_captured = TutorialManager._captured
+	_saved_checklist = TutorialManager._checklist
+	_saved_checklist_done = TutorialManager._checklist_done
 
 
 func after_each():
@@ -26,6 +32,9 @@ func after_each():
 	TutorialManager.current_lesson = _saved_lesson
 	TutorialManager._steps = _saved_steps
 	TutorialManager.current_step_index = _saved_index
+	TutorialManager._captured = _saved_captured
+	TutorialManager._checklist = _saved_checklist
+	TutorialManager._checklist_done = _saved_checklist_done
 
 
 # ------------------------------------------------------------- parsing ----
@@ -124,6 +133,107 @@ func test_gate_implicit_safe_prefix_always_passes():
 	_arm_fake_step([])
 	assert_true(TutorialManager.is_action_allowed({"type": "DECLINE_COMMAND_REROLL"}),
 		"DECLINE_* reactive actions must never be gated (soft-lock guard)")
+
+
+# ------------------------------------------------------------- checklist ---
+# The camera step used to advance on the FIRST camera input, so a player who
+# tapped one arrow key never discovered the other three or the zoom. It now
+# waits on a checklist: every item latches independently and `done.checklist`
+# only fires when all of them are ticked.
+
+func _fake_checklist_step(flags: Dictionary) -> Dictionary:
+	# Predicates read a Dictionary held in TutorialManager._captured, which the
+	# snippet host exposes as `captured` — no live camera needed.
+	var items: Array = []
+	for key in flags:
+		items.append({
+			"id": key,
+			"label": key,
+			"script": "return bool(captured[\"flags\"].get(\"%s\", false))" % key,
+		})
+	return {"id": "cl", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"label": "Try each:", "items": items}}
+
+
+func test_checklist_waits_for_every_item():
+	var flags := {"pan_up": false, "pan_down": false}
+	var step := _fake_checklist_step(flags)
+	TutorialManager._captured = {"flags": flags}
+	TutorialManager._build_checklist(step)
+	assert_eq(TutorialManager._checklist.size(), 2)
+	assert_false(TutorialManager._checklist_complete(), "nothing used yet")
+
+	flags["pan_up"] = true
+	TutorialManager._poll_checklist()
+	assert_true(TutorialManager.checklist_state().get("pan_up", false))
+	assert_false(TutorialManager._checklist_complete(),
+		"one input must NOT be enough — that is the bug this guards")
+
+	flags["pan_down"] = true
+	TutorialManager._poll_checklist()
+	assert_true(TutorialManager._checklist_complete(), "all items used -> step may advance")
+	assert_true(TutorialManager._eval_condition({"checklist": true}, "0"))
+
+
+func test_checklist_ticks_stay_latched():
+	# A pan is momentary: the predicate goes true while the key is held and the
+	# tick must survive the key coming back up.
+	var flags := {"pan_up": false}
+	TutorialManager._captured = {"flags": flags}
+	TutorialManager._build_checklist(_fake_checklist_step(flags))
+	flags["pan_up"] = true
+	TutorialManager._poll_checklist()
+	flags["pan_up"] = false
+	TutorialManager._poll_checklist()
+	assert_true(TutorialManager._checklist_complete(), "a ticked item never un-ticks")
+
+
+func test_checklist_rebuild_preserves_ticks():
+	# Swapping keyboard <-> pad mid-step rebuilds the (device-labelled) list;
+	# progress the player already made must not be thrown away.
+	var flags := {"pan_up": false, "pan_down": false}
+	var step := _fake_checklist_step(flags)
+	TutorialManager._captured = {"flags": flags}
+	TutorialManager._build_checklist(step)
+	flags["pan_up"] = true
+	TutorialManager._poll_checklist()
+	TutorialManager._build_checklist(step, TutorialManager._checklist_done)
+	assert_true(TutorialManager.checklist_state().get("pan_up", false))
+	assert_false(TutorialManager.checklist_state().get("pan_down", true))
+
+
+func test_t1_camera_step_requires_all_six_controls():
+	var out = TutorialScriptLib.load_lesson("res://data/tutorials/lessons/T1_basics.json")
+	assert_true(out.ok, "shipped T1 lesson must validate: %s" % str(out.errors))
+	var camera_step := {}
+	for step in out.lesson.steps:
+		if str(step.get("id", "")) == "camera":
+			camera_step = step
+	assert_false(camera_step.is_empty(), "T1 must still have a 'camera' step")
+	assert_true(bool(camera_step.get("done", {}).get("checklist", false)),
+		"the camera step must gate on the checklist, not on any single nudge")
+	var ids: Array = []
+	for item in camera_step.get("checklist", {}).get("items", []):
+		ids.append(str(item.get("id", "")))
+	for wanted in ["pan_up", "pan_down", "pan_left", "pan_right", "zoom_in", "zoom_out"]:
+		assert_true(ids.has(wanted), "camera checklist must cover '%s'" % wanted)
+
+
+func test_validate_rejects_bad_checklist():
+	var base := {"id": "x", "title": "x", "boot": {"fixture": "f"}}
+	var no_items = base.duplicate(true)
+	no_items["steps"] = [{"id": "a", "prompt": {"text": "t"},
+		"done": {"checklist": true}, "checklist": {"items": []}}]
+	assert_string_contains(" ".join(TutorialScriptLib.validate(no_items)), "non-empty")
+
+	var no_checklist = base.duplicate(true)
+	no_checklist["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true}}]
+	assert_string_contains(" ".join(TutorialScriptLib.validate(no_checklist)), "no 'checklist'")
+
+	var no_script = base.duplicate(true)
+	no_script["steps"] = [{"id": "a", "prompt": {"text": "t"}, "done": {"checklist": true},
+		"checklist": {"items": [{"id": "i", "label": "l"}]}}]
+	assert_string_contains(" ".join(TutorialScriptLib.validate(no_script)), "missing 'script'")
 
 
 # -------------------------------------------------------------- progress ---

--- a/PRPs/tutorial_system.md
+++ b/PRPs/tutorial_system.md
@@ -537,6 +537,22 @@ the scene swap (§3.1 gotcha).
       "anchor": { "node": "/root/PadHintBar" },
       "spotlight": "soft",
       "done": { "ack": true }                          // rare Continue-style step
+    },
+    {
+      // Multi-input step: teaches SEVERAL controls, so it must not advance on
+      // whichever one the player tries first (the shipped T1 "camera" step).
+      "id": "camera",
+      "prompt": { "bark": "EYES ON DA FIELD!", "kbm": "…", "pad": "…" },
+      "on_enter": { "script": "…" },                    // runs before the checklist is built
+      "checklist": {
+        "label": "Try each:",
+        "items": [
+          { "id": "pan_up", "label": "Up", "pad_label": "Up {rs}",
+            "script": "return main.camera_gesture_used(\"pan_up\")" }
+          // …one entry per control; optional per-item "device": any|pad|kbm
+        ]
+      },
+      "done": { "checklist": true }
     }
   ]
 }
@@ -547,9 +563,22 @@ Done-condition vocabulary (deliberately mirrors `_schema.md` asserts):
 (matched against `phase_action_taken` payloads, subset-match on listed keys),
 `node_visible` / `node_hidden`, `phase`, `signal` (autoload + signal name),
 `script` (multiline GDScript predicate — escape hatch, used sparingly),
-`ack`; combinators `any` / `all`. Glyph tokens: `{a}…{view}` (GlyphDB ids),
-`{key:<keybinding_id>}` (KeybindingManager display name), `{hint:<glyph>}`
-(live PadHintBar label).
+`ack`, `checklist`; combinators `any` / `all`. Glyph tokens: `{a}…{view}`
+(GlyphDB ids), `{key:<keybinding_id>}` (KeybindingManager display name),
+`{hint:<glyph>}` (live PadHintBar label).
+
+**`checklist` (multi-input steps).** A step that teaches more than one control
+declares `checklist.items`; each item's `script` predicate latches the moment it
+first goes true (on the 0.1s poll), the overlay renders a live tick list —
+outstanding items dim, ticked ones green — and `done: {"checklist": true}` fires
+only when every item is ticked. Ticks are latched, not sampled, so a momentary
+input (a pan that stops) stays ticked; a device swap rebuilds the list with the
+other device's labels and carries the ticks across. Use `on_enter.script` to
+clear whatever latch the predicates read, otherwise a player who wandered ahead
+during an earlier step arrives with boxes already ticked. `Skip Step` still
+bypasses the whole thing — a checklist can never trap a player. Rationale: the
+camera step used to advance on the first nudge of the view, so a player who
+tapped one key never discovered the other three pan directions or the zoom.
 
 ### 5.4 Determinism & the opponent
 


### PR DESCRIPTION
## Problem

The first camera step of Basic Trainin' ("'ave a look around") completed the moment the view moved at all. Its done-condition was "did `view_offset` or `view_zoom` change", so a single arrow-key tap jumped straight to the next step — the player never discovered the other three pan directions or the zoom. Reported on both Steam Deck and the itch.io build.

## Change

**New `checklist` feature for tutorial steps.** A step that teaches several controls declares `checklist.items`; each item's predicate latches the first time it goes true, the instructor card renders a live tick list (outstanding dim `○`, ticked green `✔`), and `done: {"checklist": true}` fires only once every item is ticked.

- Ticks are **latched, not sampled**, so a momentary input (a pan that stops) stays ticked.
- Items carry device-adaptive labels — `Up` on keyboard, `Up [RS]` on a pad — and a keyboard↔pad swap mid-step rebuilds the list with the other device's labels while carrying the ticks across.
- `on_enter.script` clears whatever latch the predicates read, so a player who panned during an earlier step doesn't arrive with boxes pre-ticked.
- **Skip Step still bypasses the whole thing** — a checklist can never trap a player.

**Camera gesture latching in `Main.gd`.** Tracks which gestures the player actually used, keyed by screen-space direction (`pan_up`/`pan_down`/`pan_left`/`pan_right`/`zoom_in`/`zoom_out`), across all three input paths: keyboard pan+zoom, pad right stick + triggers, and mouse wheel. Latched from the **input**, not from the resulting view change — zoom clamps at 0.1x/3.0x and a pan can no-op at the board edge, and a player sitting at a limit must still be able to tick the box off. Programmatic camera moves (focus/fit/unit-switch glide) latch nothing.

**Supporting changes.**
- `TutorialScript.validate` rejects mis-authored checklists (empty items, `done.checklist` with no checklist block, items missing `id`/`label`/`script`, duplicate ids) — a bad checklist would otherwise soft-lock or trivialise a lesson at runtime.
- `simulate_key` gained an optional `hold_s` so scenarios can genuinely hold a key across frames; camera pan/zoom are polled from `_process`, which a press/release straddling one frame may miss.
- The keyboard prompt now leads with the arrow keys — see the note below.

## Note: a pre-existing keybind collision this surfaced

`S` is both `camera_pan_down` and `toggle_stratagem_panel`; `A` is both `camera_pan_left` and `toggle_aura_rings`. Panning with WASD in any game pops the Stratagems dialog and flips the aura rings. The first scenario run hit exactly this and the dialog swallowed the next click.

Rather than change default hotkeys unilaterally, this PR steers around it: the keyboard prompt leads with the arrow keys and the scenario drives arrow keys. `KeybindingManager` already fixed the identical problem for `W` by unbinding the colliding panel, so applying the same fix to `S`/`A` is a small follow-up if wanted — it is deliberately **not** in this PR.

## Validation

Windowed scenarios (project gate — real UI, real input):

| Scenario | Result |
|---|---|
| `tut_t1_basics` | 79 passed, 0 failed |
| `tut_t1_basics_pad` | 85 passed, 0 failed |
| `tut_full_course_chain` / `_pad`, `tut_first_launch_nudge` | pass |
| `cursor_focused_zoom`, `controls_menu_mouse_wheel`, `ai_speed_top_menu_control` | pass |

Both T1 scenarios now assert the actual regression: one gesture does **not** advance the step, five of six does **not**, and only all six does — plus that the tick list is visible on the instructor card. Screenshots (`02b_camera_checklist_partial`) confirm the row renders correctly on keyboard and pad. Debug log clean — no `ERROR` / `SCRIPT ERROR` while driving the step.

Headless: new `tests/test_tutorial_checklist.gd` (31 checks) added to the maintained gate; full `run_pretrigger_tests.sh` run is **2173 passed, 0 failed across 104 tests**.

Not run: the checklist cases added to `tests/unit/test_tutorial_engine.gd`. That GUT suite is documented as unmaintained and hangs on network listeners (no output in 4+ minutes) — which is why the real regression net went into the maintained `-s` runner instead.

Version bumped to 1.5.0 with a player-facing changelog entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_017aNa2WhBUPG6QUE5XUvmgp)_