### PR TITLE
Say where the end-phase button is in tutorial step 10

### DIFF
--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -227,8 +227,8 @@
     {
       "id": "end_phase_intro",
       "prompt": {
-        "bark": "SEE DAT BUTTON?",
-        "text": "Dat big red button ends da current phase for good. [b]Don't[/b] press it yet — first, a bit of movin'."
+        "bark": "SEE DAT BUTTON IN DA TOP RIGHT-HAND CORNER?",
+        "text": "Dat big red button up in da top right-hand corner ends da current phase for good. [b]Don't[/b] press it yet — first, a bit of movin'."
       },
       "anchor": {
         "node": "/root/Main/PhaseActionButton"

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.6.2",
+      "date": "2026-07-28",
+      "summary": "The tutorial now tells you where the end-phase button actually is.",
+      "changes": [
+        "Step 10 of 'Scoutin' da Field' asked 'SEE DAT BUTTON?' without saying which button, and the end-phase button sits well away from the tutorial card. It now says 'SEE DAT BUTTON IN DA TOP RIGHT-HAND CORNER?', and the body text repeats the location."
+      ]
+    },
+    {
       "version": "1.6.1",
       "date": "2026-07-27",
       "summary": "Units now show — and fire — only the weapons they are actually armed with, instead of every weapon their datasheet could take.",

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -299,6 +299,20 @@
       "equals": "end_phase_intro"
     },
     {
+      "act": "expect_node_property",
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Header/BarkLabel",
+      "property": "text",
+      "equals": "SEE DAT BUTTON IN DA TOP RIGHT-HAND CORNER?",
+      "comment": "the bark has to name where the End Phase button actually is — 'SEE DAT BUTTON?' alone left players hunting for it"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var rt = tree.root.get_node_or_null(\"/root/TutorialOverlay/InstructorCard/Margin/VBox/BodyText\")\nif rt == null:\n\treturn \"<no BodyText>\"\nreturn rt.get_parsed_text().contains(\"top right-hand corner\")",
+      "equals": true,
+      "comment": "and the body repeats the location, so the card still points at the right control if the bark is skimmed"
+    },
+    {
       "act": "screenshot",
       "label": "05_end_phase_intro"
     },


### PR DESCRIPTION
## What

Step 10 of "Scoutin' da Field" (`end_phase_intro`) opened with **"SEE DAT BUTTON?"** and never said *which* button.

The end-phase button is reparented to the top-right corner at runtime (`40k/scripts/Main.gd`, `_restructure_ui_layout`), well away from the tutorial card in the middle of the screen — so the only cue was the soft spotlight, which is easy to miss.

**Before**
> **SEE DAT BUTTON?**
> Dat big red button ends da current phase for good. **Don't** press it yet — first, a bit of movin'.

**After**
> **SEE DAT BUTTON IN DA TOP RIGHT-HAND CORNER?**
> Dat big red button up in da top right-hand corner ends da current phase for good. **Don't** press it yet — first, a bit of movin'.

The body deliberately does *not* quote a button caption: the live label is phase-dependent (`[Enter] End Movement Phase` during the tutorial's movement phase), so naming "End Phase" would not match what the player sees.

## Changes

- `40k/data/tutorials/lessons/T1_basics.json` — reworded the bark and body of step `end_phase_intro`.
- `40k/tests/scenarios/sp/tut_t1_basics.json` — asserts the bark text exactly and that the body contains "top right-hand corner", so the location cue cannot silently regress.
- `40k/data/version_history.json` — new `1.6.4` entry.

## Validation

Windowed, against the running UI per the project gate — re-run after merging `main`:

- `tut_t1_basics` — **104 passed, 0 failed**, including the two new assertions at the step (bark read back as `SEE DAT BUTTON IN DA TOP RIGHT-HAND CORNER?`).
- `tut_t1_basics_pad`, `tut_t1_pad_ack_button`, and `tut_t1_lock_it_in_start_glyph` — green. The pad path shares this step's single `text` prompt (no `kbm`/`pad` variants), so there was nothing else to update.
- Screenshot at the step confirms the card renders both strings without clipping and the spotlighted button is the top-right one.

## Merge with main

#785 and #786 landed while this was open and both claimed version numbers, so this entry moved from `1.6.2` to `1.6.4`. `version_history.json` was the only conflict — the lesson JSON merged cleanly, since #786 touched step 12 and this touches step 10. All scenarios above were re-run against the merged tree, including #786's new `tut_t1_lock_it_in_start_glyph`.

## Note

The wording is corner-relative, so it assumes the top-right reparent stays. If that layout ever changes, the new scenario assertions will still pass while the text goes stale — not something guardable cheaply from the lesson JSON.