### PR TITLE
Tutorial T1: teach the move-whole-mob shortcut on the grot steps

### DIFF
--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -809,10 +809,21 @@ func _do_simulate_key(step: Dictionary) -> Dictionary:
 	# .is_action_pressed() from _process, not from an event) — a press/release
 	# straddling a single process_frame await is not reliably observed by them.
 	var hold_s: float = float(step.get("hold_s", 0.0))
+	# Optional modifier flags: KeybindingManager.matches_action() compares
+	# ctrl/shift/alt/meta on the event, so a chord binding (Ctrl+A = select_all)
+	# is unreachable without them — a bare "A" event matches no chord action.
+	var ctrl: bool = bool(step.get("ctrl", false))
+	var shift: bool = bool(step.get("shift", false))
+	var alt: bool = bool(step.get("alt", false))
+	var meta: bool = bool(step.get("meta", false))
 	var press := InputEventKey.new()
 	press.keycode = kc
 	press.physical_keycode = kc
 	press.unicode = uni
+	press.ctrl_pressed = ctrl
+	press.shift_pressed = shift
+	press.alt_pressed = alt
+	press.meta_pressed = meta
 	press.pressed = true
 	Input.parse_input_event(press)
 	await get_tree().process_frame
@@ -822,10 +833,14 @@ func _do_simulate_key(step: Dictionary) -> Dictionary:
 	release.keycode = kc
 	release.physical_keycode = kc
 	release.unicode = uni
+	release.ctrl_pressed = ctrl
+	release.shift_pressed = shift
+	release.alt_pressed = alt
+	release.meta_pressed = meta
 	release.pressed = false
 	Input.parse_input_event(release)
 	await get_tree().process_frame
