### PR TITLE
Move the Dice Log tutorial step from T1 to T4, where dice exist

### DIFF
--- a/40k/data/tutorials/lessons/T1_basics.json
+++ b/40k/data/tutorials/lessons/T1_basics.json
@@ -14,7 +14,7 @@
     "bullets": [
       "Camera: pan an' zoom anywhere on da table.",
       "Units: pick 'em from da list or da board, datasheet for da full stats.",
-      "Da left panel logs everyfing — Game Log an' Dice Log tabs.",
+      "Da left panel logs everyfing — Game Log for da story, Dice Log for every roll once dey start.",
       "Da big red button ends da phase. Da small one ends a unit's move.",
       "Forgot a control? Da pause menu (Escape, or View on a pad) lists every key under Controls an' every button under Controller.",
       "Next lesson: Musterin' da Boyz — deployment, transports an' leaders."
@@ -143,20 +143,20 @@
       }
     },
     {
-      "id": "dice_log",
+      "id": "log_panel",
       "prompt": {
         "bark": "DA PAPERWORK!",
-        "kbm": "Da left panel logs everyfing wot 'appens. Click da [b]Dice Log[/b] tab — every roll ends up dere.",
-        "pad": "Da left panel logs everyfing. Glide {ls} onto da [b]Dice Log[/b] tab an' press {a}."
+        "text": "Da panel down da left logs everyfing wot 'appens. [b]Game Log[/b] is da story so far; da [b]Dice Log[/b] tab catches every roll — nuffin's been rolled yet, so it's empty. Dakka Time puts it to work."
       },
       "anchor": {
-        "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog"
+        "node": "/root/Main/GameLogPanel"
       },
       "spotlight": "soft",
       "allow": [],
       "done": {
-        "script": "var glp = tree.root.get_node_or_null(\"/root/Main/GameLogPanel\")\nreturn glp != null and str(glp._active_tab) == \"dice\""
-      }
+        "ack": true
+      },
+      "comment": "This step used to tell the player to CLICK the Dice Log tab, in this very slot — before a single die had been rolled, so they switched to a blank panel and learned nothing. The real 'open the Dice Log and read your rolls' step now lives in T4 (Dakka Time) immediately after the shooting rolls, where the log actually has content. This keeps the log panel on the orientation tour (it is in the lesson summary) but only points at it — no click into an empty log."
     },
     {
       "id": "hint_bar",

--- a/40k/data/tutorials/lessons/T4_shooting.json
+++ b/40k/data/tutorials/lessons/T4_shooting.json
@@ -21,6 +21,7 @@
       "Each gun rolls to hit, den to wound, den da defender saves — kills from one gun are gone before da next fires.",
       "[b]Fast Roll All ⏩[/b] rolls everyfin'; [b]Roll to Hit ▶[/b] goes step by step. [b]Done[/b] closes each save card.",
       "[b]Complete Shooting[/b] finishes da unit — den pick da next shooter or end da phase.",
+      "Da [b]Dice Log[/b] tab on da left panel keeps every roll — check it when a result looks fishy.",
       "[b]Shoot All Remaining[/b] auto-fires every unit ya ain't bothered aimin' yerself.",
       "Next lesson: 'Ere We Go! — chargin'."
     ]
@@ -177,6 +178,26 @@
       "hint": {
         "text": "Da 'Every step' dropdown picks how often da rollin' pauses. Stuck? Da big dock button always shows da next step."
       }
