### PR TITLE
Track the missing .uid for test_tutorial_checklist.gd

### DIFF
--- a/40k/tests/test_tutorial_checklist.gd.uid
+++ b/40k/tests/test_tutorial_checklist.gd.uid
@@ -1,0 +1,1 @@
+uid://chrvv44t2je2j


### PR DESCRIPTION
PR #774 added `40k/tests/test_tutorial_checklist.gd` without the `.uid` file Godot 4.4 generates alongside every script.

Every other test script in the repo has one tracked — 398 under `40k/tests/` alone — and nothing in either `.gitignore` excludes them, so this is an oversight rather than a convention. Without it, each machine that opens or imports the project mints its own UID and the file shows up as untracked churn (which is exactly how it surfaced here, after running `godot --headless --path 40k --import`).

One file, generated by the engine's own import pass. No code or behaviour change.

## Note

The UID value (`uid://chrvv44t2je2j`) is the one generated in this container. If someone's editor has already minted a different UID locally, theirs will conflict on first import after this lands — resolve in favour of the committed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5tHUChYjAh23odbKwVS3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01T5tHUChYjAh23odbKwVS3w)_