### PR TITLE
Stop the command panel stacking empty gold rules under Victory Points

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.12.2",
+      "date": "2026-08-01",
+      "summary": "The Command phase panel no longer fills up with empty orange dividing lines.",
+      "changes": [
+        "In the Command phase, the right-hand panel showed a growing stack of orange divider lines under VICTORY POINTS with nothing between them — a dozen of them by the time you had drawn your secondaries and called a Waaagh!, pushing the sections you actually wanted further down the scroll.",
+        "The panel rebuilds its Battle-shock, army rules and Secondary Missions sections every time something changes (a mission drawn or discarded, a CP spent, a battle-shock resolved). Each rebuild was abandoning the divider that introduced the section instead of removing it, so the leftovers piled up all phase. Dividers are now removed with their section, and any that end up introducing nothing are swept away.",
+        "Nothing else in the panel moved — the same sections, in the same order, just without the blank band."
+      ]
+    },
+    {
       "version": "1.12.1",
       "date": "2026-07-31",
       "summary": "A unit is now offered only the weapons its army list actually bought — no more Power klaw on a mob that never took one — and a weapon swap carries its whole bundle.",

--- a/40k/scripts/CommandController.gd
+++ b/40k/scripts/CommandController.gd
@@ -11,6 +11,10 @@ const _WhiteDwarfTheme = preload("res://scripts/WhiteDwarfTheme.gd")
 signal command_action_requested(action: Dictionary)
 signal ui_update_requested()
 
+# Marks the gold rules created by _add_command_gold_separator() so a section
+# teardown can take its own separator with it (see _remove_section_with_separator).
+const COMMAND_SEPARATOR_META := "command_gold_separator"
+
 # Command state
 var current_phase = null  # Can be CommandPhase or null
 
@@ -856,10 +860,69 @@ func _on_insane_bravery_pressed(unit_id: String) -> void:
 
 func _add_command_gold_separator(parent: Control) -> void:
 	var sep = ColorRect.new()
+	# Tagged so _refresh_ui() can recognise it as "the rule that belongs to the
+	# section after me" and tear the pair down together. Matching on type alone
+	# is not enough — the panel holds other ColorRects.
+	sep.set_meta(COMMAND_SEPARATOR_META, true)
 	sep.custom_minimum_size = Vector2(0, 2)
 	sep.color = Color(_WhiteDwarfTheme.WH_GOLD.r, _WhiteDwarfTheme.WH_GOLD.g, _WhiteDwarfTheme.WH_GOLD.b, 0.4)
 	sep.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	parent.add_child(sep)
+
+func _is_command_separator(node: Node) -> bool:
+	"""True for either separator flavour used in the command panel."""
+	if node is HSeparator:
+		return true
+	return node is ColorRect and node.has_meta(COMMAND_SEPARATOR_META)
+
+func _remove_section_with_separator(command_panel: VBoxContainer, section_name: String) -> void:
+	"""Drop a rebuildable section together with the gold rule that introduces it.
+
+	Player report (T7 "Runnin' da Show", step 4): a dozen orange rules stacked up
+	under VICTORY POINTS with nothing between them. Cause: _refresh_ui() rebuilds
+	BattleShockSection / FactionAbilitiesSection / SecondaryMissionsSection on
+	every state change, and the faction + secondary teardowns only matched
+	`prev is HSeparator` — but _add_command_gold_separator() makes a ColorRect.
+	So each refresh freed the section and orphaned its 2px rule, and the rebuilt
+	section re-appended at the end of the panel, leaving the abandoned rules
+	collected into one empty band. Refresh fires on every mission draw/discard,
+	CP change and battle-shock result, so the band grew all phase.
+	"""
+	var section = command_panel.get_node_or_null(section_name)
+	if not section:
+		return
+	var idx = section.get_index()
+	if idx > 0:
+		var prev = command_panel.get_child(idx - 1)
+		if _is_command_separator(prev):
+			command_panel.remove_child(prev)
+			prev.queue_free()
+	command_panel.remove_child(section)
+	section.queue_free()
+
+func _prune_orphan_separators(command_panel: VBoxContainer) -> void:
+	"""Belt-and-braces: drop any gold rule that introduces nothing.
+
+	A separator is an orphan when the next visible sibling is another separator,
+	or when it is the last child of the panel. Keeps the panel tidy even if a
+	future section teardown forgets to take its rule with it.
+	"""
+	var children = command_panel.get_children()
+	for i in range(children.size()):
+		var node = children[i]
+		if not _is_command_separator(node):
+			continue
+		var next_content: Node = null
+		for j in range(i + 1, children.size()):
+			var candidate = children[j]
+			# Zero-height helpers (the hidden DiceRollVisual) are not content.
+			if candidate is Control and not candidate.visible:
+				continue
+			next_content = candidate
+			break
+		if next_content == null or _is_command_separator(next_content):
+			command_panel.remove_child(node)
+			node.queue_free()
 
 func set_phase(phase: BasePhase) -> void:
 	current_phase = phase
@@ -959,47 +1022,21 @@ func _refresh_ui() -> void:
 		# section appear once the phase is attached, and refresh as tests resolve.
 		# Placed before the faction rebuild so the sequential appends land in the
 		# intended order (objectives → battle-shock → faction → secondary).
-		var old_shock_section = command_panel.get_node_or_null("BattleShockSection")
-		if old_shock_section:
-			var bs_idx = old_shock_section.get_index()
-			if bs_idx > 0:
-				var bs_prev = command_panel.get_child(bs_idx - 1)
-				# The separator before the section is a gold ColorRect (see
-				# _add_command_gold_separator), not an HSeparator — check both so it
-				# doesn't leak a 2px line on every refresh.
-				if bs_prev is HSeparator or bs_prev is ColorRect:
-					command_panel.remove_child(bs_prev)
-					bs_prev.queue_free()
-			command_panel.remove_child(old_shock_section)
-			old_shock_section.queue_free()
+		# Each teardown takes its own gold rule with it — see
+		# _remove_section_with_separator() for the empty-orange-band bug this fixes.
+		_remove_section_with_separator(command_panel, "BattleShockSection")
 		_setup_battle_shock_section(command_panel)
 
 		# Rebuild the faction abilities section to reflect Oath of Moment / Waaagh! changes
-		var old_faction_section = command_panel.get_node_or_null("FactionAbilitiesSection")
-		if old_faction_section:
-			var fa_idx = old_faction_section.get_index()
-			if fa_idx > 0:
-				var fa_prev = command_panel.get_child(fa_idx - 1)
-				if fa_prev is HSeparator:
-					command_panel.remove_child(fa_prev)
-					fa_prev.queue_free()
-			command_panel.remove_child(old_faction_section)
-			old_faction_section.queue_free()
+		_remove_section_with_separator(command_panel, "FactionAbilitiesSection")
 		_setup_faction_abilities_section(command_panel)
 
 		# Rebuild the secondary missions section to reflect changes
-		var old_section = command_panel.get_node_or_null("SecondaryMissionsSection")
-		if old_section:
-			# Find the separator before it and remove both
-			var idx = old_section.get_index()
-			if idx > 0:
-				var prev = command_panel.get_child(idx - 1)
-				if prev is HSeparator:
-					command_panel.remove_child(prev)
-					prev.queue_free()
-			command_panel.remove_child(old_section)
-			old_section.queue_free()
+		_remove_section_with_separator(command_panel, "SecondaryMissionsSection")
 		_setup_secondary_missions_section(command_panel)
+
+		# Sweep up any rule that ended up introducing nothing.
+		_prune_orphan_separators(command_panel)
 
 func _on_end_command_pressed() -> void:
 	print("CommandController: End Command Phase button pressed")

--- a/40k/tests/scenarios/sp/tut_t7_command_panel_no_orphan_rules.json
+++ b/40k/tests/scenarios/sp/tut_t7_command_panel_no_orphan_rules.json
@@ -1,0 +1,115 @@
+{
+  "id": "tut_t7_command_panel_no_orphan_rules",
+  "covers": [
+    "tutorial.t7.command",
+    "ui.command_panel.separators"
+  ],
+  "rng_seed": 4242,
+  "edition": 11,
+  "description": "Player report (T7 'Runnin' da Show', step 4 — after CALL DA WAAAGH!): the right-hand command panel showed a band of ten-plus orange rules under VICTORY POINTS with nothing between them, eating vertical space. CommandController._refresh_ui() rebuilds BattleShockSection / FactionAbilitiesSection / SecondaryMissionsSection on every state change, but the faction and secondary teardowns matched only 'prev is HSeparator' while _add_command_gold_separator() makes a tagged ColorRect — so each refresh freed the section and orphaned its 2px gold rule, and the rebuilt section re-appended at the end of the panel, collecting the abandoned rules into one empty band. Refresh fires on every mission draw/discard, CP change and battle-shock result, so the band grew all phase. This scenario walks the real player path to step 4 and asserts that no gold rule is left introducing nothing.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 1.5
+    },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/ScrollContainer/MenuContainer/ButtonSection/SecondaryButtonGrid/TutorialButton"
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/MainMenu/TutorialPicker",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "click_node",
+      "node": "/root/MainMenu/TutorialPicker/Margin/VBox/LessonRows/Row_t7_runnin_da_show/Play_t7_runnin_da_show"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 8.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "review_missions"
+    },
+    {
+      "act": "execute_script",
+      "script": "var cp = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nif cp == null:\n\treturn \"no command panel\"\nvar kids = cp.get_children()\nvar is_rule = []\nfor c in kids:\n\tis_rule.append(c is ColorRect and (c.has_meta(\"command_gold_separator\") or int(c.custom_minimum_size.y) == 2))\nvar orphans = []\nfor i in range(kids.size()):\n\tif not is_rule[i]:\n\t\tcontinue\n\tvar next_i = -1\n\tfor j in range(i + 1, kids.size()):\n\t\tif kids[j] is Control and not kids[j].visible:\n\t\t\tcontinue\n\t\tnext_i = j\n\t\tbreak\n\tif next_i == -1 or is_rule[next_i]:\n\t\torphans.append(i)\nif orphans.size() > 0:\n\treturn \"orphan gold rules at child indexes %s of %d\" % [str(orphans), kids.size()]\nreturn \"clean\"",
+      "multiline": true,
+      "equals": "clean",
+      "comment": "the panel is already refreshed once by the time the first step arms — the faction + secondary rules leaked from the very first rebuild"
+    },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.root.get_node_or_null(\"/root/SecondaryMissionReviewDialog/OuterScroll/MainContainer/ButtonRow/DoneButton\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nreturn false",
+      "multiline": true,
+      "equals": true,
+      "comment": "the mission review is an embedded modal AcceptDialog on /root - emit its Continue"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.0
+    },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.root.get_node_or_null(\"/root/GuardSelectionDialog/Content/Actions/KeepAutoGuards\")\nif b != null and b.is_visible_in_tree():\n\tb.pressed.emit()\n\treturn true\nreturn false",
+      "multiline": true,
+      "equals": true,
+      "comment": "Burden of Trust asks for guards when drawn - Keep Auto Picks takes the suggested assignment. Each of these choices drives another _refresh_ui()"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.0
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "waaagh"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel/FactionAbilitiesSection/CallWaaaghButton"
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 2.5
+    },
+    {
+      "act": "execute_script",
+      "script": "TutorialManager.current_step_id()",
+      "equals": "stratagems",
+      "comment": "this is the step the player reported the empty band on"
+    },
+    {
+      "act": "execute_script",
+      "script": "var cp = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nif cp == null:\n\treturn \"no command panel\"\nvar kids = cp.get_children()\nvar is_rule = []\nfor c in kids:\n\tis_rule.append(c is ColorRect and (c.has_meta(\"command_gold_separator\") or int(c.custom_minimum_size.y) == 2))\nvar orphans = []\nfor i in range(kids.size()):\n\tif not is_rule[i]:\n\t\tcontinue\n\tvar next_i = -1\n\tfor j in range(i + 1, kids.size()):\n\t\tif kids[j] is Control and not kids[j].visible:\n\t\t\tcontinue\n\t\tnext_i = j\n\t\tbreak\n\tif next_i == -1 or is_rule[next_i]:\n\t\torphans.append(i)\nif orphans.size() > 0:\n\treturn \"orphan gold rules at child indexes %s of %d\" % [str(orphans), kids.size()]\nreturn \"clean\"",
+      "multiline": true,
+      "equals": "clean",
+      "comment": "THE regression: pre-fix this step of this lesson left 6 abandoned rules stacked under VICTORY POINTS"
+    },
+    {
+      "act": "execute_script",
+      "script": "var cp = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nvar n = 0\nfor c in cp.get_children():\n\tif c is ColorRect and (c.has_meta(\"command_gold_separator\") or int(c.custom_minimum_size.y) == 2):\n\t\tn += 1\nreturn n",
+      "multiline": true,
+      "expect_max": 8,
+      "comment": "the panel's own section rules: end-phase, round, CP, objectives, VP, faction, secondary. Pre-fix this read 12 and climbed with every refresh, so a ceiling catches a re-leak even if the orphan shape changes"
+    },
+    {
+      "act": "execute_script",
+      "script": "var cp = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer/CommandPanel\")\nvar sc = tree.root.get_node_or_null(\"/root/Main/HUD_Right/VBoxContainer/CommandScrollContainer\")\nvar vp = cp.get_node_or_null(\"VPSection\")\nif vp == null:\n\treturn \"no VPSection\"\nsc.scroll_vertical = int(vp.position.y) - 60\nreturn \"scrolled\"",
+      "multiline": true,
+      "equals": "scrolled",
+      "comment": "park the viewport on the reported area so the screenshot below shows VICTORY POINTS straight into WAAAGH!"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 5
+    },
+    {
+      "act": "screenshot",
+      "label": "01_no_empty_rule_band_under_victory_points"
+    }
+  ]
+}


