### PR TITLE
Tutorial: teach controller players the pause menu instead of Shift+/

### DIFF
--- a/40k/autoloads/TutorialManager.gd
+++ b/40k/autoloads/TutorialManager.gd
@@ -334,10 +334,8 @@ func _enter_step(index: int) -> void:
 	var step: Dictionary = _steps[index]
 
 	# Device-filtered steps (PRP §4.4) are skipped silently on the other device.
-	var dev := str(step.get("device", "any"))
-	if (dev == "pad" and not InputDeviceManager.is_pad_active()) \
-			or (dev == "kbm" and InputDeviceManager.is_pad_active()):
-		print("TutorialManager: skipping step '%s' (device=%s)" % [str(step.get("id", "")), dev])
+	if not _step_matches_device(step):
+		print("TutorialManager: skipping step '%s' (device=%s)" % [str(step.get("id", "")), str(step.get("device", "any"))])
 		_enter_step(index + 1)
 		return
 
@@ -394,12 +392,32 @@ func _show_current_step() -> void:
 func refresh_prompt() -> void:
 	if not active:
 		return
-	# Item labels (and which items apply at all) are device-dependent, so a
-	# pad<->keyboard swap mid-step has to rebuild the list — carrying the
-	# already-ticked ids across so the player never loses progress.
 	if current_step_index >= 0 and current_step_index < _steps.size():
+		# A mid-step device swap can strand the player on a step authored for the
+		# device they just put down — the Steam Deck is the live case: its right
+		# trackpad emits real mouse motion, so KBM gets claimed, a keyboard-only
+		# step is entered, and the pad can then never satisfy it (the player is
+		# told to press Shift+/ on a machine with no keyboard). Re-entering the
+		# step runs the same device filter _enter_step applies, which skips it
+		# forward to the variant that matches the device now in the player's hands.
+		if not _step_matches_device(_steps[current_step_index]):
+			_enter_step(current_step_index)
+			return
+		# Item labels (and which items apply at all) are device-dependent, so a
+		# pad<->keyboard swap mid-step has to rebuild the list — carrying the
+		# already-ticked ids across so the player never loses progress.
 		_build_checklist(_steps[current_step_index], _checklist_done)
 	_show_current_step()
+
+
+# "any" steps run on both devices; "pad"/"kbm" steps only on theirs.
+func _step_matches_device(step: Dictionary) -> bool:
+	var dev := str(step.get("device", "any"))
+	if dev == "pad":
+		return InputDeviceManager.is_pad_active()
+	if dev == "kbm":
+		return not InputDeviceManager.is_pad_active()
+	return true
 
 
 func _is_ack_step(step: Dictionary) -> bool:

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -16,6 +16,7 @@
       "Units: pick 'em from da list or da board, datasheet for da full stats.",
       "Da left panel logs everyfing — Game Log an' Dice Log tabs.",
       "Da big red button ends da phase. Da small one ends a unit's move.",
+      "Forgot a control? Da pause menu (Escape, or View on a pad) lists every key under Controls an' every button under Controller.",
       "Next lesson: Musterin' da Boyz — deployment, transports an' leaders."
     ]
   },
