### PR TITLE
Show and fire only the weapons a unit is actually equipped with

### DIFF
--- a/40k/armies/A_C_test.json
+++ b/40k/armies/A_C_test.json
@@ -296,7 +296,11 @@
     "points": 210,
     "is_warlord": false,
     "enhancements": [],
-    "wargear": [],
+    "wargear": [
+      "1x Twin iliastus accelerator cannon",
+      "1x Twin lastrum bolt cannon",
+      "1x Armoured hull"
+    ],
     "weapons": [
      {
       "name": "Twin arachnus heavy blaze cannon",

--- a/40k/armies/adeptus_custodes.json
+++ b/40k/armies/adeptus_custodes.json
@@ -38,7 +38,8 @@
     "is_warlord": true,
     "enhancements": [],
     "wargear": [
-     "Shield-Captain (Shield), Praesidium Shield"
+     "Shield-Captain (Shield), Praesidium Shield",
+     "1x Guardian spear"
     ],
     "weapons": [
      {
@@ -728,7 +729,11 @@
     "points": 210,
     "is_warlord": false,
     "enhancements": [],
-    "wargear": [],
+    "wargear": [
+      "1x Twin iliastus accelerator cannon",
+      "1x Twin lastrum bolt cannon",
+      "1x Armoured hull"
+    ],
     "weapons": [
      {
       "name": "Twin arachnus heavy blaze cannon",
@@ -856,7 +861,10 @@
     "points": 155,
     "is_warlord": false,
     "enhancements": [],
-    "wargear": [],
+    "wargear": [
+      "1x Achillus dreadspear",
+      "1x Lastrum storm bolter"
+    ],
     "weapons": [
      {
       "name": "Achillus dreadspear – Achillus dreadspear",
@@ -999,7 +1007,11 @@
     "points": 225,
     "is_warlord": false,
     "enhancements": [],
-    "wargear": [],
+    "wargear": [
+      "1x Iliastus accelerator culverin",
+      "1x Spiculus bolt launcher",
+      "1x Armoured feet"
+    ],
     "weapons": [
      {
       "name": "Arachnus storm cannon",

--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -6331,10 +6331,16 @@ static func _ensure_loadout_resolved(unit: Dictionary) -> void:
 		return
 	unit["_loadout_checked"] = true
 
-	# Multi-model units only. A single-model unit (VEHICLE / MONSTER / character)
-	# legitimately fires ALL of its weapons, so we must never collapse it to one
-	# gun — its "menu" is its real arsenal, not a per-model choice.
+	# A single-model unit (VEHICLE / MONSTER / character) DOES fire all of the
+	# weapons it carries — but `meta.weapons` is the datasheet's option MENU, not
+	# its arsenal. A Battlewagon's menu offers a kannon OR a killkannon OR a zzap
+	# gun; the roster picked one. Narrow it from the roster's wargear so the
+	# Shooting/Fight phases stop offering guns the player never took. The
+	# resolver returns the menu untouched whenever it can't read the loadout, and
+	# we only stamp when it actually narrowed something — so a unit we cannot
+	# resolve keeps the original "fires everything on the datasheet" behaviour.
 	if unit.get("models", []).size() < 2:
+		_resolve_single_model_loadout(unit)
 		return
 
 	_resolve_type_loadout(unit, "Ranged", "ranged_loadout")
@@ -6344,6 +6350,50 @@ static func _ensure_loadout_resolved(unit: Dictionary) -> void:
 	# ranged, so most units fall back to the menu; those that pin it cleanly
 	# (Kommandos -> Choppa, Burna Boyz -> Cuttin' flames + CCW) are resolved.
 	_resolve_type_loadout(unit, "Melee", "melee_loadout")
+
+
+# MA-LOADOUT: single-model narrowing. Shares ONE resolution with the datasheet
+# UI (UnitLoadoutResolver) so what a player is shown and what they can fire can
+# never disagree. Stamps `ranged_loadout` / `melee_loadout` on the lone model —
+# the same keys _get_model_weapon_ids already honours — but ONLY for a type the
+# resolver genuinely narrowed. Leaving the other type unstamped preserves the
+# old menu behaviour for it exactly.
+static func _resolve_single_model_loadout(unit: Dictionary) -> void:
+	var models = unit.get("models", [])
+	if models.size() != 1:
+		return
+	var meta = unit.get("meta", {})
+	var menu = meta.get("weapons", [])
+	if typeof(menu) != TYPE_ARRAY or menu.is_empty():
+		return
+
+	var equipped = UnitLoadoutResolver.get_equipped_weapons(unit)
+	if equipped.size() >= menu.size():
+		return  # nothing was narrowed — leave the unit untouched
+
+	# Bucket both the menu and the equipped set per weapon type, so we can tell
+	# WHICH type actually lost options (a Battlewagon narrows its ranged menu
+	# 6 -> 3 while its melee list is already exact).
+	var uname = str(meta.get("name", ""))
+	for pair in [["Ranged", "ranged_loadout"], ["Melee", "melee_loadout"]]:
+		var type_filter = str(pair[0]).to_lower()
+		var menu_names := []
+		for w in menu:
+			if typeof(w) == TYPE_DICTIONARY and str(w.get("type", "")).to_lower() == type_filter:
+				var n = str(w.get("name", ""))
+				if n not in menu_names:
+					menu_names.append(n)
+		var kept := []
+		for w in equipped:
+			if typeof(w) == TYPE_DICTIONARY and str(w.get("type", "")).to_lower() == type_filter:
+				var n = str(w.get("name", ""))
+				if n not in kept:
+					kept.append(n)
+		if kept.size() >= menu_names.size():
+			continue  # this type was not narrowed
+		models[0][str(pair[1])] = kept
+		print("[MA-LOADOUT] %s (%s): single model narrowed to roster loadout %s (menu had %d)" % [
+			uname, str(pair[0]), str(kept), menu_names.size()])
 
 
 # MA-LOADOUT: cross-check guard — may this model's type actually take

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -4,12 +4,14 @@
     {
       "version": "1.5.2",
       "date": "2026-07-27",
-      "summary": "Unit datasheets now list only the weapons a unit is actually armed with, instead of every weapon its datasheet could take.",
+      "summary": "Units now show — and fire — only the weapons they are actually armed with, instead of every weapon their datasheet could take.",
       "changes": [
         "Opening a unit's datasheet (Y on a controller, I on the keyboard) used to show the whole datasheet's weapon menu. The tutorial Battlewagon listed a killkannon, a zzap gun and a big shoota it was never armed with, alongside the kannon, lobba, deff rolla, grabbin' klaw and wreckin' ball it actually has.",
-        "Datasheets now show the roster's real loadout — including base weapons that are always fitted (the Battlewagon's tracks and wheels) and both profiles of a multi-profile weapon (Kannon – Frag and Kannon – Shell).",
+        "The Shooting and Fight phases had the same problem, which was worse: that Battlewagon could actually FIRE the killkannon and zzap gun it never bought. Single-model units — vehicles, monsters and characters — are now narrowed to their roster's real loadout everywhere, so the weapon list you are offered matches the datasheet you are shown.",
+        "Datasheets keep base weapons that are always fitted (the Battlewagon's tracks and wheels) and both profiles of a multi-profile weapon (Kannon – Frag and Kannon – Shell).",
         "Same fix for the right-click 'Unit Stats' card and the two-unit stats comparison panel.",
-        "If a unit's loadout can't be read for any reason, its datasheet still shows the full weapon list rather than showing nothing."
+        "Four units in the shipped army lists never recorded which option they took, so they showed all of them: the Caladius Grav-tank, Contemptor-Achillus Dreadnought, Telemon Heavy Dreadnought and Shield-Captain now carry their datasheet's standard loadout.",
+        "If a unit's loadout can't be read for any reason, it still shows and fires its full weapon list rather than losing weapons."
       ]
     },
     {

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.5.2",
+      "date": "2026-07-27",
+      "summary": "Unit datasheets now list only the weapons a unit is actually armed with, instead of every weapon its datasheet could take.",
+      "changes": [
+        "Opening a unit's datasheet (Y on a controller, I on the keyboard) used to show the whole datasheet's weapon menu. The tutorial Battlewagon listed a killkannon, a zzap gun and a big shoota it was never armed with, alongside the kannon, lobba, deff rolla, grabbin' klaw and wreckin' ball it actually has.",
+        "Datasheets now show the roster's real loadout — including base weapons that are always fitted (the Battlewagon's tracks and wheels) and both profiles of a multi-profile weapon (Kannon – Frag and Kannon – Shell).",
+        "Same fix for the right-click 'Unit Stats' card and the two-unit stats comparison panel.",
+        "If a unit's loadout can't be read for any reason, its datasheet still shows the full weapon list rather than showing nothing."
+      ]
+    },
+    {
       "version": "1.5.1",
       "date": "2026-07-27",
       "summary": "Fixed the tutorial being unplayable in the released builds (itch.io and Steam Deck) — the lessons' saved battles were never packaged into the game. Faction stratagems and leader pairings were missing from those builds for the same reason.",

--- a/40k/scripts/DatasheetModal.gd
+++ b/40k/scripts/DatasheetModal.gd
@@ -113,7 +113,10 @@ func _render(unit: Dictionary) -> void:
 
 	var weapons_label := Label.new()
 	weapons_label.name = "Weapons"
-	weapons_label.text = _format_weapons(meta.get("weapons", unit.get("weapons", [])))
+	# Only the weapons this unit is actually equipped with — meta.weapons is the
+	# datasheet's full option MENU (a Battlewagon lists a killkannon and a zzap
+	# gun it never took).
+	weapons_label.text = _format_weapons(UnitLoadoutResolver.get_equipped_weapons(unit))
 	weapons_label.add_theme_font_size_override("font_size", 12)
 	weapons_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_vbox.add_child(weapons_label)

--- a/40k/scripts/UnitLoadoutResolver.gd
+++ b/40k/scripts/UnitLoadoutResolver.gd
@@ -1,0 +1,274 @@
+extends RefCounted
+class_name UnitLoadoutResolver
+
+# UnitLoadoutResolver — "which of the datasheet's weapons does THIS unit
+# actually carry?"
+#
+# Why this exists
+# ---------------
+# `unit.meta.weapons` is the datasheet's full weapon MENU — every profile the
+# datasheet lists, including options this particular model never took. A
+# Battlewagon's menu is Big shoota / Kannon / Killkannon / Lobba / Zzap gun /
+# Deff rolla / Grabbin' klaw / Tracks and wheels / Wreckin' ball, but the one in
+# the tutorial roster is only armed with a Kannon, a Lobba, a Deff rolla, a
+# Grabbin' klaw and a Wreckin' ball. Rendering `meta.weapons` verbatim (which is
+# what every datasheet UI used to do) showed the player weapons the unit does
+# not have.
+#
+# The roster DOES record the chosen loadout: `unit.meta.wargear` is a list of
+# "1x Deff rolla" / "1x Kannon" / "1x 'Ard Case" style entries. That, plus the
+# datasheet's *base* kit (weapons a model always has, which are implicit and so
+# never appear in wargear — e.g. the Battlewagon's Tracks and wheels), is enough
+# to narrow the menu down to the real loadout.
+#
+# Base-kit weapons come from `data/40kdc/unitCompositions.json`
+# (`models[].default_weapon_ids`), matched by slugified datasheet name.
+#
+# Safety posture — this only ever narrows, and only when it is confident:
+#   * no parseable wargear weapon for the unit  -> return the menu untouched
+#   * the composition data is missing/unreadable -> base kit is simply empty
+#   * the filter would return nothing            -> return the menu untouched
+# So a roster we cannot read is displayed exactly as it is today.
+#
+# NOTE (scope): this is a DISPLAY resolver. The shooting/fight engine resolves
+# per-model loadouts separately in RulesEngine._ensure_loadout_resolved(), which
+# deliberately skips single-model units (vehicles/characters) — so a Battlewagon
+# can still be *offered* its unequipped guns in the Shooting phase. That is a
+# separate (engine-side) fix and is intentionally not changed here.
+
+const COMPOSITIONS_PATH := "res://data/40kdc/unitCompositions.json"
+
+# Profile-split separators used in weapon names ("Kannon – Frag", "Guardian
+# spear – Melee"). The wargear entry only ever names the base weapon.
+const PROFILE_SEPARATORS := [" – ", " — ", " - "]
+
+# 40kdc unit_id -> Array[String] of default (base-kit) weapon ids.
+static var _defaults_by_unit: Dictionary = {}
+static var _compositions_loaded: bool = false
+
+
+## The subset of the unit's datasheet weapons it is actually equipped with.
+## Returns the untouched weapon list whenever the loadout cannot be resolved.
+static func get_equipped_weapons(unit: Dictionary) -> Array:
+	var meta: Dictionary = unit.get("meta", {}) if typeof(unit.get("meta", {})) == TYPE_DICTIONARY else {}
+	var weapons = meta.get("weapons", unit.get("weapons", []))
+	if typeof(weapons) != TYPE_ARRAY or weapons.is_empty():
+		return []
+
+	# Every slug this datasheet's weapons answer to (full name AND base name, so
+	# a wargear entry of "Kannon" matches both "Kannon – Frag" and "Kannon – Shell").
+	var weapon_slugs := {}
+	for w in weapons:
+		if typeof(w) != TYPE_DICTIONARY:
+			continue
+		var wname := str(w.get("name", ""))
+		weapon_slugs[_slug(wname)] = true
+		weapon_slugs[_slug(_base_name(wname))] = true
+
+	# Wargear entries that name one of this datasheet's weapons. Entries that
+	# name a role ("9x Kommando"), a non-weapon upgrade ("1x 'Ard Case") or a
+	# weapon from another datasheet are ignored.
+	var selected := {}
+	for s in _parse_wargear_slugs(meta.get("wargear", [])):
+		if weapon_slugs.has(s):
+			selected[s] = true
+
+	if selected.is_empty():
+		# No usable loadout signal — show the datasheet as-is rather than guess.
+		return weapons
+
+	var allowed := selected.duplicate()
+	for s in _base_kit_slugs(unit, meta, weapons, selected):
+		allowed[s] = true
+
+	var out: Array = []
+	for w in weapons:
+		if typeof(w) != TYPE_DICTIONARY:
+			continue
+		var wname := str(w.get("name", ""))
+		if allowed.has(_slug(wname)) or allowed.has(_slug(_base_name(wname))):
+			out.append(w)
+
+	if out.is_empty():
+		# Defensive: never blank out the weapons section.
+		print("[LOADOUT-UI] %s: filter matched nothing, showing full datasheet menu" % str(meta.get("name", "?")))
+		return weapons
+	return out
+
+
+## Convenience for callers that only need names (tests, logging).
+static func get_equipped_weapon_names(unit: Dictionary) -> Array:
+	var names: Array = []
+	for w in get_equipped_weapons(unit):
+		if typeof(w) == TYPE_DICTIONARY:
+			names.append(str(w.get("name", "")))
+	return names
+
+
+# ── wargear parsing ─────────────────────────────────────────────────
+
+# "1x Deff rolla" -> "deff-rolla"; "2x Loota (KMB)" -> "loota";
+# "Shield-Captain (Shield), Praesidium Shield" -> ["shield-captain", "praesidium-shield"].
+static func _parse_wargear_slugs(wargear) -> Array:
+	var out: Array = []
+	if typeof(wargear) != TYPE_ARRAY:
+		return out
+	for entry in wargear:
+		for part in str(entry).split(","):
+			var txt := str(part).strip_edges()
+			if txt == "":
+				continue
+			# Strip a leading "Nx " count if present (some rosters omit it).
+			var space := txt.find(" ")
+			if space > 0:
+				var head := txt.substr(0, space)
+				if head.ends_with("x") and head.substr(0, head.length() - 1).is_valid_int():
+					txt = txt.substr(space + 1).strip_edges()
+			# Strip a trailing parenthetical qualifier ("Loota (KMB)").
+			var paren := txt.find("(")
+			if paren > 0:
+				txt = txt.substr(0, paren).strip_edges()
+			var s := _slug(txt)
+			if s != "" and s not in out:
+				out.append(s)
+	return out
+
+
+# ── base kit (weapons the model always has) ─────────────────────────
+
+# The 40kdc default weapon ids for this datasheet, minus any that the roster's
+# wargear clearly REPLACED.
+static func _base_kit_slugs(unit: Dictionary, meta: Dictionary, weapons: Array, selected: Dictionary) -> Array:
+	var unit_slug := _slug(str(meta.get("name", "")))
+	if unit_slug == "":
+		return []
+	_ensure_compositions_loaded()
+	var raw = _defaults_by_unit.get(unit_slug, [])
+	if typeof(raw) != TYPE_ARRAY or raw.is_empty():
+		return []
+
+	# 40kdc disambiguates weapon ids that clash across datasheets by appending
+	# the unit slug ("big-shoota-warboss-in-mega-armour"). Strip it back off.
+	var defaults: Array = []
+	for id in raw:
+		var s := str(id)
+		if s.ends_with("-" + unit_slug):
+			s = s.substr(0, s.length() - unit_slug.length() - 1)
+		if s != "" and s not in defaults:
+			defaults.append(s)
+
+	# Multi-model units: per-model counts make "was this default swapped out?"
+	# undecidable from unit-level wargear, so keep the whole base kit (erring
+	# towards showing a weapon rather than hiding one the player owns).
+	if unit.get("models", []).size() != 1:
+		return defaults
+
+	# Single model (vehicle / character): if the roster picked exactly as many
+	# weapons of a type as the base kit has of that type, treat it as a straight
+	# swap and drop the unpicked base weapon — a Warboss with a power klaw no
+	# longer has the default big choppa. When it picked MORE (a Battlewagon
+	# bolting a deff rolla, grabbin' klaw and wreckin' ball onto its one base
+	# melee weapon) the picks are additive and Tracks and wheels stays.
+	var type_of := _weapon_type_index(weapons)
+	var selected_by_type := {}
+	for s in selected:
+		var t := str(type_of.get(s, ""))
+		selected_by_type[t] = int(selected_by_type.get(t, 0)) + 1
+	var defaults_by_type := {}
+	for s in defaults:
+		var t := str(type_of.get(s, ""))
+		defaults_by_type[t] = int(defaults_by_type.get(t, 0)) + 1
+
+	var kept: Array = []
+	for s in defaults:
+		if selected.has(s):
+			continue  # already allowed via wargear
+		var t := str(type_of.get(s, ""))
+		var n_sel := int(selected_by_type.get(t, 0))
+		if n_sel > 0 and n_sel == int(defaults_by_type.get(t, 0)):
+			print("[LOADOUT-UI] %s: base '%s' treated as replaced by the roster's %s pick(s)" % [
+				str(meta.get("name", "?")), s, t])
+			continue
+		kept.append(s)
+	return kept
+
+
+# slug (full name AND base name) -> lowercased weapon type ("ranged"/"melee").
+static func _weapon_type_index(weapons: Array) -> Dictionary:
+	var out := {}
+	for w in weapons:
+		if typeof(w) != TYPE_DICTIONARY:
+			continue
+		var wname := str(w.get("name", ""))
+		var t := str(w.get("type", "")).to_lower()
+		out[_slug(wname)] = t
+		var b := _slug(_base_name(wname))
+		if not out.has(b):
+			out[b] = t
+	return out
+
+
+static func _ensure_compositions_loaded() -> void:
+	if _compositions_loaded:
+		return
+	_compositions_loaded = true
+	if not FileAccess.file_exists(COMPOSITIONS_PATH):
+		print("[LOADOUT-UI] %s not found — base-kit weapons unavailable" % COMPOSITIONS_PATH)
+		return
+	var f := FileAccess.open(COMPOSITIONS_PATH, FileAccess.READ)
+	if f == null:
+		print("[LOADOUT-UI] cannot open %s (err %d)" % [COMPOSITIONS_PATH, FileAccess.get_open_error()])
+		return
+	var text := f.get_as_text()
+	f.close()
+	var parsed = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_ARRAY:
+		print("[LOADOUT-UI] %s did not parse to an array — base-kit weapons unavailable" % COMPOSITIONS_PATH)
+		return
+	for entry in parsed:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var uid := str(entry.get("unit_id", ""))
+		if uid == "":
+			continue
+		var ids: Array = _defaults_by_unit.get(uid, [])
+		for m in entry.get("models", []):
+			if typeof(m) != TYPE_DICTIONARY:
+				continue
+			for wid in m.get("default_weapon_ids", []):
+				var s := str(wid)
+				if s != "" and s not in ids:
+					ids.append(s)
+		if not ids.is_empty():
+			_defaults_by_unit[uid] = ids
+	print("[LOADOUT-UI] base kits loaded for %d datasheets" % _defaults_by_unit.size())
+
+
+# ── name normalisation ──────────────────────────────────────────────
+
+## "Kannon – Frag" -> "Kannon". Leaves names without a profile suffix alone.
+static func _base_name(n: String) -> String:
+	for sep in PROFILE_SEPARATORS:
+		var idx := n.find(sep)
+		if idx > 0:
+			return n.substr(0, idx)
+	return n
+
+
+## "Grabbin' klaw" -> "grabbin-klaw", "'Ard Case" -> "ard-case".
+## Apostrophes are dropped (never a separator) to match 40kdc's id style.
+static func _slug(s: String) -> String:
+	var out := ""
+	var prev_dash := true  # true at the start so leading separators are eaten
+	var lower := s.to_lower()
+	for i in lower.length():
+		var cp := lower.unicode_at(i)
+		if (cp >= 97 and cp <= 122) or (cp >= 48 and cp <= 57):
+			out += String.chr(cp)
+			prev_dash = false
+		elif cp == 39 or cp == 0x2019:  # ' and ’
+			continue
+		elif not prev_dash:
+			out += "-"
+			prev_dash = true
+	return out.rstrip("-")

--- a/40k/scripts/UnitLoadoutResolver.gd.uid
+++ b/40k/scripts/UnitLoadoutResolver.gd.uid
@@ -1,0 +1,1 @@
+uid://dtdnyqla1awq8

--- a/40k/scripts/UnitStatsCardPopup.gd
+++ b/40k/scripts/UnitStatsCardPopup.gd
@@ -47,7 +47,7 @@ func setup(uid: String, popup_position: Vector2) -> void:
 	_build_stats_row(content, meta)
 
 	# ── Weapons Tables ──
-	_build_weapons_section(content, meta)
+	_build_weapons_section(content, unit)
 
 	# ── Abilities ──
 	_build_abilities_section(content, unit)
@@ -212,8 +212,9 @@ func _build_stats_row(parent: VBoxContainer, meta: Dictionary) -> void:
 
 # ── Weapons ─────────────────────────────────────────────────────
 
-func _build_weapons_section(parent: VBoxContainer, meta: Dictionary) -> void:
-	var weapons = meta.get("weapons", [])
+func _build_weapons_section(parent: VBoxContainer, unit: Dictionary) -> void:
+	# Equipped loadout only — meta.weapons is the datasheet's full option menu.
+	var weapons = UnitLoadoutResolver.get_equipped_weapons(unit)
 	if weapons.is_empty():
 		return
 

--- a/40k/scripts/UnitStatsPanel.gd
+++ b/40k/scripts/UnitStatsPanel.gd
@@ -397,7 +397,9 @@ func _create_weapons_tables(unit_data: Dictionary, weapons_container: VBoxContai
 	if not unit_data.has("meta") or not unit_data["meta"].has("weapons"):
 		return
 	
-	var weapons = unit_data["meta"]["weapons"]
+	# Equipped loadout only — meta.weapons is the datasheet's full option MENU,
+	# so a Battlewagon would otherwise list a killkannon/zzap gun it never took.
+	var weapons = UnitLoadoutResolver.get_equipped_weapons(unit_data)
 	if weapons.is_empty():
 		return
 

--- a/40k/tests/scenarios/sp/datasheet_equipped_weapons_only.json
+++ b/40k/tests/scenarios/sp/datasheet_equipped_weapons_only.json
@@ -1,0 +1,36 @@
+{
+  "id": "datasheet_equipped_weapons_only",
+  "covers": [
+    "ui.datasheet.equipped_weapons_only",
+    "scripts.UnitLoadoutResolver.get_equipped_weapons",
+    "scripts.DatasheetModal.render_weapons"
+  ],
+  "fixture": "fullauto_pretrigger",
+  "transition_to_phase": 7,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "Pressing Y (pad) on a selected Battlewagon opens the datasheet showing ONLY the weapons it is equipped with. Its roster wargear is Kannon / Lobba / Deff rolla / Grabbin' klaw / Wreckin' ball, so the datasheet must list those (plus the base-kit Tracks and wheels) and must NOT list the killkannon, zzap gun or big shoota the datasheet menu also contains.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "expect_token_visible", "unit_id": "U_BATTLEWAGON_G" },
+    { "act": "click_unit", "unit_id": "U_BATTLEWAGON_G" },
+    { "act": "wait_seconds", "seconds": 0.4 },
+
+    { "act": "simulate_joy_button", "button_index": 3 },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "expect_node_visible", "node": "/root/Main/DatasheetModal", "timeout_s": 2.0 },
+    { "act": "execute_script", "script": "var m=tree.root.get_node_or_null(\"Main/DatasheetModal\")\nreturn m.current_unit_id", "multiline": true, "equals": "U_BATTLEWAGON_G" },
+
+    { "act": "execute_script", "script": "var l=tree.root.get_node_or_null(\"Main/DatasheetModal/Body/Weapons\")\nreturn l.text.contains(\"Kannon\") and l.text.contains(\"Lobba\") and l.text.contains(\"Deff rolla\") and l.text.contains(\"Grabbin\") and l.text.contains(\"Wreckin\")", "multiline": true, "equals": true },
+    { "act": "execute_script", "script": "var l=tree.root.get_node_or_null(\"Main/DatasheetModal/Body/Weapons\")\nreturn l.text.contains(\"Tracks and wheels\")", "multiline": true, "equals": true },
+    { "act": "execute_script", "script": "var l=tree.root.get_node_or_null(\"Main/DatasheetModal/Body/Weapons\")\nreturn l.text.contains(\"Killkannon\")", "multiline": true, "equals": false },
+    { "act": "execute_script", "script": "var l=tree.root.get_node_or_null(\"Main/DatasheetModal/Body/Weapons\")\nreturn l.text.contains(\"Zzap gun\")", "multiline": true, "equals": false },
+    { "act": "execute_script", "script": "var l=tree.root.get_node_or_null(\"Main/DatasheetModal/Body/Weapons\")\nreturn l.text.contains(\"Big shoota\")", "multiline": true, "equals": false },
+
+    { "act": "screenshot", "label": "01_battlewagon_datasheet_equipped_only" },
+
+    { "act": "simulate_joy_button", "button_index": 3 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "expect_node_property", "node": "/root/Main/DatasheetModal", "property": "visible", "equals": false }
+  ]
+}

--- a/40k/tests/scenarios/sp/shooting_offers_equipped_weapons_only.json
+++ b/40k/tests/scenarios/sp/shooting_offers_equipped_weapons_only.json
@@ -1,0 +1,33 @@
+{
+  "id": "shooting_offers_equipped_weapons_only",
+  "covers": [
+    "shooting.weapon_tree.equipped_weapons_only",
+    "autoloads.RulesEngine._resolve_single_model_loadout",
+    "autoloads.RulesEngine.get_unit_weapons",
+    "scripts.UnitLoadoutResolver.get_equipped_weapons"
+  ],
+  "fixture": "fullauto_pretrigger",
+  "transition_to_phase": 8,
+  "rng_seed": 42,
+  "disable_ai": true,
+  "description": "A single-model VEHICLE must only be able to FIRE the guns its roster took. meta.weapons is the Battlewagon datasheet's option menu (big shoota / kannon / killkannon / lobba / zzap gun), but this roster's wargear is 1x Kannon + 1x Lobba. Selecting the Battlewagon as the shooter with a real token click must populate the weapon tree with the kannon (both profiles) and the lobba ONLY — the killkannon, zzap gun and big shoota it never bought must not be offered.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.8 },
+    { "act": "expect_phase", "equals": 8 },
+    { "act": "expect_token_visible", "unit_id": "U_BATTLEWAGON_G" },
+
+    { "act": "execute_script", "script": "var w = RulesEngine.get_unit_weapons(\"U_BATTLEWAGON_G\", GameState.state)\nvar ids = []\nfor mid in w:\n\tfor i in w[mid]:\n\t\tif i not in ids: ids.append(i)\nids.sort()\nreturn \",\".join(ids)", "multiline": true, "equals": "kannon___frag_ranged,kannon___shell_ranged,lobba_ranged" },
+
+    { "act": "click_unit", "unit_id": "U_BATTLEWAGON_G" },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "execute_script", "script": "main.shooting_controller.active_shooter_id", "equals": "U_BATTLEWAGON_G" },
+
+    { "act": "execute_script", "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nvar names = []\nwhile c:\n\tnames.append(c.get_text(0))\n\tc = c.get_next()\nreturn \" | \".join(names)", "multiline": true, "exists": true },
+    { "act": "execute_script", "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nvar txt = \"\"\nwhile c:\n\ttxt += c.get_text(0) + \" \"\n\tc = c.get_next()\nreturn txt.to_lower().contains(\"kannon\") and txt.to_lower().contains(\"lobba\")", "multiline": true, "equals": true },
+    { "act": "execute_script", "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nvar txt = \"\"\nwhile c:\n\ttxt += c.get_text(0) + \" \"\n\tc = c.get_next()\nreturn txt.to_lower().contains(\"killkannon\")", "multiline": true, "equals": false },
+    { "act": "execute_script", "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nvar txt = \"\"\nwhile c:\n\ttxt += c.get_text(0) + \" \"\n\tc = c.get_next()\nreturn txt.to_lower().contains(\"zzap\")", "multiline": true, "equals": false },
+    { "act": "execute_script", "script": "var wt = tree.current_scene.get_node(\"ShootingController\").weapon_tree\nvar c = wt.get_root().get_first_child()\nvar txt = \"\"\nwhile c:\n\ttxt += c.get_text(0) + \" \"\n\tc = c.get_next()\nreturn txt.to_lower().contains(\"big shoota\")", "multiline": true, "equals": false },
+
+    { "act": "screenshot", "label": "01_battlewagon_weapon_tree_equipped_only" }
+  ]
+}

--- a/40k/tests/test_loadout_resolution.gd
+++ b/40k/tests/test_loadout_resolution.gd
@@ -117,13 +117,20 @@ func _run():
 				if m.has("ranged_loadout"):
 					got_resolved = true
 					break
-			# INVARIANT 4: single-model units (VEHICLE/MONSTER/character) fire ALL
-			# their guns — they must NEVER be resolved/collapsed, and their weapon
-			# count must be untouched.
+			# INVARIANT 4 (revised 2026-07-27): a single-model unit (VEHICLE /
+			# MONSTER / character) DOES fire everything it carries — but
+			# meta.weapons is the datasheet's option MENU, not its arsenal. A
+			# Battlewagon whose roster took a kannon must not be offered the
+			# killkannon and zzap gun it never bought, so single-model units are
+			# now narrowed from wargear too (see _resolve_single_model_loadout).
+			# The pin is therefore "only ever REMOVES, and only menu weapons"
+			# rather than "never touched".
 			if models.size() < 2:
-				_check("single-model-untouched %s/%s" % [fname, uid],
-					not got_resolved and new_total == raw_total,
-					"resolved=%s raw=%d new=%d" % [str(got_resolved), raw_total, new_total])
+				_check("single-model-no-increase %s/%s" % [fname, uid],
+					new_total <= raw_total, "raw=%d new=%d" % [raw_total, new_total])
+				if got_resolved:
+					_check("single-model-ranged-subset %s/%s" % [fname, uid],
+						_loadout_is_menu_subset(unit, models[0], "Ranged", "ranged_loadout"), "")
 			if got_resolved:
 				resolved_units += 1
 				# INVARIANT 2 (generalized for Task C): every resolved model reports
@@ -195,9 +202,15 @@ func _run():
 				if m.has("melee_loadout"):
 					got_melee_resolved = true
 					break
-			# INVARIANT: single-model units never get a resolved melee loadout.
+			# INVARIANT (revised 2026-07-27, mirrors ranged): a single-model unit's
+			# melee list may now be narrowed from wargear too, but only ever by
+			# REMOVING weapons that were on the datasheet menu.
 			if models.size() < 2:
-				_check("single-model-melee-untouched %s/%s" % [fname, uid], not got_melee_resolved, "")
+				_check("single-model-melee-no-increase %s/%s" % [fname, uid],
+					new_melee <= raw_melee, "raw=%d new=%d" % [raw_melee, new_melee])
+				if got_melee_resolved:
+					_check("single-model-melee-subset %s/%s" % [fname, uid],
+						_loadout_is_menu_subset(unit, models[0], "Melee", "melee_loadout"), "")
 			if got_melee_resolved:
 				melee_resolved_units += 1
 				var kmin_m := 999999
@@ -354,6 +367,22 @@ func _spot_check_special_weapons():
 
 # Count melee instances a unit reports WITHOUT resolution (menu-based), mirroring
 # the pre-change get_unit_melee_weapons so we can prove melee totals only go down.
+# Single-model narrowing may only pick weapons that were already on the unit's
+# datasheet menu for that type — it must never invent a profile.
+func _loadout_is_menu_subset(unit: Dictionary, model: Dictionary, weapon_type: String, loadout_key: String) -> bool:
+	var menu := {}
+	for w in unit.get("meta", {}).get("weapons", []):
+		if str(w.get("type", "")).to_lower() == weapon_type.to_lower():
+			menu[str(w.get("name", ""))] = true
+	var resolved = model.get(loadout_key, [])
+	if typeof(resolved) != TYPE_ARRAY:
+		return false
+	for n in resolved:
+		if not menu.has(str(n)):
+			return false
+	return true
+
+
 func _raw_melee_total(unit: Dictionary) -> int:
 	var meta = unit.get("meta", {})
 	var mp = meta.get("model_profiles", {})

--- a/40k/tests/unit/test_unit_loadout_resolver.gd
+++ b/40k/tests/unit/test_unit_loadout_resolver.gd
@@ -1,0 +1,174 @@
+extends SceneTree
+
+# UnitLoadoutResolver: the datasheet UI must show the weapons a unit is
+# EQUIPPED with, not the datasheet's full option menu.
+#
+# Run: godot --headless --script tests/unit/test_unit_loadout_resolver.gd
+
+const Resolver = preload("res://scripts/UnitLoadoutResolver.gd")
+const TUTORIAL_ARMY := "res://armies/tutorial_orks.json"
+
+var pass_count: int = 0
+var fail_count: int = 0
+
+
+func _assert(condition: bool, test_name: String) -> void:
+	if condition:
+		print("PASS: %s" % test_name)
+		pass_count += 1
+	else:
+		print("FAIL: %s" % test_name)
+		fail_count += 1
+
+
+func _init():
+	print("=== UnitLoadoutResolver Test ===")
+	call_deferred("_run_tests")
+
+
+func _run_tests():
+	await root.get_tree().process_frame
+
+	_test_tutorial_battlewagon()
+	_test_additive_vs_replacement()
+	_test_safe_fallbacks()
+	_test_slugging()
+
+	print("\n=== Results: %d passed, %d failed ===" % [pass_count, fail_count])
+	quit(1 if fail_count > 0 else 0)
+
+
+# The reported bug: pressing Y on the tutorial Battlewagon listed every weapon
+# a Battlewagon *could* take.
+func _test_tutorial_battlewagon() -> void:
+	print("\n--- Tutorial Battlewagon ---")
+	var f := FileAccess.open(TUTORIAL_ARMY, FileAccess.READ)
+	if f == null:
+		_assert(false, "tutorial_orks.json readable")
+		return
+	var parsed = JSON.parse_string(f.get_as_text())
+	f.close()
+	if typeof(parsed) != TYPE_DICTIONARY:
+		_assert(false, "tutorial_orks.json parses")
+		return
+	var unit = parsed.get("units", {}).get("U_BATTLEWAGON_T", {})
+	_assert(not unit.is_empty(), "tutorial roster has U_BATTLEWAGON_T")
+	if unit.is_empty():
+		return
+
+	var all_names: Array = []
+	for w in unit.get("meta", {}).get("weapons", []):
+		all_names.append(str(w.get("name", "")))
+	var names := Resolver.get_equipped_weapon_names(unit)
+	print("   menu    : %s" % str(all_names))
+	print("   equipped: %s" % str(names))
+
+	# Wargear: Deff rolla, Grabbin' klaw, Kannon, Lobba, Wreckin' ball, 'Ard Case.
+	for expected in ["Kannon – Frag", "Kannon – Shell", "Lobba", "Deff rolla",
+			"Grabbin' klaw", "Wreckin' ball"]:
+		_assert(expected in names, "keeps equipped weapon '%s'" % expected)
+	# Base kit (implicit, never listed in wargear) must survive.
+	_assert("Tracks and wheels" in names, "keeps base-kit weapon 'Tracks and wheels'")
+	# Unpicked options must be gone.
+	for unequipped in ["Big shoota", "Killkannon", "Zzap gun"]:
+		_assert(not (unequipped in names), "drops unequipped option '%s'" % unequipped)
+
+
+# Additive picks keep the base weapon; a like-for-like swap removes it.
+func _test_additive_vs_replacement() -> void:
+	print("\n--- Additive vs replacement (single-model units) ---")
+
+	# Warboss: base kit is twin sluggas / kombi-weapon / big choppa; the roster
+	# swapped the big choppa for a power klaw, so the big choppa must not show.
+	var warboss := {
+		"models": [{"id": "m1"}],
+		"meta": {
+			"name": "Warboss",
+			"wargear": ["1x Kombi-weapon", "1x Power klaw", "1x Twin sluggas"],
+			"weapons": [
+				{"name": "Kombi-weapon", "type": "Ranged"},
+				{"name": "Twin sluggas", "type": "Ranged"},
+				{"name": "Attack squig", "type": "Melee"},
+				{"name": "Big choppa", "type": "Melee"},
+				{"name": "Power klaw", "type": "Melee"},
+			],
+		},
+	}
+	var wb := Resolver.get_equipped_weapon_names(warboss)
+	print("   warboss equipped: %s" % str(wb))
+	_assert("Power klaw" in wb, "Warboss keeps its power klaw")
+	_assert("Kombi-weapon" in wb and "Twin sluggas" in wb, "Warboss keeps its ranged kit")
+	_assert(not ("Big choppa" in wb), "Warboss drops the replaced base big choppa")
+	_assert(not ("Attack squig" in wb), "Warboss drops the unpicked attack squig")
+
+	# Warboss in Mega Armour: only its melee is in wargear; the base big shoota
+	# has no melee competitor and must stay.
+	var wbma := {
+		"models": [{"id": "m1"}],
+		"meta": {
+			"name": "Warboss in Mega Armour",
+			"wargear": ["1x 'Uge choppa"],
+			"weapons": [
+				{"name": "Big shoota", "type": "Ranged"},
+				{"name": "Uge choppa", "type": "Melee"},
+			],
+		},
+	}
+	var mega := Resolver.get_equipped_weapon_names(wbma)
+	print("   mega armour equipped: %s" % str(mega))
+	_assert("Uge choppa" in mega, "Mega Armour Warboss keeps 'Uge choppa (apostrophe-insensitive match)")
+	_assert("Big shoota" in mega, "Mega Armour Warboss keeps its base big shoota")
+
+
+func _test_safe_fallbacks() -> void:
+	print("\n--- Safe fallbacks ---")
+
+	# No wargear at all -> show the datasheet untouched.
+	var no_wargear := {
+		"models": [{"id": "m1"}],
+		"meta": {
+			"name": "Battlewagon",
+			"weapons": [
+				{"name": "Killkannon", "type": "Ranged"},
+				{"name": "Tracks and wheels", "type": "Melee"},
+			],
+		},
+	}
+	_assert(Resolver.get_equipped_weapon_names(no_wargear).size() == 2,
+		"no wargear -> full menu returned")
+
+	# Wargear naming nothing on this datasheet -> show the datasheet untouched.
+	var unrelated := {
+		"models": [{"id": "m1"}],
+		"meta": {
+			"name": "Battlewagon",
+			"wargear": ["1x 'Ard Case"],
+			"weapons": [
+				{"name": "Killkannon", "type": "Ranged"},
+				{"name": "Tracks and wheels", "type": "Melee"},
+			],
+		},
+	}
+	_assert(Resolver.get_equipped_weapon_names(unrelated).size() == 2,
+		"unmatched wargear -> full menu returned")
+
+	# No weapons -> empty, no crash.
+	_assert(Resolver.get_equipped_weapons({"meta": {"name": "X"}}).is_empty(),
+		"weaponless unit -> empty list")
+	_assert(Resolver.get_equipped_weapons({}).is_empty(), "empty unit dict -> empty list")
+
+
+func _test_slugging() -> void:
+	print("\n--- Name normalisation ---")
+	var cases := {
+		"Grabbin' klaw": "grabbin-klaw",
+		"'Ard Case": "ard-case",
+		"Tracks and wheels": "tracks-and-wheels",
+		"Kustom mega-blasta": "kustom-mega-blasta",
+		"Kannon – Frag": "kannon-frag",
+	}
+	for raw in cases:
+		_assert(Resolver._slug(raw) == cases[raw],
+			"_slug('%s') == '%s' (got '%s')" % [raw, cases[raw], Resolver._slug(raw)])
+	_assert(Resolver._base_name("Kannon – Frag") == "Kannon", "_base_name strips the profile suffix")
+	_assert(Resolver._base_name("Big shoota") == "Big shoota", "_base_name leaves plain names alone")

--- a/40k/tests/unit/test_unit_loadout_resolver.gd.uid
+++ b/40k/tests/unit/test_unit_loadout_resolver.gd.uid
@@ -1,0 +1,1 @@
+uid://esmuapwh5bqj


### PR DESCRIPTION
## Problem

`unit.meta.weapons` is the datasheet's full weapon **menu**, not the roster's loadout. Every datasheet UI rendered it verbatim, so pressing `Y` on the tutorial Battlewagon listed a killkannon, a zzap gun and a big shoota it was never armed with, alongside the kannon / lobba / deff rolla / grabbin' klaw / wreckin' ball it actually has.

Investigating turned up a worse version of the same bug in the engine. Verified live before the fix:

```
RulesEngine.get_unit_weapons("U_BATTLEWAGON_T")
  m1 -> [big_shoota, kannon-frag, kannon-shell, killkannon, lobba, zzap_gun]
```

The Battlewagon could actually **fire** the killkannon and zzap gun it never bought. `_ensure_loadout_resolved()` skipped single-model units on the reasoning that a vehicle "fires ALL of its weapons" — true of its arsenal, but not of its option menu.

## Approach

`scripts/UnitLoadoutResolver.gd` narrows the menu using the roster's `meta.wargear` plus the datasheet's base kit (`models[].default_weapon_ids` from `data/40kdc/unitCompositions.json`), so always-fitted weapons like the Battlewagon's tracks and wheels survive. Matching is slug-based and profile-aware, so `1x Kannon` keeps both `Kannon – Frag` and `Kannon – Shell`.

For single-model units a like-for-like swap is detected by count: a Warboss that picked one melee weapon replaced its one default melee weapon (base big choppa dropped), while a Battlewagon that bolted three melee options onto its one base weapon is additive (tracks and wheels kept). Multi-model units keep their whole base kit — per-model counts make swaps undecidable there.

The **same resolver** backs both layers, so display and gameplay cannot disagree. `_resolve_single_model_loadout()` stamps `ranged_loadout` / `melee_loadout` on the lone model — the keys `_get_model_weapon_ids` already honoured — and only for a weapon type it genuinely narrowed. Resolution runs at read time on the live unit dict, so existing saves are covered.

Battlewagon after: `[kannon-frag, kannon-shell, lobba]`.

**Safety posture — only ever narrows, and only when confident.** No parseable wargear, missing composition data, or a filter that would return nothing all fall back to the untouched list. Swept all 185 weapon-bearing units across `armies/*.json`: 26 narrowed, 0 emptied.

## Roster backfill

Four rosters never recorded which option they took, so nothing downstream could resolve them. All four take the datasheet's standard kit, per the list author:

| Unit | Takes | Drops |
|---|---|---|
| Caladius Grav-tank | twin iliastus accelerator cannon + twin lastrum bolt cannon | twin arachnus heavy blaze cannon |
| Contemptor-Achillus Dreadnought | lastrum storm bolter | infernus incinerator, twin adrathic destructor |
| Telemon Heavy Dreadnought | iliastus accelerator culverin + spiculus bolt launcher | arachnus storm cannon, twin arachnus heavy blaze cannon, telemon caestus |
| Shield-Captain | guardian spear | sentinel blade |

## Changes

- **New** `scripts/UnitLoadoutResolver.gd` — the shared resolver.
- **Engine** `RulesEngine._resolve_single_model_loadout()` — narrows single-model units so shooting, fight and the AI only offer real weapons.
- **UI** wired into `DatasheetModal` (Y / I), `UnitStatsCardPopup` (right-click Unit Stats) and `UnitStatsPanel` (two-unit comparison).
- **Data** backfilled `meta.wargear` in `adeptus_custodes.json` and `A_C_test.json` (surgical edits — 21 added lines, no reformatting).
- **Changelog** version 1.5.2.

## Testing

- `tests/scenarios/sp/datasheet_equipped_weapons_only.json` (new, windowed) — selects the Battlewagon in the Movement phase, presses pad Y, asserts the rendered datasheet lists the equipped weapons plus tracks and wheels and contains no Killkannon / Zzap gun / Big shoota. **17/17**
- `tests/scenarios/sp/shooting_offers_equipped_weapons_only.json` (new, windowed) — real token click selects the Battlewagon as shooter; the weapon tree offers Kannon-Frag / Kannon-Shell / Lobba only. **13/13**
- `tests/unit/test_unit_loadout_resolver.gd` (new, 28 asserts) — tutorial Battlewagon result, additive-vs-replacement, safe fallbacks, name normalisation. **28/28**
- `test_model_profiles.gd` **68/68**; `test_loadout_resolution.gd` **997/998**
- `run_scenarios.sh --changed-only` — **38/40**

`test_loadout_resolution.gd`'s two single-model invariants pinned the old rule ("never resolved, count untouched"). Replaced with the rule that now holds: resolution may only REMOVE, and only weapons already on that type's menu (new `_loadout_is_menu_subset` helper).

## Pre-existing failures (not caused by this PR, not fixed here)

- `383_battleshock_can_shoot` and `387_waaagh_energy_eadbanger` — both reproduce with an identical assertion and identical "no eligible targets" cause at the previous commit, confirmed in a clean worktree.
- `test_loadout_resolution.gd`'s remaining failure (Task C over-counter baseline, 17 vs 16) counts multi-model units, which this change does not touch.

## Notes for the reviewer

- **Data quirk not touched**: `Achillus dreadspear – Achillus dreadspear` appears twice in the Contemptor's `weapons` array (once Ranged, once Melee, both with the doubled name), so it renders twice. Independent source-data issue.
- The Telemon's **Telemon caestus** is dropped, since the chosen standard kit uses armoured feet as its melee weapon.
- Not run: the full `--sp` scenario suite and `run_pretrigger_tests.sh`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MxfUd4LhxGYBQkqHfTkrS8)_