+    },
+    {
+      "id": "dice_log",
+      "prompt": {
+        "bark": "CHECK DA NUMBERS!",
+        "kbm": "Every one of dem rolls got written down. Click da [b]Dice Log[/b] tab on da panel down da left — hits, wounds an' saves, da lot of it.",
+        "pad": "Every roll got written down. Glide {ls} onto da [b]Dice Log[/b] tab on da panel down da left an' press {a} — hits, wounds an' saves, da lot of it."
+      },
+      "anchor": {
+        "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog"
+      },
+      "spotlight": "soft",
+      "allow": [],
+      "done": {
+        "script": "var glp = tree.root.get_node_or_null(\"/root/Main/GameLogPanel\")\nreturn glp != null and str(glp.get_active_tab()) == \"dice\""
+      },
+      "hint": {
+        "text": "Da tab's up top of da left panel, next to [b]Game Log[/b] — it's wearin' a ● 'cos dere's rolls ya ain't read yet."
+      },
+      "comment": "This lived in T1 (Scoutin' da Field) between the datasheet steps, where it asked the player to open the Dice Log before anything had been rolled — an empty panel. It sits here instead: 'roll_da_dice' above it only completes once U_BOYZ_T.flags.has_shot is true, so by the time this step is up the shooting phase has written its hit/wound/save blocks into the shared dice log (see tests/scenarios/sp/dice_log_left_tab_shooting.json) and the tab is carrying its unread ● nudge."
     },
     {
       "id": "end_phase",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.7.21",
+      "date": "2026-07-30",
+      "summary": "The Dice Log lesson moved out of 'Scoutin' da Field' and into 'Dakka Time', where there are actually some rolls to read.",
+      "changes": [
+        "Step 6 of Tutorial 1 ('Scoutin' da Field') used to tell you to click the Dice Log tab — before a single die had been rolled, so you switched to a blank panel and learned nothing from it. That step is gone.",
+        "In its place, Tutorial 1 just points at the log panel down the left: Game Log for the story so far, Dice Log for every roll once they start. No click into an empty log, and it says outright that Dakka Time is where you'll use it.",
+        "Tutorial 4 ('Dakka Time') now has that step, straight after the shooting rolls: new step 'CHECK DA NUMBERS!' sends you to the Dice Log tab (wearing its unread dot) to read the hits, wounds and saves you just made.",
+        "Fixed while moving it: the Dice Log tab stayed empty for the whole phase whenever a battle STARTED in the shooting, charge or fight phase — every tutorial lesson from 'Dakka Time' on, and any save you loaded mid-combat. The phase's controls are built before the left-hand log panel exists, so the dice output went to a throwaway label instead of the tab you can actually read. Normal play never showed it because a battle begins in deployment."
+      ]
+    },
+    {
       "version": "1.7.20",
       "date": "2026-07-29",
       "summary": "An attached character's guns now count properly for Rapid Fire, Melta, cover and target eligibility — and two crash-on-use toasts are fixed.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -486,6 +486,20 @@ func _ready() -> void:
 	# Hide left panel (Mathhammer) by default — toggle with hotkey
 	_hide_left_panel()
 
+	# Game Event Log panel — MUST be built before setup_phase_controllers().
+	# It owns the shared "Dice Log" tab that the shooting/charge/fight
+	# controllers resolve at UI-build time (PhaseControllerBase
+	# .resolve_shared_dice_log). This used to run ~60 lines further down, so a
+	# controller built for the STARTING phase resolved its dice log before the
+	# panel existed and fell back to a throwaway label in the right-hand panel:
+	# every roll went there and the left panel's Dice Log tab stayed empty for
+	# the whole phase. Normal play begins in deployment and never noticed —
+	# but booting a tutorial fixture straight into shooting/charge/fight, or
+	# loading a save taken there, hit it every time. Building the panel first
+	# also means those paths lay the right-hand panel out exactly the way
+	# normal play does, with no dice-log label in it to remove later.
+	_setup_game_log_panel()
+
 	# Setup phase-specific controllers based on current phase
 	current_phase = GameState.get_current_phase()
 	await setup_phase_controllers()
@@ -543,8 +557,8 @@ func _ready() -> void:
 	# Aura range rings layer
 	_setup_aura_rings_layer()
 
-	# Setup Game Event Log panel
-	_setup_game_log_panel()
+	# (Game Event Log panel is built earlier — above setup_phase_controllers()
+	# — because the phase controllers resolve its shared Dice Log tab.)
 
 	# P3-117: Setup Dice Roll History panel
 	_setup_dice_history_panel()
@@ -12173,6 +12187,27 @@ func _setup_game_log_panel() -> void:
 	if game_log_panel.has_signal("history_step_requested"):
 		game_log_panel.history_step_requested.connect(_on_history_step_requested)
 	print("Main: Game Event Log panel created (card-based)")
+	_rebind_controller_dice_logs()
+
+func _rebind_controller_dice_logs() -> void:
+	# Safety net for the ordering above: any controller that built its UI before
+	# this panel existed resolved its dice log to a throwaway DiceLogFallback
+	# label instead of the shared "Dice Log" tab, and every roll it writes goes
+	# there where no one can read it (PhaseControllerBase.resolve_shared_dice_log
+	# / rebind_shared_dice_log). _ready() now builds the panel before
+	# setup_phase_controllers() so the battle-start path no longer needs this,
+	# but the replay-mode init also creates the panel late, and re-pointing is a
+	# cheap no-op for controllers that already share the label.
+	#
+	# Prefer keeping the panel FIRST over relying on this: rebinding frees the
+	# fallback label out of a right-hand panel that has already been laid out,
+	# and that reflow was measured to leave ChargePanel/DistanceTracking
+	# overlapping the "Confirm Charge Moves" button — visible and enabled, but
+	# swallowing real mouse clicks (caught by tests/scenarios/sp/tut_t5_ere_we_go
+	# .json).
+	for c in [shooting_controller, charge_controller, fight_controller, movement_controller]:
+		if c != null and is_instance_valid(c) and c.has_method("rebind_shared_dice_log"):
+			c.rebind_shared_dice_log()
 
 func _prune_old_log_entries() -> void:
 	"""Pruning is handled internally by GameLogPanel._trim_old_cards()."""

--- a/40k/scripts/PhaseControllerBase.gd
+++ b/40k/scripts/PhaseControllerBase.gd
@@ -61,6 +61,12 @@ func get_board_root() -> Node:
 ## shared tab unchanged. Falls back to a local right-panel label (the historical
 ## behavior) when the panel isn't present — e.g. trimmed / headless setups — so
 ## `dice_log_display` is always a valid, writable RichTextLabel.
+##
+## The fallback is deliberately NAMED "DiceLogFallback" so a controller that had
+## to fall back can be spotted afterwards: Main._setup_game_log_panel() calls
+## rebind_shared_dice_log() (see below) on every live controller once the real
+## panel exists. Main._ready() builds the panel BEFORE the phase controllers, so
+## in a normal battle start nothing falls back in the first place.
 func resolve_shared_dice_log(fallback_parent: Node = null) -> RichTextLabel:
 	var glp = SceneRefs.game_log_panel() if SceneRefs else null
 	if glp != null and glp.has_method("get_dice_log_display"):
@@ -75,7 +81,49 @@ func resolve_shared_dice_log(fallback_parent: Node = null) -> RichTextLabel:
 	rt.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	if fallback_parent != null:
 		fallback_parent.add_child(rt)
+	print("PhaseControllerBase: no GameLogPanel yet — %s writing dice output to a local DiceLogFallback until rebind_shared_dice_log()" % name)
 	return rt
+
+
+## Re-point `dice_log_display` at the shared GameLogPanel tab if this controller
+## had to fall back earlier.
+##
+## Main._setup_game_log_panel() used to run AFTER setup_phase_controllers(), so a
+## controller built during startup resolved its dice log while the panel did not
+## exist yet. That only bit when the battle STARTED in that controller's phase —
+## normal play begins in deployment, so the shooting/charge/fight controllers are
+## created on a later phase change when the panel is already up. Booting straight
+## into a phase did hit it: the tutorial lessons T4/T5/T6 boot into
+## shooting/charge/fight from a fixture, and every roll of the lesson went into a
+## stray DiceLogFallback parented in the right-hand panel while the left panel's
+## "Dice Log" tab stayed empty for the whole lesson. Loading a save taken
+## mid-shooting/charge/fight has the same start condition.
+##
+## _ready() now builds the panel first, so this is a safety net for the paths
+## that still create it late (replay mode). A no-op for controllers already
+## sharing the label. Prefer fixing the order over relying on this: the freed
+## fallback reflows an already-laid-out right panel, which was measured to leave
+## ChargePanel/DistanceTracking on top of the "Confirm Charge Moves" button,
+## eating real mouse clicks. Nothing can have been written to the fallback at
+## startup (no dice rolled yet), so re-pointing loses no output.
+func rebind_shared_dice_log() -> void:
+	if not ("dice_log_display" in self):
+		return
+	var current = get("dice_log_display")
+	if current != null and is_instance_valid(current) and str(current.name) != "DiceLogFallback":
+		return  # already the shared label (or a purpose-built one)
+	var glp = SceneRefs.game_log_panel() if SceneRefs else null
+	if glp == null or not glp.has_method("get_dice_log_display"):
+		return
+	var shared = glp.get_dice_log_display()
+	if shared == null:
+		return
+	set("dice_log_display", shared)
+	if current != null and is_instance_valid(current):
+		if current.get_parent() != null:
+			current.get_parent().remove_child(current)
+		current.queue_free()
+	print("PhaseControllerBase: %s dice log rebound to the shared GameLogPanel tab" % name)
 
 
 # ── ISS-013: phase signal registry ──────────────────────────────────

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -7,7 +7,7 @@
   ],
   "rng_seed": 4242,
   "edition": 11,
