### PR TITLE
[superseded by #805] Tutorial: shrink the dodged instructor card to fit beside the open dialog

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.7.21",
+      "date": "2026-07-30",
+      "summary": "The tutorial's instruction card no longer hides behind the Declare Battle Formations panel — it now shrinks to fit the space beside whatever dialog is open.",
+      "changes": [
+        "Step 1 of \"Musterin' da Boyz\" (MUSTER UP!) opens with the Declare Battle Formations panel already up, and the instructions card that tells you what to do sat partly underneath it: the end of every line was cut off mid-sentence and the Skip Step button was buried. Only players on the default UI Scale were spared — the card was a fixed width, but the panel is centred on screen, and raising UI Scale (or plugging in a controller, which boosts text size) moves the panel left until it swallows the card's right-hand side.",
+        "The card now measures the gap to the open dialog every frame and narrows its text to fit, leaving a clear margin. It springs back to full width the moment the dialog closes, and it never squeezes so far that the prompt turns into a column of single words.",
+        "This applies to every tutorial step that talks to you over a dialog, not just formations — the deployment and first-turn roll-offs get the same treatment."
+      ]
+    },
+    {
       "version": "1.7.20",
       "date": "2026-07-29",
       "summary": "An attached character's guns now count properly for Rapid Fire, Melta, cover and target eligibility — and two crash-on-use toasts are fixed.",

--- a/40k/scripts/tutorial/TutorialOverlay.gd
+++ b/40k/scripts/tutorial/TutorialOverlay.gd
@@ -20,6 +20,17 @@ const CARD_TOP_OFFSET := 96.0
 const CARD_BOTTOM_OFFSET := 132.0  # keeps clear of the pad hint bar
 const ANCHOR_RERESOLVE_S := 0.5
 
+# Card width, as the width of its TEXT COLUMN (the card adds _card_chrome_width()
+# on top). CARD_BODY_WIDTH is the roomy default used by "top"/"bottom" placement.
+# In "left" placement the column is squeezed to whatever strip is actually free
+# to the left of the open dialog — see _wanted_body_width(). CARD_BODY_WIDTH_MIN
+# is the floor: below it the prompt turns into a column of single words, so a
+# narrow strip keeps a slight overlap rather than becoming unreadable.
+const CARD_BODY_WIDTH := 560.0
+const CARD_BODY_WIDTH_MIN := 320.0
+const CARD_LEFT_OFFSET := 10.0
+const CARD_DODGE_GAP := 16.0  # breathing room between the card and the dialog
+
 # The two escape-hatch affordances (see "modal escape hatch" below). Both names
 # are excluded from _blocking_window() so the tutorial's own windows never read
 # as "a game dialog is open".
@@ -50,6 +61,7 @@ var _anchor_ok: bool = false
 var _spotlight_mode: String = "none"
 var _reresolve_accum: float = 0.0
 var _card_mode: String = "top"
+var _card_body_width: float = CARD_BODY_WIDTH
 var _dim_strips: Array = []
 var _modal_exit_window: Window = null   # floating hatch, for non-AcceptDialog modals
 var _modal_exit_host: Window = null     # the dialog we added an Exit button INTO
@@ -160,7 +172,7 @@ func _build() -> void:
 	_body_text.bbcode_enabled = true
 	_body_text.fit_content = true
 	_body_text.scroll_active = false
-	_body_text.custom_minimum_size = Vector2(560, 0)
+	_body_text.custom_minimum_size = Vector2(CARD_BODY_WIDTH, 0)
 	_body_text.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	# >= 12px effective at 1280x800 (Steam Deck recommendation; PRP §4.3):
 	# 15px at 1920x1080 canvas-items scaling ~= 10px physical on Deck before the
@@ -181,7 +193,7 @@ func _build() -> void:
 	_checklist_text.bbcode_enabled = true
 	_checklist_text.fit_content = true
 	_checklist_text.scroll_active = false
-	_checklist_text.custom_minimum_size = Vector2(560, 0)
+	_checklist_text.custom_minimum_size = Vector2(CARD_BODY_WIDTH, 0)
 	_checklist_text.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	_checklist_text.add_theme_font_size_override("normal_font_size", 14)
 	_checklist_text.add_theme_font_size_override("bold_font_size", 14)
@@ -193,7 +205,7 @@ func _build() -> void:
 	_hint_label = Label.new()
 	_hint_label.name = "HintLabel"
 	_hint_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	_hint_label.custom_minimum_size = Vector2(560, 0)
+	_hint_label.custom_minimum_size = Vector2(CARD_BODY_WIDTH, 0)
 	_hint_label.add_theme_font_size_override("font_size", 13)
 	_hint_label.add_theme_color_override("font_color", UIConstantsData.MARGINAL_YELLOW)
 	_hint_label.visible = false
@@ -433,7 +445,7 @@ func _place_card(mode: String) -> void:
 			_card.grow_horizontal = Control.GROW_DIRECTION_BOTH
 		"left":
 			_card.set_anchors_and_offsets_preset(Control.PRESET_CENTER_LEFT, Control.PRESET_MODE_MINSIZE)
-			_card.offset_left = 10
+			_card.offset_left = CARD_LEFT_OFFSET
 			_card.grow_vertical = Control.GROW_DIRECTION_BOTH
 			_card.grow_horizontal = Control.GROW_DIRECTION_END
 		_:
@@ -441,6 +453,59 @@ func _place_card(mode: String) -> void:
 			_card.offset_top = CARD_TOP_OFFSET
 			_card.grow_vertical = Control.GROW_DIRECTION_END
 			_card.grow_horizontal = Control.GROW_DIRECTION_BOTH
+
+
+# Horizontal chrome the card wraps around its text column: the Margin
+# container's insets plus the panel stylebox's own content margin (== the 2px
+# gold border). Measured rather than hardcoded so re-theming the card cannot
+# silently push the dodged card back under the dialog.
+func _card_chrome_width() -> float:
+	var chrome := 0.0
+	var margin := _card.get_node_or_null("Margin") as MarginContainer
+	if margin != null:
+		chrome += float(margin.get_theme_constant("margin_left")) \
+			+ float(margin.get_theme_constant("margin_right"))
+	var sb: StyleBox = _card.get_theme_stylebox("panel")
+	if sb != null:
+		chrome += sb.get_margin(SIDE_LEFT) + sb.get_margin(SIDE_RIGHT)
+	return chrome
+
+
+# How wide the text column may be for `mode`. "top"/"bottom" get the full
+# CARD_BODY_WIDTH; "left" gets only the strip between the viewport edge and the
+# open dialog's left edge.
+#
+# WHY THIS IS NOT A CONSTANT (reported on T2 step 1, "Musterin' da Boyz": the
+# MUSTER UP! prompt sat half-buried under the Declare Battle Formations panel,
+# with the end of every line and the Skip Step button hidden). The dodge only
+# ever worked at ui_scale 1.0: the card is a fixed 560+chrome wide, while the
+# dialog is CENTERED in the logical viewport — and the logical viewport SHRINKS
+# as the UI Scale slider (or the pad's x1.2 text boost) raises
+# content_scale_factor. At 1920 logical the dialog starts at x=660 and the
+# 588-wide card clears it by 62px; at ui_scale 1.25 the viewport is 1536 logical,
+# the dialog starts at x=468, and the card overruns it by 130px. Measuring the
+# dialog every frame fixes every scale and every dialog width at once.
+func _wanted_body_width(mode: String, blocker: Window) -> float:
+	if mode != "left" or blocker == null:
+		return CARD_BODY_WIDTH
+	var strip: float = float(blocker.position.x) - CARD_LEFT_OFFSET - CARD_DODGE_GAP
+	return clampf(strip - _card_chrome_width(), CARD_BODY_WIDTH_MIN, CARD_BODY_WIDTH)
+
+
+# Re-wrap the card's text to `w`. Returns true when the width actually changed,
+# so the caller knows the MINSIZE placement preset has to be re-applied (its
+# offsets are baked from the minimum size at the time it was set).
+func _set_card_body_width(w: float) -> bool:
+	if is_equal_approx(w, _card_body_width):
+		return false
+	_card_body_width = w
+	for c in [_body_text, _checklist_text, _hint_label]:
+		if c != null:
+			(c as Control).custom_minimum_size = Vector2(w, (c as Control).custom_minimum_size.y)
+	# A PanelContainer never shrinks below the size it is already at, so drop
+	# back to the (now narrower) combined minimum before the preset re-measures.
+	_card.reset_size()
+	return true
 
 
 func card_rect() -> Rect2:
@@ -645,8 +710,12 @@ func show_step(view: Dictionary) -> void:
 	_anchor_node = null
 	_anchor_ok = false
 	_reresolve_accum = ANCHOR_RERESOLVE_S  # resolve on next frame
-	if _card_mode != "top":
-		_place_card("top")
+	# Back to the roomy default, then dodge/squeeze on the spot: a card shown
+	# while a dialog is ALREADY up (T2 opens on the Formations panel) would
+	# otherwise render one frame full-width and centered — straight under it.
+	_set_card_body_width(CARD_BODY_WIDTH)
+	_place_card("top")
+	_update_card_mode()
 	_apply_pad_affordances(true)
 	_spotlight.queue_redraw()
 
@@ -700,7 +769,9 @@ func show_summary(view: Dictionary) -> void:
 	_spotlight_mode = "none"
 	for strip in _dim_strips:
 		strip.visible = false
+	_set_card_body_width(CARD_BODY_WIDTH)
 	_place_card("top")
+	_update_card_mode()
 	_apply_pad_affordances(true)
 	_spotlight.queue_redraw()
 
@@ -808,7 +879,8 @@ func _scroll_anchor_into_view(node: Node) -> void:
 # the spotlighted anchor (bottom), else top-center (PRP §4.3).
 func _update_card_mode() -> void:
 	var wanted := "top"
-	if _any_game_window_open():
+	var blocker := _blocking_window()
+	if blocker != null:
 		wanted = "left"
 	elif _anchor_ok:
 		var cr := card_rect()
@@ -818,7 +890,11 @@ func _update_card_mode() -> void:
 		else:
 			var top_rect := Rect2(cr.position.x, CARD_TOP_OFFSET, cr.size.x, cr.size.y)
 			wanted = "top" if not top_rect.grow(8).intersects(_anchor_rect) else "bottom"
-	if wanted != _card_mode:
+	# The dialog can move/resize under a standing "left" card (a UI Scale change,
+	# a taller roster widening the window), so re-measure the strip every frame —
+	# _set_card_body_width no-ops unless the answer actually changed.
+	var resized := _set_card_body_width(_wanted_body_width(wanted, blocker))
+	if wanted != _card_mode or resized:
 		_place_card(wanted)
 
 

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -8718,6 +8718,24 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "tutorial.overlay.card_dodge",
+      "description": "With a gameplay dialog open the instructor card dodges to the left flank, and its right edge stays clear of the dialog's left edge. Verified at ui_scale 1.25 (where the shrinking logical viewport drags the centred dialog left) against both the full-height Formations panel and the narrower roll-off dialog.",
+      "scenarios": [
+        "tut_t2_card_fits_left_of_formations"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "tutorial.overlay.card_width",
+      "description": "The dodged card's text column is squeezed to the free strip beside the open dialog rather than being a fixed 560px (which overran the dialog by 130px at ui_scale 1.25, clipping the prompt and burying Skip Step), never narrows past the CARD_BODY_WIDTH_MIN readability floor, keeps the prompt text intact while re-wrapping, and springs back to full width once every dialog closes.",
+      "scenarios": [
+        "tut_t2_card_fits_left_of_formations"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/tut_t2_card_fits_left_of_formations.json
+++ b/40k/tests/scenarios/sp/tut_t2_card_fits_left_of_formations.json
@@ -1,0 +1,155 @@
+{
+  "id": "tut_t2_card_fits_left_of_formations",
+  "covers": [
+    "tutorial.t2.formations",
+    "tutorial.overlay.card_dodge",
+    "tutorial.overlay.card_width"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Tutorial T2 step 1 (attach_warboss) opens with the Declare Battle Formations dialog already up, so the instructor card dodges to the left flank. At ui_scale > 1.0 the logical viewport shrinks, the CENTERED dialog moves left, and the fixed-width card used to run underneath it — the reported bug: the MUSTER UP! prompt was clipped mid-sentence and Skip Step was buried. This drives the real player path at ui_scale 1.25 and asserts (a) the card's right edge clears the dialog's left edge, (b) the card is genuinely narrower than its default 588px (i.e. it was squeezed, not merely lucky), (c) the prompt text is still the full step text, and (d) the card springs back to full width once Confirm Formations closes the dialog. ui_scale is restored to 1.0 in the last step (the runner keeps executing steps after a failure, so the restore always runs).",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "SettingsService.set_ui_scale(1.25)\nreturn true",
+      "equals": true,
+      "comment": "the real UI Scale path — this is what shrinks the logical viewport and drags the centered dialog left"
+    },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    {
+      "act": "execute_script",
+      "script": "tree.root.content_scale_factor",
+      "expect_min": 1.24
+    },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton",
+      "emit_pressed": true,
+      "comment": "emit_pressed: real mouse warps are computed in logical coords, which no longer line up once content_scale_factor != 1"
+    },
+    { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t2_musterin/Play_t2_musterin",
+      "emit_pressed": true
+    },
+    { "act": "wait_seconds", "seconds": 9.0 },
+    { "act": "execute_script", "script": "TutorialManager.active", "equals": true },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "attach_warboss" },
+    { "act": "expect_node_visible", "node": "/root/Main/FormationsDialog", "timeout_s": 3.0 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.get(\"_card_mode\")",
+      "equals": "left",
+      "comment": "an open dialog must still send the card to the left flank"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nvar gap = float(fd.position.x) - ov.card_rect().end.x\nprint(\"[T2CARD] card=\", ov.card_rect(), \" dialog_x=\", fd.position.x, \" gap=\", gap)\nreturn gap",
+      "expect_min": 8.0,
+      "comment": "THE REGRESSION: this was -130 before the fix (the card overran the dialog's left edge by 130px)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_rect().size.x",
+      "expect_max": 587.0,
+      "comment": "proves the card was actually narrowed — the unsqueezed card is 560 body + 28 chrome = 588 wide"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_rect().size.x",
+      "expect_min": 320.0,
+      "comment": "and not squeezed past the readability floor"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(ov.current_body_text())\nreturn t.contains(\"LEADER\") and t.contains(\"now he fights wiv his mob\")",
+      "equals": true,
+      "comment": "narrowing re-wraps the prompt, it must not truncate it"
+    },
+    { "act": "screenshot", "label": "01_card_clears_formations_at_scale_125" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nvar q = [fd]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is OptionButton and nd.item_count > 0 and nd.get_item_text(0) == \"(Unattached)\":\n\t\tnd.select(1)\n\t\tnd.item_selected.emit(1)\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn false",
+      "equals": true,
+      "comment": "OptionButton popups are native Windows — select+emit is the dropdown escape hatch"
+    },
+    { "act": "wait_frames", "frames": 15 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "embark_boyz" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nreturn float(fd.position.x) - ov.card_rect().end.x",
+      "expect_min": 8.0,
+      "comment": "the squeeze survives a step change (show_step resets the width, then re-dodges in the same call)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nvar q = [fd]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is CheckBox and str(nd.text).begins_with(\"Boyz\") and not (\"Reserves\" in str(nd.text)):\n\t\tnd.button_pressed = true\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn false",
+      "equals": true,
+      "comment": "the panel is a modal embedded Window — setting button_pressed emits toggled exactly like a click"
+    },
+    { "act": "wait_frames", "frames": 15 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "confirm_formations" },
+    {
+      "act": "click_node",
+      "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/ConfirmButton",
+      "emit_pressed": true
+    },
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "roll_off" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar rd = tree.root.get_node_or_null(\"/root/Main/RollOffDialog\")\nif rd == null or not rd.visible:\n\treturn 999.0\nprint(\"[T2CARD] rolloff card=\", ov.card_rect(), \" dialog_x=\", rd.position.x)\nreturn float(rd.position.x) - ov.card_rect().end.x",
+      "expect_min": 8.0,
+      "comment": "the squeeze is measured off whichever dialog is up — the roll-off dialog is a different width, so this proves it is not tuned to the Formations panel"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/RollButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\nreturn true",
+      "equals": true
+    },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/RollButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nvar q = [tree.root]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is Button and nd.is_visible_in_tree() and \"Re-roll\" in str(nd.text):\n\t\tnd.pressed.emit()\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn true",
+      "equals": true,
+      "comment": "tie tolerance: roll again if the button is still up, else press the A DEAD HEAT re-roll"
+    },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/ContinueButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\nreturn true",
+      "equals": true
+    },
+    { "act": "wait_seconds", "seconds": 2.5 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar c = ov.get_node(\"InstructorCard\")\nprint(\"[T2CARD] no-dialog card=\", ov.card_rect(), \" mode=\", ov.get(\"_card_mode\"), \" anchors=\", c.anchor_left, \"/\", c.anchor_right, \" offsets=\", c.offset_left, \"/\", c.offset_right, \" minsize=\", c.get_combined_minimum_size())\nreturn ov.card_rect().size.x",
+      "expect_min": 588.0,
+      "comment": "with every dialog closed the card springs back to its roomy default width"
+    },
+    { "act": "screenshot", "label": "02_card_back_to_full_width" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "SettingsService.set_ui_scale(1.0)\nreturn true",
+      "equals": true,
+      "comment": "ui_scale is persisted to user://settings.cfg — restore it so the rest of the suite runs at the base scale"
+    }
+  ]
+}

--- a/40k/tests/test_attached_char_bearer_ids.gd.uid
+++ b/40k/tests/test_attached_char_bearer_ids.gd.uid
@@ -1,0 +1,1 @@
+uid://k4axdfb7ckce


### PR DESCRIPTION
## Problem

Step 1 of "Musterin' da Boyz" (`attach_warboss` / **MUSTER UP!**) opens with the Declare Battle Formations panel already up, so the instructor card dodges to the left flank. The card sat partly *underneath* the panel: the end of every prompt line was clipped mid-sentence and the **Skip Step** button was buried.

The dodge only ever worked at the default UI Scale. The card was a fixed 560px text column + 28px chrome, while the dialog is **centred in the logical viewport** — and the logical viewport shrinks as `content_scale_factor` rises (the UI Scale slider, or the controller's automatic ×1.2 text boost).

| viewport | dialog left edge | card right edge | result |
|---|---|---|---|
| 1920 logical (scale 1.0) | x=660 | x=598 | 62px clear |
| 1536 logical (scale 1.25) | x=468 | x=598 | **130px underneath** |

The overlap was reproduced live at ui_scale 1.25 before anything was changed — the measured gap was −130px.

## Change

`TutorialOverlay._update_card_mode()` now measures the free strip between the viewport edge and whichever `Window` is blocking, and re-wraps the card's text column to fit:

- `_wanted_body_width()` — `left` placement gets `blocker.position.x - CARD_LEFT_OFFSET - CARD_DODGE_GAP - chrome`, clamped to `[CARD_BODY_WIDTH_MIN, CARD_BODY_WIDTH]`. `top`/`bottom` keep the roomy default.
- `_card_chrome_width()` — read off the Margin container constants and the panel stylebox rather than hardcoded, so re-theming the card can't silently push it back under the dialog.
- `_set_card_body_width()` — re-wraps the three text controls and `reset_size()`s the panel (a `PanelContainer` won't shrink below the size it is already at), returning whether the `MINSIZE` placement preset needs re-applying.
- `show_step` / `show_summary` reset the width and then dodge **in the same call**, so a card shown over an already-open dialog never renders a frame full-width and centred — i.e. straight under it.

Because it measures the live dialog rect every frame, it is scale-independent and dialog-independent: it fixes the pad text boost, every UI Scale value, and any future dialog width at once.

**Deliberate limit:** at extreme scales (ui_scale 2.0, where the dialog covers ~62% of the viewport) the `CARD_BODY_WIDTH_MIN` floor wins and a slight overlap remains. A one-word-per-line card is worse than a small overlap.

## Result

At ui_scale 1.25, same step, same dialog:

| | before | after |
|---|---|---|
| card | 588px wide, x=10..598 | 442px wide, x=10..452 |
| dialog | x=468 | x=468 |
| gap | **−130px (overlapping)** | **+16px** |
| prompt | clipped: "First: under LE…", "now he fights w…" | reads in full |
| footer | Skip Step buried | Skip Step + Exit Tutorial both visible |

## Validation

New windowed scenario `tests/scenarios/sp/tut_t2_card_fits_left_of_formations.json` drives the real player path at ui_scale 1.25 and asserts:

- the card's right edge clears the Formations panel's left edge (this read −130 before the fix);
- the card was **genuinely narrowed** (< 588px) and **not past the readability floor** (≥ 320px);
- the prompt text survives the re-wrap intact (no truncation);
- the squeeze survives a step change, and holds against the **narrower roll-off dialog** too (card 467px vs dialog at x=493) — proving it isn't tuned to the Formations panel;
- the card springs back to 588px, centred, once every dialog closes.

**37/37 steps pass.** Regression gates at base scale, all green with zero script errors:

| scenario | result |
|---|---|
| `tut_t2_musterin` (full lesson) | 107/107 |
| `tut_t1_basics` | 107/107 |
| `tut_exit_under_modal` | 35/35 |
| `tut_t1_pad_ack_button` | 99/99 |

The whole `--sp` suite was not run.

## Merging with main

Main moved four times while this was in flight (#807, #809, #812, #813), so it is merged in three times here. Each merge was followed by a re-run of the affected gates against the merged tree — final state: `tut_t2_card_fits_left_of_formations` 37/37 and `tut_t2_musterin` 107/107.

Conflicts, all resolved:

- **`version_history.json`, three times** — every landing PR claimed the next patch number. Each time the landed entry was kept at its published version and this one renumbered above it; it is now **1.7.24**, sitting above #812's 1.7.23, #809's 1.7.22 and #807's 1.7.21.
- **`test_attached_char_bearer_ids.gd.uid`** — add/add with two independently generated UIDs. Took main's (`uid://1lj5yd8w1a2`), since it is already merged and is what the project references. The commit here adding a locally-generated UID is superseded.

Worth flagging for review: **#812 also edits `TutorialOverlay.gd`**, but in `_inject_exit_button` (marking the injected Exit button as the pad's last-resort focus target) — a different function from the card-width work, so git auto-merged it. Both changes were verified present in the merged file, and #812's rewritten T2 pad prompts are covered by the `tut_t2_musterin` re-run above.

## Also in this PR

- `version_history.json` → **1.7.24** with player-facing notes.
- Two coverage tiles: `tutorial.overlay.card_dodge`, `tutorial.overlay.card_width`.
