### PR TITLE
Stop the End Phase button claiming ☰ while ☰ confirms a move

### DIFF
--- a/40k/autoloads/PadRouter.gd
+++ b/40k/autoloads/PadRouter.gd
@@ -288,6 +288,33 @@ const BOX_SELECT_HINT := "Hold {a}: Box Select"
 # (empty when none). Windowed scenarios assert this.
 var target_highlight_id: String = ""
 
+# What the pad's ☰ (Start) button means in the CURRENT board state, read straight
+# off the ☰ chip of the hint set the bar is showing — so the chip, the tutorial
+# prompts and the top-right phase-action button all quote one authority and can
+# never contradict each other. "End Phase" (the value when a set advertises no ☰
+# chip at all, e.g. the action-bar / panel-focus / tutorial-card sets) means Start
+# still presses the phase-action button; anything else ("Confirm Move",
+# "Confirm Targets", "Roll 2D6", "Confirm / End", …) means a context action owns
+# Start right now and the End-Phase button must stop advertising "[☰]".
+#
+# The reported trap: T1 step 12 ("LOCK IT IN!") tells the player ☰ confirms the
+# grots' move — which is true, Main._input routes Start to
+# MovementController.pad_confirm_move() while a move is staged — but the button in
+# the top-right corner simultaneously read "[☰] End Movement Phase". Two different
+# promises for one button. Main listens to start_action_changed and re-stamps the
+# button's glyph so only the true one is on screen.
+signal start_action_changed(label: String)
+const START_ACTION_PHASE := "End Phase"
+var start_action_label: String = START_ACTION_PHASE
+
+
+# True while ☰ still means "press the top-right phase-action button". False while
+# a context action (confirm move / targets / charge, place-and-confirm from a
+# carry, …) has claimed it. Read by Main to decide whether that button may carry
+# the "[☰] " prefix.
+func start_owns_phase_action() -> bool:
+	return start_action_label == START_ACTION_PHASE
+
 # M3 model-carry state: the model currently "picked up" rides the virtual
 # cursor (warp + held synthetic LMB — the real drag code runs underneath).
 # carry_model_index is which of the selected unit's alive models D-pad ◀ ▶
@@ -2195,7 +2222,9 @@ func _update_hints() -> void:
 	# and keeps focus, so every other promise on the bar would be a lie.
 	var tutorial_ack := _tutorial_ack_state()
 	if tutorial_ack != "":
-		PadHintBar.set_hints(HINTS_TUTORIAL_SUMMARY if tutorial_ack == "summary" else HINTS_TUTORIAL_ACK)
+		var ack_hints: Array = HINTS_TUTORIAL_SUMMARY if tutorial_ack == "summary" else HINTS_TUTORIAL_ACK
+		PadHintBar.set_hints(ack_hints)
+		_set_start_action(_start_chip_label(ack_hints))
 		return
 	var hints := HINTS_BOARD
 	if carry_active:
@@ -2244,6 +2273,30 @@ func _update_hints() -> void:
 				# focus check above stays false and this set still shows behind it.
 				hints = HINTS_FIGHT
 	PadHintBar.set_hints(_with_box_select_hint(hints))
+	# Publish what ☰ means in this state so the top-right phase-action button can
+	# drop its "[☰] " prefix while a context action (Confirm Move, Confirm
+	# Targets, …) owns Start. Done from the same `hints` the bar just rendered, so
+	# chip and button are the same statement by construction.
+	_set_start_action(_start_chip_label(hints))
+
+
+# The label on a hint set's ☰ chip, or START_ACTION_PHASE when the set carries
+# none. A set without a ☰ chip (the action bar, panel focus, the tutorial card)
+# is not saying Start is dead — Main._input still routes it to the phase-action
+# button in those states — it just isn't worth a chip there, so the default is
+# the phase action.
+func _start_chip_label(hints: Array) -> String:
+	for hint in hints:
+		if hint is Array and hint.size() >= 2 and str(hint[0]) == "menu":
+			return str(hint[1])
+	return START_ACTION_PHASE
+
+
+func _set_start_action(label: String) -> void:
+	if label == start_action_label:
+		return
+	start_action_label = label
+	start_action_changed.emit(label)
 
 
 # Board box multi-select (hold A + left stick) — the pad counterpart of the

