### PR TITLE
Dakka Time step 3: lead with "press Confirm", not with the weapon list

### DIFF
--- a/40k/data/tutorials/lessons/T4_shooting.json
+++ b/40k/data/tutorials/lessons/T4_shooting.json
@@ -44,8 +44,8 @@
       "id": "confirm_dakka",
       "prompt": {
         "bark": "LOCK DA TARGETS!",
-        "kbm": "Da weapon list shows every gun an' who it's pointin' at — da button counts how many is locked. If a row still says [b](Click to Select)[/b], click da row, den click da Witchseekers. Den hit [b]Confirm[/b].",
-        "pad": "Wiv a shooter armed, {dpad} ◀▶ walks da targets an' ▲▼ walks yer guns; {a} aims da current gun at da highlighted target. When yer happy, press {menu} — dat's [b]Confirm Targets[/b] on da pad."
+        "kbm": "Yer guns are aimed already — now lock 'em in: click da glowin' [b]Confirm[/b] button on da right (it counts yer guns). If a row still says [b](Click to Select)[/b], click da row, den da Witchseekers, first.",
+        "pad": "Yer guns are aimed already — now lock 'em in: press {menu}, dat's [b]Confirm Targets[/b] on da pad. Want to re-aim first? {dpad} ◀▶ walks da targets, ▲▼ walks yer guns, {a} aims da current gun."
       },
       "anchor": { "node": "/root/Main/HUD_Right/VBoxContainer/ShootingScrollContainer/ShootingPanel/DeclarationBox/TargetButtonRow/ConfirmTargetsButton" },
       "spotlight": "soft",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,14 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.6.5",
+      "date": "2026-07-29",
+      "summary": "'Dakka Time' step 3 now says up front that you have to press Confirm.",
+      "changes": [
+        "Step 3 of the shooting lesson opened with two sentences describing the weapon list and a 'if a row still says (Click to Select)' fix-up, and only mentioned hitting Confirm in the last three words — so players who had nothing to fix did not know what the step wanted. Both the mouse and controller prompts now lead with the action: lock the targets in with Confirm (mouse) or ☰ (pad), with the re-aiming instructions moved after it."
+      ]
+    },
+    {
       "version": "1.6.4",
       "date": "2026-07-28",
       "summary": "The tutorial now tells you where the end-phase button actually is.",

--- a/40k/tests/scenarios/sp/tut_t4_dakka.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka.json
@@ -76,6 +76,13 @@
       "equals": "confirm_dakka"
     },
     {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nvar confirm_at = t.find(\"Confirm\")\nvar fallback_at = t.find(\"Click to Select\")\nreturn confirm_at != -1 and fallback_at != -1 and confirm_at < fallback_at",
+      "multiline": true,
+      "equals": true,
+      "comment": "step 3 must NAME the Confirm button as the thing to press, and say it BEFORE the re-aim fallback - the old copy buried 'Den hit Confirm' at the end and players did not know what was wanted"
+    },
+    {
       "act": "screenshot",
       "label": "02_targets_assigned"
     },

--- a/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
@@ -126,6 +126,13 @@
       "equals": false
     },
     {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nvar confirm_at = t.find(\"Confirm Targets\")\nvar reaim_at = t.find(\"walks da targets\")\nreturn confirm_at != -1 and reaim_at != -1 and confirm_at < reaim_at",
+      "multiline": true,
+      "equals": true,
+      "comment": "step 3 pad copy must lead with the Confirm Targets press, not with the re-aim stick controls - the old copy taught the D-pad first and left players unsure what actually advances the step"
+    },
+    {
       "act": "screenshot",
       "label": "02_shooter_picked_pad"
     },


### PR DESCRIPTION
## Problem

Step 3 / 5 of the T4 shooting lesson ("Dakka Time" → `confirm_dakka`, bark "LOCK DA TARGETS!") never clearly told the player to press Confirm. The card read:

> Da weapon list shows every gun an' who it's pointin' at — da button counts how many is locked. If a row still says **(Click to Select)**, click da row, den click da Witchseekers. Den hit **Confirm**.

Two sentences describing the UI, then a conditional fix-up branch, and the actual instruction as the last three words. In the tutorial fixture all three weapons auto-assign to the only visible target, so the fix-up branch never applies — the player reads a paragraph about a problem they don't have and is left without a clear action.

The pad copy had the same shape inverted the same way: a D-pad / A-button aiming tutorial first, the Start press that actually advances the step last.

## Change

Both prompts now lead with the action and keep the re-aim instructions as a trailing "if you need it" clause.

**Mouse/keyboard:**
> Yer guns are aimed already — now lock 'em in: click da glowin' **Confirm** button on da right (it counts yer guns). If a row still says **(Click to Select)**, click da row, den da Witchseekers, first.

**Controller:**
> Yer guns are aimed already — now lock 'em in: press ☰, dat's **Confirm Targets** on da pad. Want to re-aim first? ✛ ◀▶ walks da targets, ▲▼ walks yer guns, [A] aims da current gun.

The kbm copy also says *where* the button is and that its label counts the guns, because the live button reads `Confirm (3 weapons)` rather than a bare "Confirm". The weapon count is not hardcoded in the prompt — it's timing-dependent.

Both bodies stay under the 220-char authoring guideline (206 / 193).

## Validation

Windowed, against the running UI via the `addons/godot_mcp` bridge:

- `tests/scenarios/sp/tut_t4_dakka.json` — **48 passed, 0 failed**
- `tests/scenarios/sp/tut_t4_dakka_pad.json` — **63 passed, 0 failed**
- `tests/test_tutorial_checklist.gd` (headless net) — **38 passed, 0 failed**
- No `ERROR` lines in the debug logs for either run

Both scenarios gain a new assertion that the rendered card names the Confirm press *before* the re-aim fallback, so the ordering cannot silently regress. Screenshots taken at the step confirm the card renders as intended with the spotlight ring on the `Confirm (3 weapons)` button, and the pad hint bar showing `☰ Confirm Targets`.

## Notes

- Version bumped to **1.6.5** in `40k/data/version_history.json` with a player-facing changelog entry.
- The card still renders top-centre while the button sits bottom-right; the soft spotlight ring remains the only spatial cue, and the copy now says "on da right" to compensate. Card placement was left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKSms2tgTevhtWYjm8aL8A)_