### PR TITLE
Keep the D-pad alive when the defender reorders allocation groups

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.12.2",
+      "date": "2026-08-01",
+      "summary": "Controller fix: reordering your allocation groups on the Allocate Attacks step no longer strands the D-pad — Confirm Order & Roll Saves stays reachable.",
+      "changes": [
+        "Moving a group up or down with the D-pad (say, dropping your 1 model W2 Sv5+ nob into second place) used to leave nothing highlighted at all: the highlight vanished and no amount of D-pad pressing could reach Confirm Order & Roll Saves, so the attack could not be resolved. The highlight now lands back on the arrow of the group you just moved, at its new position, so you can keep reordering and then walk down to Confirm.",
+        "The greyed-out arrows (▲ on the first row, ▼ on the last) no longer take the highlight — pressing A on them did nothing, which felt like the pad had died. The D-pad now skips straight past them.",
+        "Added a safety net: if the highlight is ever lost while this window is open, the next D-pad press puts it back on the current step's main button instead of doing nothing."
+      ]
+    },
+    {
       "version": "1.12.1",
       "date": "2026-07-31",
       "summary": "A unit is now offered only the weapons its army list actually bought — no more Power klaw on a mob that never took one — and a weapon swap carries its whole bundle.",

--- a/40k/scripts/AllocationGroupOverlay.gd
+++ b/40k/scripts/AllocationGroupOverlay.gd
@@ -606,12 +606,18 @@ func _rebuild_group_list() -> void:
 		up.name = "Up%d" % i
 		up.text = "▲"
 		up.disabled = i == 0
+		# CONTROLLER: a DISABLED button still accepts focus in Godot, so the
+		# D-pad used to park on the dead ▲ of the first row (and ▼ of the last)
+		# where A does nothing — indistinguishable from "the pad is broken".
+		# Take the edge arrows out of the focus chain so ui_* skips them.
+		up.focus_mode = Control.FOCUS_NONE if up.disabled else Control.FOCUS_ALL
 		up.pressed.connect(_on_move.bind(i, -1))
 		row.add_child(up)
 		var down = Button.new()
 		down.name = "Down%d" % i
 		down.text = "▼"
 		down.disabled = i == order.size() - 1
+		down.focus_mode = Control.FOCUS_NONE if down.disabled else Control.FOCUS_ALL
 		down.pressed.connect(_on_move.bind(i, 1))
 		row.add_child(down)
 		group_list.add_child(row)
@@ -625,7 +631,52 @@ func _on_move(index: int, delta: int) -> void:
 	var tmp = order[index]
 	order[index] = order[j]
 	order[j] = tmp
+	# CONTROLLER FIX: _rebuild_group_list() FREES every row — including the ▲/▼
+	# button that owns focus (the one the player just pressed). Godot clears the
+	# viewport's focus owner when a focused Control leaves the tree, and PadRouter
+	# deliberately stays out of this overlay (pad_native_nav_modal), so after a
+	# reorder the D-pad had NOTHING to navigate from: no highlight anywhere and
+	# "Confirm Order & Roll Saves" unreachable. Remember whether focus lived in
+	# the list, rebuild, then land focus on the moved group's arrow at its NEW
+	# index so the pad chain survives the reorder.
+	var had_list_focus := _focus_in_group_list()
 	_rebuild_group_list()
+	if had_list_focus or _pad_active():
+		_focus_reorder_button(j, delta)
+
+
+# True when the viewport's focus owner is one of the reorder rows — i.e. a
+# rebuild is about to destroy it and focus must be repaired afterwards.
+func _focus_in_group_list() -> bool:
+	if not is_inside_tree() or group_list == null:
+		return false
+	var owner := get_viewport().gui_get_focus_owner()
+	return owner != null and group_list.is_ancestor_of(owner)
+
+
+# Put focus back on the arrow of the group that just moved to `new_index`,
+# preferring the SAME direction the player pressed so repeated presses keep
+# walking that group along. That arrow is disabled at the list edge (▲ on the
+# first row, ▼ on the last), so fall back to the row's other arrow, then to the
+# step's primary button — focus is never left dangling.
+func _focus_reorder_button(new_index: int, delta: int) -> void:
+	if not is_inside_tree():
+		return
+	var candidates: Array = []
+	if group_list != null:
+		var row = group_list.get_node_or_null("Row%d" % new_index)
+		if row != null:
+			var same: String = "Down%d" if delta > 0 else "Up%d"
+			var other: String = "Up%d" if delta > 0 else "Down%d"
+			candidates.append(row.get_node_or_null(same % new_index))
+			candidates.append(row.get_node_or_null(other % new_index))
+	candidates.append(_current_primary_button())
+	for c in candidates:
+		if c is Button and c.is_visible_in_tree() and not c.disabled:
+			c.grab_focus()
+			print("AllocationGroupOverlay: reorder focus → %s" % c.name)
+			return
+	print("AllocationGroupOverlay: WARNING — no focusable control after reorder")
 
 
 func _validate_order() -> void:
@@ -1253,6 +1304,45 @@ func _refresh_pad_focus_now() -> void:
 	if btn != null and btn.is_visible_in_tree() and not btn.disabled:
 		btn.grab_focus()
 		print("AllocationGroupOverlay: pad focus → %s" % btn.name)
+
+
+# Focus safety net. While this overlay is up PadRouter hands the pad to Godot's
+# native ui_* navigation — which does NOTHING when there is no focus owner, so
+# ANY control freed while focused (a reorder rebuild, a re-rolled dice chip)
+# would strand the player with an un-highlighted, un-clickable window. A ui_*
+# press only reaches _unhandled_input when the GUI did not consume it, i.e.
+# exactly when focus is dangling: re-seed it on the live step's primary button
+# (or the first focusable control we own) and swallow that press.
+func _unhandled_input(event: InputEvent) -> void:
+	if not is_visible_in_tree() or not _pad_active():
+		return
+	var directional := (event.is_action_pressed("ui_up") or event.is_action_pressed("ui_down")
+		or event.is_action_pressed("ui_left") or event.is_action_pressed("ui_right")
+		or event.is_action_pressed("ui_accept"))
+	if not directional:
+		return
+	if get_viewport().gui_get_focus_owner() != null:
+		return  # native focus navigation is driving — stay out of its way
+	var btn := _current_primary_button()
+	var target: Control = btn if btn != null else _first_focusable_control(self)
+	if target == null:
+		return
+	target.grab_focus()
+	get_viewport().set_input_as_handled()
+	print("AllocationGroupOverlay: focus was dangling — pad focus re-seeded on %s" % target.name)
+
+
+# First focusable, visible, enabled Control in `root`'s subtree (depth-first) —
+# the last-resort target for the focus safety net above.
+func _first_focusable_control(root: Node) -> Control:
+	for child in root.get_children():
+		if child is Control and child.focus_mode == Control.FOCUS_ALL and child.is_visible_in_tree():
+			if not (child is BaseButton and child.disabled):
+				return child
+		var found := _first_focusable_control(child)
+		if found != null:
+			return found
+	return null
 
 
 # Trap directional focus inside this overlay: demote every focusable Control

--- a/40k/tests/scenarios/sp/pad_allocate_attacks_reorder_focus.json
+++ b/40k/tests/scenarios/sp/pad_allocate_attacks_reorder_focus.json
@@ -1,0 +1,78 @@
+{
+  "id": "pad_allocate_attacks_reorder_focus",
+  "covers": [
+    "controller.allocate_attacks.reorder_focus",
+    "controller.allocate_attacks.confirm_reachable_after_reorder",
+    "controller.allocate_attacks.disabled_arrows_skipped",
+    "scripts.AllocationGroupOverlay.reorder_focus_repair"
+  ],
+  "fixture": "audit_386_deadly_demise",
+  "rng_seed": 42,
+  "transition_to_phase": 8,
+  "description": "Steam Deck / controller regression: reordering the allocation groups must not strand the D-pad. _rebuild_group_list() frees the very row that owns focus, so pressing the focused up/down arrow cleared the viewport's focus owner outright — PadRouter defers to native ui_* nav for this modal, so nothing highlighted afterwards and 'Confirm Order & Roll Saves' was unreachable (the player could not advance the phase). Boyz F is given a W2 'nob' model so the overlay shows THREE groups (1 model W2 Sv5+, 19 models W1 Sv5+, the attached CHARACTER) with live reorder arrows. The pad walks off Confirm into the list — the disabled edge arrows must be skipped, not parked on — presses A on the nob group's down-arrow (the group really moves to second place, the exact move from the bug report), and focus must survive on that group's arrow at its NEW row. The pad then walks back down to Confirm Order & Roll Saves, presses A, and the flow advances to the casualty step.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 8 },
+
+    { "act": "execute_script", "script": "GameState.set_edition(11)", "equals": 11 },
+    { "act": "execute_script", "script": "SettingsService.set_auto_allocate_wounds(false)" },
+
+    { "act": "execute_script", "multiline": true, "script": "var pl = GameState.state.get(\"players\", {})\nfor k in pl.keys():\n\tpl[k][\"cp\"] = 0\nreturn true", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "var u = GameState.state[\"units\"][\"U_BOYZ_F\"]\nu[\"models\"][0][\"wounds\"] = 2\nu[\"models\"][0][\"current_wounds\"] = 2\nreturn int(u[\"models\"][0][\"wounds\"])", "equals": 2 },
+
+    { "act": "execute_script", "multiline": true, "script": "InputDeviceManager.claim_pad()\nreturn InputDeviceManager.is_pad_active()", "equals": true },
+
+    { "act": "execute_script", "script": "main.get_node(\"ShootingController\")._on_saves_required([RulesEngine.prepare_save_resolution(3, \"U_BOYZ_F\", \"U_CUSTODIAN_GUARD_B\", {\"name\": \"Pad Reorder Cannon\", \"ap\": -3, \"damage\": 1, \"damage_raw\": \"1\", \"keywords\": [], \"special_rules\": \"\"}, GameState.state)])" },
+
+    { "act": "wait_seconds", "seconds": 0.6 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/Center/Panel/Row/DecisionCol/ConfirmButton", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.root.get_node(\"Main/AllocationGroupOverlay\")\nreturn str(o.order)", "equals": "[\"grp_2_5_0\", \"grp_1_5_0\", \"char_20\"]" },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "ConfirmButton" },
+
+    { "act": "screenshot", "label": "01_three_groups_confirm_focused" },
+
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 14 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 11 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.root.get_node(\"Main/AllocationGroupOverlay\")\nvar fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nif not o.group_list.is_ancestor_of(fo):\n\treturn \"<outside list: %s>\" % str(fo.name)\nreturn str(fo.name)", "equals": "Down0" },
+
+    { "act": "screenshot", "label": "02_pad_on_nob_group_down_arrow" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.5 },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.root.get_node(\"Main/AllocationGroupOverlay\")\nreturn str(o.order)", "equals": "[\"grp_1_5_0\", \"grp_2_5_0\", \"char_20\"]" },
+
+    { "act": "execute_script", "multiline": true, "script": "var o = tree.root.get_node(\"Main/AllocationGroupOverlay\")\nvar fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nif not o.is_ancestor_of(fo):\n\treturn \"<outside overlay: %s>\" % str(fo.name)\nreturn str(fo.name)", "equals": "Down1" },
+
+    { "act": "screenshot", "label": "03_focus_survived_reorder" },
+
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "simulate_joy_button", "button_index": 12 },
+    { "act": "wait_seconds", "seconds": 0.3 },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "ConfirmButton" },
+
+    { "act": "screenshot", "label": "04_confirm_reachable_after_reorder" },
+
+    { "act": "simulate_joy_button", "button_index": 0 },
+    { "act": "wait_seconds", "seconds": 0.8 },
+
+    { "act": "expect_node_visible", "node": "/root/Main/AllocationGroupOverlay/PickPanel", "timeout_s": 3.0 },
+
+    { "act": "execute_script", "multiline": true, "script": "var fo = tree.root.get_viewport().gui_get_focus_owner()\nif fo == null:\n\treturn \"<none>\"\nreturn str(fo.name)", "equals": "AutoPickButton" },
+
+    { "act": "screenshot", "label": "05_advanced_to_casualty_step" },
+
+    { "act": "execute_script", "script": "GameState.set_edition(10)", "equals": 10 }
+  ]
+}


