### PR TITLE
Scout step: say who can Scout, or why nobody can

### DIFF
--- a/40k/autoloads/GameState.gd
+++ b/40k/autoloads/GameState.gd
@@ -631,6 +631,35 @@ func return_aircraft_to_reserves(player: int) -> Array:
 		apply_state_changes(changes)
 	return affected
 
+# Scouts ability text matching.
+#
+# Ability names arrive as "Scout 6\"" (hand-authored 10e rosters) or
+# "Scouts 6\"" (11e datasheets and the 40kdc dataset). The distance pattern
+# therefore has to allow the plural: the previous regex was
+# "scout\\s+(\\d+)", which cannot match "Scouts 9\"" because an `s` sits
+# where the whitespace was required — every Scouts 7"/8"/9" unit silently
+# fell through to the 6" default and made a 6" scout move.
+const SCOUT_DISTANCE_PATTERN: String = "(?i)\\bscouts?\\s*(\\d+)"
+# Stricter form for the description fallback: the rule text always spells the
+# distance with an inches mark ("Scouts 6\": ..."), so requiring it keeps
+# flavour text that merely mentions scouts from being read as the ability.
+const SCOUT_DESCRIPTION_PATTERN: String = "(?i)\\bscouts?\\s+(\\d+)\\s*\""
+
+var _scout_distance_regex: RegEx = null
+var _scout_description_regex: RegEx = null
+
+func _get_scout_distance_regex() -> RegEx:
+	if _scout_distance_regex == null:
+		_scout_distance_regex = RegEx.new()
+		_scout_distance_regex.compile(SCOUT_DISTANCE_PATTERN)
+	return _scout_distance_regex
+
+func _get_scout_description_regex() -> RegEx:
+	if _scout_description_regex == null:
+		_scout_description_regex = RegEx.new()
+		_scout_description_regex.compile(SCOUT_DESCRIPTION_PATTERN)
+	return _scout_description_regex
+
 func _unit_has_scout_own(unit_id: String) -> bool:
 	"""Check if a unit itself (not inherited) has the Scout ability.
 	Issue #389: also check description for the Scouts text — defends against
@@ -652,8 +681,10 @@ func _unit_has_scout_own(unit_id: String) -> bool:
 		if name.to_lower().begins_with("scout"):
 			return true
 		# Issue #389 fallback: detect "Scouts X\"" in the description text
-		# even when the name field is mis-tagged.
-		if "scouts " in description.to_lower() and "scouts x" in description.to_lower():
+		# even when the name field is mis-tagged. The original check required
+		# the literal substring "scouts x", which no real datasheet text
+		# contains, so this fallback never actually fired.
+		if description != "" and _get_scout_description_regex().search(description):
 			return true
 	# Glory Hog (Da Big Hunt): models in the bearer's unit have Scouts 9" —
 	# the bearer's own unit, and the bodyguard unit while attached.
@@ -668,24 +699,40 @@ func _get_scout_distance_from_abilities(abilities: Array) -> float:
 	"""Extract Scout distance from an abilities array. Returns 0.0 if no Scout ability found."""
 	for ability in abilities:
 		var name = ""
+		var description = ""
 		var value = 0
+		var parameter = ""
 		if ability is String:
 			name = ability
 		elif ability is Dictionary:
 			name = ability.get("name", "")
+			description = ability.get("description", "")
 			value = ability.get("value", 0)
-		if name.to_lower().begins_with("scout"):
-			# If value is explicitly set, use it
-			if value > 0:
-				return float(value)
-			# Try to parse distance from name, e.g. "Scout 6\"" or "Scout 6"
-			var regex = RegEx.new()
-			regex.compile("(?i)scout\\s+(\\d+)")
-			var result = regex.search(name)
-			if result:
-				return float(result.get_string(1))
-			# Default Scout distance is 6"
-			return 6.0
+			parameter = str(ability.get("parameter", ""))
+		var name_is_scout = name.to_lower().begins_with("scout")
+		# Mis-tagged entries (name "Core"/"Ability") still carry the rule text.
+		var desc_match = null
+		if not name_is_scout and description != "":
+			desc_match = _get_scout_description_regex().search(description)
+		if not name_is_scout and desc_match == null:
+			continue
+		# If value is explicitly set, use it
+		if value > 0:
+			return float(value)
+		# Try to parse distance from name, e.g. "Scout 6\"", "Scouts 9\"" or "Scout 6"
+		var result = _get_scout_distance_regex().search(name)
+		if result:
+			return float(result.get_string(1))
+		# Web-built rosters carry the distance in a separate `parameter` field
+		# ({"name": "Scouts 6\"", "type": "Core", "parameter": "6\""}).
+		if parameter != "":
+			var param_match = _get_scout_distance_regex().search("scout " + parameter)
+			if param_match:
+				return float(param_match.get_string(1))
+		if desc_match:
+			return float(desc_match.get_string(1))
+		# Default Scout distance is 6"
+		return 6.0
 	return 0.0
 
 func unit_has_scout(unit_id: String) -> bool:
@@ -802,6 +849,51 @@ func get_scout_units_for_player(player: int) -> Array:
 		if unit_has_scout(unit_id):
 			scout_units.append(unit_id)
 	return scout_units
+
+## Diagnostic for the Scout step: every unit in `player`'s army that the game
+## considers to have the Scouts ability, split into the ones that can act now
+## and the ones that cannot, with a plain-English reason for each blocker.
+##
+## Drives the player-visible narration in ScoutPhase. Before this existed the
+## Scout step auto-completed with nothing on screen but a phase header, so a
+## player whose army the game does not think has any Scouts unit saw the step
+## vanish and landed on the secondary-mission draw with no idea why.
+func get_scout_eligibility_report(player: int) -> Dictionary:
+	var eligible: Array = []
+	var blocked: Array = []
+	var reserve_eligible := get_scout_reserve_units_for_player(player)
+	for unit_id in state["units"]:
+		var unit = state["units"][unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if not unit_has_scout(unit_id):
+			continue
+		var unit_name = str(unit.get("meta", {}).get("name", unit_id))
+		var status = int(unit.get("status", 0))
+		var reason := ""
+		if unit.get("attached_to", null) != null:
+			reason = "it is leading %s and scouts with that unit" % _unit_display_name(str(unit.get("attached_to", "")))
+		elif unit.get("embarked_in", null) != null:
+			reason = "it is embarked in %s" % _unit_display_name(str(unit.get("embarked_in", "")))
+		elif status == UnitStatus.IN_RESERVES:
+			# 11e 24.31 lets a Strategic Reserves Scout unit set up in its own
+			# deployment zone instead; anything else in reserves cannot act.
+			if unit_id in reserve_eligible:
+				reason = ""
+			else:
+				reason = "it is in Reserves"
+		elif status != UnitStatus.DEPLOYED:
+			reason = "it is not set up on the battlefield"
+		if reason == "":
+			eligible.append({"unit_id": unit_id, "name": unit_name})
+		else:
+			blocked.append({"unit_id": unit_id, "name": unit_name, "reason": reason})
+	return {"eligible": eligible, "blocked": blocked}
+
+func _unit_display_name(unit_id: String) -> String:
+	if unit_id == "" or not state.get("units", {}).has(unit_id):
+		return unit_id
+	return str(state["units"][unit_id].get("meta", {}).get("name", unit_id))
 
 func unit_has_redeploy(unit_id: String) -> bool:
 	"""Check if a unit has a redeployment ability (e.g. from datasheet or detachment rules).

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.17.1",
+      "date": "2026-08-03",
+      "summary": "The Scout step no longer vanishes without a word — it now tells you who can Scout, or why nobody can.",
+      "changes": [
+        "Fixed (reported): a player deployed what they believed were Scout units and never got the Scout move prompt — the step ran and ended in a single frame, so the first thing they saw was their secondary-mission draw. The Scout step now always writes to the Game Log: who may make Scout moves, and when nobody can, that no unit in the army has the Scouts ability.",
+        "If a unit HAS Scouts but cannot act — it is in Reserves, embarked in a transport, or leading another unit — the log names the unit and the reason instead of silently leaving it out.",
+        "When the Scout step is skipped entirely, an on-screen notice now says so, so it is obvious the game made that call rather than the step being missed.",
+        "Fixed: units with Scouts 7”, 8” or 9” were only moving 6”. 11th-edition datasheets write the ability name in the plural (Scouts 9”) and the distance reader only understood the singular form, so every longer Scout move quietly fell back to the 6” default.",
+        "Fixed: a Scouts ability recorded under a generic name (with the real rule text in its description) is now recognised, instead of the unit being treated as having no Scouts at all."
+      ]
+    },
+    {
       "version": "1.17.0",
       "date": "2026-08-03",
       "summary": "A Leader and the squad he joined now fight in ONE activation — one row, one attack panel, one swing. The enemy no longer gets a turn in between.",

--- a/40k/phases/ScoutPhase.gd
+++ b/40k/phases/ScoutPhase.gd
@@ -57,6 +57,13 @@ func _on_phase_enter() -> void:
 	var total_scouts = p1_scouts.size() + p2_scouts.size() \
 		+ scout_reserve_units_pending[1].size() + scout_reserve_units_pending[2].size()
 
+	# Tell the player what this step resolved to, in the on-screen log. Without
+	# this the whole step is invisible when nobody can Scout: the phase
+	# auto-completes and the player is dropped straight onto the
+	# secondary-mission draw, unable to tell whether the game decided none of
+	# their units are Scouts or whether the Scout step is simply broken.
+	_announce_scout_step(total_scouts)
+
 	if total_scouts == 0:
 		log_phase_message("No units with Scout ability found, skipping Scout phase")
 		# Use call_deferred to avoid emitting signal during enter_phase
@@ -75,6 +82,50 @@ func _on_phase_enter() -> void:
 
 func _complete_phase() -> void:
 	emit_signal("phase_completed")
+
+# ========================================
+# Player-visible narration
+# ========================================
+
+func _log_to_players(text: String) -> void:
+	# log_phase_message() only reaches the debug log file — the player never
+	# sees it. GameEventLog is the on-screen Game Log panel.
+	var gel = get_node_or_null("/root/GameEventLog")
+	if gel and gel.has_method("add_info_entry"):
+		gel.add_info_entry(text)
+	log_phase_message(text)
+
+func _announce_scout_step(total_scouts: int) -> void:
+	"""Spell out, per player, who may Scout and why anyone eligible-looking cannot."""
+	for p in [1, 2]:
+		var report = GameState.get_scout_eligibility_report(p)
+		var names: Array = []
+		for entry in report.get("eligible", []):
+			names.append(str(entry.get("name", entry.get("unit_id", ""))))
+		if names.is_empty():
+			_log_to_players("Scout step — Player %d: no unit in this army has the Scouts ability." % p)
+		else:
+			_log_to_players("Scout step — Player %d may make Scout moves with: %s." % [p, ", ".join(names)])
+		for blocker in report.get("blocked", []):
+			_log_to_players("Scout step — Player %d: %s has Scouts but cannot move — %s." % [
+				p, str(blocker.get("name", "")), str(blocker.get("reason", ""))
+			])
+
+	if total_scouts > 0:
+		return
+
+	_log_to_players("No Scout moves are available — skipping the Scout step.")
+	# A log line alone is easy to miss when the step lasts a single frame, so
+	# surface it as a toast too — but only when a human is actually watching.
+	var ai = get_node_or_null("/root/AIPlayer")
+	var human_present := true
+	if ai and ai.has_method("is_ai_player"):
+		human_present = not (ai.is_ai_player(1) and ai.is_ai_player(2))
+	if not human_present:
+		return
+	var toast = get_node_or_null("/root/ToastManager")
+	if toast and toast.has_method("show_info"):
+		toast.show_info("Scout step skipped — no unit in either army has the Scouts ability", 5.0)
 
 func _on_phase_exit() -> void:
 	log_phase_message("Exiting Scout Phase")

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -8979,6 +8979,22 @@
       ],
       "last_verified_commit": "HEAD",
       "status": "covered"
