### PR TITLE
Tutorial: the pad's A button presses the instructor card's Continue

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -149,6 +149,22 @@ const HINTS_FOCUS := [
 	["a", "Press"],
 	["b", "Back To Board"],
 ]
+# The tutorial's instructor card is waiting on a button press — a "Continue"
+# step (ack) or the end-of-lesson summary. The card owns A while it is up
+# (TutorialOverlay._input), so the bar promises exactly that and nothing the
+# card would swallow. Reported trap: at T1 step 7 ("Read da Bar") a pad player
+# had no advertised way to press Continue and had to hunt for it with the
+# left-stick cursor — the bar now answers its own lesson.
+const HINTS_TUTORIAL_ACK := [
+	["a", "Continue"],
+	["ls", "Point"],
+	["view", "Pause Menu"],
+]
+const HINTS_TUTORIAL_SUMMARY := [
+	["dpad", "Navigate"],
+	["a", "Choose"],
+	["ls", "Point"],
+]
 # Charge carry (one model at a time): the plain set — no per-model advance and
 # no group grab, so neither "X Finish Model" nor "dpad Grab All". Start drops
 # the held model and confirms the charge when every declared target is reached.
@@ -2134,6 +2150,16 @@ func refresh_hints() -> void:
 	_update_hints()
 
 
+# "", "ack" or "summary" — whether the tutorial instructor card is waiting on a
+# button press (TutorialOverlay.pad_ack_state). Empty outside a lesson and in
+# harnesses that run without the tutorial autoloads.
+func _tutorial_ack_state() -> String:
+	var overlay := get_node_or_null("/root/TutorialOverlay")
+	if overlay == null or not overlay.has_method("pad_ack_state"):
+		return ""
+	return str(overlay.pad_ack_state())
+
+
 # The FightController while the Fight phase is live, else null. Used by the
 # bumper button-cycle and the fight hint sets so each reads the same authority.
 func _fight_controller() -> Node:
@@ -2149,6 +2175,12 @@ func _fight_controller() -> Node:
 
 
 func _update_hints() -> void:
+	# The tutorial card is modal-in-spirit while it waits on a press: it owns A
+	# and keeps focus, so every other promise on the bar would be a lie.
+	var tutorial_ack := _tutorial_ack_state()
+	if tutorial_ack != "":
+		PadHintBar.set_hints(HINTS_TUTORIAL_SUMMARY if tutorial_ack == "summary" else HINTS_TUTORIAL_ACK)
+		return
 	var hints := HINTS_BOARD
 	if carry_active:
 		if group_carry_active:

--- a/40k/autoloads/TutorialManager.gd
+++ b/40k/autoloads/TutorialManager.gd
@@ -394,6 +394,14 @@ func _show_current_step() -> void:
 func refresh_prompt() -> void:
 	if not active:
 		return
+	# The lesson stays active under the end-of-lesson summary card, and
+	# current_step_index still points at the last step — re-rendering it here
+	# would replace the summary with a step the player already finished. The
+	# overlay re-applies its own device-dependent dressing on the same signal.
+	var overlay_now := get_node_or_null("/root/TutorialOverlay")
+	if overlay_now != null and overlay_now.has_method("pad_ack_state") \
+			and str(overlay_now.pad_ack_state()) == "summary":
+		return
 	# Item labels (and which items apply at all) are device-dependent, so a
 	# pad<->keyboard swap mid-step has to rebuild the list — carrying the
 	# already-ticked ids across so the player never loses progress.

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -24,7 +24,8 @@
       "id": "welcome",
       "prompt": {
         "bark": "OI, LISTEN UP!",
-        "text": "Welcome to Basic Trainin'. You know da rules of da tabletop — dis teaches how [b]da app[/b] works. Use [i]Skip Step[/i] or [i]Exit Tutorial[/i] up 'ere any time."
+        "kbm": "Welcome to Basic Trainin'. You know da rules of da tabletop — dis teaches how [b]da app[/b] works. Use [i]Skip Step[/i] or [i]Exit Tutorial[/i] up 'ere any time.",
+        "pad": "Welcome to Basic Trainin'. You know da rules — dis teaches how [b]da app[/b] works. Whenever dis card shows [b]Continue[/b], press {a}. [i]Skip Step[/i] an' [i]Exit Tutorial[/i] are up 'ere too."
       },
       "spotlight": "none",
       "allow": [],