-	return {"pass": true, "hold_s": hold_s}
+	return {"pass": true, "hold_s": hold_s, "ctrl": ctrl, "shift": shift, "alt": alt, "meta": meta}
 
 
 func _do_simulate_wheel(step: Dictionary) -> Dictionary:

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -217,8 +217,8 @@
       "id": "move_grots",
       "prompt": {
         "bark": "MOVE DA GROTS!",
-        "kbm": "Click [b]Gretchin[/b] in da unit list, den [b]drag[/b] one grot a short way forward an' drop it.",
-        "pad": "Tap {rb} until da [b]Gretchin[/b] are picked, glide {ls} onto a grot, press {a} to grab it, walk it forward an' press {a} to drop it."
+        "kbm": "Click [b]Gretchin[/b] in da unit list. Loads of 'em, so press {key:select_all} — dat grabs [b]every[/b] grot at once. Now drag any one of 'em forward an' da whole mob shifts togevver. Much faster.",
+        "pad": "Tap {rb} until da [b]Gretchin[/b] are picked an' start da move wiv {a}. Loads of 'em, so press {dpad} ▲ — dat lifts [b]every[/b] grot at once. Glide {ls} forward an' {a} drops da lot. Much faster."
       },
       "anchor": {
         "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList"
@@ -237,15 +237,16 @@
         }
       },
       "hint": {
-        "text": "Pick da Gretchin row first — den drag any single grot base. Keep 'im near his mates (wivin 2\") an' don't drop him on top of anyone."
+        "kbm": "Pick da Gretchin row first, den {key:select_all} to select 'em all — one drag moves da lot an' keeps da mob togevver. Draggin' a single base works too, but it's slow.",
+        "pad": "Pick da Gretchin an' start da move first — {dpad} ▲ only grabs da whole mob once dey're movin'. One grot at a time works too, but it's slow."
       }
     },
     {
       "id": "confirm_grots",
       "prompt": {
         "bark": "LOCK IT IN!",
-        "kbm": "Press [b]End This Unit's Move[/b] on da right to lock da move in.",
-        "pad": "Check da hint bar — confirm da move to lock it in."
+        "kbm": "Grots left behind? {key:select_all} grabs 'em all an' one drag brings 'em along. When yer happy, press [b]End This Unit's Move[/b] on da right to lock it in.",
+        "pad": "Grots left behind? {dpad} ▲ grabs every one dat ain't moved yet, so {a} places 'em in one go. When yer happy, check da hint bar an' confirm da move."
       },
       "anchor": {
         "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton"

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -232,21 +232,29 @@
         "UNDO_LAST_MODEL_MOVE"
       ],
       "done": {
-        "action": {
-          "type": "STAGE_MODEL_MOVE"
-        }
+        "any": [
+          {
+            "script": "var phase = PhaseManager.get_current_phase_instance()\nif phase == null or not phase.has_method(\"get_active_move_data\"):\n\treturn false\nvar am = phase.get(\"active_moves\")\nif typeof(am) != TYPE_DICTIONARY:\n\treturn false\nfor uid in am:\n\tvar dists = am[uid].get(\"model_distances\", {})\n\tfor k in dists:\n\t\tif float(dists[k]) >= 0.1:\n\t\t\treturn true\nreturn false",
+            "comment": "NOT `action: STAGE_MODEL_MOVE`. On the pad, grabbing the whole mob with D-pad up runs PadRouter._grab_all_from_carry -> _cancel_carry, which re-projects the pickup point and releases there — staging a junk move that is undone two frames later. An action leaf latches permanently, so that junk stage flipped this step to 'LOCK IT IN!' the instant the player grabbed the squad, before a single grot had moved. This polls live state for a model that actually covered ground instead. The 0.1 inch floor is not arbitrary: the junk stage was measured at 0.0000015 inches (float noise from the re-projection), four orders of magnitude below, while any real drop on a 6 inch move is inches. Below a tenth of an inch nothing has meaningfully moved, which is what this step is asking for."
+          },
+          {
+            "state": "units.U_GRETCHIN_T.flags.moved",
+            "equals": true,
+            "comment": "backstop: if the grots' move somehow gets confirmed while this step is still up, do not strand the player on a step whose goal is already met"
+          }
+        ]
       },
       "hint": {
-        "kbm": "Pick da Gretchin row first, den {key:select_all} to select 'em all — one drag moves da lot an' keeps da mob togevver. Draggin' a single base works too, but it's slow.",
-        "pad": "Pick da Gretchin an' start da move first — {dpad} ▲ only grabs da whole mob once dey're movin'. One grot at a time works too, but it's slow."
+        "kbm": "Pick da Gretchin row first, den {key:select_all} to select 'em all — one drag moves da lot. If dey don't all fit where ya drop 'em, only da ones dat fit land; da rest stay selected, so drag 'em again somewhere else.",
+        "pad": "Pick da Gretchin an' start da move first — {dpad} ▲ only grabs da whole mob once dey're movin'. If dey don't all fit where ya drop 'em, only da ones dat fit land; another {dpad} ▲ grabs whoever's still standin' about."
       }
     },
     {
       "id": "confirm_grots",
       "prompt": {
         "bark": "LOCK IT IN!",
-        "kbm": "Grots left behind? {key:select_all} grabs 'em all an' one drag brings 'em along. When yer happy, press [b]End This Unit's Move[/b] on da right to lock it in.",
-        "pad": "Grots left behind? {dpad} ▲ grabs every one dat ain't moved yet, so {a} places 'em in one go. When yer happy, check da hint bar an' confirm da move."
+        "kbm": "Grots left behind? Only da ones dat fit got placed — da rest are still selected, so drag 'em again somewhere dey fit ({key:select_all} re-grabs da lot). When every grot's down, press [b]End This Unit's Move[/b].",
+        "pad": "Grots left behind? Only da ones dat fit got placed. Press {dpad} ▲ again — it grabs every grot dat still ain't moved — den {a} drops 'em somewhere dey fit. When every grot's down, {menu} confirms da move."
       },
       "anchor": {
         "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton"

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,15 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.3",
+      "date": "2026-07-27",
+      "summary": "Basic Trainin's grot steps now explain what happens when a squad won't all fit where you drop it, and the 'Move da grots' step no longer skips ahead the moment you pick the mob up on a controller.",
+      "changes": [
+        "The grot steps now spell out partial placement: drop the whole mob somewhere they can't all fit and only the ones that fit are placed. On mouse and keyboard the ones that couldn't be placed stay selected, so one more drag takes exactly those somewhere else; on a controller another D-pad ▲ picks up every model that still hasn't moved. The game already worked this way — the tutorial just never said so, which made a half-placed squad look like a bug.",
+        "Fixed 'Move da grots' jumping to 'Lock it in!' on a controller the instant you pressed D-pad ▲ to grab the squad, before a single grot had actually moved. The step now waits until a model has really covered ground."
+      ]
+    },
+    {
       "version": "1.5.2",
       "date": "2026-07-27",
       "summary": "Basic Trainin' now teaches the move-the-whole-squad shortcut on the grot step, instead of leaving you to drag eleven bases one at a time.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.2",
+      "date": "2026-07-27",
+      "summary": "Basic Trainin' now teaches the move-the-whole-squad shortcut on the grot step, instead of leaving you to drag eleven bases one at a time.",
+      "changes": [
+        "The 'Move da grots' step (step 11) now tells you how to move all eleven models at once — Ctrl+A on mouse and keyboard, D-pad ▲ on a controller — and says to use it because it is much faster. Previously it just said to drag one grot, and with a mob that size it was not obvious there was any other way.",
+        "The 'Lock it in' step (step 12) repeats the shortcut for any grots you left behind, so a half-moved mob can be caught up in one go before you confirm.",
+        "The step hint now explains the shortcut too, including the controller detail that the whole-squad grab only works once the move has actually started."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -305,6 +305,13 @@
       "equals": "move_grots"
     },
     {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"Ctrl+A\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "the grot step must TELL the player about select-all: the unit is 11 models and dragging them one at a time is the slow path players were falling into. {key:select_all} renders through KeybindingManager, so this also proves the token resolved (an unresolved token would read '{key:select_all}')."
+    },
+    {
       "act": "click_item_list",
       "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section1_UnitList/MovementUnitList",
       "index": 2
@@ -312,6 +319,27 @@
     {
       "act": "wait_frames",
       "frames": 15
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "A",
+      "ctrl": true,
+      "comment": "the shortcut the instructor card now advertises — Ctrl+A selects every model of the active unit"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "execute_script",
+      "script": "var mc = tree.current_scene.movement_controller\nvar models = GameState.get_unit(\"U_GRETCHIN_T\").get(\"models\", [])\nvar alive = 0\nfor m in models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive > 1 and mc.selected_models.size() == alive and str(mc.selection_mode) == \"MULTI\"",
+      "multiline": true,
+      "equals": true,
+      "comment": "Ctrl+A really did grab EVERY alive grot, not just the one under the cursor — the card's advice has to be true"
+    },
+    {
+      "act": "screenshot",
+      "label": "06a_grots_all_selected"
     },
     {
       "act": "drag_board",
@@ -330,8 +358,22 @@
       "equals": "confirm_grots"
     },
     {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar staged := {}\nfor sm in md.get(\"staged_moves\", []):\n\tstaged[str(sm.get(\"model_id\", \"\"))] = true\nvar models = GameState.get_unit(\"U_GRETCHIN_T\").get(\"models\", [])\nvar alive = 0\nfor m in models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive > 1 and staged.size() == alive",
+      "multiline": true,
+      "equals": true,
+      "comment": "one drag after Ctrl+A staged the WHOLE mob — the speed-up the step promises actually happens (previously this drag staged exactly one grot)"
+    },
+    {
       "act": "screenshot",
       "label": "06_grot_staged"
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"Ctrl+A\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "the confirm step repeats the shortcut for any grots left behind"
     },
     {
       "act": "click_node",

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -338,6 +338,12 @@
       "comment": "Ctrl+A really did grab EVERY alive grot, not just the one under the cursor — the card's advice has to be true"
     },
     {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "move_grots",
+      "comment": "selecting the mob is not moving it — the step stays put until a grot has actually covered ground"
+    },
+    {
       "act": "screenshot",
       "label": "06a_grots_all_selected"
     },
@@ -370,10 +376,81 @@
     },
     {
       "act": "execute_script",
-      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"Ctrl+A\")",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"Ctrl+A\") and o.current_body_text().contains(\"still selected\")",
       "multiline": true,
       "equals": true,
-      "comment": "the confirm step repeats the shortcut for any grots left behind"
+      "comment": "the confirm step repeats the shortcut AND explains what happens to grots that could not be placed"
+    },
+    {
+      "act": "drag_board",
+      "from_x": 1290.0,
+      "from_y": 755.0,
+      "to_x": 1335.0,
+      "to_y": 800.0,
+      "shift": true,
+      "comment": "narrow the selection to ONE grot with a Shift box-drag (MovementController._select_models_in_box). A fully-successful group drop leaves the whole mob selected — only a PARTIAL drop narrows the selection to the leftovers — so without this the next drag would move all eleven again instead of the single grot the setup needs. The box is tight around the grot at 1312,776: its nearest neighbours are 48px away in x and at y=824."
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.movement_controller.selected_models.size()",
+      "multiline": true,
+      "equals": 1
+    },
+    {
+      "act": "drag_board",
+      "from_x": 1312.0,
+      "from_y": 776.0,
+      "to_x": 1264.0,
+      "to_y": 900.0,
+      "comment": "PARTIAL-PLACEMENT SETUP: run one grot out to 5.5 of its 6 inch move on its own (world px, 40px = 1 inch; it started at 1280,680 and the group drag put it at 1312,776). Every other grot has used 2.5 inches. That asymmetry is what makes the next group drop legal for the mob and illegal for this one."
+    },
+    {
+      "act": "wait_frames",
+      "frames": 25
+    },
+    {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar d := {}\nfor sm in md.get(\"staged_moves\", []):\n\td[str(sm.get(\"model_id\", \"\"))] = str(sm.get(\"dest\"))\nInputDeviceManager.set_meta(\"pre_drop_dests\", d)\nreturn d.size()",
+      "multiline": true,
+      "equals": 11,
+      "comment": "snapshot every grot's staged destination so the next drop can be judged model by model"
+    },
+    {
+      "act": "simulate_key",
+      "keycode": "A",
+      "ctrl": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 10
+    },
+    {
+      "act": "drag_board",
+      "from_x": 1072.0,
+      "from_y": 776.0,
+      "to_x": 1072.0,
+      "to_y": 816.0,
+      "comment": "select-all, then nudge the whole mob 1 inch. The far grot would land 6.5 inches from where it started - past its move - so it CANNOT be placed; the rest are only 3.5 inches out and can."
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5,
+      "comment": "let the staging batch and its one retry pass finish before judging the drop"
+    },
+    {
+      "act": "execute_script",
+      "script": "var mc = tree.current_scene.movement_controller\nvar md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar pre = InputDeviceManager.get_meta(\"pre_drop_dests\")\nvar landed := {}\nvar stayed := {}\nfor sm in md.get(\"staged_moves\", []):\n\tvar mid = str(sm.get(\"model_id\", \"\"))\n\tif str(sm.get(\"dest\")) != str(pre.get(mid, \"\")):\n\t\tlanded[mid] = true\n\telse:\n\t\tstayed[mid] = true\nvar sel := {}\nfor m in mc.selected_models:\n\tsel[str(m.get(\"model_id\", \"\"))] = true\nif landed.is_empty() or stayed.is_empty():\n\treturn \"not a partial drop: landed=%d stayed=%d\" % [landed.size(), stayed.size()]\nif sel.size() != stayed.size():\n\treturn \"selection %d != leftovers %d\" % [sel.size(), stayed.size()]\nfor k in stayed:\n\tif not sel.has(k):\n\t\treturn \"leftover %s is not selected\" % k\nreturn \"ok\"",
+      "multiline": true,
+      "equals": "ok",
+      "comment": "THE CLAIM THE STEP TEXT NOW MAKES, driven end to end: the drop was partial - some grots moved to the new spot and at least one did not - and the models still selected are EXACTLY the ones that could not be placed, so the player's next drag moves those and nothing else (MovementController._end_group_drag: `selected_models = blocked.duplicate()`). Deliberately count-agnostic: how many grots are refused depends on base spacing around the blocked one, and the text does not promise a number."
+    },
+    {
+      "act": "screenshot",
+      "label": "06b_partial_drop_leftovers_selected"
     },
     {
       "act": "click_node",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -285,6 +285,13 @@
       "equals": "move_grots"
     },
     {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"▲\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "the grot step must TELL the pad player about D-pad up: the unit is 11 models and carrying them one at a time is the slow path players were falling into"
+    },
+    {
       "act": "pad_cursor_glide",
       "unit_id": "U_GRETCHIN_T"
     },
@@ -303,11 +310,47 @@
     },
     {
       "act": "simulate_joy_button",
-      "button_index": 0
+      "button_index": 11,
+      "comment": "D-pad up with the mode decision still open opens the move menu (PadRouter._try_open_move_menu runs ahead of _try_grab_all_remaining)"
     },
     {
       "act": "wait_seconds",
-      "seconds": 0.4
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "return PadActionBar.is_open()",
+      "multiline": true,
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "A takes the highlighted chip - 'Move' - which starts the move session and puts one grot in hand"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 11,
+      "comment": "the shortcut the instructor card now advertises: D-pad up mid-move grabs EVERY grot still to be moved as one group carry"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "var pr = tree.root.get_node(\"/root/PadRouter\")\nvar mc = tree.current_scene.movement_controller\nvar models = GameState.get_unit(\"U_GRETCHIN_T\").get(\"models\", [])\nvar alive = 0\nfor m in models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive > 1 and pr.group_carry_active and mc.selected_models.size() == alive",
+      "multiline": true,
+      "equals": true,
+      "comment": "D-pad up really did lift EVERY alive grot, not just the one in hand - the card's advice has to be true"
+    },
+    {
+      "act": "screenshot",
+      "label": "05a_grots_group_carry_pad"
     },
     {
       "act": "pad_cursor_glide",
@@ -328,8 +371,43 @@
       "equals": "confirm_grots"
     },
     {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar staged := {}\nfor sm in md.get(\"staged_moves\", []):\n\tstaged[str(sm.get(\"model_id\", \"\"))] = true\nreturn staged.size() > 1",
+      "multiline": true,
+      "equals": true,
+      "comment": "the ONE A press after the group grab staged MANY grots, not one - that is the speed-up the step promises. Not asserted as all 11: a group drop places the models that fit and hands the rest back as a smaller carry (v0.83.0 partial placement), and how many fit at this exact spot varies with the camera framing."
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 1060.0,
+      "y": 760.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "place the handful handed back by the partial drop"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar staged := {}\nfor sm in md.get(\"staged_moves\", []):\n\tstaged[str(sm.get(\"model_id\", \"\"))] = true\nvar models = GameState.get_unit(\"U_GRETCHIN_T\").get(\"models\", [])\nvar alive = 0\nfor m in models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive > 1 and staged.size() == alive",
+      "multiline": true,
+      "equals": true,
+      "comment": "two A presses moved the entire 11-model mob - versus eleven pick-up/drop cycles the old wording led players into"
+    },
+    {
       "act": "screenshot",
       "label": "05_grot_carried_pad"
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"▲\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "the confirm step repeats the shortcut for any grots left behind"
     },
     {
       "act": "pad_cursor_glide",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -349,6 +349,12 @@
       "comment": "D-pad up really did lift EVERY alive grot, not just the one in hand - the card's advice has to be true"
     },
     {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "move_grots",
+      "comment": "REGRESSION: grabbing the squad must NOT complete the step. The grab-all cancels the single carry, whose synthetic release stages a zero-distance move and undoes it; with done as `action: STAGE_MODEL_MOVE` that junk stage latched and the card jumped to 'LOCK IT IN!' while the mob was still in the air. The done condition now polls for a staged move that actually covered ground."
+    },
+    {
       "act": "screenshot",
       "label": "05a_grots_group_carry_pad"
     },
@@ -363,7 +369,8 @@
     },
     {
       "act": "wait_seconds",
-      "seconds": 0.8
+      "seconds": 2.5,
+      "comment": "_end_group_drag stages the members one at a time (0.01s apart), then waits 0.1s and RETRIES any that did not land, then waits 0.1s again - so the staged count is still climbing for roughly a third of a second after the drop. Sampling early reads a half-finished drop as a partial one."
     },
     {
       "act": "execute_script",
@@ -372,31 +379,10 @@
     },
     {
       "act": "execute_script",
-      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar staged := {}\nfor sm in md.get(\"staged_moves\", []):\n\tstaged[str(sm.get(\"model_id\", \"\"))] = true\nreturn staged.size() > 1",
-      "multiline": true,
-      "equals": true,
-      "comment": "the ONE A press after the group grab staged MANY grots, not one - that is the speed-up the step promises. Not asserted as all 11: a group drop places the models that fit and hands the rest back as a smaller carry (v0.83.0 partial placement), and how many fit at this exact spot varies with the camera framing."
-    },
-    {
-      "act": "pad_cursor_glide",
-      "x": 1060.0,
-      "y": 760.0
-    },
-    {
-      "act": "simulate_joy_button",
-      "button_index": 0,
-      "comment": "place the handful handed back by the partial drop"
-    },
-    {
-      "act": "wait_seconds",
-      "seconds": 0.8
-    },
-    {
-      "act": "execute_script",
       "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar staged := {}\nfor sm in md.get(\"staged_moves\", []):\n\tstaged[str(sm.get(\"model_id\", \"\"))] = true\nvar models = GameState.get_unit(\"U_GRETCHIN_T\").get(\"models\", [])\nvar alive = 0\nfor m in models:\n\tif m.get(\"alive\", true):\n\t\talive += 1\nreturn alive > 1 and staged.size() == alive",
       "multiline": true,
       "equals": true,
-      "comment": "two A presses moved the entire 11-model mob - versus eleven pick-up/drop cycles the old wording led players into"
+      "comment": "ONE A press after the group grab staged the whole 11-model mob - the speed-up the step promises, versus eleven pick-up/drop cycles the old wording led players into. Everything fits at this drop spot, so this run does not exercise partial placement - the mouse half of the lesson (tut_t1_basics) drives a genuinely partial group drop instead."
     },
     {
       "act": "screenshot",
@@ -404,10 +390,34 @@
     },
     {
       "act": "execute_script",
-      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"▲\")",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn o.current_body_text().contains(\"▲\") and o.current_body_text().contains(\"ain't moved\")",
       "multiline": true,
       "equals": true,
-      "comment": "the confirm step repeats the shortcut for any grots left behind"
+      "comment": "the confirm step repeats the shortcut AND tells the player it only picks up grots that are still to be moved"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 11,
+      "comment": "the confirm step promises D-pad up 'grabs every grot dat still ain't moved'. With all eleven already placed there is nothing left to grab, so it must NOT re-lift the mob (pad_select_unmoved_models filters out models that already have a staged move, and _try_begin_group_carry bails on a count of 0)."
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5,
+      "comment": "_grab_all_from_carry cancels, waits three frames and only then tries the group grab, so the carry flags settle a beat after the press"
+    },
+    {
+      "act": "execute_script",
+      "script": "var mc = tree.current_scene.movement_controller\nreturn mc.pad_select_unmoved_models()",
+      "multiline": true,
+      "equals": 0,
+      "comment": "the 'still to be moved' set really is empty once every grot is placed - the wording is a filter, not 'grabs everything again'"
+    },
+    {
+      "act": "execute_script",
+      "script": "var pr = tree.root.get_node(\"/root/PadRouter\")\nreturn not pr.group_carry_active and not pr.carry_active",
+      "multiline": true,
+      "equals": true,
+      "comment": "and so nothing was picked back up by that press"
     },
     {
       "act": "pad_cursor_glide",

--- a/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
+++ b/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
@@ -311,11 +311,30 @@
     },
     {
       "act": "simulate_joy_button",
-      "button_index": 0
+      "button_index": 11,
+      "comment": "This leg used to be A, A, glide, A - and it never moved a grot. With the virtual cursor active every A is a click at the cursor, so the second A picked the model up and dropped it on the spot (a zero-distance stage) and the third landed on empty board. move_grots completed anyway because its done condition was `action: STAGE_MODEL_MOVE`, which latches on that junk stage. Now that the step waits for real movement, the leg has to actually move the mob: D-pad up opens the move menu (the mode decision is still open)."
     },
     {
       "act": "wait_seconds",
-      "seconds": 0.4
+      "seconds": 0.5
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "A takes the highlighted chip - Move - which starts the move session and puts one grot in hand"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 11,
+      "comment": "D-pad up mid-move grabs every grot still to be moved as one group carry"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
     },
     {
       "act": "pad_cursor_glide",
@@ -328,7 +347,14 @@
     },
     {
       "act": "wait_seconds",
-      "seconds": 0.8
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar dists = md.get(\"model_distances\", {})\nvar mx = 0.0\nfor k in dists:\n\tmx = max(mx, float(dists[k]))\nreturn mx > 1.0",
+      "multiline": true,
+      "equals": true,
+      "comment": "a grot really covered ground this time - the old leg left maxdist at 0.0000"
     },
     {
       "act": "execute_script",


### PR DESCRIPTION
Basic Trainin' steps 11 and 12 move an 11-model Gretchin unit, but the prompts only described dragging (mouse) or carrying (pad) a single base — so players worked through the mob one model at a time with no hint there was a faster way.

## What changed

**Step 11 (`move_grots`) and step 12 (`confirm_grots`) now name the select-all shortcut and tell the player to use it**, per device:

- **Mouse/keyboard** — `{key:select_all}` (renders `[Ctrl+A]`, so it follows a rebind) selects every model of the active unit; one drag then shifts the whole mob.
- **Controller** — D-pad ▲ grabs every model still to be moved as one group carry. The hint spells out the ordering constraint found while validating this: `PadRouter._try_open_move_menu` runs ahead of `_try_grab_all_remaining`, so before a move mode is chosen the same press opens the move menu; the whole-squad grab only arms once the move is under way.

**Both steps now explain partial placement.** Drop the mob somewhere they can't all fit and only the ones that fit are placed. On mouse and keyboard the rest stay selected, so one more drag takes exactly those somewhere else; on a controller another D-pad ▲ picks up every model that still hasn't moved. The game already worked this way — the tutorial just never said so, which made a half-placed squad look like a bug.

**`move_grots` no longer completes when the player merely picks the squad up.** Its done condition was `action: STAGE_MODEL_MOVE`, and action leaves latch permanently. On the pad, D-pad ▲ runs `_grab_all_from_carry` → `_cancel_carry`, which re-projects the pickup point and releases there; that stages a junk move (measured at **0.0000015″**) and undoes it two frames later — but the latch had already fired, so the card flipped to "LOCK IT IN!" while the mob was still in the air. The step now polls live state for a model that has actually covered ground (≥ 0.1″, four orders of magnitude above the junk value), with a `flags.moved` backstop so a confirmed move can never strand the player.

**`ScenarioRunner.simulate_key` gained `ctrl`/`shift`/`alt`/`meta` flags.** Without them a chord binding is unreachable from a scenario, because `KeybindingManager.matches_action` compares the modifier state on the event.

## Validation

Run locally on the merge with main: `tut_t1_basics` 100/100, `tut_t1_basics_pad` 100/100, `tut_t1_pad_ack_button` 92/92, `tut_blocked_toast_names_continue` 36/36, `tut_t3_get_movin` 63/63. The only `ERROR` in the debug log is the fixture-guard failure `tut_t1_basics` deliberately provokes.

`tut_t1_basics` (mouse):
- asserts the card actually renders `Ctrl+A`, proving the `{key:...}` token resolved
- drives the real Ctrl+A and asserts all 11 alive grots are selected in `MULTI` mode
- asserts one drag then staged all 11
- drives a **genuinely partial** group drop — shift box-drag to narrow the selection to one grot, run it out to 5.5″ of its 6″, then Ctrl+A and nudge the mob 1″. The game refuses that grot (`Placed 10 of 11 models — 1 couldn't be placed there (Movement exceeds 6.0" cap (would be 6.9"))`) and the scenario asserts the models still selected are **exactly** the ones that could not be placed. Count-agnostic, since how many are refused depends on base spacing.

`tut_t1_basics_pad` (controller):
- asserts the card renders the D-pad glyph
- drives D-pad ▲ → move menu → A (Move) → D-pad ▲, and asserts `group_carry_active` with all 11 selected
- asserts the step is **still** `move_grots` at that moment — the regression pin for the gate fix
- asserts one A press then staged the whole mob, and that a further D-pad ▲ with everything placed grabs nothing (`pad_select_unmoved_models() == 0`), which is what the step's "every grot dat still ain't moved" wording promises

## Also in this branch

`tut_t1_pad_ack_button` (from main) had a `move_grots` leg of A, A, glide, A that **never moved a grot** — with the virtual cursor active every A is a click at the cursor, so the second A picked a grot up and dropped it on the spot and the third landed on empty board (measured `staged=1, maxdist=0.0000`). It passed only because of the same latching gate this PR fixes. Its grot leg now drives the real path and asserts a grot covered ground; the scenario's own subject — A alone pressing the instructor card's Continue with the cursor parked away from it — is untouched.

Merge resolution: main landed 1.5.2, 1.5.3 and 1.5.4 while this branch was open, so its two changelog entries sit above them at **1.5.5** and **1.5.6**.

## CI

`Automated Test Suite` is **green** on the head commit, as are `Coverage matrix validation` and `Headless audit suite`.

Two checks are red, and both are red on `main` independently of this branch:

| Check | This branch | `main` @ `94497b5` |
| --- | --- | --- |
| `loop-prefilter.yml` | failure | failure (every recent commit) |
| `Windowed Scenario Suite` → `Multi-peer integration (GUT)` | failure | failure — same job, 9 failing multiplayer save-dialog/broadcast-id tests |
| `Windowed Scenario Suite` → `Windowed scenarios (Xvfb)` | cancelled — hits the job's `timeout-minutes: 30` | cancelled — same 30-minute timeout (16:25:22 → 16:55:40) |

Neither is caused by this change; the affected tutorial scenarios were run locally instead (see Validation).

## Notes

- The pad text deliberately does **not** claim the leftovers are handed back automatically. `PadRouter._auto_regrab_after_group_drop` does exactly that in real play, but it is suppressed under the scenario runner by design (`_in_windowed_scenario()`), so that specific behavior is not covered here — the wording describes the manual D-pad ▲ instead, which is.
- The 0.1″ floor is a threshold, not a structural fix. The root cause is `_cancel_carry` staging-then-undoing a move at all; leaving that alone kept the change inside the tutorial layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ANwAMvNfB1uPWRSWwFTYpd