--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -280,7 +280,7 @@
       "prompt": {
         "bark": "LOCK IT IN!",
         "kbm": "Grots left behind? Only da ones dat fit got placed — da rest are still selected, so drag 'em again somewhere dey fit ({key:select_all} re-grabs da lot). When every grot's down, press [b]End This Unit's Move[/b].",
-        "pad": "Grots left behind? Only da ones dat fit got placed. Press {dpad} ▲ again — it grabs every grot dat still ain't moved — den {a} drops 'em somewhere dey fit. When every grot's down, {menu} confirms da move."
+        "pad": "Grots left behind? Only da ones dat fit got placed. Press {dpad} ▲ again — it grabs every grot dat still ain't moved — den {a} drops 'em somewhere dey fit. When every grot's down, {menu} confirms da move \u2014 dat's why da big [b]End Phase[/b] button drops its {menu} while a move's on da go. {menu} only ends da phase once nuffin's mid-move."
       },
       "anchor": {
         "node": "/root/Main/HUD_Right/VBoxContainer/MovementScrollContainer/MovementPanel/Section4_Actions/ActionButtons/ConfirmMoveButton"

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.6.2",
+      "date": "2026-07-28",
+      "summary": "The Menu (☰) button no longer promises two different things at once: the End Phase button stops advertising ☰ while ☰ is busy confirming a move.",
+      "changes": [
+        "Tutorial step 12 ('Lock it in!') tells a controller player that ☰ confirms the grots' move — which is true — but the big red button in the top-right corner read '[☰] End Movement Phase' at the same time, so the one button appeared to be tied to both. The End Phase button now drops its ☰ badge for exactly as long as ☰ belongs to something else, and gets it straight back the moment ☰ can end the phase again.",
+        "This applies everywhere ☰ is context-sensitive, not just the tutorial: confirming a unit's move, confirming shooting targets, declaring a charge, rolling 2D6, confirming a charge move, and placing the last model of a unit during deployment.",
+        "The button's badge and the hint bar's ☰ chip are now driven by the same reading of the game state, so they can no longer disagree.",
+        "Step 12 of the Basic Trainin' lesson also spells this out: ☰ only ends the phase once nothing is mid-move."
+      ]
+    },
+    {
       "version": "1.6.1",
       "date": "2026-07-27",
       "summary": "Units now show — and fire — only the weapons they are actually armed with, instead of every weapon their datasheet could take.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -306,6 +306,13 @@ func _ready() -> void:
 	# controller could end the phase at all.
 	if InputDeviceManager and not InputDeviceManager.device_changed.is_connected(_on_input_device_changed):
 		InputDeviceManager.device_changed.connect(_on_input_device_changed)
+	# ☰ is context-dependent, so the prefix has to follow the board state as well
+	# as the device: while a move is staged ☰ confirms that move (T1 step 12's
+	# "LOCK IT IN!") and this button must NOT also claim "[☰] End Movement Phase".
+	# PadRouter fires this whenever the ☰ chip's meaning flips.
+	if PadRouter and PadRouter.has_signal("start_action_changed") \
+			and not PadRouter.start_action_changed.is_connected(_on_pad_start_action_changed):
+		PadRouter.start_action_changed.connect(_on_pad_start_action_changed)
 	# Initial pass in case a pad is already the active device at startup (the
 	# phase button self-corrects via update_ui_for_phase; the stratagem button
 	# has no other refresh path, so seed it here).
@@ -5590,6 +5597,14 @@ func _pad_native_nav_modal_open() -> bool:
 # confirmation, reusing whatever the button currently does/says.
 var _pad_phase_confirm: ConfirmationDialog = null
 
+# Start-button presses are consumed here, which stops the event before
+# PadRouter._input ever sees it — so the hint bar (and, through it, this button's
+# "[☰] " prefix) would keep describing the state Start just left behind. Deferred
+# so the confirm/end it triggered has landed in state before the recompute reads it.
+func _refresh_pad_start_meaning() -> void:
+	if PadRouter and PadRouter.has_method("refresh_hints"):
+		PadRouter.call_deferred("refresh_hints")
+
 func _show_pad_phase_confirm() -> void:
 	if _pad_phase_confirm == null or not is_instance_valid(_pad_phase_confirm):
 		_pad_phase_confirm = ConfirmationDialog.new()
@@ -5629,6 +5644,7 @@ func _input(event: InputEvent) -> void:
 			# live carry and stranding the still-held cursor. State-checked here
 			# (not just consumed in PadRouter._input) so it works regardless of
 			# _input order.
+			_refresh_pad_start_meaning()
 			get_viewport().set_input_as_handled()
 			return
 		if current_phase == GameStateData.Phase.SHOOTING and shooting_controller \
@@ -5661,6 +5677,7 @@ func _input(event: InputEvent) -> void:
 			pass
 		elif phase_action_button and phase_action_button.visible and not phase_action_button.disabled:
 			_show_pad_phase_confirm()
+		_refresh_pad_start_meaning()
 		get_viewport().set_input_as_handled()
 		return
 
@@ -10345,9 +10362,25 @@ func _get_phase_tooltip_text(phase: GameStateData.Phase) -> String:
 func _phase_action_pad_prefix() -> String:
 	return "[%s] " % GlyphDB.glyph_text("menu")
 
+# True while the pad's ☰ (Start) button still presses THIS button. ☰ is
+# context-dependent (see _input's pad_phase_action branch): mid-move it confirms
+# the unit's move, with targets assigned it confirms targets, mid-carry it places
+# the held model and confirms, and only when none of those apply does it fall
+# through to the End-Phase confirm. PadRouter computes that meaning once, for the
+# hint bar's ☰ chip; this reads the same value so the button and the chip agree.
+func _pad_start_ends_phase() -> bool:
+	if PadRouter == null or not PadRouter.has_method("start_owns_phase_action"):
+		return true
+	return PadRouter.start_owns_phase_action()
+
 # The shortcut prefix for the current input device: pad → "[☰] ", KBM → "[Enter] ".
+# On a pad the "[☰] " is dropped while a context action owns Start — otherwise the
+# button claims "[☰] End Movement Phase" at the very moment ☰ means "confirm this
+# unit's move" (the contradiction T1 step 12, "LOCK IT IN!", walked players into).
 func _phase_action_prefix() -> String:
 	if InputDeviceManager and InputDeviceManager.is_pad_active():
+		if not _pad_start_ends_phase():
+			return ""
 		return _phase_action_pad_prefix()
 	return _PHASE_ACTION_KBM_PREFIX
 
@@ -10365,20 +10398,29 @@ func _phase_action_bare_label() -> String:
 
 # Re-stamp the button's shortcut prefix for the active device without touching
 # the label — so switching KBM ⇄ pad live swaps "[Enter] " ⇄ "[☰] " and leaves
-# any custom label (Continue, the Fight-phase step labels) intact.
+# any custom label (Continue, the Fight-phase step labels) intact. Also runs when
+# ☰ changes meaning mid-phase, which is why it must cope with the button already
+# being bare: with a context action owning Start the prefix is "", and a
+# begins_with-only version could never put the "[☰] " back once ☰ came free.
 func _sync_phase_action_glyph() -> void:
 	if not phase_action_button or not is_instance_valid(phase_action_button):
 		return
-	var t: String = phase_action_button.text
-	for p in [_PHASE_ACTION_KBM_PREFIX, _phase_action_pad_prefix()]:
-		if t.begins_with(p):
-			phase_action_button.text = _phase_action_prefix() + t.substr(p.length())
-			return
-	# No recognized shortcut prefix — leave the text untouched.
+	var bare: String = _phase_action_bare_label()
+	if bare == "":
+		return
+	var want: String = _phase_action_prefix() + bare
+	if phase_action_button.text != want:
+		phase_action_button.text = want
 
 func _on_input_device_changed(_mode: int) -> void:
 	_sync_phase_action_glyph()
 	_sync_stratagem_button_glyph()
+
+# PadRouter re-derived what ☰ does in the current board state (mid-move →
+# "Confirm Move", targets assigned → "Confirm Targets", …). Re-stamp the
+# phase-action button so it only advertises "[☰]" while ☰ would actually press it.
+func _on_pad_start_action_changed(_label: String) -> void:
+	_sync_phase_action_glyph()
 
 # Drop / restore the Stratagems button's "[S] " keyboard hint for the active
 # device: pad → "Stratagems" (reached via D-pad panel focus + A, no key), KBM →

--- a/40k/tests/scenarios/sp/pad_charge_full_flow.json
+++ b/40k/tests/scenarios/sp/pad_charge_full_flow.json
@@ -47,6 +47,8 @@
     { "act": "execute_script", "script": "main.charge_controller.pad_target_cursor", "equals": 0 },
     { "act": "execute_script", "script": "PadRouter.carry_active", "equals": false },
     { "act": "execute_script", "multiline": true, "script": "var labels = []\nfor chip in PadHintBar._row.get_children():\n\tfor l in chip.find_children(\"*\", \"Label\", true, false):\n\t\tlabels.append(l.text)\nreturn \"Declare Charge\" in labels", "equals": true },
+    { "act": "execute_script", "script": "str(main.phase_action_button.text)", "equals": "End Charge Phase", "comment": "the ☰ chip says Declare Charge, so the top-right button must NOT also read '[☰] End Charge Phase' - same one-glyph-two-promises trap the tutorial's LOCK IT IN step hit in the Movement phase" },
+    { "act": "execute_script", "script": "PadRouter.start_owns_phase_action()", "equals": false },
 
     { "act": "simulate_joy_button", "button_index": 14 },
     { "act": "wait_seconds", "seconds": 0.3 },

--- a/40k/tests/scenarios/sp/tut_t1_lock_it_in_start_glyph.json
+++ b/40k/tests/scenarios/sp/tut_t1_lock_it_in_start_glyph.json
@@ -1,0 +1,417 @@
+{
+  "id": "tut_t1_lock_it_in_start_glyph",
+  "covers": [
+    "tutorial.t1.basics.pad",
+    "pad.hint_bar.start_chip",
+    "pad.phase_action_button.glyph",
+    "Main.gd",
+    "PadRouter.gd",
+    "T1_basics.json"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Reported contradiction at T1 step 12 (LOCK IT IN!): the card tells a pad player that the Menu button (the one with three lines) confirms da grots' move, while the button in the top-right corner of the screen simultaneously read '[☰] End Movement Phase'. One glyph, two promises. ☰ really is context-dependent - Main._input routes it to MovementController.pad_confirm_move() whenever a move is staged - so the End-Phase button is the one that was lying. This scenario drives T1 on a pad to step 12 and asserts the button drops its '[☰] ' prefix for exactly as long as ☰ belongs to the move, that the hint bar's ☰ chip and PadRouter.start_action_label say the same thing, that ☰ does in fact confirm the move from that state, and that the prefix comes straight back once ☰ is free again.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var mm = tree.root.get_node_or_null(\"/root/MainMenu\")\nif mm != null and mm._tutorial_nudge != null and mm._tutorial_nudge.visible:\n\tmm._tutorial_nudge._on_dismiss()\n\tvar q = [mm]\n\twhile not q.is_empty():\n\t\tvar n = q.pop_back()\n\t\tif n is Button and str(n.name) == \"StartButton\":\n\t\t\tn.grab_focus()\n\t\t\tbreak\n\t\tfor c in n.get_children():\n\t\t\tq.append(c)\nreturn TutorialManager.should_show_first_launch_nudge()",
+      "multiline": true,
+      "equals": false,
+      "comment": "retire the first-launch nudge so this scenario runs standalone on a pristine profile"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 9,
+      "comment": "LB claims pad mode on the main menu - every glyph assertion below is pad-only"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "script": "InputDeviceManager.is_pad_active()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 12
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.2
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialPicker",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "welcome"
+    },
+    {
+      "act": "execute_script",
+      "script": "int(main.current_phase)",
+      "equals": 7,
+      "comment": "T1 boots straight into the Movement phase (lesson boot.phase 7), so the top-right button is the End-Movement-Phase button throughout"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "[☰] End Movement Phase",
+      "comment": "BASELINE: nothing is staged, ☰ really does press this button, so it may advertise itself"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"menu\")",
+      "equals": "",
+      "comment": "the instructor card owns the bar while it waits on Continue, so there is no ☰ chip yet - a set with no chip is not a set that disowns Start, which is why PadRouter still defaults to the phase action below (asserted on the board proper at move_grots)"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.start_owns_phase_action()",
+      "equals": true
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "camera"
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 2,
+      "value": -1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": -1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 3,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 5,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "simulate_joy_axis",
+      "axis": 4,
+      "value": 1.0,
+      "hold_s": 0.4
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "select_wagon"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 10
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "open_datasheet"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 3
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 3
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "dice_log"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "button_text": "Dice Log"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "hint_bar"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "controls_reference_open"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 4
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/SettingsMenu",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 1
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase_intro"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "[☰] End Movement Phase",
+      "comment": "step 10 spotlights this very button and calls it the end-phase button - with nothing staged that is still true"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 15
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "move_grots"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"menu\")",
+      "equals": "End Phase",
+      "comment": "board context with nothing staged: the ☰ chip and the top-right button make the same promise"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "[☰] End Movement Phase"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "unit_id": "U_GRETCHIN_T"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.movement_controller.active_unit_id)",
+      "equals": "U_GRETCHIN_T"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 11,
+      "comment": "D-pad up opens the move menu (the mode decision is still open)"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "A takes the highlighted chip - Move - which starts the move session and puts one grot in hand"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.6
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 11,
+      "comment": "D-pad up mid-move grabs every grot still to be moved as one group carry"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "pad_cursor_glide",
+      "x": 1000.0,
+      "y": 724.0
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "var md = PhaseManager.current_phase_instance.get_active_move_data(\"U_GRETCHIN_T\")\nvar dists = md.get(\"model_distances\", {})\nvar mx = 0.0\nfor k in dists:\n\tmx = max(mx, float(dists[k]))\nreturn mx > 1.0",
+      "multiline": true,
+      "equals": true,
+      "comment": "grots really covered ground, so there is a move to lock in"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "confirm_grots",
+      "comment": "STEP 12 - LOCK IT IN! - the reported contradiction"
+    },
+    {
+      "act": "execute_script",
+      "script": "main.movement_controller._has_pending_unconfirmed_move(\"U_GRETCHIN_T\")",
+      "equals": true,
+      "comment": "☰ in this state routes to pad_confirm_move(), NOT to the end-phase confirm - the card's claim is the true one"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.start_owns_phase_action()",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "End Movement Phase",
+      "comment": "THE FIX: the top-right button no longer claims '[☰] End Movement Phase' while ☰ belongs to the move. Label intact, glyph withdrawn."
+    },
+    {
+      "act": "execute_script",
+      "script": "not str(main.phase_action_button.text).begins_with(main._phase_action_pad_prefix())",
+      "equals": true,
+      "comment": "glyph-agnostic restatement, so a remap in Settings > Controller cannot sneak the contradiction back"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(PadRouter.start_action_label) == str(PadHintBar.label_for(\"menu\"))",
+      "equals": true,
+      "comment": "the button and the hint bar read one authority - PadRouter derives start_action_label from the very hint set the bar rendered"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadHintBar.label_for(\"menu\")",
+      "not_equals": "End Phase",
+      "comment": "whichever mid-move set is up (staged / locked / carry), the ☰ chip names a confirm, never the phase end"
+    },
+    {
+      "act": "screenshot",
+      "label": "01_step12_lock_it_in_no_menu_glyph_on_end_phase"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 6,
+      "comment": "☰ (Start) - the button with three lines. Per the card this confirms the move; per the old top-right label it would have ended the phase."
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "execute_script",
+      "script": "int(main.current_phase)",
+      "equals": 7,
+      "comment": "☰ did NOT end the phase"
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.get_unit(\"U_GRETCHIN_T\").get(\"flags\", {}).get(\"moved\", false)",
+      "equals": true,
+      "comment": "☰ DID confirm the grots' move - exactly what the card promised"
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "wrap"
+    },
+    {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "[☰] End Movement Phase",
+      "comment": "and the prefix comes straight back the moment ☰ is free again - the withdrawal is state-scoped, not a one-way strip"
+    },
+    {
+      "act": "screenshot",
+      "label": "02_after_lock_in_menu_glyph_restored"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
@@ -115,6 +115,17 @@
       "equals": "confirm_dakka"
     },
     {
+      "act": "execute_script",
+      "script": "str(main.phase_action_button.text)",
+      "equals": "End Shooting Phase",
+      "comment": "Start means Confirm Targets here, so the top-right button must not also advertise '[☰] End Shooting Phase' - one glyph, one promise"
+    },
+    {
+      "act": "execute_script",
+      "script": "PadRouter.start_owns_phase_action()",
+      "equals": false
+    },
+    {
       "act": "screenshot",
       "label": "02_shooter_picked_pad"
     },


### PR DESCRIPTION
## The problem

Tutorial T1 step 12 ("LOCK IT IN!") tells a controller player that the Menu button — the one with three lines — confirms da grots' move. Meanwhile the big red button in the top-right corner read `[☰] End Movement Phase`. One glyph, two contradictory promises.

The tutorial was the honest one. `Main._input`'s `pad_phase_action` branch makes ☰ context-dependent: with a move staged it routes to `MovementController.pad_confirm_move()`; with targets assigned, Confirm Targets; through the charge flow, Declare / Roll 2D6 / Confirm Charge; mid-carry it places the held model and confirms. Only when none of those apply does it fall through to the End-Phase confirm. The button was stamping `"[☰] "` on unconditionally.

## The fix

`PadRouter` already works out the true ☰ meaning once, to label the hint bar's ☰ chip. It now publishes that as `start_action_label` + a `start_action_changed` signal, derived from the very hint set the bar just rendered — so the chip and the button are the same statement by construction and cannot drift apart.

`Main` drops the `"[☰] "` prefix from the phase-action button for exactly as long as a context action owns Start, and restores it the moment ☰ can end the phase again. The label text is never touched, only the badge.

Two supporting fixes fell out of this:

- `_sync_phase_action_glyph` is rebuilt around `_phase_action_bare_label`, so it can re-prefix a button that is currently bare. The old `begins_with`-only version could strip the glyph but never put it back.
- Main consumes the Start event, which halts propagation before `PadRouter._input` sees it — so the hint bar (and now the button) kept describing the state Start had just left. Both exits of that branch now request a deferred `refresh_hints`.

Step 12's pad prompt also spells the rule out: ☰ only ends the phase once nothing is mid-move.

## Screens

Mid-move at step 12 — button reads `End Movement Phase`, hint bar reads `☰ Confirm Move`. After ☰ locks the move in (Gretchin → `COMPLETED MOVING`, still the Movement phase) the button reads `[☰] End Movement Phase` again.

## Validation

Windowed on the pad, all three contexts:

- **New** `40k/tests/scenarios/sp/tut_t1_lock_it_in_start_glyph.json` (83 steps) — drives T1 to step 12, asserts the prefix is withdrawn while the hint chip names a confirm, that ☰ confirms the move *without* ending the phase, and that the prefix returns once ☰ is free.
- `pad_charge_full_flow.json` — charge phase, chip `Declare Charge`, assertions added.
- `tut_t4_dakka_pad.json` — shooting phase, chip `Confirm Targets`, assertions added.

Also green: the headless audit suite (2180 passed, 0 failed) and the pad tutorial / `715_controller_end_phase_glyph` scenarios. No ERROR lines in the debug logs across the runs.

## Notes

- Deployment ("Confirm / End" once every model is placed) rides the same mechanism but was **not** driven live.
- Hint recomputation is pad-event-driven, so a state change made with the *mouse* while the pad is the active device won't re-stamp the button until the next pad input. Pre-existing limitation of the hint bar, now inherited by the badge.
- `T23_end_phase_position` / `T27_end_phase_refactor` fail identically before and after this change — they look up a node named `EndPhaseButton` that doesn't exist. Pre-existing, left alone.
- Separately noticed and untouched: the KBM `[Enter]` prefix on that button has no matching Enter handler I could find. Unverified.

Version bumped to 1.6.2 with a changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Axd6v1M8yozg5wtvkCvnmq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Axd6v1M8yozg5wtvkCvnmq)_