@@ -173,29 +174,47 @@
       }
     },
     {
-      "id": "hotkey_help_open",
-      "device": "kbm",
+      "id": "controls_reference_open",
       "prompt": {
         "bark": "DA CHEAT SHEET!",
-        "kbm": "Press {key:hotkey_help} to see every keyboard shortcut in da game."
+        "kbm": "Press {key:hotkey_help} to see every keyboard shortcut in da game.",
+        "pad": "Press {view} for da pause menu. Da [b]Controller[/b] tab lists every button ya got — an' lets ya swap 'em about."
       },
       "spotlight": "none",
       "allow": [],
       "done": {
-        "node_visible": "/root/Main/HotkeyHelpOverlay"
+        "any": [
+          {
+            "node_visible": "/root/Main/HotkeyHelpOverlay"
+          },
+          {
+            "node_visible": "/root/Main/SettingsMenu"
+          }
+        ]
+      },
+      "hint": {
+        "kbm": "No keyboard handy (Steam Deck an' such)? Grab da pad: {view} opens da pause menu, an' da [b]Controller[/b] tab lists every button.",
+        "pad": "{view} is da ⧉ View/Select button — dat opens da pause menu. Da tab row is along da top: land on [b]Controller[/b] an' press {a}."
       }
     },
     {
-      "id": "hotkey_help_close",
-      "device": "kbm",
+      "id": "controls_reference_close",
       "prompt": {
         "bark": "BACK TO WORK!",
-        "kbm": "Press {key:hotkey_help} again to put da cheat sheet away."
+        "kbm": "Press {key:hotkey_help} again to put da cheat sheet away.",
+        "pad": "Give da [b]Controller[/b] tab a butcher's, den press {b} (or {view}) to shut da menu."
       },
       "spotlight": "none",
       "allow": [],
       "done": {
-        "node_hidden": "/root/Main/HotkeyHelpOverlay"
+        "all": [
+          {
+            "node_hidden": "/root/Main/HotkeyHelpOverlay"
+          },
+          {
+            "node_hidden": "/root/Main/SettingsMenu"
+          }
+        ]
       }
     },
     {

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.2",
+      "date": "2026-07-27",
+      "summary": "Basic Trainin' no longer tells controller and Steam Deck players to press Shift+/ — the shortcuts step now teaches the pause menu's Controller tab, and the tutorial follows you when you switch between pad and trackpad mid-step.",
+      "changes": [
+        "The 'DA CHEAT SHEET!' step of Basic Trainin' used to be keyboard-only: on a Steam Deck it told you to press Shift+/ to list the shortcuts, a key combination a Deck has no keys for, and the step could not be finished. On a controller it now says to press View/Select for the pause menu and read the Controller tab, which lists every pad button and lets you remap them.",
+        "Pick up the controller mid-step and the tutorial now moves on from steps written for the other device instead of leaving you stuck on one you cannot complete. This bit Steam Deck players in particular, because the Deck's right trackpad counts as a mouse and quietly flips the game into keyboard mode.",
+        "The keyboard shortcut list (Shift+/) now also points controller players at Pause Menu → Settings → Controller for the pad layout."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -13207,6 +13207,18 @@ func _refresh_vp_timeline_panel() -> void:
 	totals.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	_vp_timeline_list.add_child(totals)
 
+func _pause_button_glyph() -> String:
+	# "⧉ View" by default; follows a Settings › Controller remap of the Pause
+	# Menu role. Autoload fetched by path so the bare headless harness (which
+	# runs without PadBindings) still gets a sensible label.
+	var pb := get_node_or_null("/root/PadBindings")
+	if pb != null and pb.has_method("button_full_name") and pb.has_method("get_button"):
+		var g: String = str(pb.button_full_name(pb.get_button("pad_pause")))
+		if g != "":
+			return g
+	return "⧉ View (Select)"
+
+
 func _toggle_hotkey_help_overlay() -> void:
 	if _hotkey_help_overlay and is_instance_valid(_hotkey_help_overlay):
 		_hotkey_help_overlay.queue_free()
@@ -13276,6 +13288,17 @@ func _toggle_hotkey_help_overlay() -> void:
 	hint.add_theme_font_size_override("font_size", 12)
 	hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	vbox.add_child(hint)
+	# Controller route to the same information. This help screen is keyboard-only
+	# by nature (and Shift+/ is unpressable on a Steam Deck in Game Mode), so
+	# always point pad players at the Controller tab, which lists every pad
+	# button and lets them remap it. Glyph comes from PadBindings so a remapped
+	# Pause Menu role shows the button it is actually on now.
+	var pad_hint := Label.new()
+	pad_hint.name = "PadRouteHint"
+	pad_hint.text = "On a controller: %s (Pause Menu) → Settings → Controller lists every pad button" % _pause_button_glyph()
+	pad_hint.add_theme_font_size_override("font_size", 12)
+	pad_hint.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	vbox.add_child(pad_hint)
 	add_child(_hotkey_help_overlay)
 	_hotkey_help_overlay.z_index = UI_OVERLAY_Z
 	print("Main: Hotkey help overlay opened")

--- a/40k/tests/scenarios/sp/tut_device_swap_midstep.json
+++ b/40k/tests/scenarios/sp/tut_device_swap_midstep.json
@@ -1,0 +1,147 @@
+{
+  "id": "tut_device_swap_midstep",
+  "covers": [
+    "tutorial.engine.device_adaptive",
+    "tutorial.engine.device_swap"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Reported on Steam Deck: the tutorial's controls-reference step told a controller player to press Shift+/ - a chord the Deck has no keys for - and the step could not be completed. Root cause: the Deck's right trackpad emits REAL mouse motion, so the device tracker claims KBM, a keyboard-only step is entered, and picking the pad back up left the player stranded on it (the device filter only ran on step ENTRY). This scenario reproduces the swap with a genuine buttonless mouse-motion event: on the pad-only hint-bar step it moves the 'trackpad', asserts the tutorial leaves the step that no longer matches the device instead of stranding, and then asserts the controls-reference prompt itself re-renders per device - pad wording (pause menu -> Controller tab) with a pad in hand, keyboard wording after the trackpad claims KBM.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 2.0
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var mm = tree.root.get_node(\"/root/MainMenu\")\nvar n = mm.get_node_or_null(\"TutorialNudge\")\nif n != null and n.visible:\n\tn.get_node(\"Margin/VBox/Footer/DismissNudgeButton\").pressed.emit()\nreturn true",
+      "equals": true,
+      "comment": "fresh profile: clear the first-launch nudge off the menu"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "TutorialManager.start_lesson(\"t1_basics\")\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.active",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "for i in range(20):\n\tif TutorialManager.current_step_id() == \"hint_bar\":\n\t\tbreak\n\tTutorialManager.skip_step()\nreturn TutorialManager.current_step_id()",
+      "equals": "hint_bar",
+      "comment": "walk to the pad-only step with the overlay's own Skip Step path (no state stubbing)"
+    },
+    {
+      "act": "screenshot",
+      "label": "01_pad_only_step_with_pad"
+    },
+    {
+      "act": "hover_board_at",
+      "x": 1400.0,
+      "y": 900.0,
+      "comment": "the Steam Deck trackpad: a real buttonless mouse-motion event, far enough to pass the 12px hysteresis and claim KBM"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": false,
+      "comment": "trackpad motion claimed KBM mid-step, exactly as on the Deck"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_open",
+      "comment": "THE FIX: the pad-only step no longer matches the device in the player's hands, so the tutorial moves on instead of leaving them on a step they can no longer satisfy"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nreturn t.contains(\"Shift\") and not t.contains(\"pause menu\")",
+      "equals": true,
+      "comment": "on keyboard the step reads as the keyboard cheat sheet"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_after_trackpad_claimed_kbm"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": 1.0,
+      "hold_s": 0.4,
+      "comment": "player picks the pad back up - a right-stick camera nudge, the most side-effect-free pad input there is (LB here cycles units and can pop the disembark dialog)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_open",
+      "comment": "the controls-reference step runs on BOTH devices now, so picking the pad back up keeps the player on it"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nreturn t.contains(\"pause menu\") and t.contains(\"Controller\") and not t.contains(\"Shift\")",
+      "equals": true,
+      "comment": "and the wording swapped live: pad players are pointed at the pause menu's Controller tab, never at Shift+/"
+    },
+    {
+      "act": "screenshot",
+      "label": "03_pad_prompt_after_swap_back"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 4
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/SettingsMenu",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_close",
+      "comment": "and the pad route completes the step"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -259,7 +259,7 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "hotkey_help_open"
+      "equals": "controls_reference_open"
     },
     {
       "act": "simulate_key",
@@ -272,7 +272,18 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "hotkey_help_close"
+      "equals": "controls_reference_close"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var lbl = tree.root.get_node_or_null(\"/root/Main/HotkeyHelpOverlay\")\nif lbl == null:\n\treturn \"\"\nvar hit = \"\"\nvar stack = [lbl]\nwhile stack.size() > 0:\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\tif n is Label and str(n.name) == \"PadRouteHint\":\n\t\thit = str(n.text)\nreturn hit",
+      "equals": "On a controller: ⧉ View (Select) (Pause Menu) → Settings → Controller lists every pad button",
+      "comment": "the keyboard-only cheat sheet also names the controller route to the same information (Steam Deck has no Shift+/)"
+    },
+    {
+      "act": "screenshot",
+      "label": "04b_hotkey_help_with_pad_route"
     },
     {
       "act": "simulate_key",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -6,11 +6,18 @@
   ],
   "rng_seed": 4242,
   "edition": 11,
-  "description": "Tutorial lesson T1 driven entirely with a gamepad: LB claims pad mode on the main menu, D-pad+A opens the Tutorial picker and starts the lesson, then every step is completed with pad input only - RS camera pan, RB unit cycling, Y datasheet toggle, virtual-cursor clicks on the Dice Log tab and instructor-card buttons, the pad-only hint-bar step (skipped on kbm), and a full carry-mode grot move (A select, A menu, A pick Normal, glide, X drop) before confirming via the End This Unit's Move button. Verifies the pad-only step appears, kbm-only steps are skipped, and completion persists.",
+  "description": "Tutorial lesson T1 driven entirely with a gamepad: LB claims pad mode on the main menu, D-pad+A opens the Tutorial picker and starts the lesson, then every step is completed with pad input only - RS camera pan, RB unit cycling, Y datasheet toggle, virtual-cursor clicks on the Dice Log tab and instructor-card buttons, the pad-only hint-bar step (skipped on kbm), the controls-reference step reached with the View button (pause menu -> Controller tab) instead of the keyboard-only Shift+/ chord, and a full carry-mode grot move (A select, A menu, A pick Normal, glide, X drop) before confirming via the End This Unit's Move button. Verifies the pad-only step appears, kbm-only steps are skipped, and completion persists.",
   "steps": [
     {
       "act": "wait_seconds",
       "seconds": 1.5
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var mm = tree.root.get_node(\"/root/MainMenu\")\nvar n = mm.get_node_or_null(\"TutorialNudge\")\nif n != null and n.visible:\n\tn.get_node(\"Margin/VBox/Footer/DismissNudgeButton\").pressed.emit()\nreturn true",
+      "equals": true,
+      "comment": "on a genuinely fresh profile (fresh clone / container) the first-launch nudge covers the menu and swallows the D-pad, so the pad presses below landed on the Terrain Layout dropdown instead of the Tutorial button. Dismiss it first; the kbm twin never noticed because click_node emits pressed directly."
     },
     {
       "act": "simulate_joy_button",
@@ -26,8 +33,9 @@
       "equals": true
     },
     {
-      "act": "simulate_joy_button",
-      "button_index": 12
+      "act": "pad_cursor_glide",
+      "button_text": "Tutorial",
+      "comment": "virtual cursor onto the menu's Tutorial button. Was a blind D-pad-down + A, which assumed the menu's initial focus sat one row above Tutorial - it does not on a fresh profile, so the press landed on Multiplayer and the picker never opened."
     },
     {
       "act": "wait_seconds",
@@ -45,6 +53,11 @@
     {
       "act": "screenshot",
       "label": "01_picker_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Start",
+      "comment": "the cursor is still parked on the menu button behind the picker, so A there presses nothing - glide onto lesson 1's Start first"
     },
     {
       "act": "simulate_joy_button",
@@ -261,6 +274,85 @@
     {
       "act": "wait_frames",
       "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_open",
+      "comment": "reported bug (Steam Deck): this step used to be keyboard-only and told the pad player to press Shift+/ - a chord a Deck has no keys for. It now runs on both devices and the pad prompt teaches the pause-menu route instead."
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nreturn t.contains(\"pause menu\") and t.contains(\"Controller\") and not t.contains(\"Shift\")",
+      "equals": true,
+      "comment": "the pad player is told where the controls live, not which keyboard chord to press"
+    },
+    {
+      "act": "screenshot",
+      "label": "04b_controls_reference_pad_prompt"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 4,
+      "comment": "View/Select = Pause Menu, the pad's Escape"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/SettingsMenu",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_close",
+      "comment": "opening the pause menu with the pad completes the step - no keyboard needed"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.root.get_node(\"/root/Main/SettingsMenu\")\nvar names = []\nfor b in m._tab_buttons:\n\tnames.append(str(b.text))\nreturn names",
+      "equals": ["Audio", "Visual", "Gameplay", "Controls", "Controller"],
+      "comment": "the Controller tab the prompt points at is really there"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.root.get_node(\"/root/Main/SettingsMenu\")\nm._on_tab_pressed(4)\nreturn int(m._active_tab)",
+      "equals": 4
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var m = tree.root.get_node(\"/root/Main/SettingsMenu\")\nvar rows = m._pad_role_buttons\nreturn rows.has(\"pad_pause\") and rows.has(\"pad_select\") and rows.size() >= 10",
+      "equals": true,
+      "comment": "Settings > Controller is the pad's cheat sheet: every role row, rebindable"
+    },
+    {
+      "act": "screenshot",
+      "label": "04c_controller_tab_pad"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1,
+      "comment": "B closes the pause menu (ui_cancel)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "is_instance_valid(main._settings_menu)",
+      "equals": false
     },
     {
       "act": "execute_script",

--- a/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
+++ b/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
@@ -256,8 +256,41 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "end_phase_intro",
-      "comment": "THE FIX: A advanced step 7 with the cursor parked in the opposite corner"
+      "equals": "controls_reference_open",
+      "comment": "THE FIX: A advanced step 7 with the cursor parked in the opposite corner. Step 8 is the controls reference, which on a pad is reached with View (pause menu), not the Shift+/ chord a Deck cannot press."
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 4,
+      "comment": "View/Select opens the pause menu - the pad's route to the controls list"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/SettingsMenu",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_close"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1,
+      "comment": "B closes it again"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase_intro"
     },
     {
       "act": "screenshot",


### PR DESCRIPTION
## The bug

Step 8 of Basic Trainin' ("DA CHEAT SHEET!") told a controller player to press **Shift+/** to list the shortcuts. A Steam Deck in Game Mode has no keys for that chord, so the advice was useless *and* the step could not be completed.

Two causes, both fixed:

1. **The step was authored `device: "kbm"` with no pad counterpart.** A pad player either skipped it entirely — learning nothing about where the controls live — or, as reported, got the keyboard wording anyway.
2. **The device filter only ran on step ENTRY.** The Deck's right trackpad emits real mouse motion, which claims KBM, so a keyboard-only step could be entered and then never satisfied once the pad was picked back up.

## Changes

- `40k/data/tutorials/lessons/T1_basics.json` — `hotkey_help_open`/`_close` become device-agnostic `controls_reference_open`/`_close`. The pad prompt points at the pause menu (View / Select) and its **Controller** tab, which already lists every pad role and lets the player remap it. `done:` accepts *either* the hotkey overlay or the settings menu, so whichever route the player takes completes the step; the close step accepts both being shut again. Lesson summary gained a bullet naming both routes.
- `40k/autoloads/TutorialManager.gd` — device matching extracted to `_step_matches_device()`, and `refresh_prompt()` (already wired to `device_changed`) now re-checks it and re-enters the step, which skips it forward to the variant matching the device in the player's hands.
- `40k/scripts/Main.gd` — the keyboard shortcut overlay carries a controller route line (`Pause Menu → Settings → Controller`), with the button label read live from `PadBindings` so a remapped Pause Menu role shows the right button.
- `40k/data/version_history.json` — 1.5.2.

## Validation (windowed, per the project gate)

| Scenario | Result |
| --- | --- |
| `tests/scenarios/sp/tut_t1_basics_pad.json` | 102/102 — drives step 8 with pad input only: asserts the prompt has no `Shift`, opens the pause menu with View, asserts the Controller tab and its role rows, closes with B (screenshots `04b`/`04c`) |
| `tests/scenarios/sp/tut_t1_basics.json` | 82/82 — incl. the new `PadRouteHint` line on the keyboard cheat sheet (screenshot `04b`) |
| `tests/scenarios/sp/tut_device_swap_midstep.json` *(new)* | 26/26 — reproduces the trackpad swap with a real mouse-motion event, asserts the tutorial leaves the step that no longer matches the device, and that the prompt wording swaps back when the pad is used again |
| `tut_full_course_chain` / `_pad` | 23/23 and 30/30 |
| `test_tutorial_checklist.gd` (headless) | 31/31 |

No `ERROR` lines in the debug logs for any run.

## Drive-by

`tut_t1_basics_pad.json` could not reach the lesson at all on a fresh profile: the first-launch nudge covered the menu and swallowed the D-pad, and the blind D-pad+A presses assumed a menu focus position that does not hold. Both replaced with cursor glides onto the real buttons. Pre-existing and unrelated to the reported bug, but it blocked validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014UrmXPLZ1QDR7ftzSFzH9v

---
_Generated by [Claude Code](https://claude.ai/code/session_014UrmXPLZ1QDR7ftzSFzH9v)_