### PR TITLE
Save cards: show the real battle round, and lead autosave names with it

### DIFF
--- a/40k/autoloads/SaveLoadManager.gd
+++ b/40k/autoloads/SaveLoadManager.gd
@@ -341,11 +341,14 @@ func _on_phase_changed_named_autosave(new_phase: int) -> void:
 		var display_path = ("cloud://" + _sanitize_filename(save_name)) if is_web_platform else (save_directory + _sanitize_filename(save_name) + SAVE_EXTENSION)
 		emit_signal("autosave_completed", display_path)
 
-# Build the "<army1> vs <army2> - <phase>" name for the phase-start autosave.
+# Build the "R<round> - <army1> vs <army2> - <phase>" name for the phase-start
+# autosave. The battle round leads so the load list groups and name-sorts by
+# round, and so each round keeps its own set of phase autosaves instead of every
+# round overwriting one shared slot per phase.
 func _phase_start_save_name(phase: int) -> String:
 	var army1 = GameState.get_faction_name(1)
 	var army2 = GameState.get_faction_name(2)
-	return "%s vs %s - %s" % [army1, army2, _phase_display_name(phase)]
+	return "R%d - %s vs %s - %s" % [GameState.get_battle_round(), army1, army2, _phase_display_name(phase)]
 
 # Human-readable, Title-Cased phase name ("MOVEMENT" -> "Movement",
 # "FIRST_TURN_ROLLOFF" -> "First Turn Rolloff").