### PR DESCRIPTION
## The report

T7 "Runnin' da Show", step 4 (after CALL DA WAAAGH!): the right-hand command panel showed a band of ten-plus orange divider lines under VICTORY POINTS with nothing between them, pushing the sections the player wants further down the scroll.

## Root cause

`CommandController._refresh_ui()` rebuilds `BattleShockSection` / `FactionAbilitiesSection` / `SecondaryMissionsSection` on every state change. Each section is introduced by a gold rule from `_add_command_gold_separator()`, which builds a **`ColorRect`** — but the faction and secondary teardowns tested `if prev is HSeparator`, which is never true for one.

So each refresh freed the section and orphaned its 2px rule, while the rebuilt section re-appended at the *end* of the panel — collecting the abandoned rules into one growing empty band right after `VPSection`. Refresh fires on every mission draw/discard, CP change and battle-shock result, so the band grew all phase.

Measured live at that step against the pre-fix build: **12 rules, 6 of them orphans.**

## Changes

- `40k/scripts/CommandController.gd`
  - Tag the gold rules with a meta flag (`COMMAND_SEPARATOR_META`) so a teardown can recognise its own rule.
  - Replace all three inlined teardowns with one shared `_remove_section_with_separator()` that matches both separator flavours.
  - Add `_prune_orphan_separators()` — sweeps any rule whose next visible sibling is another rule, or that trails the panel — so a future teardown that forgets its rule cannot reopen this.