+    },
+    {
+      "id": "phases.ScoutPhase.UI.skipped_step_is_announced",
+      "description": "When no unit in either army is recognised as having the Scouts ability, ScoutPhase auto-completes on enter. It now says so in the player-visible Game Log ('No Scout moves are available — skipping the Scout step.' plus a per-player reason) and raises a toast, instead of vanishing silently and dropping the player onto the secondary-mission draw. Validated by 'scout_step_explains_itself'.",
+      "scenarios": [
+        "scout_step_explains_itself"
+      ],
+      "status": "covered"
+    },
+    {
+      "id": "phases.ScoutPhase.UI.eligible_units_are_named",
+      "description": "On entering the Scout step the Game Log names, per player, which units may make Scout moves, and names any unit that has Scouts but cannot act (in Reserves / embarked / leading another unit) together with the reason. Validated by 'scout_step_explains_itself'.",
+      "scenarios": [
+        "scout_step_explains_itself"
+      ],
+      "status": "covered"
     }
   ]
 }

--- a/40k/tests/run_pretrigger_tests.sh
+++ b/40k/tests/run_pretrigger_tests.sh
@@ -137,6 +137,7 @@ TESTS=(
     "tests/test_global_consolidation_ai_11e.gd"
     "tests/test_global_pile_in_11e.gd"
     "tests/test_iss067_scouts_11e.gd"
+    "tests/test_scout_detection_and_visibility.gd"
     "tests/test_iss068_infiltrators_11e.gd"
     "tests/test_iss069_lone_operative_11e.gd"
     "tests/test_iss070_keyword_scoped_abilities.gd"

--- a/40k/tests/scenarios/sp/scout_step_explains_itself.json
+++ b/40k/tests/scenarios/sp/scout_step_explains_itself.json
@@ -1,0 +1,95 @@
+{
+  "id": "scout_step_explains_itself",
+  "covers": [
+    "phases.ScoutPhase.UI.skipped_step_is_announced",
+    "phases.ScoutPhase.UI.eligible_units_are_named"
+  ],
+  "fixture": "audit_baseline_postdeploy",
+  "disable_ai": true,
+  "description": "Reported bug: 'I had scouts in my list and deployed them, but I did not appear to get the option to make a scout move — the first interaction I have is showing what secondary I've drawn.' Root cause: when no unit is recognised as having Scouts, ScoutPhase._on_phase_enter auto-completes on the very frame it is entered, leaving nothing on screen but a bare phase header, so the player is dropped straight onto the secondary-mission draw with no way to tell whether the game decided none of their units were Scouts or whether the step is broken. This scenario drives both halves against the live UI: (1) with every Scouts ability stripped, the SCOUT phase still self-completes to COMMAND but the on-screen Game Log now spells out that no unit in either army has Scouts; (2) with Scouts restored on the Witchseekers, the log names exactly which units may Scout and the phase stays put for the player to act.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.3
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "for uid in GameState.state.units:\n\tvar abs_ = GameState.state.units[uid].get(\"meta\", {}).get(\"abilities\", [])\n\tfor i in range(abs_.size() - 1, -1, -1):\n\t\tvar a = abs_[i]\n\t\tvar n = str(a.get(\"name\", \"\")) if a is Dictionary else str(a)\n\t\tif n.to_lower().begins_with(\"scout\"):\n\t\t\tabs_.remove_at(i)\nreturn GameState.get_scout_units_for_player(1).size() + GameState.get_scout_units_for_player(2).size()",
+      "equals": 0
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 6
+    },
+    {
+      "act": "expect_phase",
+      "equals": 6
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var panel = tree.root.get_node_or_null(\"Main/GameLogPanel\")\nif panel == null:\n\treturn \"NO PANEL\"\nvar stack = [panel]\nvar out = \"\"\nwhile not stack.is_empty():\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\tif n is RichTextLabel:\n\t\tout += n.get_parsed_text() + \"\\n\"\n\telif n is Label:\n\t\tout += str(n.text) + \"\\n\"\nreturn out.contains(\"No Scout moves are available\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var panel = tree.root.get_node_or_null(\"Main/GameLogPanel\")\nif panel == null:\n\treturn \"NO PANEL\"\nvar stack = [panel]\nvar out = \"\"\nwhile not stack.is_empty():\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\tif n is RichTextLabel:\n\t\tout += n.get_parsed_text() + \"\\n\"\n\telif n is Label:\n\t\tout += str(n.text) + \"\\n\"\nreturn out.contains(\"Player 1: no unit in this army has the Scouts ability\")",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var tm = tree.root.get_node_or_null(\"ToastManager\")\nif tm == null:\n\treturn \"NO TOAST MANAGER\"\nvar stack = [tm]\nvar out = \"\"\nwhile not stack.is_empty():\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\tif n is Label:\n\t\tout += str(n.text) + \"\\n\"\nreturn out.contains(\"Scout step skipped\")",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "no_scouts_skip_explained"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.state.units.U_WITCHSEEKERS_C.meta.abilities.append({\"name\": \"Scouts 6\\\"\", \"type\": \"Core\"})\nGameState.state.units.U_WITCHSEEKERS_D.meta.abilities.append({\"name\": \"Scouts 6\\\"\", \"type\": \"Core\"})\nGameState.set_active_player(1)\nreturn GameState.get_scout_units_for_player(1).size()",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "script": "PhaseManager.transition_to_phase(4)"
+    },
+    {
+      "act": "wait_frames",
+      "frames": 6
+    },
+    {
+      "act": "expect_phase",
+      "equals": 4
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var panel = tree.root.get_node_or_null(\"Main/GameLogPanel\")\nif panel == null:\n\treturn \"NO PANEL\"\nvar stack = [panel]\nvar out = \"\"\nwhile not stack.is_empty():\n\tvar n = stack.pop_back()\n\tfor c in n.get_children():\n\t\tstack.append(c)\n\tif n is RichTextLabel:\n\t\tout += n.get_parsed_text() + \"\\n\"\n\telif n is Label:\n\t\tout += str(n.text) + \"\\n\"\nreturn out.contains(\"Player 1 may make Scout moves with: Witchseekers, Witchseekers\")",
+      "equals": true
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/HUD_Right/VBoxContainer/UnitListPanel",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ul = tree.root.get_node_or_null(\"Main/HUD_Right/VBoxContainer/UnitListPanel\")\nvar rows = 0\nfor i in range(ul.item_count):\n\tif str(ul.get_item_text(i)).contains(\"Witchseekers\"):\n\t\trows += 1\nreturn rows",
+      "equals": 2
+    },
+    {
+      "act": "screenshot",
+      "label": "scout_step_lists_eligible_units"
+    }
+  ]
+}

--- a/40k/tests/test_scout_detection_and_visibility.gd
+++ b/40k/tests/test_scout_detection_and_visibility.gd
@@ -1,0 +1,176 @@
+extends SceneTree
+
+# Scout step legibility + detection fixes.
+#
+# Reported bug: "I had <unit> who are scouts in my list and deployed them, but
+# I did not appear to get the option to make a scout move with them. The first
+# interaction I have is showing what secondary I've drawn." Reproduced: when no
+# unit is recognised as having Scouts, ScoutPhase auto-completes on enter with
+# nothing but a phase header in the log, so the player is dropped straight onto
+# the secondary-mission draw with no way to tell why.
+#
+# Covers:
+#   (A) Scout distance parsing — the old regex "scout\s+(\d+)" could not match
+#       the PLURAL name form ("Scouts 9\""), so every Scouts 7"/8"/9" unit
+#       silently made a 6" scout move.
+#   (B) The Issue #389 description fallback — it required the literal substring
+#       "scouts x", which no real datasheet text contains, so a mis-tagged
+#       ability (name "Core", description "Scouts 6\": ...") was never detected.
+#   (C) get_scout_eligibility_report() — per-unit "why can't this Scout?".
+#   (D) ScoutPhase pushes player-visible GameEventLog entries on enter, both
+#       when Scout moves are available and when the step is skipped.
+#
+# Usage: godot --headless --path . -s tests/test_scout_detection_and_visibility.gd
+
+var passed := 0
+var failed := 0
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, "  --  " + detail if detail != "" else ""])
+
+func _init():
+	root.connect("ready", Callable(self, "_run_tests"))
+	create_timer(0.1).timeout.connect(_run_tests)
+
+func _model(mid: String, pos) -> Dictionary:
+	return {"id": mid, "alive": true, "wounds": 1, "current_wounds": 1,
+		"base_mm": 32, "base_type": "circular", "position": pos}
+
+func _setup(gs) -> void:
+	gs.state["board"]["deployment_zones"] = [
+		{"player": 1, "poly": [{"x": 0, "y": 0}, {"x": 20, "y": 0}, {"x": 20, "y": 60}, {"x": 0, "y": 60}]},
+		{"player": 2, "poly": [{"x": 24, "y": 0}, {"x": 44, "y": 0}, {"x": 44, "y": 60}, {"x": 24, "y": 60}]},
+	]
+	gs.state["units"] = {
+		# Plural name with a non-6" distance — the (A) regression.
+		"U_FAST": {"id": "U_FAST", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Outriders", "keywords": ["INFANTRY"],
+				"abilities": [{"name": "Scouts 9\""}], "stats": {"move": 6}},
+			"models": [_model("m0", {"x": 400, "y": 400})]},
+		# Mis-tagged ability: the name is not "Scouts", the rule text is in the
+		# description — the (B) regression.
+		"U_MISTAG": {"id": "U_MISTAG", "owner": 1, "status": 2, "flags": {},
+			"meta": {"name": "Mistagged Scouts", "keywords": ["INFANTRY"],
+				"abilities": [{"name": "Core", "description": "Scouts 8\": This unit can make a pre-battle move."}],
+				"stats": {"move": 6}},
+			"models": [_model("m0", {"x": 300, "y": 900})]},
+		# Has Scouts but is still in reserves — reported as blocked, not silent.
+		"U_RES": {"id": "U_RES", "owner": 1, "status": 7, "reserve_type": "deep_strike", "flags": {},
+			"meta": {"name": "Reserved Scouts", "keywords": ["INFANTRY"],
+				"abilities": [{"name": "Scouts 6\""}], "stats": {"move": 6}},
+			"models": [_model("m0", null)]},
+		# No Scouts at all — the reported army's situation.
+		"U_PLAIN": {"id": "U_PLAIN", "owner": 2, "status": 2, "flags": {},
+			"meta": {"name": "Plain Infantry", "keywords": ["INFANTRY"],
+				"abilities": [{"name": "Purity of Execution"}], "stats": {"move": 6}},
+			"models": [_model("e0", {"x": 1400, "y": 400})]},
+	}
+	gs.state["meta"]["active_player"] = 1
+	gs.state["meta"]["phase"] = 4
+
+func _log_texts(gel, since: int) -> String:
+	var out := ""
+	for i in range(since, gel.entries.size()):
+		out += str(gel.entries[i].get("text", "")) + "\n"
+	return out
+
+func _run_tests():
+	if passed > 0 or failed > 0:
+		return
+	print("\n=== test_scout_detection_and_visibility ===\n")
+	var gs = root.get_node_or_null("GameState")
+	var pm = root.get_node_or_null("PhaseManager")
+	var gel = root.get_node_or_null("GameEventLog")
+	if gs == null or pm == null or gel == null:
+		_check("autoloads (GameState/PhaseManager/GameEventLog)", false); _finish(); return
+	var prev_state = gs.state.duplicate(true)
+	var prev_edition = GameConstants.edition
+	GameConstants.edition = 11
+	_setup(gs)
+
+	# ---- (A) plural Scout distance parsing ----
+	print("-- (A) Scout distance parsing --")
+	_check("\"Scouts 9\\\"\" parses as 9\" (was 6\")",
+		gs._get_scout_distance_from_abilities([{"name": "Scouts 9\""}]) == 9.0,
+		str(gs._get_scout_distance_from_abilities([{"name": "Scouts 9\""}])))
+	_check("\"Scouts 8\\\"\" parses as 8\" (was 6\")",
+		gs._get_scout_distance_from_abilities([{"name": "Scouts 8\""}]) == 8.0,
+		str(gs._get_scout_distance_from_abilities([{"name": "Scouts 8\""}])))
+	_check("singular \"Scout 9\\\"\" still parses as 9\"",
+		gs._get_scout_distance_from_abilities([{"name": "Scout 9\""}]) == 9.0)
+	_check("\"Scouts 6\\\"\" still parses as 6\"",
+		gs._get_scout_distance_from_abilities([{"name": "Scouts 6\""}]) == 6.0)
+	_check("bare \"Scouts\" falls back to the 6\" default",
+		gs._get_scout_distance_from_abilities([{"name": "Scouts"}]) == 6.0)
+	_check("a non-Scout ability yields 0.0",
+		gs._get_scout_distance_from_abilities([{"name": "Purity of Execution"}]) == 0.0)
+	_check("web-roster `parameter` field is read",
+		gs._get_scout_distance_from_abilities([{"name": "Scouts 7\"", "type": "Core", "parameter": "7\""}]) == 7.0)
+	_check("unit-level get_scout_distance sees the plural distance",
+		gs.get_scout_distance("U_FAST") == 9.0, str(gs.get_scout_distance("U_FAST")))
+
+	# ---- (B) mis-tagged ability detected via description ----
+	print("\n-- (B) mis-tagged ability (Issue #389 fallback) --")
+	_check("mis-tagged Scouts ability is detected", gs.unit_has_scout("U_MISTAG"))
+	_check("mis-tagged Scouts distance comes from the description",
+		gs.get_scout_distance("U_MISTAG") == 8.0, str(gs.get_scout_distance("U_MISTAG")))
+	_check("flavour text mentioning scouts is NOT read as the ability",
+		not gs._get_scout_distance_from_abilities([
+			{"name": "Recon", "description": "The scouts range ahead of the army."}]) > 0.0)
+
+	# ---- (C) eligibility report ----
+	print("\n-- (C) get_scout_eligibility_report --")
+	var r1 = gs.get_scout_eligibility_report(1)
+	var eligible_ids := []
+	for e in r1.get("eligible", []):
+		eligible_ids.append(e.get("unit_id", ""))
+	var blocked_ids := []
+	for b in r1.get("blocked", []):
+		blocked_ids.append(b.get("unit_id", ""))
+	_check("P1 eligible lists both deployed Scout units",
+		"U_FAST" in eligible_ids and "U_MISTAG" in eligible_ids, str(eligible_ids))
+	_check("P1 blocked lists the reserved Scout unit with a reason",
+		"U_RES" in blocked_ids and str(r1.get("blocked", [])).to_lower().contains("reserves"),
+		str(r1.get("blocked", [])))
+	var r2 = gs.get_scout_eligibility_report(2)
+	_check("P2 (no Scouts ability anywhere) reports nothing eligible and nothing blocked",
+		r2.get("eligible", []).is_empty() and r2.get("blocked", []).is_empty(), str(r2))
+
+	# ---- (D) player-visible narration on phase enter ----
+	print("\n-- (D) ScoutPhase narration --")
+	var mark = gel.entries.size()
+	pm.transition_to_phase(4)  # SCOUT
+	var text = _log_texts(gel, mark)
+	_check("log names the units P1 may Scout with",
+		text.contains("Outriders") and text.contains("Player 1 may make Scout moves"), text)
+	_check("log explains the blocked reserve Scout",
+		text.contains("Reserved Scouts") and text.contains("cannot move"), text)
+	_check("log states P2 has no unit with the Scouts ability",
+		text.contains("Player 2: no unit in this army has the Scouts ability"), text)
+
+	# Now the reported case: nobody has Scouts at all.
+	print("\n-- (D2) skipped step is announced, not silent --")
+	for uid in ["U_FAST", "U_MISTAG", "U_RES"]:
+		gs.state["units"][uid]["meta"]["abilities"] = []
+	gs.state["meta"]["active_player"] = 1
+	var mark2 = gel.entries.size()
+	pm.transition_to_phase(4)  # SCOUT — auto-completes
+	var text2 = _log_texts(gel, mark2)
+	_check("skip is spelled out in the player-visible log",
+		text2.contains("No Scout moves are available"), text2)
+	_check("skip log says why for each player",
+		text2.contains("Player 1: no unit in this army has the Scouts ability")
+		and text2.contains("Player 2: no unit in this army has the Scouts ability"), text2)
+
+	gs.state = prev_state
+	GameConstants.edition = prev_edition
+	_finish()
+
+func _finish():
+	print("\n=== Result: %d passed, %d failed ===" % [passed, failed])
+	quit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Reported

> I had prosecutors who are scouts in my list and deployed them, but I did not appear to get the option to make a scout move with them. I went second, if that makes a difference. The first interaction I have is showing what secondary I've drawn, while the scout loop should have occurred before this.

## What was actually wrong

**Prosecutors do not have Scouts.** Their datasheet abilities are *Daughters of the Abyss* and *Purity of Execution*; the Adeptus Custodes unit with `Scouts 6"` is **Witchseekers**. The game's data was right — it just never said so.

Going second was not a factor. I drove a full Custodes-vs-AI game live, forced the AI to win the first-turn roll-off, and the Scout prompt appeared normally for the human going second — both with and without the AI holding its own scout units.

The real defect is that the step is **invisible when nobody can Scout**. With zero recognised Scout units, `ScoutPhase._on_phase_enter()` defers `_complete_phase()` on the frame it is entered. The only trace is a bare `Scout Phase` header in the log, immediately followed by the CP tick and the secondary-mission draw — exactly the reported sequence. A player has no way to tell whether the game decided none of their units are Scouts, or whether the step is broken.

Reproduced live in the running game; the log went straight from `--- Scout Phase ---` to `P1 secondaries: ...` with nothing in between.

## Changes

**Narrate the Scout step (`ScoutPhase.gd`)**

On phase enter, write to the player-visible Game Log:
- per player, which units may make Scout moves;
- for any unit that *has* Scouts but cannot act, the unit name and the reason (in Reserves, embarked in a transport, leading another unit);
- when nobody can Scout, `No Scout moves are available — skipping the Scout step.` plus a toast, so a skipped step reads as a decision rather than a missing feature.

`log_phase_message()` only reaches the debug log file, so this routes through `GameEventLog` instead. The toast is suppressed in AI-vs-AI.

**Two detection bugs found while tracing this**

- Scout distance parsing used the regex `scout\s+(\d+)`, which cannot match the **plural** name form that 11e datasheets and the 40kdc dataset use — an `s` sits where whitespace was required. `Scouts 9"` found no match and fell through to the 6" default, so every `Scouts 7"/8"/9"` unit silently made a 6" scout move: Serberys Raiders, Eversor Assassin, Scout Sentinels, Tomb Blades, Hernkyn Pioneers, Invictor Tactical Warsuit, War Walkers, Piranhas, Atalan Jackals, Seekers, Wolf Scouts, Striking Scorpions, Krootox Rampagers, Hand of the Archon, Chaos Spawn, Broodlord, Canoptek Macrocytes. Verified live before/after: `get_scout_distance` returns `9.0` where it returned `6.0`.
- The Issue #389 description fallback required the literal substring `"scouts x"`, which no real datasheet text contains — the "defends against mis-tagged ability entries" comment described something that never fired once. Replaced with a regex for the actual rule-text form, kept strict enough (requires the inches mark) that flavour text mentioning scouts is not misread as the ability. Also reads the `parameter` field web-built rosters use.

**New API**

`GameState.get_scout_eligibility_report(player)` returns `{eligible, blocked}` with a plain-English reason per blocker. 11e 24.31 reserve Scouts count as eligible.

## Testing

New:
- `tests/test_scout_detection_and_visibility.gd` — 19 assertions covering distance parsing, the mis-tagged fallback, the eligibility report and the log narration. Registered in `run_pretrigger_tests.sh`.
- `tests/scenarios/sp/scout_step_explains_itself.json` — windowed scenario, 17 steps, all green. Drives both halves against the live UI: the skipped-step log lines and toast scraped off the real `GameLogPanel` and `ToastManager` nodes, then the eligible-unit listing with both Witchseekers rows read out of the real unit-list `ItemList`.

Re-run green: `test_iss067_scouts_11e` (11/11), `test_t015_witchseekers_scouts` (9/9), `test_iss001_pipeline_mutations` (9/9), `scout_confirm_after_reselect` (29/29), `scout_no_overlap` (26/26).

Pre-existing failures confirmed identical on the unmodified tree and left untouched: `test_audit_already_done_pin` (3, ungated `print()` counts) and `iss067_scout_reserves_deploy_11e` (4, click-placement steps).

## Screenshots

Both captured from the running game via the scenario runner.

`scout_step_explains_itself_no_scouts_skip_explained.png` — no unit has Scouts. Toast reads *"Scout step skipped — no unit in either army has the Scouts ability"*; the Game Log shows the per-player reason directly above the CP and secondary-mission lines the reporter saw.

`scout_step_explains_itself_scout_step_lists_eligible_units.png` — Scouts restored on the Witchseekers. The log reads *"Scout step — Player 1 may make Scout moves with: Witchseekers, Witchseekers."* and the picker offers both, each tagged `[Scout 6"]`.

Version bumped to 1.17.1 with a player-facing changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNUjVT4Pmoj3en9aHnupNH

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNUjVT4Pmoj3en9aHnupNH)_