@@ -1188,7 +1191,17 @@ func _create_save_metadata(custom_metadata: Dictionary = {}) -> Dictionary:
 		"version": StateSerializer.CURRENT_VERSION if StateSerializer else "1.1.0",
 		"created_at": Time.get_unix_time_from_system(),
 		"game_state": {
-			"turn": GameState.get_turn_number(),
+			# The player-facing "turn" is the BATTLE ROUND (the HUD reads
+			# "ROUND n/5" off meta.battle_round). meta.turn_number is a legacy
+			# counter that nothing advances anymore — the phases that used to
+			# bump it (PhaseManager's end-of-turn branch, TurnManager on MORALE)
+			# are unreachable now that SCORING wraps straight back to COMMAND,
+			# so it sat at 1 for the whole game and every save card claimed
+			# "Turn: 1". Record the battle round here and keep the raw legacy
+			# counter alongside it for diagnostics.
+			"turn": GameState.get_battle_round(),
+			"battle_round": GameState.get_battle_round(),
+			"turn_number": GameState.get_turn_number(),
 			"phase": GameState.get_current_phase(),
 			"active_player": GameState.get_active_player(),
 			"game_id": GameState.state.get("meta", {}).get("game_id", ""),

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,18 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.25.1",
+      "date": "2026-08-04",
+      "summary": "Autosaves now show the battle round they were taken on — and lead with it in the name — instead of claiming 'Turn: 1' for the whole game.",
+      "changes": [
+        "Every save card in the Load Game list said 'Turn: 1' no matter how far into the battle you were. The save itself was always fine — loading it put you back on the right round — but the card was reading a dead internal counter that nothing has advanced since scoring started looping straight back to the Command phase. Cards now read the real battle round.",
+        "Phase-start autosaves are now named 'R2 - Adeptus Custodes vs Orks - Fight' — round first — so the list groups by round and each round keeps its own set of phase autosaves instead of every round overwriting one shared slot per phase. Note that this means more autosave entries build up over a game.",
+        "The tooltip now reads 'Round: 2 / Phase: Fight' instead of the raw numbers 'Turn: 1.0 / Phase: 10.0'.",
+        "Fixed the phase name on save cards being one phase behind — a save taken in the Fight phase was labelled 'Scoring'.",
+        "Older saves made before this fix also display their correct round, read from the preview data they already stored."
+      ]
+    },
+    {
       "version": "1.25.0",
       "date": "2026-08-04",
       "summary": "You can now choose the order your melee weapons swing in — the Assign Attacks dialog lists the plan as reorderable rows.",

--- a/40k/scripts/SaveLoadDialog.gd
+++ b/40k/scripts/SaveLoadDialog.gd
@@ -791,13 +791,40 @@ func _create_save_tooltip(save_info: Dictionary) -> String:
 
 	if metadata.has("game_state"):
 		var game_state = metadata["game_state"]
-		tooltip_lines.append("Turn: " + str(game_state.get("turn", "Unknown")))
-		tooltip_lines.append("Phase: " + str(game_state.get("phase", "Unknown")))
-		tooltip_lines.append("Active Player: " + str(game_state.get("active_player", "Unknown")))
+		# JSON round-trips these ints as floats, so str() used to render
+		# "Turn: 1.0" / "Phase: 10.0" — format them as ints, and show the phase
+		# by name like the preview panel does.
+		tooltip_lines.append("Round: " + _get_round_text(metadata))
+		var phase_num = int(game_state.get("phase", -1))
+		tooltip_lines.append("Phase: " + (_get_phase_name(phase_num) if phase_num >= 0 else "Unknown"))
+		if game_state.has("active_player"):
+			tooltip_lines.append("Active Player: %d" % int(game_state["active_player"]))
+		else:
+			tooltip_lines.append("Active Player: Unknown")
 
 	tooltip_lines.append("File: " + save_info.get("display_name", "Unknown"))
 
 	return "\n".join(tooltip_lines)
+
+# The player-facing round for a save card ("ROUND n/5" in the HUD).
+# Saves written before the metadata fix carry a stale game_state.turn of 1
+# (meta.turn_number never advanced), but their preview block always recorded the
+# real meta.battle_round — prefer that so old saves still read correctly.
+func _get_round_text(metadata: Dictionary) -> String:
+	var preview = metadata.get("preview", {})
+	if preview.has("battle_round"):
+		return _round_to_text(preview["battle_round"])
+	var game_state = metadata.get("game_state", {})
+	for key in ["battle_round", "turn"]:
+		if game_state.has(key):
+			return _round_to_text(game_state[key])
+	return "?"
+
+# JSON round-trips these ints as floats, so a bare str() renders "1.0".
+func _round_to_text(value) -> String:
+	if typeof(value) == TYPE_INT or typeof(value) == TYPE_FLOAT:
+		return str(int(value))
+	return str(value)
 
 func _update_button_states() -> void:
 	var has_selection = selected_save_index >= 0 and selected_save_index < save_files_data.size()
@@ -1231,8 +1258,8 @@ func _update_preview_panel() -> void:
 
 func _render_preview(metadata: Dictionary, preview: Dictionary) -> void:
 	var game_state = metadata.get("game_state", {})
-	var battle_round = preview.get("battle_round", game_state.get("turn", "?"))
-	var phase_num = game_state.get("phase", -1)
+	var battle_round = _get_round_text(metadata)
+	var phase_num = int(game_state.get("phase", -1))
 	var phase_name = _get_phase_name(phase_num)
 
 	var bbcode = ""
@@ -1309,21 +1336,19 @@ func _render_preview(metadata: Dictionary, preview: Dictionary) -> void:
 
 	preview_label.text = bbcode
 
+# Title-cased phase name straight off the enum ("FIRST_TURN_ROLLOFF" -> "First
+# Turn Rolloff"). This used to be a hand-written match that predated SCOUT_MOVES
+# being inserted into GameStateData.Phase, so every id from ROLL_OFF up was
+# labelled with the previous phase's name (a FIGHT save read "Scoring").
 func _get_phase_name(phase_num: int) -> String:
-	match phase_num:
-		0: return "Formations"
-		1: return "Deployment"
-		2: return "Redeployment"
-		3: return "Scout"
-		4: return "Roll Off"
-		5: return "Command"
-		6: return "Movement"
-		7: return "Shooting"
-		8: return "Charge"
-		9: return "Fight"
-		10: return "Scoring"
-		11: return "Morale"
-		_: return "Unknown"
+	if phase_num < 0 or phase_num >= GameStateData.Phase.size():
+		return "Unknown"
+	var words = []
+	for part in String(GameStateData.Phase.keys()[phase_num]).split("_", false):
+		if part.is_empty():
+			continue
+		words.append(part.substr(0, 1).to_upper() + part.substr(1).to_lower())
+	return " ".join(words)
 
 # ============================================================================
 # SAVE-16: Save Slots
@@ -1340,8 +1365,8 @@ func _refresh_slot_info() -> void:
 			if has_save:
 				var metadata = info.get("metadata", {})
 				var game_state = metadata.get("game_state", {})
-				var turn = game_state.get("turn", "?")
-				var phase = game_state.get("phase", -1)
+				var round_text = _get_round_text(metadata)
+				var phase = int(game_state.get("phase", -1))
 				var phase_name = _get_phase_name(phase) if phase >= 0 else "?"
 				var created_at = metadata.get("created_at", 0)
 				var timestamp_text = ""
@@ -1359,7 +1384,7 @@ func _refresh_slot_info() -> void:
 				var faction_text = ""
 				if not p1_faction.is_empty() and not p2_faction.is_empty():
 					faction_text = "%s vs %s  " % [p1_faction, p2_faction]
-				slot_labels[i].text = "%sTurn %s - %s  %s" % [faction_text, str(turn), phase_name, timestamp_text]
+				slot_labels[i].text = "%sRound %s - %s  %s" % [faction_text, round_text, phase_name, timestamp_text]
 				slot_labels[i].add_theme_color_override("font_color", WhiteDwarfThemeData.WH_PARCHMENT)
 			else:
 				slot_labels[i].text = "[Empty]"

--- a/40k/tests/coverage.json
+++ b/40k/tests/coverage.json
@@ -6764,6 +6764,56 @@
       "fidelity": "DECLARED"
     },
     {
+      "id": "save.autosave_round_prefix",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "save.card_round_display",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "SaveLoadManager._phase_start_save_name",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "SaveLoadManager._create_save_metadata",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
+      "id": "SaveLoadDialog._create_save_tooltip",
+      "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: auto_save_phase_start.",
+      "scenarios": [
+        "auto_save_phase_start"
+      ],
+      "last_verified_commit": "HEAD",
+      "status": "covered",
+      "fidelity": "DECLARED"
+    },
+    {
       "id": "save.dialog_roundtrip",
       "description": "Auto-registered from the scenario 'covers' declaration; the backing windowed scenario is the verification. Not independently audited — upgrade to a CLICK/HANDLER/RULES tile when reviewed. Declared by: save_dialog_user_dir_roundtrip.",
       "scenarios": [

--- a/40k/tests/scenarios/sp/auto_save_phase_start.json
+++ b/40k/tests/scenarios/sp/auto_save_phase_start.json
@@ -2,32 +2,59 @@
   "id": "auto_save_phase_start",
   "covers": [
     "save.autosave_on_phase_start",
+    "save.autosave_round_prefix",
+    "save.card_round_display",
     "SaveLoadManager._on_phase_changed_named_autosave",
+    "SaveLoadManager._phase_start_save_name",
+    "SaveLoadManager._create_save_metadata",
+    "SaveLoadDialog._create_save_tooltip",
     "SettingsService.set_autosave_on_phase_start"
   ],
   "fixture": "audit_382_cp_grant",
   "transition_to_phase": 6,
-  "description": "Phase-start autosave: at the start of each phase the controlling player writes/overwrites a save named '<army1> vs <army2> - <phase>'. On by default with a Settings > Gameplay toggle. This drives real PhaseManager transitions (the same signal a player's End Phase triggers) and asserts the named save appears when ON, does NOT appear when the toggle is OFF, and reappears when turned back ON.",
+  "description": "Phase-start autosave: at the start of each phase the controlling player writes/overwrites a save named 'R<round> - <army1> vs <army2> - <phase>'. On by default with a Settings > Gameplay toggle. This drives real PhaseManager transitions (the same signal a player's End Phase triggers) and asserts (a) the round-prefixed named save appears when ON, does NOT appear when the toggle is OFF, and reappears when turned back ON; (b) the save's metadata records the REAL battle round (it used to record meta.turn_number, a dead counter stuck at 1, so every save card read 'Turn: 1'); (c) the Save/Load dialog's list row and tooltip show that round back to the player.",
   "steps": [
     { "act": "wait_seconds", "seconds": 0.5 },
     { "act": "expect_state", "path": "meta.phase", "equals": 6 },
 
     { "act": "execute_script", "multiline": true, "script": "DirAccess.remove_absolute(ProjectSettings.globalize_path(\"user://settings.cfg\"))\nSettingsService._load_settings()\nSaveLoadManager.set_autosave_on_phase_start(SettingsService.autosave_on_phase_start)\nreturn (SettingsService.autosave_on_phase_start and SaveLoadManager.autosave_on_phase_start)", "equals": true },
 
-    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn true", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "while GameState.get_battle_round() < 2:\n\tGameState.advance_battle_round()\nreturn GameState.get_battle_round()", "equals": 2 },
+
+    { "act": "execute_script", "multiline": true, "script": "var n = SaveLoadManager._phase_start_save_name(7)\nvar want = \"R2 - %s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn n if n != want else \"ok\"", "equals": "ok" },
     { "act": "wait_seconds", "seconds": 0.3 },
     { "act": "expect_state", "path": "meta.phase", "equals": 7 },
-    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
-    { "act": "screenshot", "label": "01_movement_autosave_written" },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
 
-    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(false)\nvar n = \"%s vs %s - Command\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(6)\nreturn SaveLoadManager.autosave_on_phase_start", "equals": false },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nvar md = SaveLoadManager.get_save_info(n).get(\"metadata\", {})\nvar gs = md.get(\"game_state\", {})\nreturn \"%d/%d/%d\" % [int(gs.get(\"turn\", -1)), int(gs.get(\"battle_round\", -1)), int(md.get(\"preview\", {}).get(\"battle_round\", -1))]", "equals": "2/2/2" },
+
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nd.show_dialog()\nreturn d.visible", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.6 },
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nvar want = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nfor i in range(d.save_files_data.size()):\n\tif d.save_files_data[i].get(\"display_name\", \"\") != want:\n\t\tcontinue\n\tvar row = d.saves_list.get_item_text(i)\n\tvar tip = d.saves_list.get_item_tooltip(i)\n\tif not row.begins_with(\"R2 - \"):\n\t\treturn \"row did not start with the round: \" + row\n\tif not (\"Round: 2\" in tip):\n\t\treturn \"tooltip round wrong: \" + tip\n\tif not (\"Phase: Movement\" in tip):\n\t\treturn \"tooltip phase wrong: \" + tip\n\treturn \"ok\"\nreturn \"row not found for \" + want", "equals": "ok" },
+    { "act": "screenshot", "label": "01_movement_autosave_card_shows_round_2" },
+
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nvar want = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nd.filter_input.text = want\nd._on_filter_text_changed(want)\nreturn d.save_files_data.size()", "equals": 1 },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Command\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": false },
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nvar lst = d.saves_list\nvar r = lst.get_item_rect(0)\nvar p = lst.get_global_rect().position + r.position + r.size * 0.5\np.y -= lst.get_v_scroll_bar().value\nInput.warp_mouse(p)\nfor down in [true, false]:\n\tvar ev = InputEventMouseButton.new()\n\tev.button_index = MOUSE_BUTTON_LEFT\n\tev.pressed = down\n\tev.position = p\n\tev.global_position = p\n\tInput.parse_input_event(ev)\nreturn true", "equals": true },
+    { "act": "wait_seconds", "seconds": 0.4 },
+    { "act": "execute_script", "multiline": true, "script": "return tree.root.get_node(\"/root/Main/SaveLoadDialog\").selected_save_index", "equals": 0 },
+    { "act": "execute_script", "multiline": true, "script": "var t = tree.root.get_node(\"/root/Main/SaveLoadDialog\").preview_label.get_parsed_text()\nreturn t if not (\"Round 2\" in t) else \"ok\"", "equals": "ok" },
+    { "act": "screenshot", "label": "02_preview_panel_reads_round_2" },
+
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nvar lst = d.saves_list\nvar r = lst.get_item_rect(0)\nvar p = lst.get_global_rect().position + r.position + r.size * 0.5\np.y -= lst.get_v_scroll_bar().value\nInput.warp_mouse(p)\nvar ev = InputEventMouseMotion.new()\nev.position = p\nev.global_position = p\nInput.parse_input_event(ev)\nreturn true", "equals": true },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "screenshot", "label": "03_tooltip_reads_round_2_phase_movement" },
+
+    { "act": "execute_script", "multiline": true, "script": "var d = tree.root.get_node(\"/root/Main/SaveLoadDialog\")\nd.filter_input.text = \"\"\nd._on_filter_text_changed(\"\")\nd.hide()\nreturn true", "equals": true },
+
+    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(false)\nvar n = \"R%d - %s vs %s - Command\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(6)\nreturn SaveLoadManager.autosave_on_phase_start", "equals": false },
+    { "act": "wait_seconds", "seconds": 0.3 },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"R%d - %s vs %s - Command\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": false },
     { "act": "screenshot", "label": "02_toggle_off_no_autosave" },
 
