### PR TITLE
Controller: LB/RB cycle straight through the disembark pop-up

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -639,6 +639,17 @@ func _reopen_move_menu() -> void:
 # Cycling
 # ============================================================================
 
+# Public bumper-cycle entry for dialogs that run in their own exclusive
+# Window (e.g. DisembarkDialog): joypad events route into the focused
+# Window's viewport, so this router's _input never sees LB/RB while such a
+# dialog is up. The dialog dismisses itself first, then forwards the press
+# here so the bumpers keep their one global meaning — switch units.
+func cycle_units(dir: int) -> void:
+	InputDeviceManager.claim_pad()
+	_cycle(dir)
+	_update_hints()
+
+
 func _cycle(dir: int) -> void:
 	# Fight phase: the bumpers cycle keyboard focus among the ACTION BUTTONS of
 	# the visible fight-panel section (fighter picks, pile-in / consolidate unit

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.2",
+      "date": "2026-07-27",
+      "summary": "Controller: LB/RB now cycle straight through the disembark pop-up instead of getting stuck on it.",
+      "changes": [
+        "Bumper-cycling onto a unit embarked in a transport no longer traps you in the 'Disembark Unit?' pop-up — pressing LB or RB while it is open now stays embarked, closes the pop-up, and cycles to the previous/next unit in one press.",
+        "Nothing else about the pop-up changed: A still confirms Disembark, B / Stay Embarked still declines, and cycling back onto the embarked unit reopens it."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/scripts/DisembarkDialog.gd
+++ b/40k/scripts/DisembarkDialog.gd
@@ -31,6 +31,14 @@ func _ready() -> void:
 	get_cancel_button().text = "Stay Embarked"
 	get_cancel_button().pressed.connect(_on_cancel_pressed)
 
+	# Pad: LB/RB keep their one global meaning — switch units — even while
+	# this dialog is up. An exclusive dialog Window routes joypad events into
+	# its own viewport, so PadRouter's _input never sees the bumpers here;
+	# without this handler, bumper-cycling onto an embarked unit trapped the
+	# player in the popup until they dismissed it. Handled on the dialog's own
+	# window_input (mirrors PileInDialog / AttackAssignmentDialog).
+	window_input.connect(_pad_handle_input)
+
 	print("DisembarkDialog initialized")
 
 func setup(p_unit_id: String) -> void:
@@ -170,6 +178,33 @@ func _combat_disembark_could_apply() -> bool:
 					print("DisembarkDialog: Combat Disembark offered — enemy %s within %.1f\" of transport" % [enemy_id, threshold_inches])
 					return true
 	return false
+
+# A bumper press means "stay embarked and keep browsing": close exactly like
+# the Stay Embarked button, then forward the cycle to PadRouter once the
+# dialog is out of the way — so cycling flows straight through embarked units
+# instead of stopping dead at the popup. Cycling back onto this unit simply
+# reopens the dialog, so no functionality is lost.
+func _pad_handle_input(event: InputEvent) -> void:
+	if not (event is InputEventJoypadButton) or not event.pressed:
+		return
+	var dir := 0
+	# Settings › Controller remaps: match on the canonical button of the role
+	# the pressed physical button carries.
+	match PadBindings.canonical(event.button_index):
+		JOY_BUTTON_LEFT_SHOULDER:
+			dir = -1
+		JOY_BUTTON_RIGHT_SHOULDER:
+			dir = 1
+		_:
+			return
+	set_input_as_handled()
+	print("DisembarkDialog: bumper press — staying embarked, cycling units (dir=%d)" % dir)
+	emit_signal("disembark_canceled")
+	hide()
+	queue_free()
+	# Deferred so the cancel handlers (selection clear, dialog teardown)
+	# settle before the cycle re-selects a row in the unit list.
+	PadRouter.call_deferred("cycle_units", dir)
 
 func _on_ok_pressed() -> void:
 	var combat_mode: bool = combat_checkbox != null and combat_checkbox.button_pressed

--- a/40k/tests/scenarios/sp/pad_disembark_dialog_bumper_cycle.json
+++ b/40k/tests/scenarios/sp/pad_disembark_dialog_bumper_cycle.json
@@ -1,0 +1,55 @@
+{
+  "id": "pad_disembark_dialog_bumper_cycle",
+  "covers": [
+    "controller.bumper_cycle_through_disembark_dialog",
+    "controller.bumper_only_unit_cycling",
+    "DisembarkDialog",
+    "PadRouter.cycle_units"
+  ],
+  "fixture": "grenade_shooting_desync",
+  "edition": 11,
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "description": "LB/RB keep cycling units THROUGH the disembark popup. The fixture has Kommandos embarked in Battlewagon Alpha; selecting them in the Movement phase pops the DisembarkDialog. Previously the exclusive dialog Window swallowed the bumpers, trapping the player until they dismissed the popup. Now RB while the dialog is up acts as 'stay embarked + next unit': the dialog closes (cancel semantics, no disembark) and the selection steps to the next unit. LB from that unit cycles straight back onto the Kommandos, which reopens the dialog — proving no functionality was lost — and RB flows through it again. Kommandos stay embarked throughout.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_KOMMANDOS_A\").get(\"embarked_in\", \"\")", "equals": "U_BATTLEWAGON_A" },
+    { "act": "execute_script", "script": "str(main.movement_controller.unit_list.get_item_metadata(7))", "equals": "U_KOMMANDOS_A" },
+
+    { "act": "execute_script", "multiline": true,
+      "script": "var ul = tree.current_scene.movement_controller.unit_list\nul.get_v_scroll_bar().value = ul.get_item_rect(7).position.y\nreturn ul.get_v_scroll_bar().value >= 0.0" },
+    { "act": "wait_frames", "frames": 2 },
+    { "act": "click_item_list", "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList", "index": 7 },
+    { "act": "wait_for_tweens", "timeout_s": 3.0 },
+    { "act": "expect_node_visible", "node": "/root/DisembarkDialog", "timeout_s": 2.0 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_KOMMANDOS_A" },
+    { "act": "screenshot", "label": "01_dialog_open_on_embarked_unit" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "multiline": true,
+      "script": "var d = tree.root.get_node_or_null(\"DisembarkDialog\")\nreturn d == null or not is_instance_valid(d) or not d.visible or str(d.unit_id) != \"U_KOMMANDOS_A\"",
+      "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) != \"U_KOMMANDOS_A\" and str(main.movement_controller.active_unit_id) != \"\"", "equals": true },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_KOMMANDOS_A\").get(\"embarked_in\", \"\")", "equals": "U_BATTLEWAGON_A" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"after_rb\", str(main.movement_controller.active_unit_id))" },
+    { "act": "screenshot", "label": "02_rb_cycled_past_dialog_to_next_unit" },
+
+    { "act": "simulate_joy_button", "button_index": 9 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_node_visible", "node": "/root/DisembarkDialog", "timeout_s": 2.0 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_KOMMANDOS_A" },
+    { "act": "screenshot", "label": "03_lb_cycled_back_dialog_reopens" },
+
+    { "act": "simulate_joy_button", "button_index": 10 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "multiline": true,
+      "script": "var d = tree.root.get_node_or_null(\"DisembarkDialog\")\nreturn d == null or not is_instance_valid(d) or not d.visible or str(d.unit_id) != \"U_KOMMANDOS_A\"",
+      "equals": true },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id) == str(InputDeviceManager.get_meta(\"after_rb\"))", "equals": true },
+    { "act": "execute_script", "script": "GameState.get_unit(\"U_KOMMANDOS_A\").get(\"embarked_in\", \"\")", "equals": "U_BATTLEWAGON_A" },
+    { "act": "screenshot", "label": "04_rb_flows_through_again_still_embarked" }
+  ]
+}