### PR DESCRIPTION
## Problem

On the 11e **Allocate Attacks** step, moving an allocation group up or down with the D-pad killed controller navigation outright: nothing highlighted afterwards, and **Confirm Order & Roll Saves** could never be reached, so the attack could not be resolved.

Root cause: `_on_move()` calls `_rebuild_group_list()`, which frees **every** row — including the ▲/▼ button that currently owns focus. Godot clears the viewport's focus owner when a focused `Control` leaves the tree, and this overlay is in the `pad_native_nav_modal` group, so `PadRouter._input()` returns early and hands the pad to Godot's native `ui_*` navigation — which does nothing at all with no focus owner.

## Changes

`40k/scripts/AllocationGroupOverlay.gd`:

- `_on_move()` remembers whether focus lived in the list and, after the rebuild, lands it on the moved group's arrow at its **new** index — same direction first, so repeated presses keep walking the group along; falls back to the row's other arrow (the pressed one is disabled at the list edge), then to the step's primary button.
- Disabled edge arrows (▲ on the first row, ▼ on the last) are taken out of the focus chain (`FOCUS_NONE`). The D-pad used to park on them, where A does nothing — indistinguishable from "the pad is broken".
- Safety net: with a pad active, a `ui_*` press that reaches `_unhandled_input` (i.e. no focus owner consumed it) re-seeds focus on the live step's primary button, so any future focus loss in this window self-heals.