-    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(true)\nvar n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn true", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "SettingsService.set_autosave_on_phase_start(true)\nvar n = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nSaveLoadManager.delete_save_file(n)\nPhaseManager.transition_to_phase(7)\nreturn true", "equals": true },
     { "act": "wait_seconds", "seconds": 0.3 },
-    { "act": "execute_script", "multiline": true, "script": "var n = \"%s vs %s - Movement\" % [GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
+    { "act": "execute_script", "multiline": true, "script": "var n = \"R%d - %s vs %s - Movement\" % [GameState.get_battle_round(), GameState.get_faction_name(1), GameState.get_faction_name(2)]\nreturn SaveLoadManager.save_exists(n)", "equals": true },
     { "act": "screenshot", "label": "03_reenabled_autosave_written" }
   ]
 }


### PR DESCRIPTION
Every save card in the Load Game list read **"Turn: 1"** no matter how far into the battle the save was taken. The save data itself was always correct — loading put you back on the right round — only the card was wrong.

## Root cause

`SaveLoadManager._create_save_metadata` recorded `meta.turn_number`, a legacy counter that nothing advances anymore. Both sites that used to bump it are dead code:

- `PhaseManager.advance_to_next_phase()`'s end-of-turn branch — SCORING now wraps straight back to COMMAND, so `_get_next_phase` never returns the current phase and the `else` branch is unreachable.
- `TurnManager`'s `Phase.MORALE` case — `PhaseManager` skips MORALE outright as a deprecated phase (`PhaseManager.gd:102`).

