### PR TITLE
Controller: box multi-select by holding A and dragging the left stick

### DIFF
--- a/40k/autoloads/PadHintBar.gd
+++ b/40k/autoloads/PadHintBar.gd
@@ -66,7 +66,10 @@ func set_hints(hints: Array) -> void:
 func label_for(glyph_id: String) -> String:
 	for hint in current_hints:
 		if str(hint[0]) == glyph_id:
-			return str(hint[1])
+			# Expanded, not raw: a label may name a second button with a "{a}"
+			# token so it follows Settings › Controller remaps, and what the
+			# player READS is the expansion.
+			return GlyphDB.expand_label(str(hint[1]))
 	return ""
 
 

--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -263,6 +263,11 @@ const HINTS_FIGHT := [
 	["view", "Pause Menu"],
 ]
 
+# LS chip label for the board box multi-select gesture. "{a}" expands to the
+# button the select role currently sits on (GlyphDB.expand_label), so a layout
+# remapped in Settings › Controller is reflected in the promise.
+const BOX_SELECT_HINT := "Hold {a}: Box Select"
+
 # The target currently highlighted by LB/RB in shooting TARGET_SELECT mode
 # (empty when none). Windowed scenarios assert this.
 var target_highlight_id: String = ""
@@ -2195,7 +2200,48 @@ func _update_hints() -> void:
 				# its focus lives in the modal's own viewport, so the main-viewport
 				# focus check above stays false and this set still shows behind it.
 				hints = HINTS_FIGHT
