### PR TITLE
Direct pad players to the d-pad for Musterin' da Boyz steps 2-3

### DIFF
--- a/40k/data/tutorials/lessons/T2_deployment.json
+++ b/40k/data/tutorials/lessons/T2_deployment.json
@@ -56,7 +56,7 @@
       "prompt": {
         "bark": "GET IN DA WAGON!",
         "kbm": "Under [b]TRANSPORT EMBARKATION[/b], tick [b]Boyz[/b] — da mob (an' da Boss wiv 'em) starts da battle inside da Battlewagon.",
-        "pad": "Glide {ls} onto da [b]Boyz[/b] tickbox under TRANSPORT EMBARKATION an' press {a}."
+        "pad": "{dpad} ▼ walks down onto da [b]Boyz[/b] tickbox under TRANSPORT EMBARKATION — or glide {ls} onto it — den press {a}."
       },
       "anchor": { "button_text": "Boyz (10 models)" },
       "spotlight": "soft",
@@ -70,7 +70,7 @@
       "prompt": {
         "bark": "LOCK DA MUSTER!",
         "kbm": "Hit [b]Confirm Formations[/b] — dat sends all yer declarations at once. Da enemy declares deirs after.",
-        "pad": "Glide onto [b]Confirm Formations[/b] an' press {a}."
+        "pad": "{dpad} ▼ walks down past da tickboxes to da button row — dat lands ya on [b]Skip[/b] first, so tap ▶ to swap onto [b]Confirm Formations[/b] — or glide {ls} onto it — den press {a}."
       },
       "anchor": { "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/ConfirmButton" },
       "spotlight": "soft",


### PR DESCRIPTION
## Summary
- The "Musterin' da Boyz" (T2) tutorial's pad prompts for step 2 (tick Boyz into the Battlewagon) and step 3 (Confirm Formations) only told controller players to glide the left-stick cursor, even though the FormationsDialog's checkboxes and buttons are d-pad focus-navigable and the lesson otherwise favors the d-pad.
- Updated both `pad` prompt strings in `40k/data/tutorials/lessons/T2_deployment.json` to lead with `{dpad}` navigation, keeping `{ls}` glide as a fallback.
- While validating live, found that d-pad-down from the tickbox list lands on **Skip (No Declarations)** before **Confirm Formations** (they're a horizontal Skip→Confirm pair, not stacked) — pressing A there silently discards all staged declarations. The confirm_formations prompt now explicitly calls out pressing right once to swap off Skip onto Confirm.

## Test plan
- [x] Booted the game windowed (`godot --path 40k --rendering-method gl_compatibility`) and drove the live FormationsDialog through the `addons/godot_mcp` bridge with real `simulate_joy_button` d-pad/A presses (not headless-only).
- [x] Confirmed d-pad down lands directly on the Boyz tickbox for step 2, and toggling it via A sets `button_pressed = true`.
- [x] Confirmed the Skip-before-Confirm focus order, then verified the documented path (down × N, right, A) lands on Confirm Formations and correctly commits declarations: `U_WARBOSS_T.attached_to == U_BOYZ_T`, `U_BOYZ_T.embarked_in == U_BATTLEWAGON_T`.
- [x] Tutorial step advanced correctly to `roll_off` after confirming.
- [x] `read_debug_log` showed zero errors during the whole flow.
- [x] Screenshotted both updated prompts in-game to confirm the `{dpad}`/`{ls}` glyphs and text render correctly (no clipping/breakage).

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01J5DeZk23JYS2CVc1kbnPvK

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5DeZk23JYS2CVc1kbnPvK)_