So `turn_number` sat at 1 for the whole game. The counter the HUD actually shows as "ROUND n/5" is `meta.battle_round` — which is why the loaded game was right and only the card was wrong.

## Changes

- **`_create_save_metadata`** — `game_state.turn` is now the battle round, with `battle_round` stored explicitly alongside it and the raw `turn_number` kept for diagnostics.
- **`SaveLoadDialog._get_round_text`** (new) — prefers the preview block's `battle_round`, which was always recorded correctly, so **saves written before this fix also display their real round** without needing a re-save. Falls back to `game_state.battle_round`, then `game_state.turn`.
- **Tooltip** — reads `Round: 2 / Phase: Movement` instead of `Turn: 1.0 / Phase: 10.0`; JSON round-trips these ints as floats and they were being `str()`'d raw.
- **`_get_phase_name`** — was a hand-written match that predated `SCOUT_MOVES` being inserted into `GameStateData.Phase`, so every id from `ROLL_OFF` up was labelled one phase behind (a FIGHT save read "Scoring"). Now derived from the enum.
- **Phase-start autosave names** — `R2 - Adeptus Custodes vs Orks - Fight`, i.e. `R<round> - <army1> vs <army2> - <phase>`. The round leads so the list groups and name-sorts by round.
- **Save-slot labels** — "Round N" instead of "Turn N".
- Version bumped to 1.27.1 with a changelog entry.