- `40k/tests/scenarios/sp/tut_t7_command_panel_no_orphan_rules.json` — new windowed scenario.
- `40k/data/version_history.json` — 1.12.2 entry.

Section content and ordering are unchanged; only the abandoned rules go away.

## Validation

Driven live against the running game via the `addons/godot_mcp` bridge, walking the real player path to T7 step 4 (Continue on the mission review → Keep Auto Picks → CALL DA WAAAGH!).

- After the fix at that step: **6 rules, 0 orphans**, panel height 1785 → 1749px. `read_debug_log`: 0 errors. `verify_delivery`: `verdict: PASS`.
- The new scenario identifies a rule by shape as well as by the new tag, so it is a real regression net rather than a vacuous one — verified in both directions by stashing the fix:
  - pre-fix: **17 passed / 3 failed** (`orphan gold rules at child indexes [12, 17, 18, 19, 20, 21] of 26`, and `expected <= 8, got 12`)
  - post-fix: **20 passed / 0 failed**
- `tut_t7_runnin_da_show.json` and `command_battleshock_ui_renders.json` still pass.

### Pre-existing failure, not from this change

`tut_t7_runnin_da_show_pad.json` fails 22 steps — it dies at step 7 because the gamepad path never opens the tutorial picker on the main menu. Confirmed identical 33 passed / 22 failed with this change stashed.

### Known, not changed

After the first refresh the WAAAGH! and Secondary Missions sections sit *below* VICTORY POINTS rather than above, because rebuilds append to the end of the panel. That is pre-existing ordering, not a leak; re-inserting at the original index would move the tutorial's anchored `CallWaaaghButton`, so it is left alone here.

## Screenshots

Both at step 4/6 with the panel scrolled to the same anchor.

| | |
|---|---|
| **Before** | ~5 blank rules between "Player 2: 2 VP" and "WAAAGH!" |
| **After** | a single rule, straight into WAAAGH! |

---
_Generated by [Claude Code](https://claude.ai/code/session_01CQmLThw8n286z2HjEUe6oN)_