`40k/data/version_history.json`: version bumped to 1.12.2 with player-facing notes.

## Validation

New windowed scenario `40k/tests/scenarios/sp/pad_allocate_attacks_reorder_focus.json` drives the reported path against the running UI: Boyz F is given a W2 "nob" model so the overlay shows three groups, the pad walks off Confirm into the list, presses A on the nob group's ▼ (the order really changes to `[grp_1_5_0, grp_2_5_0, char_20]`), focus survives on `Down1`, the pad walks back down to Confirm, presses A, and the flow advances to the casualty step.

- **38/38 pass** with the fix; reverting *only* the `_on_move` repair fails that scenario with focus `<none>` — the exact reported bug.
- Live log: `AllocationGroupOverlay: reorder focus → Down1`, 0 `SCRIPT ERROR`s during the run.
- Still green: windowed `pad_allocate_attacks_interactive_11e`, `pad_allocate_attacks_done_11e`, `iss045_allocation_groups`, `auto_allocate_wounds`; headless `test_iss045_allocation_overlay` (19/19), `test_t005_defender_allocation_pin` (7/7), `test_iss041_allocation_groups` (14/14).

Mouse/keyboard behaviour is unchanged in practice — the repair only fires when focus actually lived in the list (which a mouse click had already put there) or when a pad is active.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vqz7dTrGToDephkoR1T8gq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vqz7dTrGToDephkoR1T8gq)_