### Behaviour change worth calling out

Autosave names are now round-scoped, so each round keeps its own set of phase autosaves instead of all 5 rounds overwriting one shared slot per phase. That means up to ~31 autosave entries build up per game instead of 7 — better for going back a round, but a longer Load list. No pruning was added; happy to follow up with a "keep the last N rounds" bound if that's preferred.

Both players' turns within a round still share one name per phase (P2's Fight autosave overwrites P1's), unchanged from before.

`meta.turn_number` was deliberately **not** revived — it feeds NetworkManager's RNG seeding and ActionLogger, so making it advance again would change dice sequences and replays.

## Validation

Windowed scenario `tests/scenarios/sp/auto_save_phase_start.json` extended to advance to battle round 2, then:

- assert `_phase_start_save_name(MOVEMENT)` matches `R2 - <army1> vs <army2> - Movement` and that the file is written
- assert the recorded round is `2/2/2` across `game_state.turn`, `game_state.battle_round` and `preview.battle_round`
- open the real Save/Load dialog, filter to the row, **click** it and **hover** it, then assert the list row starts with `R2 - `, the tooltip contains `Round: 2` and `Phase: Movement`, and the preview panel renders `Round 2`
- existing coverage retained: no save when the Settings toggle is off, save reappears when turned back on

`32/32` steps pass, including after merging `main` into this branch. The four other save-dialog scenarios also pass unchanged: `save_dialog_user_dir_roundtrip` (19/19), `save_load_dialog_above_log` (15/15), `pad_saveload_menu_focus` (36/36), `pad_saveload_ingame_focus` (20/20). No script errors in the run log.

`tests/test_save_load_ai.gd` could not be run to completion — it hangs in CloudStorage's save-server registration retries in this container. Confirmed it hangs identically with these changes stashed, so it's the environment, not this change.