@@ -161,7 +162,7 @@
       "device": "pad",
       "prompt": {
         "bark": "READ DA BAR!",
-        "pad": "Dat strip at da bottom always shows wot each button does [i]right now[/i]. It changes wiv da situation — when in doubt, read da bar."
+        "pad": "Dat strip at da bottom always shows wot each button does [i]right now[/i]. It changes wiv da situation — when in doubt, read da bar. Right now it says {a} Continue, so squeeze {a} to carry on."
       },
       "anchor": {
         "node": "/root/PadHintBar"
@@ -170,6 +171,9 @@
       "allow": [],
       "done": {
         "ack": true
+      },
+      "hint": {
+        "pad": "Da bar 'as da answer: press {a} to hit [b]Continue[/b]. Or point {ls} at da button an' press {a} — bofe work."
       }
     },
     {

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.2",
+      "date": "2026-07-27",
+      "summary": "On a controller, the tutorial's Continue button is now just the A button — Basic Trainin' step 7 ('Read da Bar') could leave you stuck with no obvious way to move on.",
+      "changes": [
+        "Fixed being stuck on a controller whenever a tutorial card asked you to press Continue — most obviously at Basic Trainin' step 7, 'Read da Bar'. The only way past it was to steer the pointer onto the button with the left stick and click it, which nothing told you to do. Pressing A now presses the card's button, wherever the pointer happens to be.",
+        "The card now shows an [A] badge next to Continue, and the button is outlined so you can see it is selected.",
+        "The hint bar at the bottom of the screen now reads 'A Continue' while a tutorial card is waiting — so the 'read da bar' step answers its own question. The end-of-lesson card reads 'Navigate / Choose' and the D-pad moves between Next Lesson and Back to Menu.",
+        "The D-pad can no longer wander off the tutorial card while it is waiting for you, so you can't lose the Continue button in the side panels.",
+        "Basic Trainin's opening card and the 'Read da Bar' step now say outright that A is Continue."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/scripts/tutorial/TutorialOverlay.gd
+++ b/40k/scripts/tutorial/TutorialOverlay.gd
@@ -4,14 +4,17 @@ extends CanvasLayer
 # spotlight ring. CanvasLayer 93 — above PadActionBar (92), below VirtualCursor
 # (95) so the pad cursor stays visible, below ToastManager (100).
 #
-# The overlay never consumes _input (the pad input chain order is load-bearing,
-# PadRouter.gd:76-80); all its controls are plain buttons the mouse or the
-# virtual cursor can click. Colors come from UIConstants / WhiteDwarfTheme —
-# no new hex literals (design guidelines §9).
+# The overlay consumes exactly ONE input (the pad input chain order is
+# load-bearing otherwise, PadRouter.gd:76-80): the pad's select button while
+# the card is waiting on a Continue / Next Lesson press — see _input(). Every
+# other control stays a plain button the mouse or the virtual cursor can click.
+# Colors come from UIConstants / WhiteDwarfTheme — no new hex literals (design
+# guidelines §9).
 
 const WhiteDwarfThemeData = preload("res://scripts/WhiteDwarfTheme.gd")
 const UIConstantsData = preload("res://autoloads/UIConstants.gd")
 const AnchorResolverLib = preload("res://scripts/tutorial/AnchorResolver.gd")
+const GlyphDB = preload("res://scripts/input/GlyphDB.gd")
 
 const CARD_TOP_OFFSET := 96.0
 const CARD_BOTTOM_OFFSET := 132.0  # keeps clear of the pad hint bar
@@ -30,6 +33,7 @@ var _skip_button: Button
 var _exit_button: Button
 var _next_button: Button
 var _menu_button: Button
+var _ack_glyph: HBoxContainer   # [A] badge shown beside Continue on a pad
 
 var _checklist_label: String = ""
 var _anchor_spec: Dictionary = {}
@@ -47,6 +51,16 @@ func _ready() -> void:
 	_build()
 	visible = false
 	set_process(false)
+	# The card's pad affordances (the [A] badge, which button holds focus, the
+	# hint-bar promise) are all device-dependent — re-apply them whenever the
+	# player swaps between pad and mouse mid-card, and re-render the badge when
+	# a controller remap moves the select role to a different button.
+	var idm := get_node_or_null("/root/InputDeviceManager")
+	if idm != null and idm.has_signal("device_changed"):
+		idm.device_changed.connect(func(_mode): _apply_pad_affordances(false))
+	var pb := get_node_or_null("/root/PadBindings")
+	if pb != null and pb.has_signal("pad_binding_changed"):
+		pb.pad_binding_changed.connect(func(_role_id): _rebuild_ack_glyph())
 
 
 func _mgr() -> Node:
@@ -189,6 +203,18 @@ func _build() -> void:
 	_progress_label.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	footer.add_child(_progress_label)
 
+	# Pad players had no way of knowing the card's Continue was reachable at all
+	# — the reported "Read da Bar" dead end, where the only way forward was to
+	# discover the left-stick cursor and click the button with it. The badge
+	# names the button that presses it (kept OUTSIDE the Button so its text
+	# stays exactly "Continue" — windowed scenarios address it by text).
+	_ack_glyph = HBoxContainer.new()
+	_ack_glyph.name = "AckGlyph"
+	_ack_glyph.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	_ack_glyph.visible = false
+	footer.add_child(_ack_glyph)
+	_rebuild_ack_glyph()
+
 	_continue_button = Button.new()
 	_continue_button.name = "ContinueButton"
 	_continue_button.text = "Continue"
@@ -238,6 +264,152 @@ func _build() -> void:
 	footer.add_child(_exit_button)
 
 	_place_card("top")
+
+
+# ------------------------------------------------------- pad affordances ----
+#
+# THE PROBLEM THIS SOLVES (reported on the Steam Deck at T1 step 7, "Read da
+# Bar"): the card's Continue button was focus-grabbed on pad, but the moment
+# the player had touched the left stick — which every earlier step asks them to
+# do — VirtualCursor is in CURSOR mode and consumes A as a synthetic click AT
+# THE CURSOR (VirtualCursor.gd:248-256). So A did nothing unless the cursor
+# happened to be parked on top of Continue, and the ONLY way past an ack step
+# was to hunt the button down with the stick. Three fixes, together:
+#   1. _input() below: while the card waits on a press, the pad's select button
+#      presses it — cursor mode or not, focus or not.
+#   2. the [A] badge beside the button + the hint bar's "Ⓐ Continue" chip
+#      (PadRouter.HINTS_TUTORIAL_ACK) say so on screen.
+#   3. focus is parked on the card and kept there (_wire_card_focus +
+#      the _process re-grab), so the gold PadFocusRing marks the button and no
+#      D-pad press can strand the player in a HUD panel with no way back.
+
+
+# "" (nothing pending), "ack" (a Continue step) or "summary" (the end-of-lesson
+# card). Read by PadRouter for the hint bar, and by windowed scenarios.
+func pad_ack_state() -> String:
+	if not visible:
+		return ""
+	if _continue_button != null and _continue_button.visible:
+		return "ack"
+	if (_next_button != null and _next_button.visible) or (_menu_button != null and _menu_button.visible):
+		return "summary"
+	return ""
+
+
+# The card button the pad's select button should press: whichever of them holds
+# focus, else the leading one (Continue on a step, Next Lesson on a summary).
+func _pad_ack_button() -> Button:
+	if not visible:
+		return null
+	var focused := get_viewport().gui_get_focus_owner()
+	var candidates: Array = []
+	for b in [_continue_button, _next_button, _menu_button]:
+		if b != null and b.visible and not b.disabled:
+			candidates.append(b)
+	for b in candidates:
+		if b == focused:
+			return b
+	return candidates[0] if not candidates.is_empty() else null
+
+
+func _rebuild_ack_glyph() -> void:
+	if _ack_glyph == null:
+		return
+	for child in _ack_glyph.get_children():
+		child.queue_free()
+	# Label-less chip: the button text next to it already says "Continue".
+	_ack_glyph.add_child(GlyphDB.make_chip("a", ""))
+
+
+# Keep D-pad focus navigation INSIDE the card while it is waiting on a press:
+# left/right walk the card's own buttons, up/down/tab stay put. Without this a
+# D-pad press walks focus off into the HUD and the player has no way back to
+# Continue (the reported "I can't get to the button" trap).
+func _wire_card_focus(buttons: Array) -> void:
+	for i in range(buttons.size()):
+		var b: Button = buttons[i]
+		var prev: Button = buttons[max(i - 1, 0)]
+		var nxt: Button = buttons[min(i + 1, buttons.size() - 1)]
+		b.focus_neighbor_left = b.get_path_to(prev)
+		b.focus_neighbor_right = b.get_path_to(nxt)
+		b.focus_neighbor_top = b.get_path_to(b)
+		b.focus_neighbor_bottom = b.get_path_to(b)
+		b.focus_next = b.get_path_to(nxt)
+		b.focus_previous = b.get_path_to(prev)
+
+
+# `grab` = take focus now (a freshly shown card); false only re-applies the
+# device-dependent dressing (a mid-card device swap / remap).
+func _apply_pad_affordances(grab: bool) -> void:
+	if _continue_button == null:
+		return  # _build() has not run yet
+	var idm := get_node_or_null("/root/InputDeviceManager")
+	var pad: bool = idm != null and idm.is_pad_active()
+	_ack_glyph.visible = pad and visible and _continue_button.visible
+	var buttons: Array = []
+	for b in [_continue_button, _next_button, _menu_button]:
+		if b.visible:
+			buttons.append(b)
+	if pad and visible and not buttons.is_empty():
+		_wire_card_focus(buttons)
+		# Hand the pad back to FOCUS mode: parked, A means "press the
+		# highlighted card button" (and the focus ring shows which). A live
+		# model carry owns the cursor, so never yank it out from under one.
+		var vc := get_node_or_null("/root/VirtualCursor")
+		var router := get_node_or_null("/root/PadRouter")
+		if vc != null and (router == null or not router.is_carrying()):
+			vc.park()
+		if grab or get_viewport().gui_get_focus_owner() == null:
+			buttons[0].grab_focus()
+	_refresh_pad_hints()
+
+
+# The hint bar reads pad_ack_state() itself; poke it so the promise flips the
+# moment the card appears or clears, rather than on the next button press.
+func _refresh_pad_hints() -> void:
+	var router := get_node_or_null("/root/PadRouter")
+	if router != null and router.has_method("refresh_hints"):
+		router.refresh_hints()
+
+
+# The one consumed input (see the header + the block comment above): the pad's
+# select button presses the card's pending button. Runs BEFORE VirtualCursor in
+# the _input chain (autoload order: … PadRouter, VirtualCursor, … ,
+# TutorialOverlay, TutorialManager, Main — _input walks the tree in reverse),
+# so it wins over the cursor's synthetic click.
+func _input(event: InputEvent) -> void:
+	if not visible:
+		return
+	if not (event is InputEventJoypadButton) or not event.pressed:
+		return
+	var idm := get_node_or_null("/root/InputDeviceManager")
+	if idm == null or not idm.is_pad_active():
+		return  # first press of a session claims pad mode (PadRouter); act on the next
+	var pb := get_node_or_null("/root/PadBindings")
+	var button: int = pb.canonical(event.button_index) if pb != null else event.button_index
+	if button != JOY_BUTTON_A:
+		return
+	# An embedded game dialog and the pad action bar are each modal over the
+	# card — they own A while they are up.
+	if _any_game_window_open():
+		return
+	var bar := get_node_or_null("/root/PadActionBar")
+	if bar != null and bar.has_method("is_open") and bar.is_open():
+		return
+	# Cursor mode with the pointer resting ON the card: the aim is explicit, so
+	# let the cursor's own click pick the button. Gliding onto "Back to Menu"
+	# must not press the focused "Next Lesson", and Skip Step / Exit Tutorial
+	# stay clickable. Anywhere else — over the board, over a HUD panel the last
+	# step left the cursor on, or parked — A belongs to the card.
+	var vc := get_node_or_null("/root/VirtualCursor")
+	var hovered := get_viewport().gui_get_hovered_control()
+	if vc != null and vc.is_cursor_active() and hovered != null and _card.is_ancestor_of(hovered):
+		return
+	var target := _pad_ack_button()
+	if target == null:
+		return
+	get_viewport().set_input_as_handled()
+	target.emit_signal("pressed")
 
 
 # Card placement modes: "top" (default), "bottom" (dodging a board anchor),
@@ -303,9 +475,7 @@ func show_step(view: Dictionary) -> void:
 	_reresolve_accum = ANCHOR_RERESOLVE_S  # resolve on next frame
 	if _card_mode != "top":
 		_place_card("top")
-	var idm := get_node_or_null("/root/InputDeviceManager")
-	if _continue_button.visible and idm != null and idm.is_pad_active():
-		_continue_button.grab_focus()
+	_apply_pad_affordances(true)
 	_spotlight.queue_redraw()
 
 
@@ -359,12 +529,7 @@ func show_summary(view: Dictionary) -> void:
 	for strip in _dim_strips:
 		strip.visible = false
 	_place_card("top")
-	var idm := get_node_or_null("/root/InputDeviceManager")
-	if idm != null and idm.is_pad_active():
-		if _next_button.visible:
-			_next_button.grab_focus()
-		else:
-			_menu_button.grab_focus()
+	_apply_pad_affordances(true)
 	_spotlight.queue_redraw()
 
 
@@ -377,6 +542,9 @@ func hide_all() -> void:
 	_spotlight_mode = "none"
 	for strip in _dim_strips:
 		strip.visible = false
+	_ack_glyph.visible = false
+	# Hand the hint bar back to the board context — the card no longer owns A.
+	_refresh_pad_hints()
 
 
 func shake() -> void:
@@ -406,6 +574,7 @@ func current_checklist_text() -> String:
 
 func _process(delta: float) -> void:
 	_update_card_mode()
+	_keep_ack_focus()
 	if _anchor_spec.is_empty():
 		_anchor_ok = false
 		_spotlight.queue_redraw()
@@ -431,6 +600,21 @@ func _process(delta: float) -> void:
 			_scroll_anchor_into_view(res.node)
 	_update_dim_strips()
 	_spotlight.queue_redraw()
+
+
+# A B press (PadRouter._handle_back), a stray cursor click on the board or a
+# panel rebuild can all drop focus. While the card is waiting on a press the
+# ring must come back on its own, or the player is left with no visible
+# selection and no obvious way to make one.
+func _keep_ack_focus() -> void:
+	if get_viewport().gui_get_focus_owner() != null:
+		return
+	var idm := get_node_or_null("/root/InputDeviceManager")
+	if idm == null or not idm.is_pad_active():
+		return
+	var target := _pad_ack_button()
+	if target != null:
+		target.grab_focus()
 
 
 func _scroll_anchor_into_view(node: Node) -> void:

--- a/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
+++ b/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
@@ -1,0 +1,433 @@
+{
+  "id": "tut_t1_pad_ack_button",
+  "covers": [
+    "tutorial.t1.basics.pad",
+    "tutorial.overlay.pad_ack",
+    "pad.hint_bar.tutorial"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Reported Steam Deck trap: at T1 step 7 (READ DA BAR) a gamepad player could not press the instructor card's Continue button at all - once the left stick had been touched, VirtualCursor owns A as a click AT THE CURSOR, so the only way past an ack step was to hunt the button down with the stick. This scenario drives the lesson with the pad and NEVER glides onto Continue: A alone advances every ack step, with the cursor deliberately parked in the far corner of the screen to prove it is not a synthetic click landing on the button. Also asserts the on-screen affordances that tell the player so - the [A] badge beside Continue, the gold focus ring on the button, and the hint bar's own 'A Continue' chip (the step's whole lesson is 'read da bar', so the bar must answer it).",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var mm = tree.root.get_node_or_null(\"/root/MainMenu\")\nif mm != null and mm._tutorial_nudge != null and mm._tutorial_nudge.visible:\n\tmm._tutorial_nudge._on_dismiss()\n\tvar q = [mm]\n\twhile not q.is_empty():\n\t\tvar n = q.pop_back()\n\t\tif n is Button and str(n.name) == \"StartButton\":\n\t\t\tn.grab_focus()\n\t\t\tbreak\n\t\tfor c in n.get_children():\n\t\t\tq.append(c)\nreturn TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": false,
+      "comment": "retire the first-launch nudge so this scenario also runs standalone on a pristine profile (the suite otherwise relies on tut_first_launch_nudge having run first) - it would sit over the menu buttons the D-pad is about to walk"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9,
+      "comment": "LB claims pad mode on the main menu"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 12
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialPicker",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "welcome"
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node(\"/root/TutorialOverlay\").pad_ack_state()",
+      "equals": "ack"
+    },
+    {
+      "act": "execute_script",
+      "script": "var f = tree.root.get_viewport().gui_get_focus_owner()\nreturn f != null and str(f.name) == \"ContinueButton\"",
+      "multiline": true,
+      "equals": true,
+      "comment": "the card takes focus on a pad, so the gold PadFocusRing marks Continue"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadFocusRing.is_ring_visible()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"a\")",
+      "equals": "Continue",
+      "comment": "the bar promises exactly what A does while the card waits"
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node(\"/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/AckGlyph\").visible",
+      "equals": true,
+      "comment": "[A] badge sits beside the button so the affordance is on the card too"
+    },
+    {
+      "act": "screenshot",
+      "label": "01_welcome_ack_affordances"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "A alone - no glide, no cursor - presses Continue"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "camera"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"a\")",
+      "not_equals": "Continue",
+      "comment": "and the bar hands straight back to the board context once the card is done with A"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": -1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": -1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 5,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 4,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "select_wagon"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 10
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "open_datasheet"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 3
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 3
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "dice_log"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Dice Log",
+      "comment": "the ONE glide in this run - the step teaches the cursor, and it is what leaves the cursor active and armed the reported trap"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "hint_bar",
+      "comment": "STEP 7 - the reported dead end"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 60.0,
+      "y": 60.0,
+      "space": "screen",
+      "comment": "shove the cursor into the far corner: whatever A does next, it is NOT a click on Continue"
+    },
+    {
+      "act": "execute_script",
+      "script": "var vc = tree.root.get_node(\"/root/VirtualCursor\")\nvar btn = tree.root.get_node(\"/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/ContinueButton\")\nreturn not btn.get_global_rect().grow(40.0).has_point(vc.get_cursor_pos())",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"a\")",
+      "equals": "Continue",
+      "comment": "the step tells the player to read the bar - so the bar had better say how to leave the step"
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"[A]\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "and the prompt itself names the button ({a} renders as the live [A] chip)"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_read_da_bar_step7"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase_intro",
+      "comment": "THE FIX: A advanced step 7 with the cursor parked in the opposite corner"
+    },
+    {
+      "act": "screenshot",
+      "label": "03_advanced_past_step7"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 13,
+      "comment": "D-pad down on an ack step must NOT strand focus in a HUD panel"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "execute_script",
+      "script": "var f = tree.root.get_viewport().gui_get_focus_owner()\nreturn f != null and str(f.name) == \"ContinueButton\"",
+      "multiline": true,
+      "equals": true,
+      "comment": "focus is locked to the card while it waits, so there is always a way back"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "move_grots"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_GRETCHIN_T"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_GRETCHIN_T"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 1000.0,
+      "y": 724.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "confirm_grots"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "End This Unit's Move"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 25
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "wrap"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "final ack, again with A only"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/BackToMenuButton",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "tree.root.get_node(\"/root/TutorialOverlay\").pad_ack_state()",
+      "equals": "summary"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"a\")",
+      "equals": "Choose",
+      "comment": "two buttons on the summary card, so the bar advertises navigate-then-choose"
+    },
+    {
+      "act": "execute_script",
+      "script": "var f = tree.root.get_viewport().gui_get_focus_owner()\nreturn f != null and str(f.name) == \"NextLessonButton\"",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "04_summary_pad_focus"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 14,
+      "comment": "D-pad right walks WITHIN the card - Next Lesson -> Back to Menu"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "execute_script",
+      "script": "var f = tree.root.get_viewport().gui_get_focus_owner()\nreturn f != null and str(f.name) == \"BackToMenuButton\"",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 3.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/ScrollContainer",
+      "timeout_s": 5.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.active",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.is_completed(\"t1_basics\")",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "05_back_at_menu"
+    }
+  ]
+}


### PR DESCRIPTION
## The bug

Reported on the Steam Deck at Basic Trainin' step 7 ("Read da Bar"): there was no way to get past the instructor card.

The Continue button *was* being focus-grabbed on a pad — the fix is not "wire up focus". The real cause is `VirtualCursor`: the moment the player has touched the left stick — which steps 2 and 6 both require — it is in CURSOR mode and consumes A as a synthetic click **at the cursor position** (`VirtualCursor.gd:248-256`). At step 7 the cursor was parked on the Dice Log tab from the previous step, so A clicked a log tab and the focused Continue never fired. Hunting the button down with the stick was genuinely the only way through, and nothing on screen said so.

## The fix

- **`TutorialOverlay._input`** — the one input the overlay consumes: while the card is waiting on a press, the pad's select button presses it. The overlay sits after `VirtualCursor` in the autoload list, so its `_input` runs first and wins over the cursor's synthetic click. Carve-out: with the cursor active **and** resting on the card, the event falls through so the pointer picks the button (gliding onto "Back to Menu" must not press the focused "Next Lesson"; Skip Step / Exit Tutorial stay clickable).
- **The card says so** — an `[A]` badge beside Continue (kept outside the Button so its text stays exactly `"Continue"` for the scenario resolver), and the pad is handed back to FOCUS mode so the gold `PadFocusRing` outlines the button.
- **The bar says so** — `HINTS_TUTORIAL_ACK` / `HINTS_TUTORIAL_SUMMARY`: `Ⓐ Continue` while a card waits, `✚ Navigate · Ⓐ Choose` on the summary. The step whose whole lesson is *"read da bar"* now has the bar answer its own question.
- **No way to lose the card** — focus neighbours are wired within the card's own buttons and re-grabbed if anything drops them, so no D-pad press can strand the player in a HUD panel with no way back.
- T1's `welcome` and `hint_bar` prompts now say outright that A is Continue, and `hint_bar` gains a 25s hint naming both routes.

Also fixes a device swap on the end-of-lesson summary replacing it with the last step: `refresh_prompt` now stands down while the summary is up (the lesson stays active under it and `current_step_index` still points at the last step).

## Validation

New windowed scenario `tut_t1_pad_ack_button` drives T1 on a pad and **never glides onto Continue** — A alone advances every ack step, with the cursor deliberately parked in the opposite corner at step 7 to prove it is not a click landing on the button. It asserts the `[A]` badge, the focus ring, the hint-bar chip, the D-pad focus lock, and summary navigation. **87/87.**

- Full tutorial suite green: **17/17**.
- The regression this caught mid-run — pad summary "Back to Menu" pressing "Next Lesson" — is exactly what the cursor carve-out above fixes.
- `pad_m0_menu_nav` (15/4) and `pad_move_staged_hint_labels` (36/1) fail **identically with and without** this change; verified against a stashed baseline. Stale expectations (menu button order, movement hint labels), pre-existing, left alone.
- No `ERROR` lines from this code in the debug log during the runs.

One deliberate trade-off: during an ack step, A goes to the card even if the cursor is over some other HUD control. The mouse still clicks it, and guaranteeing the player can always leave the step is worth more than clicking a log tab with A.

Version bumped to 1.5.2 with a player-facing changelog entry.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZV2iEzfHhsEAvbjQptaFP

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZV2iEzfHhsEAvbjQptaFP)_