-	PadHintBar.set_hints(hints)
+	PadHintBar.set_hints(_with_box_select_hint(hints))
+
+
+# Board box multi-select (hold A + left stick) — the pad counterpart of the
+# mouse's Shift+drag. Offered from the RESTING mid-move states, one step before
+# the controllers' own _pad_box_select_armed() will accept the press: that adds
+# "cursor already active", and the player has to read the chip BEFORE deflecting
+# the stick for the gesture to be discoverable at all.
+func _box_select_offered() -> bool:
+	if carry_active:
+		return false
+	# The action bar and any focused panel own the pad exclusively while up.
+	if PadActionBar.is_open() or get_viewport().gui_get_focus_owner() != null:
+		return false
+	var mc := _movement_controller()
+	if mc != null and mc.has_method("pad_can_grab_group"):
+		return bool(mc.pad_can_grab_group())
+	var cc := _charge_controller_any()
+	if cc != null and ("awaiting_movement" in cc) and ("active_unit_id" in cc):
+		return bool(cc.awaiting_movement) and str(cc.active_unit_id) != ""
+	return false
+
+
+# Point the LS chip at the box-select promise while the gesture is live (adding
+# one when the set has no LS chip). Applied here rather than baked into the const
+# sets because one gesture spans several of them — HINTS_MOVE while the mode
+# decision is still re-openable, HINTS_MOVE_STAGED / _LOCKED mid-move, and
+# HINTS_CHARGE_MOVE — and only the router can see which are actually armed.
+func _with_box_select_hint(hints: Array) -> Array:
+	if not _box_select_offered():
+		return hints
+	var out: Array = []
+	var replaced := false
+	for hint in hints:
+		if str(hint[0]) == "ls":
+			out.append(["ls", BOX_SELECT_HINT])
+			replaced = true
+		else:
+			out.append(hint)
+	if not replaced:
+		out.append(["ls", BOX_SELECT_HINT])
+	return out
 
 
 # The MovementController while the Movement phase is live, else null. Used by the

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.6.0",
+      "date": "2026-07-27",
+      "summary": "Controller players can now box-select several models at once — hold A on empty board and steer with the left stick, the pad version of the mouse's Shift+click-drag.",
+      "changes": [
+        "Added box multi-select on the controller. While a unit is mid-move (Movement phase) or making its charge move, hold A with the cursor over empty board and push the left stick: a selection rectangle follows the cursor, and letting go of A selects every one of that unit's models inside it. Press A on one of them to drag the whole group together, exactly as with a mouse.",
+        "No button changed meaning to make room for this. Holding A on empty board previously did nothing at all, and A only becomes a plain click once you have moved the stick — so A still opens the Move Menu and picks models up exactly as before, and pressing A on a model still drags just that model.",
+        "The hint bar now advertises the gesture ('Hold A: Box Select') whenever it is available, and follows a remapped Select button if you have changed the controller layout in Settings.",
+        "Fixed a selection box getting stuck 'open' if you released the button over the HUD panels instead of the board — it would keep re-selecting models as you moved afterwards. It now closes where you let go. This affected the mouse's Shift+drag too."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/scripts/ChargeController.gd
+++ b/40k/scripts/ChargeController.gd
@@ -209,11 +209,21 @@ func _input(event: InputEvent) -> void:
 			# whitelisted here — that is why "Undo Last Model" appeared dead when a
 			# player clicked it (and why "Snap to Contact" only worked via the
 			# test's emit_pressed shortcut, not a real mouse click).
-			for panel_button in [confirm_button, undo_charge_model_button, auto_path_charge_button]:
-				if is_instance_valid(panel_button) and panel_button.visible:
-					if panel_button.get_global_rect().has_point(mouse_event.global_position):
-						print("DEBUG: Click is within a charge-panel button, not handling")
-						return  # Let the button handle this click
+			# A live drag owns its own release: finishing a box / group / model drag
+			# with the cursor over a panel button must still reach
+			# _handle_mouse_release, or the gesture is stranded. Only presses (and
+			# releases with nothing in flight) are handed to the buttons.
+			# Explicitly typed: dragging_model is an untyped `null`-default var, so
+			# `:=` here cannot infer a type and fails to COMPILE — which silently
+			# nulls the whole controller (and with it the overwatch auto-decline
+			# signal), rather than erroring anywhere near this line.
+			var drag_live: bool = dragging_model != null or drag_box_active or group_dragging
+			if mouse_event.pressed or not drag_live:
+				for panel_button in [confirm_button, undo_charge_model_button, auto_path_charge_button]:
+					if is_instance_valid(panel_button) and panel_button.visible:
+						if panel_button.get_global_rect().has_point(mouse_event.global_position):
+							print("DEBUG: Click is within a charge-panel button, not handling")
+							return  # Let the button handle this click
 
 			print("DEBUG: ChargeController _input - Left mouse button, pressed: ", mouse_event.pressed)
 			if mouse_event.pressed:
@@ -254,7 +264,9 @@ func _handle_mouse_down(global_pos: Vector2) -> void:
 	# Shift+press on empty board space starts drag-box multi-selection of the
 	# charging unit's models (mirrors the Movement phase multi-select UX).
 	# Pressing ON a model with Shift held falls through to a normal drag.
-	if Input.is_key_pressed(KEY_SHIFT) and _find_draggable_charge_model_at(global_pos).is_empty():
+	# On the pad the A press itself is the modifier — see _pad_box_select_armed().
+	if (Input.is_key_pressed(KEY_SHIFT) or _pad_box_select_armed()) \
+			and _find_draggable_charge_model_at(global_pos).is_empty():
 		if board_root:
 			_start_drag_box_selection(board_root.to_local(global_pos))
 		return
@@ -389,6 +401,13 @@ func _handle_mouse_motion(global_pos: Vector2) -> void:
 	var local_pos = board_root.to_local(global_pos)
 
 	if drag_box_active:
+		if not Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
+			# Safety net (mirrors MovementController): a release swallowed by a
+			# charge-panel button never reaches _handle_mouse_release, which would
+			# strand the box open and keep re-selecting on every later move.
+			print("ChargeController: Drag box lost its release — completing at ", local_pos)
+			_complete_drag_box_selection(local_pos)
+			return
 		_update_drag_box_selection(local_pos)
 		return
 	if group_dragging:
@@ -498,6 +517,23 @@ func _update_charge_selection_visuals() -> void:
 		indicator.ring_radius = Measurement.base_radius_px(model.get("base_mm", 32))
 		board_root.add_child(indicator)
 		selection_indicators.append(indicator)
+
+func _pad_box_select_armed() -> bool:
+	"""Controller box multi-select: hold A and drag with the left stick — the pad
+	counterpart of Shift+drag. Same contract as MovementController's helper of the
+	same name (see the long note there): once the left stick deflects, the virtual
+	cursor goes active, PadRouter hands A to VirtualCursor as a plain synthetic
+	click, and an A press on EMPTY board was a dead gesture. Narrow on purpose so
+	a parked cursor and a live carry both keep their own A meanings. The caller
+	pairs this with the "no draggable model here" check, so a press ON a model
+	stays a model / group drag."""
+	if not InputDeviceManager.is_pad_active():
+		return false
+	if not VirtualCursor.is_cursor_active():
+		return false
+	if PadRouter.is_carrying():
+		return false
+	return active_unit_id != ""
 
 func _start_drag_box_selection(local_pos: Vector2) -> void:
 	drag_box_active = true

--- a/40k/scripts/MovementController.gd
+++ b/40k/scripts/MovementController.gd
@@ -2115,8 +2115,10 @@ func _unhandled_input(event: InputEvent) -> void:
 				# Multi-selection input handling
 				if Input.is_key_pressed(KEY_CTRL):
 					_handle_ctrl_click_selection(event.position)
-				elif Input.is_key_pressed(KEY_SHIFT) and _should_start_drag_box():
-					# Require Shift key for drag-box selection to avoid conflicts
+				elif (Input.is_key_pressed(KEY_SHIFT) or _pad_box_select_armed()) and _should_start_drag_box():
+					# Require Shift key for drag-box selection to avoid conflicts.
+					# On the pad the modifier is the A press itself — see
+					# _pad_box_select_armed() for why that button is free here.
 					_start_drag_box_selection(event.position)
 				elif _try_click_select_unit(event.position):
 					pass  # Click on a different friendly unit's model — selection/switch handled
@@ -2146,7 +2148,17 @@ func _unhandled_input(event: InputEvent) -> void:
 					_end_model_rotation(event.position)
 	elif event is InputEventMouseMotion:
 		if drag_box_active:
-			_update_drag_box_selection(event.position)
+			if not Input.is_mouse_button_pressed(MOUSE_BUTTON_LEFT):
+				# Safety net: a release that landed on a HUD Control is consumed by
+				# the GUI pass and never reaches _unhandled_input, which strands the
+				# box "open" — it then keeps re-selecting on every later mouse move.
+				# If the button is no longer held, close the box where it stands.
+				# Matters most on the pad, where the hint bar and right-hand panel
+				# sit right under a Deck-sized drag.
+				print("MovementController: Drag box lost its release — completing at ", event.position)
+				_complete_drag_box_selection(event.position)
+			else:
+				_update_drag_box_selection(event.position)
 		elif group_dragging:
 			_update_group_drag(event.position)
 		elif dragging_model:
@@ -3968,9 +3980,43 @@ func _on_unit_switch_confirmed(target_unit_id: String) -> void:
 	print("MovementController: Unit switch confirmed — selecting %s" % target_unit_id)
 	_select_unit_in_list_by_id(target_unit_id)
 
+func _pad_box_select_armed() -> bool:
+	"""Controller box multi-select: hold A and drag with the left stick.
+
+	The pad needs no modifier button here because A is ALREADY a plain click in
+	exactly this state. Once the left stick is deflected the virtual cursor goes
+	active, and both of PadRouter's own A meanings stand down on that same flag
+	(_try_open_move_menu and _try_begin_carry each bail on
+	VirtualCursor.is_cursor_active()) — A is handed to VirtualCursor, which emits
+	a synthetic left press/release at the cursor. A press on EMPTY board then ran
+	_handle_single_model_selection, which cleared the selection and returned
+	immediately (no model to drag), so holding A and pushing the stick was a dead
+	gesture. That is the gesture this claims — the same one Shift+drag claims for
+	the mouse, and no spare Deck button is spent on it.
+
+	Deliberately narrow, so the states where A means something keep it:
+	  * pad active + cursor active — a parked cursor means A is still "open the
+	    move menu" / "pick up the indexed model" (see PadRouter._handle_a).
+	  * not mid-carry — the router owns A while a model or group is in hand.
+	  * a live, unfinished move session — the same gate the pad's ▲ "grab all"
+	    uses (pad_can_grab_group). Without it a box could select models before a
+	    move mode is chosen, and the follow-up group drag would have no mode to
+	    stage against. The mouse's Shift+drag is deliberately left as it was.
+	The caller pairs this with _should_start_drag_box(), which refuses when the
+	cursor is over a model — that press stays a model / group drag."""
+	if not InputDeviceManager.is_pad_active():
+		return false
+	if not VirtualCursor.is_cursor_active():
+		return false
+	if PadRouter.is_carrying():
+		return false
+	return pad_can_grab_group()
+
 func _should_start_drag_box() -> bool:
-	"""Determine if we should start drag-box selection (requires Shift key)"""
-	# Start drag box only when Shift is held and we're not clicking directly on a model
+	"""Determine if we should start drag-box selection. The caller supplies the
+	modifier (Shift on the mouse, a held A on the pad — _pad_box_select_armed);
+	this is the shared "the press is not on a model" half."""
+	# Start drag box only when the modifier is held and we're not clicking directly on a model
 	# This prevents conflicts with normal drag-to-move operations
 	# Convert screen position to board-local coords before checking model overlap
 	var board_root = SceneRefs.board_root()

--- a/40k/scripts/input/GlyphDB.gd
+++ b/40k/scripts/input/GlyphDB.gd
@@ -58,6 +58,22 @@ static func _pad_bindings() -> Node:
 	return null
 
 
+# Expand "{id}" tokens in a hint label to the button that glyph id currently
+# sits on: "Hold {a}: Box Select" -> "Hold A: Box Select", and "Hold Y: Box
+# Select" once the select role has been rebound onto Y in Settings › Controller.
+# Lets a chip name a SECOND button in its label without hardcoding a layout —
+# the hint sets stay const arrays and still follow a remap.
+static func expand_label(label_text: String) -> String:
+	if not label_text.contains("{"):
+		return label_text
+	var out := label_text
+	for glyph_id in GLYPHS:
+		var token := "{%s}" % glyph_id
+		if out.contains(token):
+			out = out.replace(token, glyph_text(glyph_id))
+	return out
+
+
 # A single "⟨glyph⟩ label" hint chip, e.g. [RS] Pan Camera.
 static func make_chip(glyph_id: String, label_text: String) -> Control:
 	var row := HBoxContainer.new()
@@ -85,7 +101,7 @@ static func make_chip(glyph_id: String, label_text: String) -> Control:
 	row.add_child(badge)
 
 	var text_label := Label.new()
-	text_label.text = label_text
+	text_label.text = expand_label(label_text)
 	text_label.add_theme_font_size_override("font_size", 13)
 	text_label.add_theme_color_override("font_color", Color(_UIConstants.NEUTRAL_UI_PALE_WHITE, 0.8))
 	row.add_child(text_label)

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -8515,6 +8515,56 @@
       "last_verified_commit": "HEAD",
       "status": "covered",
       "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.box_select_hold_a_drag",
+      "description": "Pad box multi-select: holding A on empty board and steering with the left stick draws the selection rectangle and releasing A selects the models inside it. Declared by: pad_box_multi_select.",
+      "scenarios": [
+        "pad_box_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.box_select_subset_then_group_drag",
+      "description": "A pad box selects a STRICT SUBSET of a unit's models (asserted by model id), and group-dragging then moves only those models. Declared by: pad_box_multi_select.",
+      "scenarios": [
+        "pad_box_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.box_select_requires_active_cursor",
+      "description": "The pad box gesture is disarmed while the virtual cursor is parked, so A keeps its Move Menu / pick-up-model meanings. Declared by: pad_box_multi_select.",
+      "scenarios": [
+        "pad_box_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.box_select_skips_press_on_model",
+      "description": "A pad press with the cursor over a model starts a model / group drag, never a selection box. Declared by: pad_box_multi_select.",
+      "scenarios": [
+        "pad_box_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "controller.move.box_select_hint_chip",
+      "description": "The LS hint chip advertises the gesture ('Hold A: Box Select') while it is armed, so it is discoverable. Declared by: pad_box_multi_select.",
+      "scenarios": [
+        "pad_box_multi_select"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/pad_box_multi_select.json
+++ b/40k/tests/scenarios/sp/pad_box_multi_select.json
@@ -1,0 +1,104 @@
+{
+  "id": "pad_box_multi_select",
+  "covers": [
+    "controller.move.box_select_hold_a_drag",
+    "controller.move.box_select_subset_then_group_drag",
+    "controller.move.box_select_requires_active_cursor",
+    "controller.move.box_select_skips_press_on_model",
+    "controller.move.box_select_hint_chip"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "transition_to_phase": 7,
+  "disable_ai": true,
+  "rng_seed": 42,
+  "description": "Steam Deck box multi-select: the pad counterpart of the mouse's Shift+click-drag. Holding A on EMPTY board and steering with the left stick draws the same selection rectangle, and releasing A selects the models inside it — no spare Deck button and no synthetic Shift. Drives the real path on U_WITCHSEEKERS_C (four models in a row at board x=850/910/970/1030, y=50): select the unit, choose Move, cancel the auto-carry so nothing is staged, then hold A from an empty spot at (820,10) and drag to (940,90) — a box that encloses models 1 and 2 only. Asserts a STRICT SUBSET is selected (2 of 4, by model id), then group-drags exactly those two and confirms only they moved. Also pins the two guards that keep A's other meanings intact: with the cursor PARKED the gesture is disarmed (A still means Move Menu / pick up model), and with the cursor over a MODEL the press stays a model drag rather than a box. Finally checks the player can actually discover it — the LS hint chip reads 'Hold A: Box Select'.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 7 },
+
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"m0y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y)" },
+    { "act": "execute_script", "script": "InputDeviceManager.set_meta(\"m2y\", GameState.state.units[\"U_WITCHSEEKERS_C\"].models[2].position.y)" },
+
+    { "act": "pad_cursor_glide", "unit_id": "U_WITCHSEEKERS_C" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "str(main.movement_controller.active_unit_id)", "equals": "U_WITCHSEEKERS_C" },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": false },
+    { "act": "execute_script", "script": "main.movement_controller._pad_box_select_armed()", "equals": false },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "PadActionBar.is_open()", "equals": true },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 1 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "PadRouter.is_carrying()", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 0 },
+    { "act": "execute_script", "script": "main.movement_controller.pad_can_grab_group()", "equals": true },
+
+    { "act": "execute_script", "script": "PadHintBar.label_for(\"ls\")", "equals": "Hold A: Box Select" },
+
+    { "act": "execute_script", "script": "main._zoom_about(2.4, main.world_to_screen_position(Vector2(940, 50)))" },
+    { "act": "execute_script", "script": "main.update_view_transform()" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "script": "main.view_zoom", "expect_min": 2.0 },
+
+    { "act": "pad_cursor_glide", "x": 820.0, "y": 10.0 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "VirtualCursor.is_cursor_active()", "equals": true },
+    { "act": "execute_script", "script": "main.movement_controller._pad_box_select_armed()", "equals": true },
+    { "act": "execute_script", "script": "main.movement_controller._should_start_drag_box()", "equals": true },
+
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 50.0 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "main.movement_controller._should_start_drag_box()", "equals": false },
+
+    { "act": "pad_cursor_glide", "x": 820.0, "y": 10.0 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "execute_script", "script": "main.movement_controller._should_start_drag_box()", "equals": true },
+
+    { "act": "simulate_joy_button", "button_index": 0, "state": "press" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.movement_controller.drag_box_active", "equals": true },
+
+    { "act": "pad_cursor_glide", "x": 940.0, "y": 90.0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.movement_controller.drag_box_active", "equals": true },
+    { "act": "screenshot", "label": "01_box_live_while_a_held" },
+
+    { "act": "simulate_joy_button", "button_index": 0, "state": "release" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.movement_controller.drag_box_active", "equals": false },
+    { "act": "execute_script", "script": "main.movement_controller.selected_models.size()", "equals": 2 },
+    { "act": "execute_script", "script": "str(main.movement_controller.selected_models[0].model_id)", "equals": "m1" },
+    { "act": "execute_script", "script": "str(main.movement_controller.selected_models[1].model_id)", "equals": "m2" },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 0 },
+    { "act": "screenshot", "label": "02_subset_of_two_selected" },
+
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 50.0 },
+    { "act": "wait_seconds", "seconds": 0.2 },
+    { "act": "simulate_joy_button", "button_index": 0, "state": "press" },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "script": "main.movement_controller.group_dragging", "equals": true },
+    { "act": "pad_cursor_glide", "x": 850.0, "y": 170.0 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 0, "state": "release" },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "main.movement_controller.group_dragging", "equals": false },
+    { "act": "execute_script", "script": "PhaseManager.current_phase_instance.active_moves[\"U_WITCHSEEKERS_C\"].staged_moves.size()", "equals": 2 },
+    { "act": "screenshot", "label": "03_only_the_boxed_pair_staged" },
+
+    { "act": "pad_cursor_glide", "button_text": "End This Unit's Move" },
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WITCHSEEKERS_C\"].models[0].position.y - InputDeviceManager.get_meta(\"m0y\")", "expect_min": 60 },
+    { "act": "execute_script", "script": "GameState.state.units[\"U_WITCHSEEKERS_C\"].models[2].position.y - InputDeviceManager.get_meta(\"m2y\")", "equals": 0 },
+    { "act": "screenshot", "label": "04_confirmed_only_boxed_models_moved" }
+  ]
+}