### PR DESCRIPTION
## Problem

Bumper-cycling onto a unit embarked in a transport pops the "Disembark Unit?" dialog — but the exclusive dialog Window routes joypad events into its own viewport, so `PadRouter` never saw LB/RB while it was open. Cycling stopped dead until the player dismissed the pop-up, which made browsing units with the bumpers jarring.

## Change

- **`scripts/DisembarkDialog.gd`** — handles LB/RB on its own `window_input` (the established PileInDialog / AttackAssignmentDialog pattern). A bumper press means "stay embarked and keep browsing": it fires the same cancel path as the Stay Embarked button, closes the dialog, and forwards the cycle. Respects Settings › Controller remaps via `PadBindings.canonical`.
- **`autoloads/PadRouter.gd`** — new public `cycle_units(dir)` entry point for dialogs that live in their own exclusive Window (claims pad, cycles, refreshes hints).
- **`data/version_history.json`** — v1.5.2 changelog entry.
- Functionality is otherwise unchanged: A still confirms Disembark, B / Stay Embarked still declines, and cycling back onto an embarked unit reopens the pop-up.

## Validation

New windowed scenario **`tests/scenarios/sp/pad_disembark_dialog_bumper_cycle.json`** (28/28 steps pass) drives the loop end-to-end with real joypad events: dialog opens on the embarked Kommandos → RB closes it and lands on the next unit (Lootas Alpha, also embarked — bumpers flow through its dialog too) → LB cycles back and reopens the Kommandos dialog → RB flows through again; the unit stays embarked throughout, screenshots captured at each state.

Regression scenarios `pad_bumper_only_unit_cycling` and `iss058_disembark_11e` still pass.

**Note**: `movement_embarked_select_pans_to_transport` fails its camera-pan assertions on a clean tree too — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XXCC4r575QL171fyX5Fvjy

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXCC4r575QL171fyX5Fvjy)_