-  "description": "Tutorial lesson T1 (Scoutin' da Field), mouse+keyboard player path, end to end: main menu -> Tutorial button -> lesson picker -> lesson boots from the tutorial_postdeploy fixture -> every step is completed with real input (camera wheel, unit-list clicks, datasheet key, dice-log tab, hotkey help, grot drag, confirm move) -> the action gate blocks an out-of-scope END_MOVEMENT with tutorial_blocked -> lesson completes, summary shows, completion is persisted, Back to Menu returns to the main menu.",
+  "description": "Tutorial lesson T1 (Scoutin' da Field), mouse+keyboard player path, end to end: main menu -> Tutorial button -> lesson picker -> lesson boots from the tutorial_postdeploy fixture -> every step is completed with real input (camera wheel, unit-list clicks, datasheet key, log-panel card, hotkey help, grot drag, confirm move) -> the action gate blocks an out-of-scope END_MOVEMENT with tutorial_blocked -> lesson completes, summary shows, completion is persisted, Back to Menu returns to the main menu.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -242,19 +242,41 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "dice_log"
+      "equals": "log_panel",
+      "comment": "this slot used to be a 'dice_log' step that told the player to click the Dice Log tab. Nothing has been rolled by here, so it switched them to a blank panel; the interactive version now lives in T4 after the shooting rolls (tut_t4_dakka.json)."
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_dice_log_display().get_total_character_count()",
+      "multiline": true,
+      "equals": 0,
+      "comment": "the reason the step moved, asserted: at this point in T1 the dice log is genuinely empty — no roll has happened — so there is nothing for a player to read there."
+    },
+    {
+      "act": "execute_script",
+      "script": "var o = tree.root.get_node(\"/root/TutorialOverlay\")\nvar t = str(o.current_body_text())\nreturn t.contains(\"Game Log\") and t.contains(\"Dice Log\") and t.contains(\"empty\")",
+      "multiline": true,
+      "equals": true,
+      "comment": "the step still puts the log panel on the orientation tour — both tabs named — and is honest that the Dice Log has nothing in it yet"
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_active_tab()",
+      "multiline": true,
+      "equals": "game",
+      "comment": "and it does not demand a tab switch to advance"
+    },
+    {
+      "act": "screenshot",
+      "label": "04_log_panel"
     },
     {
       "act": "click_node",
-      "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog"
+      "node": "/root/TutorialOverlay/InstructorCard/Margin/VBox/Footer/ContinueButton"
     },
     {
       "act": "wait_frames",
       "frames": 20
-    },
-    {
-      "act": "screenshot",
-      "label": "04_dice_log"
     },
     {
       "act": "execute_script",

--- a/40k/tests/scenarios/sp/tut_t1_basics_pad.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics_pad.json
@@ -6,7 +6,7 @@
   ],
   "rng_seed": 4242,
   "edition": 11,