### PR DESCRIPTION
## What

The mouse has Shift+click-drag to box-select several of a unit's models. The pad had only "all" (D-pad ▲) or "one" (D-pad ▼) — never an arbitrary subset. This adds the pad counterpart of Shift+drag, in the Movement phase and during charge moves.

**Hold A on empty board and steer with the left stick** → a selection rectangle follows the cursor; release A to select every model of that unit inside it. Press A on one of them to drag the whole group together, exactly as with a mouse.

## Why no modifier button was needed

A is *already* a plain click in exactly the state a box-select happens in. Once the left stick deflects, the virtual cursor goes active and both of `PadRouter`'s own A meanings stand down on that same flag — `_try_open_move_menu` and `_try_begin_carry` each bail on `VirtualCursor.is_cursor_active()` — so A is handed to `VirtualCursor` as a synthetic left press/release. An A press on empty board then ran `_handle_single_model_selection`, which cleared the selection and returned with no model to drag, making hold-A-and-steer a dead gesture.

That dead gesture is what this claims. No spare Deck button is spent, and no synthetic `KEY_SHIFT` is involved.

`_pad_box_select_armed()` is deliberately narrow, so every state where A means something keeps it:

- **pad active AND cursor active** — a parked cursor still means "open the Move Menu" / "pick up the indexed model"
- **not mid-carry** — the router owns A while a model or group is in hand
- **only during a live, unfinished move session** — the same gate the pad's ▲ "grab all" uses

