### PR TITLE
Commit the generated .uid for the charge-target test added in #843

### DIFF
--- a/40k/tests/test_charge_target_ineligibility_reason.gd.uid
+++ b/40k/tests/test_charge_target_ineligibility_reason.gd.uid
@@ -1,0 +1,1 @@
+uid://c3iketaosjb3y


### PR DESCRIPTION
## What

Follow-up to #843. Godot 4.4 writes a `.uid` file alongside every script when the project is imported, and this repo tracks them — 238 are already committed under `40k/tests/` alone.

The `.uid` for `40k/tests/test_charge_target_ineligibility_reason.gd` (added in #843) was generated by a project import that ran *after* that commit was made, so it never landed. Without it, Godot mints a fresh UID in every clone instead of using the shared one.

One file, one line: `uid://c3iketaosjb3y`.

## Why a new PR

#843 is already merged, so this is a fresh change on a branch restarted from `main` rather than new commits on merged history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VtmrAZyzAnkLtCgobzmFmA

---
_Generated by [Claude Code](https://claude.ai/code/session_01VtmrAZyzAnkLtCgobzmFmA)_