-  "description": "Tutorial lesson T1 driven entirely with a gamepad: LB claims pad mode on the main menu, D-pad+A opens the Tutorial picker and starts the lesson, then every step is completed with pad input only - RS camera pan, RB unit cycling, Y datasheet toggle, virtual-cursor clicks on the Dice Log tab and instructor-card buttons, the pad-only hint-bar step (skipped on kbm), the controls-reference step reached with the View button (pause menu -> Controller tab) instead of the keyboard-only Shift+/ chord, and a full carry-mode grot move (A select, A menu, A pick Normal, glide, X drop) before confirming via the End This Unit's Move button. Verifies the pad-only step appears, kbm-only steps are skipped, and completion persists.",
+  "description": "Tutorial lesson T1 driven entirely with a gamepad: LB claims pad mode on the main menu, D-pad+A opens the Tutorial picker and starts the lesson, then every step is completed with pad input only - RS camera pan, RB unit cycling, Y datasheet toggle, virtual-cursor clicks on the instructor-card buttons, the pad-only hint-bar step (skipped on kbm), the controls-reference step reached with the View button (pause menu -> Controller tab) instead of the keyboard-only Shift+/ chord, and a full carry-mode grot move (A select, A menu, A pick Normal, glide, X drop) before confirming via the End This Unit's Move button. Verifies the pad-only step appears, kbm-only steps are skipped, and completion persists.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -263,15 +263,20 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "dice_log"
+      "equals": "log_panel",
+      "comment": "was a 'dice_log' step that made the pad player glide onto the Dice Log tab before anything had been rolled — a blank panel. The interactive version moved to T4 (tut_t4_dakka_pad.json), after the shooting rolls; this one just points at the panel and takes Ⓐ."
     },
     {
-      "act": "pad_cursor_glide",
-      "button_text": "Dice Log"
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_dice_log_display().get_total_character_count()",
+      "multiline": true,
+      "equals": 0,
+      "comment": "why it moved: nothing has been rolled yet, so the dice log has nothing in it"
     },
     {
       "act": "simulate_joy_button",
-      "button_index": 0
+      "button_index": 0,
+      "comment": "closed ack step: Ⓐ is rerouted to the card's Continue, so no cursor glide is needed to leave it"
     },
     {
       "act": "wait_frames",

--- a/40k/tests/scenarios/sp/tut_t1_lock_it_in_start_glyph.json
+++ b/40k/tests/scenarios/sp/tut_t1_lock_it_in_start_glyph.json
@@ -180,11 +180,8 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "dice_log"
-    },
-    {
-      "act": "pad_cursor_glide",
-      "button_text": "Dice Log"
+      "equals": "log_panel",
+      "comment": "the old 'dice_log' step (click the Dice Log tab) moved to T4, where dice have actually been rolled; this slot is now an ack-only look at the log panel"
     },
     {
       "act": "simulate_joy_button",

--- a/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
+++ b/40k/tests/scenarios/sp/tut_t1_pad_ack_button.json
@@ -194,12 +194,12 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "dice_log"
+      "equals": "log_panel"
     },
     {
       "act": "pad_cursor_glide",
-      "button_text": "Dice Log",
-      "comment": "the ONE glide in this run - the step teaches the cursor, and it is what leaves the cursor active and armed the reported trap"
+      "node": "/root/Main/GameLogPanel",
+      "comment": "the ONE glide in this run - it parks the cursor on the panel this step points at, and (the load-bearing part) leaves VirtualCursor ACTIVE, which is what arms the reported trap on the next step. Not a click target: the step is ack-only, Ⓐ below goes to Continue."
     },
     {
       "act": "simulate_joy_button",

--- a/40k/tests/scenarios/sp/tut_t4_dakka.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka.json
@@ -7,7 +7,7 @@
   ],
   "rng_seed": 4242,
   "edition": 11,