It pairs with the existing `_should_start_drag_box()`, which refuses when the cursor is over a model — that press stays a model/group drag. **The mouse's Shift+drag path is unchanged.**

## Discoverability

The LS hint chip reads `Hold A: Box Select` while the gesture is armed. Applied dynamically in `PadRouter` rather than baked into the const hint sets, because one gesture spans `HINTS_MOVE`, `HINTS_MOVE_STAGED`, `HINTS_MOVE_LOCKED` and `HINTS_CHARGE_MOVE`, and only the router can see which are actually armed. `GlyphDB` gained `{a}` token expansion so the label names whichever button the select role currently sits on after a Settings › Controller remap.

## Bug fixed along the way

A release that landed on a HUD `Control` was consumed by the GUI pass and never reached the controller, leaving the selection box "open" so it kept re-selecting on every later mouse move. Both controllers now close the box when the button is no longer held. **This affected the mouse's Shift+drag too**, and matters more on a Deck-sized screen where the panels sit right under the drag.

## Trap worth knowing about

The `ChargeController` guard uses an explicit `bool` rather than `:=`. `dragging_model` is an untyped `null`-default var, so `:=` there raises:

```
Parse Error: Cannot infer the type of "drag_live" variable because the value doesn't have a set type.
```

That is a **parse error which nulls the entire controller**, silently disconnecting the overwatch auto-decline signal — surfacing as charge rolls failing with "Awaiting Fire Overwatch decision", nowhere near the actual line. Reproduced in isolation and documented at the line so it isn't rediscovered the hard way.

