### PR TITLE
Tutorial T1 step 5: stop advertising B as a way to close the datasheet

### DIFF
--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -134,7 +134,7 @@
       "prompt": {
         "bark": "SEEN ENOUGH!",
         "kbm": "Close it — press [b][Escape][/b].",
-        "pad": "Close it — press {y} again (or {b})."
+        "pad": "Close it — press {y} again."
       },
       "spotlight": "none",
       "allow": [],

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.6.2",
+      "date": "2026-07-28",
+      "summary": "Tutorial no longer tells controller players that B closes the datasheet — only Y does.",
+      "changes": [
+        "Tutorial 1, step 'Seen Enough!': the controller instruction said to press Y again (or B) to close the datasheet. B does not close it, so the tutorial could stall for anyone who took it at its word. It now just says press Y again."
+      ]
+    },
+    {
       "version": "1.6.1",
       "date": "2026-07-27",
       "summary": "Units now show — and fire — only the weapons they are actually armed with, instead of every weapon their datasheet could take.",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -230,6 +230,29 @@
       "equals": "close_datasheet"
     },
     {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nreturn t.contains(\"[Y]\") and not t.contains(\"[B]\")",
+      "equals": true,
+      "comment": "reported bug: the SEEN ENOUGH prompt told the pad player to press Y again 'or B'. B does not close the datasheet (PadRouter routes it to _handle_back, which has no datasheet branch), so a player who took the card at its word sat on a step that would not advance. The prompt must name Y only."
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1,
+      "comment": "B - the button the prompt used to advertise. Proving it is a no-op here is what makes the wording fix load-bearing rather than cosmetic."
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ds = tree.current_scene.get_node_or_null(\"DatasheetModal\")\nreturn ds != null and ds.visible and TutorialManager.current_step_id() == \"close_datasheet\"",
+      "equals": true,
+      "comment": "B left the datasheet open and the lesson parked on this step"
+    },
+    {
       "act": "simulate_joy_button",
       "button_index": 3
     },


### PR DESCRIPTION
## Issue

Tutorial 1, step 5 ("SEEN ENOUGH!") told controller players: *"Close it — press Y again (or B)."* Y works; B does nothing.

This is an instruction bug, not a control bug. `PadRouter` routes `JOY_BUTTON_B` to `_handle_back()` (`40k/autoloads/PadRouter.gd:446`), which cancels carries, releases panel focus, parks the virtual cursor and undoes placements — it has no `DatasheetModal` branch anywhere in it. Only `JOY_BUTTON_Y` reaches `_toggle_datasheet()`. A player who took the card at its word pressed B and sat on a step that would never advance.

## Change

- `40k/data/tutorials/lessons/T1_basics.json` — dropped `(or {b})` from the `close_datasheet` pad prompt so it names the one button that works. The kbm prompt (Escape) is unchanged.
- `40k/tests/scenarios/sp/tut_t1_basics_pad.json` — the windowed pad scenario now asserts the rendered prompt contains `[Y]` and not `[B]`, then presses B at that step and asserts the datasheet is still open and the lesson still parked on `close_datasheet`, before Y closes it and advances. That makes the wording fix load-bearing rather than cosmetic.
- `40k/data/version_history.json` — new `1.6.2` entry (player-facing change).

No behavioural code change: B still means "back" everywhere it already did.

## Validation

Windowed, per the project gate — the game was run with the UI rendering and driven through the real lesson:

- Started `t1_basics` with pad mode claimed, reached step 5/13. Screenshot shows the instructor card reading **"Close it — press [Y] again."** over the open Battlewagon datasheet.
- Live behaviour at that step: B → datasheet still visible, still on `close_datasheet`. Y → closes, advances to `dice_log`.
- `verify_delivery` → `verdict: PASS`, 0 errors in the debug log.
- `bash 40k/tests/run_scenarios.sh tests/scenarios/sp/tut_t1_basics_pad.json` → **121 passed, 0 failed**, including the two new assertions.

## Note for reviewers

If the preference is instead that B *should* close the datasheet, that is a small addition to `PadRouter._handle_back()` and the "(or B)" wording would go back. This PR takes the reported reading: the tutorial was wrong, not the controls.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WAaW7Kfd6Gq84MUNvJDfuN)_