-  "description": "Tutorial lesson T4 (Dakka Time), mouse player path: boot from the tutorial_t4_shoot fixture -> select the Boyz as shooter by clicking their token on the board -> aim the Slugga by clicking its weapon row then the Witchseekers -> aim the rest with the 'All -> Witchseekers' quick-assign button (the lesson clears boot.auto_assign_single_target, so the player performs the assignment the lesson teaches) -> Confirm (3 weapons) -> Fast Roll All in the resolution dock -> Done on each defender save results card (tolerant: pressed only while visible) -> Complete Shooting -> end the phase with the big phase button -> lesson summary -> back to menu.",
+  "description": "Tutorial lesson T4 (Dakka Time), mouse player path: boot from the tutorial_t4_shoot fixture -> select the Boyz as shooter by clicking their token on the board -> aim the Slugga by clicking its weapon row then the Witchseekers -> aim the rest with the 'All -> Witchseekers' quick-assign button (the lesson clears boot.auto_assign_single_target, so the player performs the assignment the lesson teaches) -> Confirm (3 weapons) -> Fast Roll All in the resolution dock -> Done on each defender save results card (tolerant: pressed only while visible) -> Complete Shooting -> open the Dice Log tab on the left panel and read the rolls that were just made (this step moved here from T1, where it fired before any dice existed) -> end the phase with the big phase button -> lesson summary -> back to menu.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -283,11 +283,67 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "end_phase"
+      "equals": "dice_log",
+      "comment": "the Dice Log step moved here from T1, where it fired before anything had been rolled and opened a blank panel"
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_dice_log_display().get_total_character_count()",
+      "expect_min": 1,
+      "multiline": true,
+      "comment": "THE POINT OF THE MOVE: by the time this step is up the shooting rolls are really in the left panel's Dice Log, so the player is being sent to read something that exists. This caught a real bug rather than just passing: Main._ready() built the GameLogPanel AFTER setup_phase_controllers(), so a lesson booting straight into the shooting phase created the ShootingController first and resolve_shared_dice_log() fell back to a throwaway 'DiceLogFallback' label in the right-hand panel — every roll of the lesson went there while this tab stayed empty. The panel is now built before the controllers."
+    },
+    {
+      "act": "execute_script",
+      "script": "var glp = tree.current_scene.game_log_panel\nvar sc = tree.current_scene.shooting_controller\nreturn sc.dice_log_display == glp.get_dice_log_display()",
+      "multiline": true,
+      "equals": true,
+      "comment": "THE POINT OF THE MOVE: by the time this step is up the shooting rolls are really in the left panel's Dice Log, so the player is being sent to read something that exists. This caught a real bug rather than just passing: Main._ready() built the GameLogPanel AFTER setup_phase_controllers(), so a lesson booting straight into the shooting phase created the ShootingController first and resolve_shared_dice_log() fell back to a throwaway 'DiceLogFallback' label in the right-hand panel — every roll of the lesson went there while this tab stayed empty. The panel is now built before the controllers."
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_active_tab() == \"game\" and tree.current_scene.game_log_panel.is_dice_tab_unread()",
+      "multiline": true,
+      "equals": true,
+      "comment": "the tab is wearing the unread ● the step's hint mentions — the player has not been yanked onto it"
     },
     {
       "act": "screenshot",
       "label": "04_boyz_shot"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_active_tab()",
+      "multiline": true,
+      "equals": "dice"
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/GameLogPanel/VBox/DiceLogDisplay",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "screenshot",
+      "label": "04b_dice_log_with_rolls",
+      "region": [
+        0,
+        100,
+        360,
+        760
+      ]
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase"
     },
     {
       "act": "click_node",

--- a/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka_pad.json
@@ -354,11 +354,49 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "end_phase"
+      "equals": "dice_log",
+      "comment": "the Dice Log step moved here from T1, where the pad player was glided onto the tab before any dice existed"
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_dice_log_display().get_total_character_count()",
+      "expect_min": 1,
+      "multiline": true,
+      "comment": "the rolls the step sends them to read are really in the log by now"
     },
     {
       "act": "screenshot",
       "label": "05_boyz_shot_pad"
+    },
+    {
+      "act": "pad_cursor_glide",
+      "node": "/root/Main/GameLogPanel/VBox/HeaderRow/TabDiceLog",
+      "comment": "glide by node, NOT button_text: the tab's label is 'Dice Log  ●' while there is unread output, and _find_visible_button_by_text matches exactly"
+    },
+    {
+      "act": "simulate_joy_button",
+      "button_index": 0,
+      "comment": "no shooter is armed any more, so A falls through to the virtual cursor and clicks the tab"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 20
+    },
+    {
+      "act": "execute_script",
+      "script": "return tree.current_scene.game_log_panel.get_active_tab()",
+      "multiline": true,
+      "equals": "dice"
+    },
+    {
+      "act": "screenshot",
+      "label": "05b_dice_log_pad",
+      "region": [0, 100, 360, 760]
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "end_phase"
     },
     {
       "act": "simulate_joy_button",

--- a/40k/tests/scenarios/sp/tut_t4_dakka_reorder_pad.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka_reorder_pad.json
@@ -420,7 +420,8 @@
     {
       "act": "execute_script",
       "script": "TutorialManager.current_step_id()",
-      "equals": "end_phase"
+      "equals": "dice_log",
+      "comment": "shooting now hands off to the Dice Log step (moved here from T1) before the end-phase step this scenario used to expect"
     },
     {
       "act": "screenshot",

--- a/40k/tests/test_attached_char_bearer_ids.gd.uid
+++ b/40k/tests/test_attached_char_bearer_ids.gd.uid
@@ -1,0 +1,1 @@
+uid://dfhmp8hwh267i


### PR DESCRIPTION
Step 6 of T1 ("Scoutin' da Field") told the player to click the **Dice Log** tab before anything had been rolled, so they switched to a blank panel and learned nothing from it.

## What changed

**T1 (Scoutin' da Field)** — the interactive step is gone. In its place, an ack-only `log_panel` step ("DA PAPERWORK!") spotlights the left-hand panel, names both tabs, says outright that the Dice Log is empty because nothing has rolled yet, and points at Dakka Time. No click into a blank panel.

**T4 (Dakka Time)** — new `dice_log` step ("CHECK DA NUMBERS!") immediately after the shooting rolls, where the tab is carrying its unread ● and the hit/wound/save blocks are there to read.

## The bug this exposed

Moving the step would have made it just as useless: the left panel's Dice Log tab was empty for the **whole phase** whenever a battle *started* in shooting/charge/fight.

`Main._ready()` built the `GameLogPanel` **after** `setup_phase_controllers()`, so the controller for the starting phase resolved its dice log before the panel existed and `PhaseControllerBase.resolve_shared_dice_log()` fell back to a throwaway label parented in the right-hand panel. Measured live in the T4 lesson: 763 characters of rolls in the stray `DiceLogFallback`, 0 in the shared label. Normal play begins in deployment and never hit it — every tutorial from T4 on, and any save loaded mid-combat, did.

The panel is now built **before** the controllers, so those paths lay the right-hand panel out exactly the way normal play does.

`rebind_shared_dice_log()` stays as a safety net for paths that still create the panel late (replay mode). It is deliberately *not* the primary fix: freeing the fallback out of an already-laid-out panel left `ChargePanel/DistanceTracking` on top of "Confirm Charge Moves" — visible and enabled, but swallowing real mouse clicks. `tut_t5_ere_we_go` caught that (`pressed.emit()` worked where a click did not).

## Verification

Windowed scenarios, all 0 failures:

| scenario | passed |
| --- | --- |
| `tut_t1_basics` | 107 |
| `tut_t1_basics_pad` | 121 |
| `tut_t1_pad_ack_button` | 99 |
| `tut_t1_lock_it_in_start_glyph` | 82 |
| `tut_t4_dakka` | 78 |
| `tut_t4_dakka_pad` | 96 |
| `tut_t4_dakka_reorder_pad` | 83 |
| `tut_t5_ere_we_go` | 46 |
| `tut_t6_krumpin` | 57 |
| `dice_log_left_tab_shooting` | 31 |

Plus headless `test_tutorial_checklist`: 38 passed. Screenshots confirm both the new T1 card and the T4 Dice Log full of rolls. The T5 failure was attributed by re-running it against a stashed tree (46/46 clean), not assumed.

The T4 scenarios assert the log has content **and** that it is the same label the controller wrote to; the T1 scenario asserts it is empty there — which is why the step moved.

## Worth knowing

- In **multiplayer**, the surrender button and phase-timer chips now get added to the top HUD bar after the "Hide Log" toggle rather than before, since they are created later than the panel is now. Both are MP-only early-returns and single-player is byte-identical (verified from the screenshot); the MP chip order was **not** checked with a multiplayer scenario.
- The `DistanceTracking`-overlapping-`ConfirmChargeButton` behaviour is latent in the charge panel's layout — this PR avoids triggering it rather than fixing the panel. Worth a separate look if that panel ever gains or loses a tall child again.

Changelog entry `1.7.21` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F86V4BTJi4yPZw7EwC1zqi

---
_Generated by [Claude Code](https://claude.ai/code/session_01F86V4BTJi4yPZw7EwC1zqi)_