### PR TITLE
Unbreak the tutorial windowed scenarios, and cover the card dodge's live re-measurement

### DIFF
--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -8787,6 +8787,34 @@
       "last_verified_commit": "HEAD",
       "status": "covered",
       "fidelity": "DECLARED"
+    },
+    {
+      "id": "tutorial.overlay.dialog_dodge",
+      "description": "With a gameplay dialog open the instructor card keeps clear of it, at any UI Scale. Embedded Windows composite above every CanvasLayer, so anything the dialog covers is simply lost. _dodge_dialog measures both gutters, takes the roomier one and shrinks the text column to what fits; a dialog that never reaches the card's default top placement (bottom-docked gameplay popups) is not dodged at all. Covered against the full-height Formations panel (tut_t2_card_clears_formations_dialog) and the bottom-docked deployment roll-off (tut_t2_card_width_tracks_each_dialog).",
+      "scenarios": [
+        "tut_t2_card_clears_formations_dialog",
+        "tut_t2_card_width_tracks_each_dialog"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "tutorial.overlay.width_tracks_blocker",
+      "description": "The dodged card's text column is a live per-frame measurement of the open dialog, not a constant tuned to one panel. Asserted two ways: the squeeze survives a step change (show_step resets to full width then re-dodges in the same call, so attach_warboss -> embark_boyz under the same dialog never parks a full-width card underneath it), and the column genuinely moves between dialogs (388px beside the 600px Formations panel, back to the full 560px for the bottom-docked 550px roll-off).",
+      "scenarios": [
+        "tut_t2_card_width_tracks_each_dialog"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
+    },
+    {
+      "id": "tutorial.overlay.width_restored",
+      "description": "Narrowing the card is not a one-way latch: once every gameplay dialog closes the card returns to the full CARD_CONTENT_WIDTH at the default top placement, so the remainder of a lesson is not read through the cramped column some earlier dialog forced.",
+      "scenarios": [
+        "tut_t2_card_width_tracks_each_dialog"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/scenarios/sp/tut_blocked_toast_names_continue.json
+++ b/40k/tests/scenarios/sp/tut_blocked_toast_names_continue.json
@@ -11,7 +11,7 @@
     { "act": "wait_seconds", "seconds": 1.5 },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_card_dodges_deep_dialog.json
+++ b/40k/tests/scenarios/sp/tut_card_dodges_deep_dialog.json
@@ -20,7 +20,7 @@
     },
     {
       "act": "execute_script",
-      "script": "var sc = tree.root.get_node_or_null(\"/root/MainMenu/ScrollContainer\")\nvar b = tree.root.get_node_or_null(\"/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton\")\nif sc == null or b == null:\n\treturn false\nsc.ensure_control_visible(b)\nreturn true",
+      "script": "var sc = tree.root.get_node_or_null(\"/root/MainMenu/ScrollContainer\")\nvar b = tree.root.get_node_or_null(\"/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton\")\nif sc == null or b == null:\n\treturn false\nsc.ensure_control_visible(b)\nreturn true",
       "multiline": true,
       "equals": true,
       "comment": "ButtonSection sits below the menu's scroll fold at 1080p, and a click at an unscrolled control's coordinates lands on whatever is actually drawn there"
@@ -31,7 +31,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_exit_anywhere.json
+++ b/40k/tests/scenarios/sp/tut_exit_anywhere.json
@@ -10,7 +10,7 @@
   "description": "The other two Exit Tutorial routes. (a) Nothing blocking: the card's own Exit Tutorial button asks first, Keep Playin' leaves the lesson untouched, Leg it! returns to the menu. (b) A blocking Window that is NOT an AcceptDialog (so no button bar to add to): the floating always-on-top hatch appears instead and exits the same way. The blocker in (b) is a bare exclusive Window created for the test — every gameplay dialog in the game today is an AcceptDialog, covered by tut_exit_under_modal — but the code path it drives is the shipped one.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
-    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton" },
+    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton" },
     { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
     { "act": "click_node", "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t1_basics/Play_t1_basics" },
     { "act": "wait_seconds", "seconds": 10.0 },

--- a/40k/tests/scenarios/sp/tut_exit_under_modal.json
+++ b/40k/tests/scenarios/sp/tut_exit_under_modal.json
@@ -10,7 +10,7 @@
   "description": "Exit Tutorial has to work at ANY point of a lesson, including while a gameplay dialog owns the screen. Reproduces the reported T2 softlock — parked on 'GROTS IN A MOB!' (deploy_grots) with the FIRST_TURN_ROLLOFF dialog open, so the step's allow-list rejects the roll — and proves the escape hatch: the card's own Exit Tutorial greys out (it is unreachable under an exclusive embedded Window, which blocks every input to the parent viewport), an Exit Tutorial button is offered inside the dialog itself, it opens a confirm, and confirming lands the player back on the main menu with no tutorial state left behind. The hatch is ARMED, not always-on: it appears only once the lesson gate has actually refused something while this dialog was up, because offering it on every dialog cost pad players control of the dialog itself (tut_rolloff_pad_no_exit_hatch owns that half). So this scenario presses the blocked Roll button first — which is exactly what the stranded player did.",
   "steps": [
     { "act": "wait_seconds", "seconds": 1.5 },
-    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton" },
+    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton" },
     { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
     { "act": "click_node", "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t2_musterin/Play_t2_musterin" },
     { "act": "wait_seconds", "seconds": 10.0 },

--- a/40k/tests/scenarios/sp/tut_full_course_chain.json
+++ b/40k/tests/scenarios/sp/tut_full_course_chain.json
@@ -14,7 +14,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_rolloff_pad_no_exit_hatch.json
+++ b/40k/tests/scenarios/sp/tut_rolloff_pad_no_exit_hatch.json
@@ -17,7 +17,7 @@
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "execute_script", "script": "InputDeviceManager.is_pad_active()", "equals": true },
 
-    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton", "emit_pressed": true, "comment": "emit_pressed, not a real click: a real mouse event would hand the device back to KBM and the bug under test is pad-only" },
+    { "act": "click_node", "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton", "emit_pressed": true, "comment": "emit_pressed, not a real click: a real mouse event would hand the device back to KBM and the bug under test is pad-only" },
     { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
     { "act": "click_node", "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t2_musterin/Play_t2_musterin", "emit_pressed": true },
     { "act": "wait_seconds", "seconds": 10.0 },

--- a/40k/tests/scenarios/sp/tut_t1_basics.json
+++ b/40k/tests/scenarios/sp/tut_t1_basics.json
@@ -19,7 +19,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t2_card_clears_formations_dialog.json
+++ b/40k/tests/scenarios/sp/tut_t2_card_clears_formations_dialog.json
@@ -21,7 +21,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton",
       "emit_pressed": true,
       "comment": "signal rather than a synthetic click: the injected pointer position is in physical window px and the rescale above has moved every node's logical rect out from under it. The real click path through these two menu buttons is covered by tut_t2_musterin at the default scale; what this scenario is about starts once the lesson is up."
     },

--- a/40k/tests/scenarios/sp/tut_t2_card_width_tracks_each_dialog.json
+++ b/40k/tests/scenarios/sp/tut_t2_card_width_tracks_each_dialog.json
@@ -1,0 +1,180 @@
+{
+  "id": "tut_t2_card_width_tracks_each_dialog",
+  "covers": [
+    "tutorial.overlay.dialog_dodge",
+    "tutorial.overlay.width_tracks_blocker",
+    "tutorial.overlay.width_restored"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Follow-up coverage for the instructor card's dialog dodge. tut_t2_card_clears_formations_dialog proves the card clears the Declare Battle Formations panel at a shrunken viewport; it stops there, on step 1, against that one dialog. This picks up where it stops and pins the three properties that make the dodge a live per-frame measurement rather than a value tuned to that one panel. (1) SURVIVES A STEP CHANGE: show_step resets the card to full width and re-dodges within the same call, so advancing attach_warboss -> embark_boyz under the same dialog must not leave a full-width card parked under it — measured at content 388px on both sides of the step change, overlap 0. (2) A BOTTOM-DOCKED DIALOG IS NOT DODGED AT ALL: the deployment roll-off is both a different width (550 vs 600) and docked low enough that it never reaches the card's default top placement, so _dodge_dialog's early return must leave the card at top, full width — the column really moves 388 -> 560, which a latch or a constant could not do. Both facts are asserted from the live rects, not assumed. (3) RESTORES: once every dialog closes the card is back at the full CARD_CONTENT_WIDTH at the top placement, so the narrowing is not one-way and the rest of the lesson does not read in a cramped column. Runs at content_scale_factor 1.3 (what the UI Scale slider and the pad text boost do) because that is the regime where the gutter is actually tight; the factor is set on the root Window directly, NOT through SettingsService, so nothing is persisted to user://settings.cfg for the rest of the suite.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.5 },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton",
+      "timeout_s": 15.0,
+      "comment": "the Tutorial button is built at runtime by _create_tutorial_ui; wait for it rather than assuming a fixed boot time (a cold import makes 1.5s too optimistic)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "tree.root.content_scale_factor = 1.3\nreturn tree.root.get_visible_rect().size.x < 1600.0",
+      "equals": true,
+      "comment": "shrink the logical viewport so the centred dialog leaves a genuinely tight gutter"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton",
+      "emit_pressed": true,
+      "comment": "emit_pressed: synthetic mouse warps are computed in logical coords and no longer line up once content_scale_factor != 1"
+    },
+    { "act": "expect_node_visible", "node": "/root/MainMenu/TutorialPicker", "timeout_s": 3.0 },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t2_musterin/Play_t2_musterin",
+      "emit_pressed": true
+    },
+    { "act": "wait_seconds", "seconds": 12.0 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "attach_warboss" },
+    { "act": "expect_node_visible", "node": "/root/Main/FormationsDialog", "timeout_s": 3.0 },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nInputDeviceManager.set_meta(\"t2w_formations_w\", ov.card_blocker_rect().size.x)\nInputDeviceManager.set_meta(\"t2w_formations_content\", ov.card_content_width())\nprint(\"[T2W] formations blocker=\", ov.card_blocker_rect(), \" card=\", ov.card_rect(), \" content=\", ov.card_content_width(), \" placement=\", ov.card_placement())\nreturn ov.card_blocker_overlap()",
+      "expect_max": 0.0,
+      "comment": "baseline: card clear of the Formations panel, and remember that panel's width + the column it forced"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_content_width() < ov.CARD_CONTENT_WIDTH",
+      "equals": true,
+      "comment": "the column really was narrowed here — otherwise the later 'restored to full width' assert would pass trivially"
+    },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nvar q = [fd]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is OptionButton and nd.item_count > 0 and nd.get_item_text(0) == \"(Unattached)\":\n\t\tnd.select(1)\n\t\tnd.item_selected.emit(1)\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn false",
+      "equals": true,
+      "comment": "CASE 1 setup — advance the step while the SAME dialog stays open. OptionButton popups are native Windows, so select+emit is the dropdown escape hatch"
+    },
+    { "act": "wait_frames", "frames": 15 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "embark_boyz" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nprint(\"[T2W] after step change: card=\", ov.card_rect(), \" content=\", ov.card_content_width(), \" overlap=\", ov.card_blocker_overlap())\nreturn ov.card_blocker_overlap()",
+      "expect_max": 0.0,
+      "comment": "CASE 1: a new step re-runs show_step, which resets the card to full width — it must re-dodge in the same call, not leave the card parked under the dialog"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_content_width() < ov.CARD_CONTENT_WIDTH",
+      "equals": true,
+      "comment": "CASE 1: and it is still narrowed, not merely off to one side"
+    },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var fd = tree.root.get_node(\"/root/Main/FormationsDialog\")\nvar q = [fd]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is CheckBox and str(nd.text).begins_with(\"Boyz\") and not (\"Reserves\" in str(nd.text)):\n\t\tnd.button_pressed = true\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn false",
+      "equals": true
+    },
+    { "act": "wait_frames", "frames": 15 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "confirm_formations" },
+    {
+      "act": "click_node",
+      "node": "/root/Main/FormationsDialog/MainVBox/ButtonBar/ConfirmButton",
+      "emit_pressed": true
+    },
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "execute_script", "script": "TutorialManager.current_step_id()", "equals": "roll_off" },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar b = ov.card_blocker_rect()\nif b.size.x <= 0.0:\n\treturn \"no blocker\"\nprint(\"[T2W] rolloff blocker=\", b, \" card=\", ov.card_rect(), \" content=\", ov.card_content_width())\nvar was = float(InputDeviceManager.get_meta(\"t2w_formations_w\"))\nvar vp = tree.root.get_visible_rect().size\nvar full_w = ov.CARD_CONTENT_WIDTH + ov.CARD_CHROME_W\nvar top_band = Rect2(Vector2(maxf((vp.x - full_w) * 0.5, 0.0), ov.CARD_TOP_OFFSET), Vector2(full_w, ov.card_rect().size.y))\nif absf(b.size.x - was) <= 1.0:\n\treturn \"same width as formations (%.0f)\" % was\nreturn \"bottom-docked\" if not top_band.grow(ov.CARD_DIALOG_GAP).intersects(b) else \"reaches top band\"",
+      "equals": "bottom-docked",
+      "comment": "CASE 2 premise, measured rather than assumed: the roll-off is BOTH a different width from the Formations panel (550 vs 600) AND bottom-docked — it never reaches the card's default top placement. That is what makes the next two asserts meaningful."
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_blocker_overlap()",
+      "expect_max": 0.0,
+      "comment": "CASE 2: still clear of it. The dodge reads whichever Window is up, not a rect tuned to the Formations panel."
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar was = float(InputDeviceManager.get_meta(\"t2w_formations_content\"))\nvar now = ov.card_content_width()\nif absf(now - was) <= 1.0:\n\treturn \"latched at %.0f across two different dialogs\" % now\nreturn \"widened\" if now >= ov.CARD_CONTENT_WIDTH else \"narrowed to %.0f\" % now",
+      "equals": "widened",
+      "comment": "CASE 2, the sharp end: _dodge_dialog's early return. A bottom-docked popup does not reach the top placement, so the card must STAY there at full width rather than needlessly squeezing into a gutter — and the column really does move (388 -> 560), so it is a live measurement, not a latch."
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "return tree.root.get_node(\"/root/TutorialOverlay\").card_placement()",
+      "equals": "top",
+      "comment": "CASE 2: and it stays at the default top placement, not pinned to a flank it has no reason to use"
+    },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/RollButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\nreturn true",
+      "equals": true
+    },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/RollButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nvar q = [tree.root]\nwhile not q.is_empty():\n\tvar nd = q.pop_back()\n\tif nd is Button and nd.is_visible_in_tree() and \"Re-roll\" in str(nd.text):\n\t\tnd.pressed.emit()\n\t\treturn true\n\tfor c in nd.get_children():\n\t\tq.append(c)\nreturn true",
+      "equals": true,
+      "comment": "tie tolerance: roll again if the button is still up, else press the A DEAD HEAT re-roll"
+    },
+    { "act": "wait_seconds", "seconds": 1.2 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var b = tree.root.get_node_or_null(\"/root/Main/RollOffDialog/Content/ButtonBar/ContinueButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\nreturn true",
+      "equals": true
+    },
+    { "act": "wait_seconds", "seconds": 3.0 },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nvar b = ov.card_blocker_rect()\nprint(\"[T2W] no dialog: blocker=\", b, \" card=\", ov.card_rect(), \" content=\", ov.card_content_width(), \" placement=\", ov.card_placement())\nreturn b.size == Vector2.ZERO",
+      "equals": true,
+      "comment": "CASE 3 premise: every gameplay dialog really is closed now"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ov = tree.root.get_node(\"/root/TutorialOverlay\")\nreturn ov.card_content_width() >= ov.CARD_CONTENT_WIDTH",
+      "equals": true,
+      "comment": "CASE 3: the narrowing is not a one-way latch — the column springs back, so the rest of the lesson does not read in a cramped strip"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "return tree.root.get_node(\"/root/TutorialOverlay\").card_placement()",
+      "equals": "top",
+      "comment": "CASE 3: and the card returns to the default top placement rather than staying pinned to a gutter"
+    },
+    { "act": "screenshot", "label": "01_card_restored_after_dialogs" },
+
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "tree.root.content_scale_factor = 1.0\nreturn true",
+      "equals": true,
+      "comment": "hand the viewport back at the base scale (the runner keeps executing steps after a failure, so this always runs)"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/tut_t2_musterin.json
+++ b/40k/tests/scenarios/sp/tut_t2_musterin.json
@@ -18,7 +18,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t2_musterin_pad_formation.json
+++ b/40k/tests/scenarios/sp/tut_t2_musterin_pad_formation.json
@@ -17,7 +17,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t3_get_movin.json
+++ b/40k/tests/scenarios/sp/tut_t3_get_movin.json
@@ -22,7 +22,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t4_dakka.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka.json
@@ -15,7 +15,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t4_dakka_reorder_pad.json
+++ b/40k/tests/scenarios/sp/tut_t4_dakka_reorder_pad.json
@@ -14,7 +14,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton",
       "comment": "the lesson is opened with the mouse on purpose - pad entry from the main menu is tut_t4_dakka_pad's job, this scenario is about the dock"
     },
     {

--- a/40k/tests/scenarios/sp/tut_t5_ere_we_go.json
+++ b/40k/tests/scenarios/sp/tut_t5_ere_we_go.json
@@ -14,7 +14,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t6_krumpin.json
+++ b/40k/tests/scenarios/sp/tut_t6_krumpin.json
@@ -14,7 +14,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",

--- a/40k/tests/scenarios/sp/tut_t7_runnin_da_show.json
+++ b/40k/tests/scenarios/sp/tut_t7_runnin_da_show.json
@@ -15,7 +15,7 @@
     },
     {
       "act": "click_node",
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
     },
     {
       "act": "expect_node_visible",


### PR DESCRIPTION
Follow-up to #808 (closed as superseded by #805). Two things — the first blocking the second.

## 1. The whole tutorial windowed suite is currently failing

`bae642b` ("Launch batch 3: … above-the-fold menu …") added `_promote_buttons_above_fold()`, which reparents `TutorialButton` and five siblings into a new `SecondaryButtonGrid`:

```gdscript
for btn_name in ["TutorialButton", "MultiplayerButton", "LoadButton", "ReplayButton", "SettingsButton", "QuitButton"]:
    var b = buttons.get_node_or_null(NodePath(btn_name))
    if b != null:
        buttons.remove_child(b)
        grid.add_child(b)          # <- path changes here
```

Every tutorial scenario opens its lesson by clicking that button, so **all 17 have been failing at the first click ever since** — including `tut_t2_card_clears_formations_dialog`, the scenario #805 added to guard the card fix.

Measured on `main`, not inferred:

| | before | after |
|---|---|---|
| `tut_t2_card_clears_formations_dialog` | **6 passed / 9 failed** — first failure `no node at path .../ButtonSection/TutorialButton` | **15 / 15** |

`StartButton` is *not* in that reparent list, so the three scenarios referencing it were always fine and are left alone. The edit to the 16 pre-existing files is the node path and nothing else:

```diff
-      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/TutorialButton"
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
```

## 2. New scenario: `tut_t2_card_width_tracks_each_dialog`

#805's scenario proves the card clears the Formations panel on step 1 of T2 and stops there, against that one dialog. This picks up where it stops and pins the properties that make `_dodge_dialog` a **live per-frame measurement** rather than a value tuned to that panel. Everything is asserted off live rects at `content_scale_factor` 1.3, where the gutter is genuinely tight:

| case | what it pins | measured |
|---|---|---|
| **survives a step change** | `show_step` resets the card to full width then re-dodges *in the same call*, so `attach_warboss` → `embark_boyz` under the same dialog never parks a full-width card underneath it | content `388px` either side of the step change, overlap `0` |
| **bottom-docked dialog is not dodged at all** | the roll-off is a different width (550 vs 600) *and* docked too low to reach the card's top placement, so `_dodge_dialog`'s early return must leave the card at top, full width | blocker `(463,328) 550×454`; column moves `388 → 560` |
| **restores** | the narrowing lasts no longer than the dialog — full `CARD_CONTENT_WIDTH` at the top placement once everything closes | `content=560, placement=top` |

Both premises of the middle case (different width, *and* bottom-docked) are asserted rather than assumed — otherwise "card is full width" would pass for the wrong reason.

I originally framed that middle case as "re-measures for a different-width dialog". The live rects said otherwise: the roll-off is bottom-docked, so it is never dodged. The scenario and its description now say what actually happens, and it covers the early-return branch — which was uncovered.

`content_scale_factor` is set on the root `Window` directly rather than through `SettingsService`, so nothing is persisted to `user://settings.cfg` for the rest of the suite.

## Coverage

Three tiles added, including one for `tutorial.overlay.dialog_dodge` — a tag #805's scenario already declared but which had no tile. `check_coverage.py` passes.

## Validation

| scenario | result |
|---|---|
| `tut_t2_card_width_tracks_each_dialog` (new) | 37 / 37 |
| `tut_t2_card_clears_formations_dialog` | 15 / 15 (was 6/15) |
| `tut_t1_basics` | 107 / 107 |
| `tut_exit_under_modal` | 39 / 39 |
| `tut_t2_musterin` | 107 / 107 |

Test-only change — no `version_history` entry, per the convention for internal/tooling work.

## Note on CI

`Multi-peer integration (GUT)` is red on `main` independently of any PR: clean `main` scores 7/39 failing on `run_multiplayer_tests.sh`, and it is non-deterministic (CI 6, two local runs 7, different scripts each time). Unrelated to this diff, but it fail-fasts the `Windowed scenarios (Xvfb)` job — which is why the suite above was run locally.


---
_Generated by [Claude Code](https://claude.ai/code/session_0141evCpdv3y619Se2YGh5d1)_