## Validation

| Gate | Result |
| --- | --- |
| `pad_box_multi_select` (new windowed scenario) | **72/72 steps** |
| `pad_group_move_all`, `charge_group_drag_multi_select`, `pad_controller_layout_rebind`, `pad_m1_cursor_basics` | **5/5 pass** |
| Headless audit suite (`run_pretrigger_tests.sh`) | **2173 passed, 0 failed across 104 tests** |
| Compile check, all 5 edited scripts | OK |

The new scenario drives the real player path — select the unit, choose Move, cancel the auto-carry, then hold A from empty board and drag a box enclosing two of the four models — and asserts a **strict subset** is selected by model id, that group-dragging moves only those two, and that the confirmed state leaves the other two where they were. It also pins both guards: with the cursor parked the gesture is disarmed, and with the cursor over a model the press stays a model drag.

## Notes for the reviewer

- **`pad_move_staged_hint_labels` fails on `main` as well as on this branch.** It asserts `label_for("dpad") == "Grab All"` while the committed const reads `"◀▶ Model · ▲ All"`. No dpad chip is touched by this diff. Pre-existing, left alone because fixing it means deciding which side is correct.
- **The charge half is code-verified but not windowed.** `ChargeController` gets the identical gate and shares the drag-box machinery, and `charge_group_drag_multi_select` still passes, but the new scenario exercises the Movement phase. A dedicated charge-phase scenario would close that gap.

Changelog entry added as **v1.6.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AbDNigdqdLWvBv6okoPqZ

---
_Generated by [Claude Code](https://claude.ai/code/session_016AbDNigdqdLWvBv6okoPqZ)_