### PR TITLE
Mine 40k YouTube corpus into evidence-backed AI learnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ ai_loop_log.txt
 ai_loop_status.txt
 ai_loop_tracker.json
 ai_loop_tracker.json.games
+
+# YouTube transcript corpus for AI research (19MB) — see research/youtube/README.md
+research/youtube/transcripts_text.jsonl.gz

--- a/research/youtube/.gitignore
+++ b/research/youtube/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/research/youtube/README.md
+++ b/research/youtube/README.md
@@ -1,0 +1,85 @@
+# YouTube transcript mining → AI learnings
+
+Turns a corpus of Warhammer 40,000 11th-edition YouTube transcripts into
+evidence-backed, actionable changes for `40k/scripts/AIDecisionMaker.gd`.
+
+## Provenance
+
+`transcripts_text.jsonl.gz` — **gitignored** (19 MB). 1,029 transcripts,
+10.5M words, 90 channels, 2026-04-04 → 2026-08-04 (68 records carry no `date`).
+Gzipped JSONL, one object per line:
+
+| field | notes |
+|---|---|
+| `video_id`, `title`, `channel`, `date`, `url` | as published |
+| `cats` | one or more of Rules, Lists, Deployment, Missions, Phases, Factions, Batreps, Meta |
+| `auto` | `true` for auto-generated captions — 1027 of 1029 |
+| `words` | word count |
+| `text` | caption text with per-minute `[MM:00]` markers |
+
+Read it with `gzip.open(path, 'rt')`. **If the file is absent, stop and ask for
+it** — every script here exits with an error rather than proceeding, and no
+finding in `ai_learnings.json` may be written without a verifiable quote.
+
+The captions are auto-generated, so proper nouns are frequently wrong
+(`Orks`→`orcs`, `Waaagh!`→`wall`, `Votann`→`voltan`, `genestealer`→`genailer`).
+Quotes in the outputs are **verbatim, errors included** — they are checked
+mechanically against the corpus, so "fixing" them would break verification.
+
+## Outputs
+
+| file | what it is |
+|---|---|
+| `ai_learnings.json` | primary machine-readable output: 31 findings on two axes (decision × faction), each with evidence, rules status and a concrete AI change |
+| `ai_learnings.html` | self-contained reader-facing page (no external CSS/JS/fonts), filterable on both axes, light + dark |
+| `profiles/*.json` | draft AI profiles in the `ProfileManager` format — **drafts for review, not tuned values** |
+
+## Scripts
+
+```bash
+# search: filtered / regex search with timestamps and deep links
+python3 search_transcripts.py 'reactive move' --window 260 --limit 10
+python3 search_transcripts.py 'oath of moment' --cat Factions --count-only
+
+# compact batch scan — one line per hit, for finding signal fast
+python3 mine.py THEME 'regex' --max 20
+python3 batch.py screening          # named themed batches
+
+# faction attribution and per-faction mining
+python3 faction_index.py                       # transcript counts per faction
+python3 faction_index.py --faction Orks        # which transcripts, and why
+python3 faction_mine.py Orks 'waaa+gh.{0,80}'  # title-attributed pool only
+python3 exact_quote.py <video_id> 'probe words'  # verbatim span + true timestamp
+
+# build the outputs
+python3 build_learnings.py     # -> ai_learnings.json
+python3 build_profiles.py      # -> profiles/*.json
+python3 build_html.py          # -> ai_learnings.html  (reads the JSON)
+
+# gate: every quote must exist in the corpus at its cited timestamp
+python3 verify_evidence.py
+```
+
+`verify_evidence.py` exits non-zero if any evidence quote is missing, is
+attributed to the wrong channel, or sits more than two minutes from its cited
+timestamp. Run it after editing `build_learnings.py`.
+
+## Method notes
+
+**Faction attribution.** A transcript counts toward a faction when the *title*
+names it (human-written, so reliable) or the body carries ≥6 distinct alias
+hits. Faction *findings* are drawn from the title-attributed pool only, unless
+noted — one mis-hearable mention is never enough.
+
+**Confidence.** `high` requires multiple independent channels stating the same
+decision rule. Single-channel claims are `low` and do not get a profile; they
+are listed under `gaps` instead.
+
+**Rules status.** `confirmed` means checked against the 11e core rules
+(<https://wahapedia.ru/wh40k11ed/the-rules/core-rules/>). `player_opinion` is
+judgement rather than rules. `contradicts_rules` is a widespread misconception —
+recorded as a finding, never taught to the AI.
+
+**Staleness.** Faction balance moves with dataslates. ~92% of the corpus is
+June–August 2026 and most of it post-dates the late-July balance pass, but each
+finding's evidence carries dates so a stale claim can be spotted.

--- a/research/youtube/ai_learnings.html
+++ b/research/youtube/ai_learnings.html
@@ -1,0 +1,1067 @@
+<title>How good 40k players think — mined from 1,029 YouTube transcripts</title>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+:root{
+  --bg:#fbfaf8; --panel:#ffffff; --ink:#1c1a17; --muted:#6a6560; --line:#e4e0da;
+  --accent:#8a2f24; --accent-soft:#f3e6e3; --chip:#f1eee9;
+  --hi:#2f6b4f; --hi-soft:#e6f0ea; --mid:#8a6a1f; --mid-soft:#f6efdd;
+  --lo:#6a6560; --lo-soft:#efedea;
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#16151a; --panel:#1e1d23; --ink:#eceaf0; --muted:#9a95a3; --line:#302e38;
+    --accent:#e0857a; --accent-soft:#33232a; --chip:#282730;
+    --hi:#7fd0a5; --hi-soft:#1b2f26; --mid:#e3c274; --mid-soft:#332c1c;
+    --lo:#9a95a3; --lo-soft:#26252c;
+  }
+}
+:root[data-theme=light]{
+  --bg:#fbfaf8; --panel:#ffffff; --ink:#1c1a17; --muted:#6a6560; --line:#e4e0da;
+  --accent:#8a2f24; --accent-soft:#f3e6e3; --chip:#f1eee9;
+  --hi:#2f6b4f; --hi-soft:#e6f0ea; --mid:#8a6a1f; --mid-soft:#f6efdd;
+  --lo:#6a6560; --lo-soft:#efedea;
+}
+:root[data-theme=dark]{
+  --bg:#16151a; --panel:#1e1d23; --ink:#eceaf0; --muted:#9a95a3; --line:#302e38;
+  --accent:#e0857a; --accent-soft:#33232a; --chip:#282730;
+  --hi:#7fd0a5; --hi-soft:#1b2f26; --mid:#e3c274; --mid-soft:#332c1c;
+  --lo:#9a95a3; --lo-soft:#26252c;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:16px/1.6 ui-serif,Georgia,'Iowan Old Style','Times New Roman',serif;
+  -webkit-text-size-adjust:100%}
+.wrap{max-width:920px;margin:0 auto;padding:0 20px 96px}
+header{padding:56px 0 8px;border-bottom:1px solid var(--line);margin-bottom:28px}
+h1{font-size:2.1rem;line-height:1.15;margin:0 0 10px;letter-spacing:-.01em}
+.sub{color:var(--muted);margin:0;max-width:62ch}
+.meta{color:var(--muted);font-size:.85rem;margin-top:14px}
+.sans{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}
+h2{font-size:1.32rem;margin:44px 0 4px;letter-spacing:-.01em;scroll-margin-top:16px}
+h2 .n{color:var(--muted);font-size:.8rem;font-weight:400;margin-left:8px;
+  font-family:ui-sans-serif,system-ui,sans-serif}
+.dfn{color:var(--muted);font-size:.92rem;margin:0 0 18px;max-width:64ch}
+.controls{position:sticky;top:0;z-index:5;background:var(--bg);
+  border-bottom:1px solid var(--line);padding:12px 0 12px;margin-bottom:6px}
+.row{display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-bottom:7px}
+.row:last-child{margin-bottom:0}
+.lbl{font-size:.72rem;text-transform:uppercase;letter-spacing:.09em;color:var(--muted);
+  font-family:ui-sans-serif,system-ui,sans-serif;margin-right:6px;min-width:66px}
+button{font:inherit;font-family:ui-sans-serif,system-ui,sans-serif;font-size:.8rem;
+  background:var(--chip);color:var(--ink);border:1px solid transparent;
+  border-radius:999px;padding:4px 11px;cursor:pointer;line-height:1.4}
+button:hover{border-color:var(--line)}
+button[aria-pressed=true]{background:var(--accent-soft);border-color:var(--accent);
+  color:var(--accent);font-weight:600}
+.theme{margin-left:auto}
+article{background:var(--panel);border:1px solid var(--line);border-radius:12px;
+  padding:20px 22px;margin:0 0 14px}
+.claim{font-size:1.06rem;font-weight:600;margin:0 0 10px;line-height:1.45}
+.tags{display:flex;flex-wrap:wrap;gap:6px;margin:0 0 12px}
+.tag{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.7rem;
+  letter-spacing:.03em;padding:2px 9px;border-radius:999px;background:var(--chip);
+  color:var(--muted);white-space:nowrap}
+.tag.fac{background:var(--accent-soft);color:var(--accent);font-weight:600}
+.tag.high{background:var(--hi-soft);color:var(--hi)}
+.tag.medium{background:var(--mid-soft);color:var(--mid)}
+.tag.low{background:var(--lo-soft);color:var(--lo)}
+.tag.warn{background:var(--accent-soft);color:var(--accent);font-weight:600}
+p.detail{margin:0 0 12px}
+.diff{margin:0 0 12px;padding:10px 14px;border-left:3px solid var(--accent);
+  background:var(--accent-soft);border-radius:0 8px 8px 0;font-size:.94rem}
+.diff b{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.7rem;
+  text-transform:uppercase;letter-spacing:.08em;display:block;margin-bottom:3px;
+  color:var(--accent)}
+.src{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.85rem;
+  color:var(--muted);margin-top:12px}
+.src li{margin-bottom:5px}
+.src ul{margin:6px 0 0;padding-left:18px}
+.src a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent}
+.src a:hover{border-bottom-color:var(--accent)}
+.q{color:var(--ink);opacity:.85}
+details{margin-top:14px;border-top:1px dashed var(--line);padding-top:10px}
+summary{cursor:pointer;font-family:ui-sans-serif,system-ui,sans-serif;
+  font-size:.78rem;color:var(--muted);letter-spacing:.03em;list-style:none}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"▸ ";color:var(--accent)}
+details[open] summary::before{content:"▾ "}
+details .body{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.85rem;
+  color:var(--muted);margin-top:10px}
+details .body div{margin-bottom:7px}
+details .body b{color:var(--ink);font-weight:600}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.85em;
+  background:var(--chip);padding:1px 5px;border-radius:4px}
+.tblwrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px;
+  background:var(--panel)}
+table{border-collapse:collapse;font-family:ui-sans-serif,system-ui,sans-serif;
+  font-size:.8rem;width:100%}
+th,td{padding:7px 10px;text-align:left;border-bottom:1px solid var(--line);
+  white-space:nowrap}
+th{color:var(--muted);font-weight:600;font-size:.72rem;text-transform:uppercase;
+  letter-spacing:.05em}
+td.n{text-align:center;color:var(--muted)}
+td.n.has{color:var(--accent);font-weight:700}
+tr:last-child td{border-bottom:none}
+.note{background:var(--panel);border:1px solid var(--line);border-radius:12px;
+  padding:18px 22px;margin-bottom:14px}
+.note h3{margin:0 0 8px;font-size:1rem}
+.note ul{margin:0;padding-left:20px;font-size:.94rem}
+.note li{margin-bottom:7px}
+.empty{color:var(--muted);font-style:italic;padding:26px 0}
+footer{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);
+  color:var(--muted);font-size:.82rem;font-family:ui-sans-serif,system-ui,sans-serif}
+@media(max-width:620px){
+  h1{font-size:1.6rem} .wrap{padding:0 14px 64px} header{padding-top:32px}
+  article{padding:16px 15px} .lbl{min-width:100%;margin-bottom:2px}
+}
+</style>
+<div class="wrap">
+<header>
+<h1>How good 40k players actually think</h1>
+<p class="sub">31 decision patterns pulled out of roughly 1,200 hours of 11th-edition Warhammer 40,000 talk — tournament coverage, battle reports and list reviews — organised by the decision you are making, not by the video it came from. Every claim links to the moment somebody said it.</p>
+<p class="meta sans">1029 transcripts · 90 channels · 2026-04-04 to 2026-08-04 (68 transcripts carry no date field) · generated 2026-08-05</p>
+</header>
+<div class="controls sans">
+<div class="row"><span class="lbl">Decision</span>
+<button data-k="d" data-v="all" aria-pressed="true">Everything</button>
+<button data-k="d" data-v="positioning_and_concealment" aria-pressed="false">Where to stand</button>
+<button data-k="d" data-v="screening_and_zoning" aria-pressed="false">Screening and denying space</button>
+<button data-k="d" data-v="target_selection" aria-pressed="false">What to shoot</button>
+<button data-k="d" data-v="objective_trade" aria-pressed="false">Objectives and scoring</button>
+<button data-k="d" data-v="attrition_and_trades" aria-pressed="false">When to accept a bad trade</button>
+<button data-k="d" data-v="melee_commitment" aria-pressed="false">When to charge</button>
+<button data-k="d" data-v="disengage_and_lock" aria-pressed="false">Staying in combat, or getting out</button>
+<button data-k="d" data-v="reserves_and_arrival" aria-pressed="false">Reserves and arrival</button>
+<button data-k="d" data-v="ability_timing" aria-pressed="false">When to spend your big ability</button>
+<button data-k="d" data-v="action_economy" aria-pressed="false">Who performs the actions</button>
+<button data-k="d" data-v="tempo_and_commitment" aria-pressed="false">Turn order and commitment</button>
+</div>
+<div class="row"><span class="lbl">Army</span>
+<button data-k="f" data-v="all" aria-pressed="true">All armies</button>
+<button data-k="f" data-v="general" aria-pressed="false">Holds for everyone</button>
+<button data-k="f" data-v="Adeptus Custodes" aria-pressed="false">Adeptus Custodes</button>
+<button data-k="f" data-v="Death Guard" aria-pressed="false">Death Guard</button>
+<button data-k="f" data-v="Drukhari" aria-pressed="false">Drukhari</button>
+<button data-k="f" data-v="Grey Knights" aria-pressed="false">Grey Knights</button>
+<button data-k="f" data-v="Orks" aria-pressed="false">Orks</button>
+<button data-k="f" data-v="Space Marines" aria-pressed="false">Space Marines</button>
+<button data-k="f" data-v="Tyranids" aria-pressed="false">Tyranids</button>
+<button class="theme" data-k="theme" data-v="t">Light / dark</button>
+</div></div>
+<section data-d="positioning_and_concealment">
+<h2>Where to stand<span class="n"></span></h2>
+<p class="dfn">Where a unit physically stands: what it can see, what can see it, what terrain state it ends its move in, and what that costs or buys.</p>
+<article data-d="positioning_and_concealment" data-f="general">
+<p class="claim">Infantry should end movement inside dense terrain so they gain Hidden, which makes them untargetable beyond 15&quot; (12&quot; when the shooter&#x27;s view is broken by dense terrain).</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">11e&#x27;s Hidden rule (core rules 13.09) gives INFANTRY/BEASTS/SWARM in a dense terrain area a detection range — enemies further away simply cannot target them, regardless of line of sight. Good players treat &#x27;get to hidden 12&#x27; as the primary movement objective for infantry in the first two rounds, because it converts an entire enemy shooting phase into nothing. The 3&quot; reduction for being obscured by dense terrain is deliberately farmed, not incidental.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=0Gcpze1G4Lc&amp;t=600s" target="_blank" rel="noopener">40K Dirtbags @ 10:00</a> — <span class="q">&ldquo;I try and get that dense cover for the hidden 12 ... How fast can I get to hidden 12&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=SkaqF6vbCYA&amp;t=720s" target="_blank" rel="noopener">Happy Krumping @ 12:00</a> — <span class="q">&ldquo;elite infantry is incredibly powerful, making use of the hidden rule ... can&#x27;t be targeted outside of 15 or 12&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=dPFfT2IIlME&amp;t=900s" target="_blank" rel="noopener">Tabletop Titans @ 15:00</a> — <span class="q">&ldquo;if you want to be a shooting army right now ... you have to be able to get within hidden range quickly&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=HQ0sQa37uHA&amp;t=780s" target="_blank" rel="noopener">Planet 40K @ 13:00</a> — <span class="q">&ldquo;as it&#x27;s a monster, you&#x27;re not going to be getting the hidden keyword&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> AIDecisionMaker.gd contains zero references to &#x27;hidden&#x27; (grep -ci hidden = 0), while RulesEngine.gd fully implements 13.09 (hidden_model_visible_to, TerrainManager.detection_range_inches_for, 15&quot; base minus a 3&quot; dense penalty). The AI therefore benefits from Hidden only by accident when a destination happens to be in terrain.</div>
+<div><b>Change:</b> Add a movement-destination bonus (start ~4.0, comparable to SECONDARY_POSITIONAL_BONUS 4.0) when the destination puts an INFANTRY/BEASTS/SWARM unit inside a dense terrain area and the unit has not shot this turn. Scale by how many enemy units are further than the detection range returned by TerrainManager.detection_range_inches_for — a Hidden position that hides from nothing is worth nothing.</div>
+<div><b>Risk:</b> Over-weighting drags infantry into terrain and off objectives; Hidden does not stop charges or blast/indirect, so a Hidden unit can still be run down. Gate it against the objective VP estimator so it never outbids a scoring move.</div>
+<div><b>Where:</b> <code>_score_movement_destination (movement scoring) — new WEIGHT_HIDDEN_GAINED constant</code> &middot; new_heuristic &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="positioning_and_concealment" data-f="general">
+<p class="claim">Shooting surrenders Hidden for this turn and the next, so a unit that cannot meaningfully hurt anything should hold its fire and stay untargetable.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Hidden requires that the unit made no ranged attacks this turn or last turn, so pulling the trigger is a two-turn commitment to being shootable. Players explicitly weigh a marginal shooting phase against a turn of immunity, and will decline shots with backfield or objective-holding infantry to keep the state. This is a genuine per-unit decision every shooting phase, not a list-building consideration.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=TJQWtTZiP1g&amp;t=3480s" target="_blank" rel="noopener">Zeeto @ 58:00</a> — <span class="q">&ldquo;as soon as you give up hidden, you shoot a ball across the map ... you&#x27;ve got the 15 inch hidden anyway&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=k-IMme1pngY&amp;t=2520s" target="_blank" rel="noopener">Mid Table Tactics @ 42:00</a> — <span class="q">&ldquo;They&#x27;re not going to be hidden though because they are probably going to shoot&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VqwMdS9MuIY&amp;t=11160s" target="_blank" rel="noopener">TacticalTortoise 40k @ 186:00</a> — <span class="q">&ldquo;I&#x27;m hidden in the line like this cuz I just got to shoot there ... not hidden cuz they&#x27;re shooting&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=f_z0hvW0VMk&amp;t=2940s" target="_blank" rel="noopener">Proxy Hammer @ 49:00</a> — <span class="q">&ldquo;you don&#x27;t have to move out into the open ... remain hidden even while shooting&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> The AI shoots whenever a legal shooting action scores above zero. It has no concept of a non-damage cost to firing, so it will trade two turns of untargetability for one low-value shooting action.</div>
+<div><b>Change:</b> When the shooter is currently Hidden, subtract a penalty from every shooting assignment for that unit — scale it by how many enemy units are outside detection range (i.e. how much immunity is being sold). Suggested start: 3.0, so the unit still fires when the expected damage is real but declines chip shots.</div>
+<div><b>Risk:</b> An over-large penalty produces a passive gunline that never shoots. The penalty must be zero for units that already shot this turn (Hidden is already lost) and for units with a &#x27;remain hidden while shooting&#x27; ability.</div>
+<div><b>Where:</b> <code>shooting-phase target scoring — new HIDDEN_FORFEIT_PENALTY constant</code> &middot; new_heuristic &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="positioning_and_concealment" data-f="general">
+<p class="claim">Every move into enemy line of sight is taxed by Overwatch, which in 11e fires at the end of the opponent&#x27;s Movement phase and can no longer be baited out with a single expendable model.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Overwatch moved to the end of the opponent&#x27;s Movement phase and uses snap shooting (hits only on unmodified 6s, no re-rolls). Because the defender now watches the whole movement phase resolve before choosing a target, the old trick of pushing one cheap model out to draw the shot is dead — the defender simply waits and picks the best target. Players describe this as having to declare their whole movement plan to the opponent before paying for it.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=qahZnQPN8a8&amp;t=1620s" target="_blank" rel="noopener">Vanguard Tactics @ 27:00</a> — <span class="q">&ldquo;Overwatch is so powerful in this game now because you can&#x27;t ... put one model out ... you can&#x27;t bait them out anymore&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=eUpeWbN7gF4&amp;t=1680s" target="_blank" rel="noopener">StrikingScorpion82 @ 28:00</a> — <span class="q">&ldquo;overwatch is done at the end of the opponent&#x27;s movement phase ... it&#x27;s a decision we can make uh once movement&#x27;s done&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=FT5JoL5Myis&amp;t=300s" target="_blank" rel="noopener">Deploy on the Line 40K @ 05:00</a> — <span class="q">&ldquo;it&#x27;s just too easy to overwatch in 11th edition. You can&#x27;t play around it anymore with these big squads&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=uKl8cEJlk0c&amp;t=1620s" target="_blank" rel="noopener">6 Plus Plus Gaming @ 27:00</a> — <span class="q">&ldquo;with how Overwatch is now, that&#x27;s really really powerful to have a reactive move&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> THREAT_SHOOTING_PENALTY is 0.5 and commented &#x27;Lighter penalty for moving into shooting range (reduced from 1.0 — often unavoidable)&#x27;. That reasoning was written for a shooting phase the mover could answer; 11e Overwatch is paid inside the mover&#x27;s own turn, before it acts.</div>
+<div><b>Change:</b> Raise THREAT_SHOOTING_PENALTY to ~1.0 and add a separate OVERWATCH_EXPOSURE_PENALTY applied only when the destination is visible to an enemy unit that has not yet used Fire Overwatch this round, weighted by that unit&#x27;s raw shot volume (snap shooting rewards volume and torrent, not quality). Do not apply it to destinations already inside enemy line of sight before the move.</div>
+<div><b>Risk:</b> Too high and the AI refuses to cross the board at all, which loses on primary. The penalty should be suppressed for melee-archetype units (they already discount threat via THREAT_MELEE_UNIT_IGNORE) and in rounds 4-5.</div>
+<div><b>Where:</b> <code>THREAT_SHOOTING_PENALTY (currently 0.5)</code> &middot; weight_constant &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="positioning_and_concealment" data-f="general">
+<p class="claim">The default opening is to stage the army out of line of sight behind mid-board terrain and physically occupy the staging point the opponent wants.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Because shooting is punishing and Hidden is available, the first-turn move is usually to get behind the centre ruin rather than onto the mid-board objectives. The refinement is that the terrain piece is a contested resource: putting bodies against it denies the opponent the same protection, so the move is simultaneously defensive and a denial play.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=-Bh3n-_Tpfs&amp;t=3660s" target="_blank" rel="noopener">40K Fireside @ 61:00</a> — <span class="q">&ldquo;move block your opponent from touching the middle ruin and staging your army behind it&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=6Lgr1hUGsgw&amp;t=840s" target="_blank" rel="noopener">Master Crafted @ 14:00</a> — <span class="q">&ldquo;we&#x27;re behind it, we&#x27;re hidden, they can&#x27;t see us, but at least we know that we&#x27;re taking up the space&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=1SRkN4Drhs4&amp;t=1080s" target="_blank" rel="noopener">Play On Tabletop @ 18:00</a> — <span class="q">&ldquo;my jumpack intercessors will move to stage behind this terrain ... I just don&#x27;t want to be shot&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=mX7VBM9qJjY&amp;t=420s" target="_blank" rel="noopener">Auspex Tactics @ 07:00</a> — <span class="q">&ldquo;staged as far forward as possible but out of line of sight&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Corridor blocking already exists but is keyed to objectives — it places blockers 55% of the way from an objective toward a threatening enemy. It has no notion of terrain pieces as the thing worth denying.</div>
+<div><b>Change:</b> Extend the corridor-block candidate set with the mid-board dense terrain areas TerrainManager already exposes, scoring a blocking position that both breaks enemy line of sight to our army and sits against the terrain the enemy would otherwise stage in. Reuse CORRIDOR_BLOCK_SCORE_BASE so the two compete on one scale.</div>
+<div><b>Risk:</b> Terrain-hugging can strand units away from scoring positions in rounds 4-5, where STRATEGY_LATE_OBJECTIVE (1.6) should dominate. Gate to rounds 1-2.</div>
+<div><b>Where:</b> <code>CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_POSITION_RATIO (0.55)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="positioning_and_concealment" data-f="general">
+<p class="claim">Cover in 11e worsens the attacker&#x27;s Ballistic Skill by 1 rather than improving the defender&#x27;s save, so seeking cover degrades incoming fire and ignore-cover weapons are worth aiming deliberately.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Benefit of Cover (13.08) applies a -1 to hit rather than a save bonus, which is a different shape of protection: it scales with the number of shots rather than with AP, and it stacks differently with re-rolls. Players call it out in play as &#x27;your storm bolters will be at minus one to hit&#x27;, and treat ignore-cover as a targeting consideration rather than a list-building nicety.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=aQsog-fkQJ8&amp;t=5100s" target="_blank" rel="noopener">Maelstrom Gaming Studios - Tyranids @ 85:00</a> — <span class="q">&ldquo;partially obscured ... your storm bolters will be at minus one to hit&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VqwMdS9MuIY&amp;t=10260s" target="_blank" rel="noopener">TacticalTortoise 40k @ 171:00</a> — <span class="q">&ldquo;Don&#x27;t get cover, right? Yeah. No, it&#x27;s ignore cover for all&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=1SRkN4Drhs4&amp;t=3120s" target="_blank" rel="noopener">Play On Tabletop @ 52:00</a> — <span class="q">&ldquo;because you&#x27;re not an infantry, so you have to be obscured by the terrain itself&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Cover terrain types are enumerated (COVER_TERRAIN_WITHIN_AND_BEHIND, COVER_TERRAIN_WITHIN_ONLY) and RulesEngine resolves the modifier, but movement scoring has no explicit term for ending in cover, and target scoring has no term for the target being in cover.</div>
+<div><b>Change:</b> Add a modest movement bonus for destinations granting Benefit of Cover (smaller than the Hidden bonus in F001 — cover is a -1, Hidden is immunity), and reduce a target&#x27;s efficiency multiplier when it has cover against the shooter unless the weapon ignores cover.</div>
+<div><b>Risk:</b> Cover and Hidden are sought in the same terrain, so the two bonuses can double-count and over-concentrate the army into one ruin. Apply cover only when Hidden does not already apply.</div>
+<div><b>Where:</b> <code>movement destination scoring + EFFICIENCY_* target matching</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="screening_and_zoning">
+<h2>Screening and denying space<span class="n"></span></h2>
+<p class="dfn">Using bodies to deny space — blocking deep strike arrival, blocking charge lanes, and blocking physical movement paths.</p>
+<article data-d="screening_and_zoning" data-f="general">
+<p class="claim">A screen is defined by the gaps between its models relative to the enemy&#x27;s base size, not by the unit&#x27;s overall position — gaps must be too narrow for an enemy base to pass through while staying more than 1&quot; away.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Models cannot move within Engagement Range of enemies during a normal move, so two screening models placed a base-width-plus-2&quot; apart form a wall; placed wider, they are decoration. Players talk in terms of the specific enemy base they are screening against (32mm, 2&quot;), and losing a game to a single unplanned gap is a recurring post-mortem. Consolidation compounds the error: a model that squeezes through kills the screen and then consolidates into whatever was behind it.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=gRqdSBkqVlA&amp;t=1320s" target="_blank" rel="noopener">6 Plus Plus Gaming @ 22:00</a> — <span class="q">&ldquo;What I didn&#x27;t think of was leaving gaps between my models to screen a 32 mil base&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VqwMdS9MuIY&amp;t=30840s" target="_blank" rel="noopener">TacticalTortoise 40k @ 514:00</a> — <span class="q">&ldquo;create a gap that is less than 1 in between all of those models ... will prevent any orc model from going through&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=xFGyuYmXyJY&amp;t=600s" target="_blank" rel="noopener">Proxy Hammer @ 10:00</a> — <span class="q">&ldquo;you can have a little bit of space in between your models that they won&#x27;t be able to actually fit through&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VPTL092E0VI&amp;t=780s" target="_blank" rel="noopener">Grimdark Breakdown @ 13:00</a> — <span class="q">&ldquo;The amount of times that I have tried to screen and there&#x27;s a tiny hole&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Screening is scored at unit granularity: SCREEN_SPACING_PX (18&quot;) spaces whole screening units, and AI_B2B_GAP_PX (0.5px) is only used for base-to-base packing. Nothing checks whether the resulting model line has a passable gap.</div>
+<div><b>Change:</b> When laying out a unit flagged as a screener, cap inter-model spacing at (largest enemy base diameter + 2&quot;) and validate the finished line against the widest enemy base on the board. Expose the cap as SCREEN_MAX_MODEL_GAP_PX so it is tunable per profile.</div>
+<div><b>Risk:</b> Tight spacing shortens the screen, so fewer inches are covered per unit and blast weapons get better value. It also interacts with unit coherency — the layout must still satisfy coherency after casualties.</div>
+<div><b>Where:</b> <code>screening placement (SCREEN_SCORE_BASE path) — new SCREEN_MODEL_GAP logic</code> &middot; new_heuristic &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="screening_and_zoning" data-f="general">
+<p class="claim">Deep-strike denial must use the arriving unit&#x27;s own minimum distance, because 6&quot; deep strike is common in 11e and a 9&quot;-spaced screen does not stop it.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Numerous 11e detachments and enhancements grant deep strike at 6&quot; rather than the core 9&quot;, and players describe having to screen &#x27;really aggressively&#x27; as a result. Denial geometry is the sum of two radii: to deny a 9&quot; arrival, screeners must be within 18&quot; of each other; to deny a 6&quot; arrival, within 12&quot;. Using one fixed number under-screens against exactly the units most able to punish it.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=uYFHWwWSklU&amp;t=5220s" target="_blank" rel="noopener">Odyssey40k @ 87:00</a> — <span class="q">&ldquo;there&#x27;s a 6-in deep strike in retaliation ... you have to screen really aggressively for it&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=SyVxk7EW_tI&amp;t=7920s" target="_blank" rel="noopener">Tactical Sugar @ 132:00</a> — <span class="q">&ldquo;it&#x27;s so much harder screen out now in 11th and deep strikes are so much more important in 11th&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=nGqRAvAMTYA&amp;t=3960s" target="_blank" rel="noopener">TacticalTortoise 40k @ 66:00</a> — <span class="q">&ldquo;He also can 6 in deep strike high OC onto an objective in order to grab it&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=8_HAdKldvhs&amp;t=1200s" target="_blank" rel="noopener">The Tabletop Alliance 40K @ 20:00</a> — <span class="q">&ldquo;What do you have in reserve? Screamers ... 6 in deep strike now&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Both constants are hardcoded to the core-rules 9&quot; case. _find_screening_positions steps the board every SCREEN_SPACING_PX and treats any point further than DEEP_STRIKE_DENIAL_RANGE_PX from a friendly model as deniable.</div>
+<div><b>Change:</b> Derive the radius per threat: scan enemy units still in reserve for a deep-strike ability naming a distance, take the minimum across them, and use 2x that as the screen spacing for this game. Keep the current values as the fallback when no reserve unit advertises a shorter range.</div>
+<div><b>Risk:</b> A 12&quot; spacing needs ~50% more screening bodies to cover the same frontage; on low-model armies this will starve objectives. Pair with a cap on how many units may take screening assignments.</div>
+<div><b>Where:</b> <code>DEEP_STRIKE_DENIAL_RANGE_PX (360.0 = 9&quot;) and SCREEN_SPACING_PX (720.0 = 18&quot;)</code> &middot; weight_constant &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="screening_and_zoning" data-f="Orks">
+<p class="claim">Gretchin exist to absorb the screening and home-objective jobs so Boyz mobs are never assigned to them.</p>
+<div class="tags">
+<span class="tag fac">Orks</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">2 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Ork lists carry multiple cheap Gretchin units specifically as job-units: sit on home, screen the deployment zone, and block deep strike, leaving the 20-model Boyz mobs free to be the offensive units the army actually wins with. The failure mode players describe is a Boyz mob that ends up babysitting an objective — a 200-point unit doing a 40-point unit&#x27;s job.</p>
+<div class="diff"><b>Why this army is different</b>The general AI picks screeners by cost threshold (SCREEN_CHEAP_UNIT_POINTS 100) and would happily assign a cheap-ish melee unit to a screen. For Orks the assignment should be near-absolute: Gretchin take these roles first and Boyz take them only when no Gretchin remain, even if the Boyz mob is closer.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=QZ9wggn2oUo&amp;t=420s" target="_blank" rel="noopener">Tabletop Nexus @ 07:00</a> — <span class="q">&ldquo;Gretchen handle the boring jobs, your home objectives, more screening so boys don&#x27;t have to&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=300s" target="_blank" rel="noopener">40K Dirtbags @ 05:00</a> — <span class="q">&ldquo;we have three units of Gretchen, 120 men, two 10 mans&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=DHVBk9vnR8w&amp;t=120s" target="_blank" rel="noopener">40K Dirtbags @ 02:00</a> — <span class="q">&ldquo;20-man gretchin with Zagdrod, two 10-man gretchin which I really liked having extra gretchin unit&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Any unit at or below 100 points is a screening candidate, scored at SCREEN_SCORE_BASE 8.0 against objective priorities. Ork Boyz mobs are above the threshold so they are not screen candidates, but they are still eligible for home-objective assignments.</div>
+<div><b>Change:</b> Ork profile: lower SCREEN_CHEAP_UNIT_POINTS to ~60 so only Gretchin-class units qualify, and raise SCREEN_SCORE_BASE to ~10.0 so those units take screening over a marginal objective push. Pair with a rule that raises WEIGHT_ALREADY_HELD_OBJ for melee units so Boyz leave held objectives.</div>
+<div><b>Risk:</b> If the army has lost its Gretchin, a 60-point threshold leaves nothing eligible to screen at all. Needs a fallback to the default threshold when no candidate exists.</div>
+<div><b>Where:</b> <code>SCREEN_CHEAP_UNIT_POINTS (100) / SCREEN_SCORE_BASE (8.0)</code> &middot; profile_rule &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="screening_and_zoning" data-f="general">
+<p class="claim">A screen must still be intact during the opponent&#x27;s turn, because Rapid Ingress lets reserves arrive in the opponent&#x27;s Movement phase.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Rapid Ingress moves a reserve unit onto the table during the opponent&#x27;s movement phase, so a screen evaluated only at the end of the AI&#x27;s own turn can be bypassed the moment it takes casualties or moves. Players build lists specifically around having a Rapid Ingress target and describe screening against it as a distinct obligation from screening against normal deep strike.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=240s" target="_blank" rel="noopener">40K Dirtbags @ 04:00</a> — <span class="q">&ldquo;at least one unit in reserves cuz you&#x27;re making lists to have a reserve rapid ingress target&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=1AwnDclFviQ&amp;t=9540s" target="_blank" rel="noopener">WarGames Live @ 159:00</a> — <span class="q">&ldquo;this dog is doing some rapid ingress screening which is nice ... Deep strike denying&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=pAk1YiuioNQ&amp;t=3420s" target="_blank" rel="noopener">Happy Krumping @ 57:00</a> — <span class="q">&ldquo;You don&#x27;t have to screen the rapid ingress. You don&#x27;t have to worry about screening&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=gRqdSBkqVlA&amp;t=360s" target="_blank" rel="noopener">6 Plus Plus Gaming @ 06:00</a> — <span class="q">&ldquo;a big Helion Brick for rapid ingress threats ... I needed a infiltrate screen unit against things like Emperor&#x27;s Children&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Screening positions are chosen during the AI&#x27;s movement phase and evaluated against the board as it stands then. Nothing re-checks coverage after the AI&#x27;s own shooting/charge phases move or lose the screening unit.</div>
+<div><b>Change:</b> Re-validate screening coverage at the end of the AI&#x27;s turn and, when a gap has opened, prefer keeping a screening unit stationary over using it in a charge. Simplest form: mark units holding a screening assignment as ineligible for charges unless the charge itself closes the gap.</div>
+<div><b>Risk:</b> Locking screeners out of charges wastes them when no reserves remain. Skip the restriction entirely once the opponent has nothing left in reserve — the AI can see reserve counts in the snapshot.</div>
+<div><b>Where:</b> <code>screening assignment validity window</code> &middot; new_heuristic &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="screening_and_zoning" data-f="Tyranids">
+<p class="claim">Tyranids should spend cheap broods and spore mines as disposable movement blockers placed in the enemy&#x27;s path, not as objective holders held back safely.</p>
+<div class="tags">
+<span class="tag fac">Tyranids</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Tyranid screening pieces are cheap enough to be spent every turn and are placed specifically to force the opponent to go around — the value is the movement tax, not the bodies. Players describe placing spore mines downfield turn after turn to close deep-strike lanes, and describe a single unscreened gap as what lets the opponent through.</p>
+<div class="diff"><b>Why this army is different</b>The general AI picks screeners by cost threshold and places them to cover deep-strike arrival zones near its own objectives. Tyranids should also project blockers forward into the enemy&#x27;s approach lanes and treat them as consumable each turn, which the general threat model would penalise as walking into danger.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=K8OD14Mz6N4&amp;t=540s" target="_blank" rel="noopener">Into the Hive Mind @ 09:00</a> — <span class="q">&ldquo;putting these spore mines out that screen out deep strikers or any kind of reserve&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VPTL092E0VI&amp;t=780s" target="_blank" rel="noopener">Grimdark Breakdown @ 13:00</a> — <span class="q">&ldquo;you could put things in their way to block their easy path&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=sPWC5HujB_Y&amp;t=1140s" target="_blank" rel="noopener">StrikingScorpion82 @ 19:00</a> — <span class="q">&ldquo;holding objectives, picking on isolated, tying units down, blocking movements ... it&#x27;s no big deal if they&#x27;re slain&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Corridor blocking exists at 7.0 base priority — below screening&#x27;s 8.0 — capped at 4 positions, and requires an enemy within 30&quot; of the objective being protected.</div>
+<div><b>Change:</b> Tyranid profile: raise CORRIDOR_BLOCK_SCORE_BASE to ~9.0 so blocking outbids screening for cheap broods, and raise CORRIDOR_BLOCK_MAX_POSITIONS to 6. Lower THREAT_FRAGILE_BONUS so the blockers accept being killed.</div>
+<div><b>Risk:</b> Cheap Tyranid units are also the army&#x27;s OC on objectives; spending them all as blockers can leave nothing scoring. Cap the number of units that may take a blocking assignment as a fraction of the army.</div>
+<div><b>Where:</b> <code>CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_MAX_POSITIONS (4)</code> &middot; profile_rule &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="target_selection">
+<h2>What to shoot<span class="n"></span></h2>
+<p class="dfn">Given a set of legal targets, which one to shoot or fight, and how much to commit to it.</p>
+<article data-d="target_selection" data-f="general">
+<p class="claim">Enemy infantry that is about to regain Hidden should be shot this turn, because next turn it may be untargetable.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">2 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Hidden returns once a unit goes a full turn without shooting, so an enemy unit that fired last turn but not this one is on a timer. Players consciously reprioritise onto those units while the window is open, rather than picking the highest-value target and finding it unshootable next turn. This is the mirror image of the decision to hold fire.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=gRQZh-QYBIQ&amp;t=1200s" target="_blank" rel="noopener">Boltgun Tactics @ 20:00</a> — <span class="q">&ldquo;I&#x27;m not going to shoot the raptors cuz they might get hidden um if I don&#x27;t shoot&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=420s" target="_blank" rel="noopener">40K Dirtbags @ 07:00</a> — <span class="q">&ldquo;these guys won&#x27;t be able to shoot me turn one if everybody&#x27;s hidden&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Target value is computed from points, output, survivability and objective presence. Availability is treated as binary and permanent: there is no notion of a target that is legal now and illegal later.</div>
+<div><b>Change:</b> Multiply target value by ~1.25 when the target is an INFANTRY/BEASTS/SWARM unit standing in dense terrain that did not make ranged attacks this turn — it will be Hidden on the opponent&#x27;s next turn. Read the same flags RulesEngine uses for 13.09.</div>
+<div><b>Risk:</b> Chasing the window can pull fire off a genuinely more dangerous target. Keep the multiplier modest so it breaks ties rather than overriding threat.</div>
+<div><b>Where:</b> <code>_calculate_target_value — new HIDDEN_WINDOW_BONUS</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="target_selection" data-f="general">
+<p class="claim">Clearing enemy screens is worth more than the screen&#x27;s points, because the screen is what stops the rest of the army from scoring or charging.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Players routinely commit an expensive unit to kill a cheap one and describe it as a good decision, because the cheap unit is denying a charge lane, an objective, or a deep-strike landing zone. Points-per-wound efficiency scores this as a bad trade; the players&#x27; framing is that the screen&#x27;s value is the value of everything it is blocking. The counterweight they also state is not to use your best melee unit on chaff when a cheaper one will do.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=VqwMdS9MuIY&amp;t=3720s" target="_blank" rel="noopener">TacticalTortoise 40k @ 62:00</a> — <span class="q">&ldquo;it&#x27;s absolutely worth a genailer squad to eviscerate one of those ranger squads even though it&#x27;s a trade down&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=_xKjN6N1jT0&amp;t=240s" target="_blank" rel="noopener">40K Fireside @ 04:00</a> — <span class="q">&ldquo;you need to kill like I don&#x27;t know, 10 guardsmen move blocking your big charges&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=7AgzQIEq3j4&amp;t=5580s" target="_blank" rel="noopener">TacticalTortoise 40k @ 93:00</a> — <span class="q">&ldquo;you can clear screening units and infiltrators ... have to run 20 possessed into ... 10 commandos&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=D5XVd0FRgK8&amp;t=120s" target="_blank" rel="noopener">Warpbane Tactics @ 02:00</a> — <span class="q">&ldquo;unit left alive on one wood can still hold an objective, block our movement ... That is why finis&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Trade analysis penalises killing cheap units with expensive ones (TRADE_UNFAVORABLE_PENALTY 0.7), and is gated to Competitive difficulty only (use_trade_analysis). A screening unit is scored as its points and output, so it looks like a bad target.</div>
+<div><b>Change:</b> Add a positional-value term to _calculate_target_value: if the target is currently inside our own screening-denial evaluation (it is blocking a charge lane, sitting in a deep-strike landing zone we want, or contesting an objective our VP estimator prices), suppress the TRADE_UNFAVORABLE_PENALTY for that target rather than adding raw score. Suppression, not a bonus, keeps the existing scale intact.</div>
+<div><b>Risk:</b> Suppressing the penalty too broadly recreates the pre-trade-analysis behaviour of shooting lascannons at Grots. It must key off an explicit blocking role, not off cheapness.</div>
+<div><b>Where:</b> <code>TRADE_PPW_WEIGHT (0.25) / TRADE_UNFAVORABLE_PENALTY (0.7)</code> &middot; weight_constant &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="target_selection" data-f="general">
+<p class="claim">Battle-shocking a unit strips its Objective Control to zero, so an objective can be flipped without killing anything.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">A battle-shocked unit&#x27;s models have OC &#x27;-&#x27;, cannot be targeted by stratagems and cannot start actions. Players describe whole lists built around it (&#x27;battleshock OC denial&#x27;) and use forced battle-shock tests specifically to deny a primary score in the opponent&#x27;s command phase. Against durable objective-holders this is far cheaper than killing them, and it is the counter to armies that ignore attrition.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=TJQWtTZiP1g&amp;t=120s" target="_blank" rel="noopener">Zeeto @ 02:00</a> — <span class="q">&ldquo;That sort of Battleshock um OC denial sort of list ... would probably work well in teams&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=eokQteHr0Fo&amp;t=1140s" target="_blank" rel="noopener">6 Plus Plus Gaming @ 19:00</a> — <span class="q">&ldquo;if you really need them to not have a secondary uh primary point ... it&#x27;s a really powerful strategy&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=qwnHaQvzCq0&amp;t=840s" target="_blank" rel="noopener">Grimdark Breakdown @ 14:00</a> — <span class="q">&ldquo;If you Battle Shock me, I go to 1 OC instead of 0&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=ewxyBDMvC64&amp;t=1380s" target="_blank" rel="noopener">The Six Machine @ 23:00</a> — <span class="q">&ldquo;it is more likely that you will get battleshocked and potentially stay battleshocked&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> The AI reads the battle_shocked flag defensively (it un-shocks its own units via &#x27;Da Captain&#x27;, and skips shocked enemies in some checks) but never evaluates inflicting battle-shock as a route to controlling an objective. Objective contest is computed from raw OC only.</div>
+<div><b>Change:</b> When scoring an ability or stratagem that forces a battle-shock test, add the VP the objective would be worth if the target&#x27;s OC went to zero — reuse _estimate_objective_vp_value with the target&#x27;s OC removed and score the delta. Same term should make a shocked enemy unit a lower-priority shooting target while it is shocked and already contributing nothing.</div>
+<div><b>Risk:</b> Battle-shock is a leadership roll and often fails; the score must be multiplied by the actual pass probability or the AI will spend CP on coin flips. It also lasts only until the next command phase, so it is worthless outside the scoring window.</div>
+<div><b>Where:</b> <code>objective contest evaluation + battle-shock-inflicting ability/stratagem scoring</code> &middot; new_heuristic &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="target_selection" data-f="general">
+<p class="claim">Concentrate onto one target until it is destroyed rather than spreading damage; a unit left on one wound still holds objectives and blocks movement.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">2 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">A surviving model retains full Objective Control and full blocking geometry, so partial damage buys almost nothing in a mission-scored edition. Players describe spreading fire as the specific mistake that cost them a game, and finishing targets as the corrective. This mostly corroborates what the AI already does, but the mechanism matters: the reason to finish is positional, not damage-economic.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=PWtaFLZYu_U&amp;t=180s" target="_blank" rel="noopener">Warpbane Tactics @ 03:00</a> — <span class="q">&ldquo;spreading my damage across multiple units would have been a massive mistake. I focused on completely removing one unit at a time&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=D5XVd0FRgK8&amp;t=120s" target="_blank" rel="noopener">Warpbane Tactics @ 02:00</a> — <span class="q">&ldquo;unit left alive on one wood can still hold an objective, block our movement&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=lNn0zv_w8t8&amp;t=300s" target="_blank" rel="noopener">Planet 40K @ 05:00</a> — <span class="q">&ldquo;another bad priority target ... is just simply bad trades&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Focus fire already exists at Normal+ and MICRO_MARGINAL_KILL_BONUS rewards the assignment that crosses the kill threshold. The weighting is damage-denominated, so a target holding an objective is not preferentially finished.</div>
+<div><b>Change:</b> Multiply MICRO_MARGINAL_KILL_BONUS by ~1.4 when the target currently contributes OC to an objective our VP estimator prices above zero, so finishing a scoring unit outbids starting on a fresh one.</div>
+<div><b>Risk:</b> Low. The main hazard is stacking with the disposition kill-pressure term and producing tunnel vision on one objective.</div>
+<div><b>Where:</b> <code>MICRO_MARGINAL_KILL_BONUS (2.5) / MICRO_OVERKILL_DECAY (0.35) / OVERKILL_TOLERANCE (1.15)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="target_selection" data-f="general">
+<p class="claim">Units standing on objectives are premium targets in every round, not just rounds 4-5, because several common secondaries pay for killing them.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">&#x27;Kill things on objectives&#x27; recurs as a secondary across the corpus, and players reshuffle their whole shooting plan when they draw it — sometimes needing two kills on markers for full value. Combined with the primary card, an enemy unit on a marker is being paid for twice: once by removing its OC, once by the secondary. This is a scoring decision dressed as a target-priority decision.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=Krfpc2el0cA&amp;t=1500s" target="_blank" rel="noopener">Tabletop Titans @ 25:00</a> — <span class="q">&ldquo;Overwhelming is good. This is kill things on objectives. It&#x27;s what I want to do ... you really want to try to get two kills&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VvZD_rjUBjE&amp;t=1140s" target="_blank" rel="noopener">MiniWarGaming @ 19:00</a> — <span class="q">&ldquo;Kill things on the critical objectives with overwhelming force&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=TPV3hVKSUxw&amp;t=2520s" target="_blank" rel="noopener">Play On Tabletop @ 42:00</a> — <span class="q">&ldquo;we&#x27;ve got overwhelming force. So, kill things on objectives&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=1AwnDclFviQ&amp;t=33120s" target="_blank" rel="noopener">WarGames Live @ 552:00</a> — <span class="q">&ldquo;Kill things on objectives. Easy. And do actions&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> The bonus for shooting units on objectives is part of the rounds-4-5 strategy block only. In rounds 1-3 an enemy unit on a marker is valued the same as one in the open.</div>
+<div><b>Change:</b> Move the objective-occupancy bonus out of the late-game block and apply it whenever the active secondary or primary card pays for kills on objectives — the SecondaryMissionManager hints already surface this. Keep the extra late-game multiplier on top.</div>
+<div><b>Risk:</b> Applied unconditionally it double-counts with the OC-denial value of the same kill and can pull fire off genuinely dangerous units early. Gate it on the mission actually paying for it.</div>
+<div><b>Where:</b> <code>STRATEGY_LATE_OBJ_TARGET_BONUS (1.3)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="objective_trade">
+<h2>Objectives and scoring<span class="n"></span></h2>
+<p class="dfn">Whether to take, hold, contest, or give up an objective, and what that is worth relative to killing something.</p>
+<article data-d="objective_trade" data-f="general">
+<p class="claim">Tabling the opponent is no longer a win condition in 11e; the AI should accept losing units it cannot save if the exchange keeps it ahead on primary.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag high">high confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Multiple channels contrast 11e with 10e explicitly: in 10e killing the opponent&#x27;s army was a common route to victory, in 11e games are decided on accumulated primary and secondary VP with a 45-point primary cap. The practical consequence is that a durable army can lose the attrition war and still win, and an aggressive army that wins every fight can lose on points.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=MG546BN181w&amp;t=2820s" target="_blank" rel="noopener">Grimdark Breakdown @ 47:00</a> — <span class="q">&ldquo;You do not have to kill your opponent in 11th edition. A giant condition of winning was tableabling your opponent in 10th&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=9fuvetVLB3s&amp;t=1740s" target="_blank" rel="noopener">Master Crafted @ 29:00</a> — <span class="q">&ldquo;they don&#x27;t have to kill you. It&#x27;s just going to take you five turns to kill their army and they&#x27;re just going to keep scoring&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=EBJW0VDeT_Q&amp;t=2700s" target="_blank" rel="noopener">40K Dirtbags @ 45:00</a> — <span class="q">&ldquo;win on primary by denying primary and stuff like that. It&#x27;s really the only way to to win 40k&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VU4S_6e1NgE&amp;t=1440s" target="_blank" rel="noopener">Deploy on the Line 40K @ 24:00</a> — <span class="q">&ldquo;you&#x27;re just going to win on primary points as long as you don&#x27;t burn out&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Rounds 1-2 boost kill-seeking 30% and hold objective weight just below full (0.95). The VP-denominated objective estimator already exists, so the framework is right, but the early-round modifiers still tilt toward damage.</div>
+<div><b>Change:</b> Bring STRATEGY_EARLY_AGGRESSION down toward 1.1 and STRATEGY_EARLY_OBJECTIVE up to 1.0, and A/B it the way orks_discipline_a.json A/B&#x27;d the Ork constant. Do not change the late modifiers — they already favour objectives.</div>
+<div><b>Risk:</b> Reduced early aggression can let an aggressive opponent establish the mid-board unopposed, which loses on primary for the opposite reason. This is a benchmark question, not a settled one — hence the profile arm rather than a constant edit.</div>
+<div><b>Where:</b> <code>STRATEGY_EARLY_AGGRESSION (1.3) / STRATEGY_EARLY_OBJECTIVE (0.95)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="objective_trade" data-f="general">
+<p class="claim">The force disposition should modulate how much the AI values killing versus holding, not just which objectives it prices.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">11e pairs each player&#x27;s disposition deck against the opponent&#x27;s, and the five dispositions reward very different behaviour: Purge the Foe pays for destroying units every turn, Take and Hold pays for straightforward objective control, Recon and Priority Assets pay for actions in specific places, and Disruption scores poorly overall — which players treat as licence to stop caring about scoring and simply attack. That last inversion is the clearest evidence that disposition should change aggression, not only objective pricing.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=pAk1YiuioNQ&amp;t=4200s" target="_blank" rel="noopener">Happy Krumping @ 70:00</a> — <span class="q">&ldquo;disruption scores poorly, it kind of releases you to not have to worry about scoring ... you might as well just obliterate your opponents&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=14LSO7MS3QI&amp;t=5100s" target="_blank" rel="noopener">Deploy on the Line 40K @ 85:00</a> — <span class="q">&ldquo;if they were taking recon they&#x27;re just trying to kill people and say whatever you score your points later&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=ogMKXBVh4g0&amp;t=120s" target="_blank" rel="noopener">Warpbane Tactics @ 02:00</a> — <span class="q">&ldquo;Disruption is about interfering with your opponent&#x27;s plans, it rewards movement, positioning&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=i7MkaccGXeA&amp;t=1500s" target="_blank" rel="noopener">TacticalTortoise 40k @ 25:00</a> — <span class="q">&ldquo;gives you points where you destroy enemies ... So it&#x27;s a simply a race&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> _build_primary_awareness already parses the player&#x27;s own 11e primary card and sets objective_pressure, enemy_home_bonus, central_bonus and a boolean kill_pressure. objective_pressure feeds objective scoring, but kill_pressure is only recorded — it does not modify the aggression/charge-threshold modifiers.</div>
+<div><b>Change:</b> Multiply the aggression modifier by ~1.2 and the charge threshold by ~0.9 while awareness.kill_pressure is true, and apply the inverse when objective_pressure is high and kill_pressure false. This is a small change because the parsing already exists.</div>
+<div><b>Risk:</b> Double-counting: kill-based primary rules already raise the VP value of killing through the estimator, so a second multiplier can over-rotate. Cap the combined aggression modifier.</div>
+<div><b>Where:</b> <code>_build_primary_awareness → feed kill_pressure into the aggression modifier stack</code> &middot; new_heuristic &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="objective_trade" data-f="Adeptus Custodes">
+<p class="claim">Custodes cannot screen and score simultaneously; they should concentrate into one or two bricks and concede board area rather than spreading to cover objectives.</p>
+<div class="tags">
+<span class="tag fac">Adeptus Custodes</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">With roughly a third of a normal army&#x27;s unit count, every Custodes unit split off to hold a marker is a unit missing from the one place the army can win a fight. Players describe the army as wanting to move as a wrecking ball, and describe splitting as the mistake. The army&#x27;s compensation is that its units are individually hard enough to hold an objective against a much larger force, so it can arrive late and still take the ground.</p>
+<div class="diff"><b>Why this army is different</b>The general AI spreads units across objectives by score, using SUPPORT_STACK_PENALTY (3.5) to actively discourage stacking. For Custodes that penalty is backwards: concentration is the plan, and the army should accept holding fewer objectives for longer rather than contesting more of them briefly.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=EAqaLgAudQo&amp;t=12960s" target="_blank" rel="noopener">Tabletop Titans @ 216:00</a> — <span class="q">&ldquo;custodians are just not designed that way. They want to be hanging out together just few units but just wrecking ball&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=9fuvetVLB3s&amp;t=3780s" target="_blank" rel="noopener">Master Crafted @ 63:00</a> — <span class="q">&ldquo;it still just didn&#x27;t feel great as a custod player to have to uh be playing might with purge&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=ET9gYSgKRfs&amp;t=240s" target="_blank" rel="noopener">Hubtown Hammer @ 04:00</a> — <span class="q">&ldquo;we will always have minus one to hit in the fight phase since they will be within 12 in with the hidden rule&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Custodes get a single scalar aggression of 1.5, which raises kill-seeking and lowers the charge threshold. Nothing changes how widely the army spreads; SUPPORT_STACK_PENALTY 3.5 applies as normal and pushes units apart.</div>
+<div><b>Change:</b> This is the clearest evidence that a single &#x27;aggression&#x27; scalar is the wrong model. For Custodes the differentiating parameter is concentration, not aggression: drop SUPPORT_STACK_PENALTY to ~1.5 in the Custodes profile and raise WEIGHT_ALREADY_HELD_OBJ toward -1.0 so units stay on ground they already hold, while leaving FACTION_AGGRESSION_CUSTODES at 1.5.</div>
+<div><b>Risk:</b> Concentration loses to mission formats that reward spread (Recon table quarters, Priority Assets actions). The profile should be benchmarked per disposition, not adopted globally.</div>
+<div><b>Where:</b> <code>FACTION_AGGRESSION_CUSTODES (1.5) — plus SUPPORT_STACK_PENALTY in the profile</code> &middot; faction_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="objective_trade" data-f="Grey Knights">
+<p class="claim">Grey Knights teleport (pick a unit up and redeploy it) costs objective control, so its value is disposition-dependent — under Take and Hold, teleporting a scoring unit is usually a net loss.</p>
+<div class="tags">
+<span class="tag fac">Grey Knights</span>
+<span class="tag low">low confidence</span>
+<span class="tag">1 channel agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Repositioning a unit off an objective removes its OC contribution for the scoring window, so the same ability that is a free reposition under a kill-oriented card is a self-inflicted VP loss under an objective-oriented one. The arrival-turn buffs that reward teleporting are also limited to the turn the unit arrives, so the benefit is one turn while the objective loss can span two.</p>
+<div class="diff"><b>Why this army is different</b>A general AI treats a free reposition as unambiguously good. For Grey Knights the ability has to be priced against the VP estimator before use, and its worth swings with the primary card.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=veM7sLjtdIw&amp;t=60s" target="_blank" rel="noopener">Warpbane Tactics @ 01:00</a> — <span class="q">&ldquo;being careful about when we use our teleportation. Picking a unit up is incredibly useful, but under Take and Hold, that decision becomes more costly&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=D5XVd0FRgK8&amp;t=180s" target="_blank" rel="noopener">Warpbane Tactics @ 03:00</a> — <span class="q">&ldquo;Fury of the Titan. Each time one of our units is set up using the deep strike ability until the end of that turn&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Repositioning abilities are scored on the destination&#x27;s movement value. The VP the unit was contributing at its origin is not subtracted.</div>
+<div><b>Change:</b> Subtract _estimate_objective_vp_value for the origin objective from the score of any pick-up-and-place ability, so the decision is a net VP comparison. This is a general improvement that Grey Knights make most visible.</div>
+<div><b>Risk:</b> Low confidence — a single channel. Implement the VP subtraction as general logic rather than as a Grey Knights special case, and do not ship a Grey Knights profile on this evidence.</div>
+<div><b>Where:</b> <code>teleport / redeploy ability scoring</code> &middot; faction_ability &middot; low priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="attrition_and_trades">
+<h2>When to accept a bad trade<span class="n"></span></h2>
+<p class="dfn">Whether a unit&#x27;s likely loss is acceptable for what it buys.</p>
+<article data-d="attrition_and_trades" data-f="Drukhari">
+<p class="claim">Drukhari should fight out of transports and treat committed squads as expendable — a squad that disembarks, kills, and dies has done its job.</p>
+<div class="tags">
+<span class="tag fac">Drukhari</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">Drukhari infantry are fast and lethal but do not survive being shot, so the transport is not a delivery convenience but the unit&#x27;s durability. Players describe squads as explicitly suicidal — sent to remove a key piece with no expectation of returning — and describe leaving a unit outside its transport as the error. The army&#x27;s economy assumes it trades its units away and keeps scoring with what is left.</p>
+<div class="diff"><b>Why this army is different</b>The general AI protects expensive and fragile units (THREAT_FRAGILE_BONUS 1.3, ARCHETYPE_ELITE_SURVIVAL 1.25) and penalises trading an expensive unit into a cheaper one. Drukhari should accept those trades when the target is a key enabler, and should weight embarkation far more heavily than a general army would.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=jJwrYZs3l-I&amp;t=660s" target="_blank" rel="noopener">Deploy on the Line 40K @ 11:00</a> — <span class="q">&ldquo;squad in transport. They&#x27;re going to suicide themselves&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=nCQuNE_8V44&amp;t=1140s" target="_blank" rel="noopener">SkaredCast @ 19:00</a> — <span class="q">&ldquo;you didn&#x27;t need the entire unit to kill them. They died very fast. Should have kept them in the transport&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=gRqdSBkqVlA&amp;t=420s" target="_blank" rel="noopener">6 Plus Plus Gaming @ 07:00</a> — <span class="q">&ldquo;Drukhari really love it in Sky Splinter Assault ... it gives them that bit of protection&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=3lwK9jAR0RM&amp;t=1380s" target="_blank" rel="noopener">MiniWarGaming @ 23:00</a> — <span class="q">&ldquo;going to pick Drazar up to protect Drazar from at least a round of shooting&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Trade analysis penalises expensive-kills-cheap down to 0.7, and fragile high-value units get a 1.3x threat multiplier steering them away from danger. Both push against the Drukhari pattern.</div>
+<div><b>Change:</b> Drukhari profile: raise TRADE_UNFAVORABLE_PENALTY to ~0.9 (nearly neutral) and lower THREAT_FRAGILE_BONUS to ~1.0, so committed units accept exposure. Add a rule that restores caution in rounds 4-5 (round_gte 4 → multiply THREAT_FRAGILE_BONUS by 1.3) so the AI stops throwing units away once the trades no longer buy anything.</div>
+<div><b>Risk:</b> Under Purge the Foe the opponent is paid for every unit destroyed, so an expendable-units profile actively feeds their primary. Benchmark specifically against a Purge opponent before adopting.</div>
+<div><b>Where:</b> <code>TRADE_UNFAVORABLE_PENALTY (0.7) / THREAT_FRAGILE_BONUS (1.3)</code> &middot; profile_rule &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="melee_commitment">
+<h2>When to charge<span class="n"></span></h2>
+<p class="dfn">Whether to charge, what to charge, and what a charge is for when it is not for damage.</p>
+<article data-d="melee_commitment" data-f="general">
+<p class="claim">Charging purely to tie up a dangerous shooter is worth doing even when the charging unit expects to deal and receive negligible damage.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">A unit locked in engagement generally cannot shoot, so a cheap charge can switch off an expensive gun for a full turn. Players make this charge knowing they will lose the melee, and specifically use it against vehicles and gunline units that would otherwise fire freely. The value is the enemy&#x27;s forgone shooting phase, not the combat result.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=MkeH0tr1o_o&amp;t=3420s" target="_blank" rel="noopener">WednesdayNightWarhammer @ 57:00</a> — <span class="q">&ldquo;I guess I would attempt the charge to get just to tie you up&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=0Gcpze1G4Lc&amp;t=840s" target="_blank" rel="noopener">40K Dirtbags @ 14:00</a> — <span class="q">&ldquo;this thing was within range to move up and shoot her. So, I needed to make this charge to stop this tank&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=HER6VzUGO60&amp;t=39480s" target="_blank" rel="noopener">WarGames Live @ 658:00</a> — <span class="q">&ldquo;We&#x27;ll charge the truck in just to lock you in because we can still touch you and still be on the objective&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=lp4j3iYlpQ4&amp;t=1500s" target="_blank" rel="noopener">Mordian Glory @ 25:00</a> — <span class="q">&ldquo;I charged up to the hell hound just to tie them up again&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> The multi-phase planner already gives a 3.0 bonus for charging dangerous shooters, but it is gated behind use_multi_phase_planning (Hard+), and the charge must still clear the normal charge threshold that is driven by expected damage.</div>
+<div><b>Change:</b> Make the lock bonus able to carry a charge on its own: when the target exceeds PHASE_PLAN_RANGED_STRENGTH_DANGEROUS and the charger is cheap relative to it, bypass the expected-damage component of the charge threshold rather than adding to it. Consider lowering the gate to Normal, since players treat this as basic play.</div>
+<div><b>Risk:</b> Feeding cheap units into melee they lose can hand the opponent Purge-the-Foe VP and free consolidation moves toward objectives. Require that the charger is not currently contributing OC to a priced objective.</div>
+<div><b>Where:</b> <code>PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / PHASE_PLAN_RANGED_STRENGTH_DANGEROUS (5.0)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="melee_commitment" data-f="general">
+<p class="claim">Consolidation should be scored as a positioning move — onto an objective, into a new enemy unit, or backwards out of line of sight — not as a default 3&quot; shuffle.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">After fighting, the 3&quot; consolidation is often the most valuable move of the turn: it can put a unit onto an objective it could not have charged, drag it into a second enemy unit to lock that one too, or pull it back behind terrain so it is not shot in the opponent&#x27;s turn. Players choose deliberately between those three outcomes and name the reason each time.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=1440s" target="_blank" rel="noopener">40K Dirtbags @ 24:00</a> — <span class="q">&ldquo;I picked this objective to cons consolidate backwards a little bit so he doesn&#x27;t get shot&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=aQsog-fkQJ8&amp;t=4260s" target="_blank" rel="noopener">Maelstrom Gaming Studios - Tyranids @ 71:00</a> — <span class="q">&ldquo;I will tow this guy onto the objective ... get a tiny bit further away&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=YM1sRZGVOhw&amp;t=720s" target="_blank" rel="noopener">Auspex Tactics @ 12:00</a> — <span class="q">&ldquo;If you&#x27;re able to hit something, destroy something, consolidate into something else&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=6V8asnfgFUE&amp;t=9660s" target="_blank" rel="noopener">Boltgun Tactics @ 161:00</a> — <span class="q">&ldquo;We&#x27;ll just consolidate into the middle&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Consolidation is resolved without a dedicated scoring pass comparable to _score_movement_destination; there is no explicit objective/LoS evaluation of the 3&quot; options.</div>
+<div><b>Change:</b> Score consolidation destinations with the same three terms used for movement — objective VP delta (via _estimate_objective_vp_value), number of additional enemy units brought into engagement, and whether the destination breaks enemy line of sight — and pick the max.</div>
+<div><b>Risk:</b> Consolidating out of line of sight can also leave an objective; the VP term must dominate. Rules constraints on consolidation (must end closer to the nearest enemy, or toward an objective) restrict the legal set and must be respected.</div>
+<div><b>Where:</b> <code>consolidation move selection in the FIGHT phase</code> &middot; new_heuristic &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="disengage_and_lock">
+<h2>Staying in combat, or getting out<span class="n"></span></h2>
+<p class="dfn">Whether to fall back out of an engagement, or deliberately stay in one to deny the enemy its shooting.</p>
+<article data-d="disengage_and_lock" data-f="general">
+<p class="claim">Falling back is expensive: most vehicles cannot fall back and shoot, and a battle-shocked unit must make Desperate Escape rolls, so staying locked is often correct.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">2 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Fall Back normally forbids shooting and charging for the rest of the turn unless a specific ability says otherwise, and that ability is usually restricted to infantry. Players are caught out by this mid-game. The corollary drives the opposite decision too: armies that want the enemy stuck deliberately engage from multiple units so that falling back is unattractive.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=F5TL7LhZJlY&amp;t=780s" target="_blank" rel="noopener">40K Dirtbags @ 13:00</a> — <span class="q">&ldquo;He spends a CP realizing after the fact that you can&#x27;t fall back and shoot with vehicles. It&#x27;s only infantry&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=1500s" target="_blank" rel="noopener">40K Dirtbags @ 25:00</a> — <span class="q">&ldquo;If they fall back and shoot, these guys could have fell back and shot. But that&#x27;s only one unit of shooting&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=aQsog-fkQJ8&amp;t=5880s" target="_blank" rel="noopener">Maelstrom Gaming Studios - Tyranids @ 98:00</a> — <span class="q">&ldquo;no, we&#x27;ll fall back and we&#x27;ll take our hazardous roles. Ones and twos, they die&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Survival assessment (Normal+) compares expected damage against remaining wounds and adds a flat 2.0 toward falling back when the unit is threatened. The lost shooting phase is not priced.</div>
+<div><b>Change:</b> Subtract the unit&#x27;s own expected ranged output from the fall-back score unless it has a fall-back-and-shoot ability, and subtract more when the unit is battle-shocked (Desperate Escape casualties). A VEHICLE without that ability should almost never fall back purely for survival.</div>
+<div><b>Risk:</b> Holding a losing combat can lose the unit outright. The change should only reweight, not veto — SURVIVAL_LETHAL_THRESHOLD (0.75) must still force the retreat when destruction is likely.</div>
+<div><b>Where:</b> <code>SURVIVAL_FALL_BACK_BONUS (2.0) / SURVIVAL_HOLD_BONUS (1.5)</code> &middot; weight_constant &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="disengage_and_lock" data-f="Death Guard">
+<p class="claim">Death Guard win by making disengagement expensive rather than by killing — they should seek to engage multiple enemy units at once and hold them there.</p>
+<div class="tags">
+<span class="tag fac">Death Guard</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Death Guard stack leadership penalties and fall-back punishment, so a unit engaged by them faces a hard Desperate Escape roll to leave. Players deliberately engage one enemy unit with two of their own so that the opponent must pass multiple tests, and describe the army as low-damage but very hard to get away from. The scoring consequence is that a locked enemy is not shooting and not scoring, which is the army&#x27;s whole engine.</p>
+<div class="diff"><b>Why this army is different</b>The general AI evaluates melee by expected damage and uses SURVIVAL_FALL_BACK_BONUS to leave losing fights. Death Guard should prefer engagements it does not win on damage, and should value multi-unit engagement (more fall-back tests) that the general model treats as inefficient over-commitment.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=F5TL7LhZJlY&amp;t=1380s" target="_blank" rel="noopener">40K Dirtbags @ 23:00</a> — <span class="q">&ldquo;If both of these guys were in combat with the death shroud ... both of them would have to pass a seven up to fall back&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=OKoDYKdWm1E&amp;t=360s" target="_blank" rel="noopener">Factions&amp;Fate @ 06:00</a> — <span class="q">&ldquo;against you you want to be in melee, so that might benefit me the most&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=u8fm403MGtg&amp;t=480s" target="_blank" rel="noopener">40K Fireside @ 08:00</a> — <span class="q">&ldquo;Plague Legion it gets stuck in combat a lot and it&#x27;s really hard to get out of combat&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Locking bonuses only apply to targets classed as dangerous shooters (PHASE_PLAN_RANGED_STRENGTH_DANGEROUS 5.0), and survival assessment pulls the AI out of losing fights from Normal upward.</div>
+<div><b>Change:</b> Death Guard profile: raise PHASE_PLAN_LOCK_SHOOTER_BONUS to ~5.0, raise SURVIVAL_HOLD_BONUS to ~3.0 so the AI stays in combats it is losing on damage, and lower SURVIVAL_FALL_BACK_BONUS to ~1.0.</div>
+<div><b>Risk:</b> Staying in fights it loses is exactly the failure mode survival assessment was added to fix; if the enemy can simply kill the engaged unit, this profile feeds it. Needs benchmarking against a high-damage melee opponent specifically.</div>
+<div><b>Where:</b> <code>PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / SURVIVAL_HOLD_BONUS (1.5)</code> &middot; profile_rule &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="reserves_and_arrival">
+<h2>Reserves and arrival<span class="n"></span></h2>
+<p class="dfn">What to hold off the table, and when to bring it on.</p>
+<article data-d="reserves_and_arrival" data-f="general">
+<p class="claim">Keeping one unit in reserve as a reactive answer is standard, but committing the whole army to the table is correct against high-pressure lists — the corpus genuinely disagrees on how much to hold back.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">player judgement</span>
+</div>
+<p class="detail">One camp treats a reserve unit as a deliberate list slot: something held to answer whatever the opponent commits, or to Rapid Ingress into a gap. The other camp says that against lists which apply immediate pressure you need every body on the table from turn one, because arriving later means arriving after the mid-board is lost. Both are stated confidently by strong players; the resolving variable appears to be the opponent&#x27;s speed, which the AI can measure.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=240s" target="_blank" rel="noopener">40K Dirtbags @ 04:00</a> — <span class="q">&ldquo;at least one unit in reserves cuz you&#x27;re making lists to have a reserve rapid ingress target&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=ym0SnzF2ydg&amp;t=9720s" target="_blank" rel="noopener">Art of War 40k @ 162:00</a> — <span class="q">&ldquo;maybe they should have just started the game in reserve so they could be a little bit more of a reactive answer&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=pAk1YiuioNQ&amp;t=540s" target="_blank" rel="noopener">Happy Krumping @ 09:00</a> — <span class="q">&ldquo;If you&#x27;re ever going to play against it, don&#x27;t start things in reserves. You need everything on the table&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=gZWxrJy66nw&amp;t=720s" target="_blank" rel="noopener">Deploy on the Line 40K @ 12:00</a> — <span class="q">&ldquo;there&#x27;s no reason to put anything in reserve because I have redeploy&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Reserves selection puts melee-oriented and short-range deep-strike units into reserve up to the 50% points / 50% units cap, without reference to how fast the opponent&#x27;s army is.</div>
+<div><b>Change:</b> Before declaring reserves, compute the opponent&#x27;s effective turn-one threat range (max Move + Advance + charge across their deployed units, plus scout moves). Above a threshold (~20&quot;), reduce the reserve budget toward one unit; below it, keep the current behaviour. Expose the threshold as RESERVE_PRESSURE_THRESHOLD_INCHES.</div>
+<div><b>Risk:</b> Threat range is a crude proxy — an army can be fast and harmless. Getting it wrong in the aggressive direction leaves the AI with nothing in reserve against alpha strikes, which is the failure mode the second camp is warning about.</div>
+<div><b>Where:</b> <code>_evaluate_reserves_declarations</code> &middot; new_heuristic &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="reserves_and_arrival" data-f="general">
+<p class="claim">Reactive movement abilities are widespread enough in 11e that the AI cannot treat enemy positions as fixed between its own decisions.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Detachment rules, enhancements and stratagems across many factions grant a move triggered by an enemy action — being shot, or an enemy coming within a set distance. Players plan around it explicitly: they decline moves that would trigger a reactive escape, and they buy reactive-move abilities specifically as insurance against 11e&#x27;s stronger Overwatch. Any AI plan that assumes the target stays put will systematically over-value long charges and precise blocking positions.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=ycW5l0xHp9s&amp;t=480s" target="_blank" rel="noopener">PNW 40K @ 08:00</a> — <span class="q">&ldquo;He can make a reactive move ... reactive moves in general are very powerful&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Wm2Hd8h74_o&amp;t=3900s" target="_blank" rel="noopener">HivemindHobbies @ 65:00</a> — <span class="q">&ldquo;if he moves up at all, then they will automatically reactive move behind this obscuring wall&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=1200s" target="_blank" rel="noopener">40K Dirtbags @ 20:00</a> — <span class="q">&ldquo;he then reactive moves and kind of spreads out to stop Ghaz from moving this way&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=VqwMdS9MuIY&amp;t=3600s" target="_blank" rel="noopener">TacticalTortoise 40k @ 60:00</a> — <span class="q">&ldquo;it has the ability to reactive move to enemies going close to it ... it may be able to jump away&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Look-ahead is Competitive-only and models opponent responses generically. Nothing detects that a specific enemy unit owns a reactive-move ability.</div>
+<div><b>Change:</b> Scan enemy datasheet abilities and the opponent&#x27;s detachment stratagems for reactive-move wording, and discount blocking-position and marginal-charge scores against those units by ~30%. Gate to Hard+ rather than Competitive-only, since it is a defensive correction rather than deep search.</div>
+<div><b>Risk:</b> Ability-text scanning is brittle and will both miss and over-match. A false positive makes the AI refuse good charges. Prefer an explicit ability list over free-text matching.</div>
+<div><b>Where:</b> <code>AIDifficultyConfig.use_look_ahead (Competitive only)</code> &middot; difficulty_gate &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="ability_timing">
+<h2>When to spend your big ability<span class="n"></span></h2>
+<p class="dfn">When to fire a once-per-battle or once-per-turn army ability, stratagem, or command resource.</p>
+<article data-d="ability_timing" data-f="Orks">
+<p class="claim">Waaagh! should not be called in round 1, nor the moment a single unit can reach something — it wants several units simultaneously in advance-and-charge range, and its 5+ invulnerable is worth calling for on its own when crossing open ground.</p>
+<div class="tags">
+<span class="tag fac">Orks</span>
+<span class="tag high">high confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Waaagh! is once per battle and grants advance-and-charge, +1 Strength and Attacks in melee, and a 5+ invulnerable save to the whole army for one battle round. Because it is a single one-shot, the payoff is the number of units that convert it into a charge at once; spending it to reach one target wastes the army-wide component. Players also call it purely defensively, to survive a turn of shooting while advancing — which means &#x27;how many units can charge&#x27; is not the only trigger.</p>
+<div class="diff"><b>Why this army is different</b>The general-case AI fires a once-per-battle offensive buff as early as it can be used, on the reasoning that more turns benefit. Waaagh! does not work that way: it lasts one battle round, so early use is pure waste, and its value is the count of units that benefit simultaneously plus the defensive save for the turn the army is most exposed.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=QZ9wggn2oUo&amp;t=240s" target="_blank" rel="noopener">Tabletop Nexus @ 04:00</a> — <span class="q">&ldquo;Don&#x27;t call it turn one, though. Don&#x27;t call it the moment you can reach something&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=QZ9wggn2oUo&amp;t=240s" target="_blank" rel="noopener">Tabletop Nexus @ 04:00</a> — <span class="q">&ldquo;A strong Waaagh! turn has several units positioned to benefit at once&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=DHVBk9vnR8w&amp;t=420s" target="_blank" rel="noopener">40K Dirtbags @ 07:00</a> — <span class="q">&ldquo;moved up a little bit like two extra inches forward uh to plan for turn two Waagh&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=vLQTE5P6pJg&amp;t=180s" target="_blank" rel="noopener">Hubtown Hammer @ 03:00</a> — <span class="q">&ldquo;Turn two, the Orks used the Waagh, which turned out to be a great choice ... blunted by some hot five plus invulnerable&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=Enm67qaqHkU&amp;t=1980s" target="_blank" rel="noopener">40K Dirtbags @ 33:00</a> — <span class="q">&ldquo;if I give up Zod turn one with a Waagh, I spent my Waagh and now I gave up Zod&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Round 1: calls Waaagh! if ANY single unit is within 22&quot; of an enemy (units_in_range &gt;= 1). Round 2+: calls it unconditionally, with the comment &#x27;Round 2+: always use it — waiting loses turns of benefit&#x27;. The unit count is computed but only used for the log line from round 2 onward, and the 5+ invulnerable is never considered.</div>
+<div><b>Change:</b> Replace the round-1 gate with a units_in_range threshold of 3+, and replace the unconditional round-2 fire with &#x27;units_in_range &gt;= 3, or round &gt;= 4 (use-it-or-lose-it)&#x27;. Add a defensive trigger: fire it regardless of charge count when more than half the army is inside enemy threat range and lacks an invulnerable save. Expose the threshold as WAAAGH_MIN_UNITS_IN_RANGE.</div>
+<div><b>Risk:</b> A threshold set too high never fires the ability, which is strictly worse than firing it late — hence the round-4 backstop. The 22&quot; advance-and-charge estimate is centroid-based and optimistic; 3 units at 22&quot; may be 1 unit in practice.</div>
+<div><b>Where:</b> <code>AIDecisionMaker.gd:4481 CALL_WAAAGH block</code> &middot; faction_ability &middot; high priority</div>
+</div></details>
+</article>
+<article data-d="ability_timing" data-f="Tyranids">
+<p class="claim">Tyranid battle-shock output is an offensive tempo tool used to strip OC and enable precision kills, not a passive debuff — the units carrying it should be positioned aggressively to keep enemies inside its range.</p>
+<div class="tags">
+<span class="tag fac">Tyranids</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Shadow in the Warp and unit-level shock effects turn enemy objective-holders into OC-0 passengers and open up follow-up plays: players describe shocking a target and then charging in to precision out the character. That makes the delivery units (Neurolictors and similar) forward-positioned pieces whose range band matters more than their survival, which is the opposite of how a support unit is normally played.</p>
+<div class="diff"><b>Why this army is different</b>The general AI treats support and buff units as things to protect, applying THREAT_FRAGILE_BONUS (1.3) to keep high-value fragile units out of danger. Tyranid shock-delivery units need to be inside their aura range of the enemy&#x27;s scoring units, which means deliberately accepting threat that the general model penalises.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=efeKiBbPUPM&amp;t=540s" target="_blank" rel="noopener">Maelstrom Gaming Studios - Tyranids @ 09:00</a> — <span class="q">&ldquo;My Neurolictor battleshocked Volus and the Paladins, which allowed both the Neurolictor and the Hive turret to charge in and precision out&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=OKoDYKdWm1E&amp;t=240s" target="_blank" rel="noopener">Factions&amp;Fate @ 04:00</a> — <span class="q">&ldquo;infiltrated up here just a little bit past my deployment line, but still within range to hand out battle shocks&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=uAmbb_rrUvM&amp;t=900s" target="_blank" rel="noopener">winters SEO @ 15:00</a> — <span class="q">&ldquo;shadow in the warp and signapse ... hurts the enemy when they&#x27;re in range of signapse&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=7AgzQIEq3j4&amp;t=7260s" target="_blank" rel="noopener">TacticalTortoise 40k @ 121:00</a> — <span class="q">&ldquo;force the battle the um shadow in the warp battle shock at a higher penalty&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Fragile high-value units get an extra threat multiplier and are steered away from the enemy. Nothing values keeping an aura source within range of enemy units.</div>
+<div><b>Change:</b> Tyranid profile: reduce THREAT_FRAGILE_BONUS toward 1.0 and add a movement term that rewards destinations keeping enemy scoring units inside the shock aura&#x27;s range — mirroring the AAO_RADIUS_INCHES / WEIGHT_AAO_ISOLATION pattern already used for Against All Odds.</div>
+<div><b>Risk:</b> Neurolictor-class units are cheap but not expendable; walking them into charge range hands over kill VP under Purge the Foe. Bound the exposure to units the enemy cannot reach with a charge this turn.</div>
+<div><b>Where:</b> <code>THREAT_FRAGILE_BONUS (1.3) / WEIGHT_OC_EFFICIENCY (2.0)</code> &middot; profile_rule &middot; medium priority</div>
+</div></details>
+</article>
+<article data-d="ability_timing" data-f="Space Marines">
+<p class="claim">Oath of Moment should be discounted against targets that our own shooters can already re-roll into — its value is the re-roll it adds, not the target&#x27;s threat.</p>
+<div class="tags">
+<span class="tag fac">Space Marines</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">3 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Oath grants re-rolls against one enemy unit, so its marginal value collapses when the units that will actually shoot the target already re-roll hits from another source. Players state this directly when reviewing lists — a unit hitting on 2s with re-roll 1s &#x27;does not need Oath of Moment&#x27;. The corollary is that Oath goes on the target the unbuffed portion of the army must kill.</p>
+<div class="diff"><b>Why this army is different</b>This is a refinement rather than a reversal: the general logic of &#x27;mark what you most want dead&#x27; is right, but for Space Marines specifically the score must be computed against the shooters that will use it, not against the target in isolation.</div>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=pAk1YiuioNQ&amp;t=1320s" target="_blank" rel="noopener">Happy Krumping @ 22:00</a> — <span class="q">&ldquo;They already hit on twos ... re-rolling hit rolls of one. They do not need oath of moment&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=eUQmB4CTKlk&amp;t=1260s" target="_blank" rel="noopener">Tabletop Tactics @ 21:00</a> — <span class="q">&ldquo;I&#x27;m going to put Oath of Moment on that big brain bug ... he&#x27;s super tough&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=qwnHaQvzCq0&amp;t=840s" target="_blank" rel="noopener">Grimdark Breakdown @ 14:00</a> — <span class="q">&ldquo;the only thing you have to remember to do in your Command phase then is ... That&#x27;s my Oath of Moment target&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Scores each candidate from _calculate_target_value plus target-side modifiers: toughness, save, remaining wounds, below-half-strength, invulnerable discount, leader-buff bonus, and a 0.5x penalty when the army lacks weapons that can hurt it. All modifiers are properties of the target; none look at the shooters&#x27; existing re-rolls.</div>
+<div><b>Change:</b> Weight each candidate by the expected damage the army would gain from the re-roll, computed over the units likely to shoot it — i.e. sum over candidate shooters of (damage with re-roll − damage without), and skip shooters that already re-roll hits. This reuses the existing _check_army_can_damage_target traversal.</div>
+<div><b>Risk:</b> More expensive to compute each command phase, and it can pick a soft target the army would have killed anyway. Keep the existing target-side terms as a tiebreak.</div>
+<div><b>Where:</b> <code>_select_oath_of_moment_target (AIDecisionMaker.gd:4844)</code> &middot; faction_ability &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="action_economy">
+<h2>Who performs the actions<span class="n"></span></h2>
+<p class="dfn">Which unit spends its turn performing a mission action rather than fighting.</p>
+<article data-d="action_economy" data-f="general">
+<p class="claim">Mission actions consume the acting unit&#x27;s shooting, so they should be assigned to the cheapest unit that can reach and survive, not to whatever is nearest.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">4 channels agree</span>
+<span class="tag">matches the rules</span>
+</div>
+<p class="detail">Recon and Priority Assets dispositions are action-heavy, actions are limited to one per turn on some cards and cannot start before round two on others, and starting an action generally costs the unit its shooting phase. Players therefore build in small, cheap, mobile units whose whole job is to walk somewhere and press a button. Notable exception in 11e: Titanic units can shoot and perform actions.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=VPTL092E0VI&amp;t=720s" target="_blank" rel="noopener">Grimdark Breakdown @ 12:00</a> — <span class="q">&ldquo;They have very small bases and then put down somewhere else on the board to do the action&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=7AgzQIEq3j4&amp;t=600s" target="_blank" rel="noopener">TacticalTortoise 40k @ 10:00</a> — <span class="q">&ldquo;Titanic units can shoot and perform actions. So, it&#x27;s not actually like that bad&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=42CPnCfuCN8&amp;t=60s" target="_blank" rel="noopener">Recon By Fire @ 01:00</a> — <span class="q">&ldquo;for one CP, they are capable of shooting and still being able to perform an action&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=mbNWzDn6Pu4&amp;t=300s" target="_blank" rel="noopener">Exile Wargaming @ 05:00</a> — <span class="q">&ldquo;we have to triangulate objectives by doing actions on them. We can only do one a turn&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Primary-card marker/action mechanics are auto-resolved by MissionManager as a headless/AI backstop, and _build_primary_awareness gives those rule types a flat +1.0 generic objective pressure. There is no cost model for which unit performs the action.</div>
+<div><b>Change:</b> When an action is available, rank candidate units by (expected ranged output forgone + points at risk) ascending and pick the cheapest that can reach. Skip the forgone-output term for TITANIC units.</div>
+<div><b>Risk:</b> The cheapest unit is often the screening unit; pulling it off a screen to press a button can open a deep-strike lane. Exclude units currently holding a screening assignment.</div>
+<div><b>Where:</b> <code>action assignment (MissionManager._run_primary_auto_actions_11e is the backstop)</code> &middot; new_heuristic &middot; medium priority</div>
+</div></details>
+</article>
+</section>
+<section data-d="tempo_and_commitment">
+<h2>Turn order and commitment<span class="n"></span></h2>
+<p class="dfn">Which battle round to commit the army, and how much to hold back.</p>
+<article data-d="tempo_and_commitment" data-f="general">
+<p class="claim">In 11e the player who rolls highest must take the first turn, so deployment has to be robust to going either first or second rather than optimised for a choice.</p>
+<div class="tags">
+<span class="tag">every army</span>
+<span class="tag medium">medium confidence</span>
+<span class="tag">2 channels agree</span>
+<span class="tag">unverified against the rules</span>
+</div>
+<p class="detail">Players describe not having to &#x27;sweat&#x27; the first-turn roll because the choice is gone, and describe being forced into a first turn they did not want for their disposition. The planning consequence is that a deployment which is only good on the play, or only good on the draw, is a liability — and that counter-deployment against what the opponent has already put down matters more than turn-order gambling.</p>
+<div class="src"><ul>
+<li><a href="https://youtube.com/watch?v=dy1zEFAKLzk&amp;t=180s" target="_blank" rel="noopener">MiniWarGaming @ 03:00</a> — <span class="q">&ldquo;This is the nice thing about the whoever rolls highest has to go first. I do not have to sweat about who gets first turn&rdquo;</span></li>
+<li><a href="https://youtube.com/watch?v=mbNWzDn6Pu4&amp;t=600s" target="_blank" rel="noopener">Exile Wargaming @ 10:00</a> — <span class="q">&ldquo;we did win the dice roll and had to go first, which I don&#x27;t really like in recon&rdquo;</span></li>
+</ul></div>
+<details><summary>What this means for the game&rsquo;s AI</summary><div class="body">
+<div><b>Today:</b> Counter-deployment is already enabled from Normal upward, which is the right call under this rule. No change is strictly required.</div>
+<div><b>Change:</b> No weight change. Record the rule so that any future &#x27;choose to go second&#x27; logic is not written, and so deployment scoring is not tuned on an assumed turn order. Verify against the 11e core rules before relying on it.</div>
+<div><b>Risk:</b> None — this finding is informational. It is marked unverified because it rests on two channels&#x27; asides rather than a rules quotation.</div>
+<div><b>Where:</b> <code>AIDifficultyConfig.use_counter_deployment (Normal+)</code> &middot; difficulty_gate &middot; low priority</div>
+</div></details>
+</article>
+</section>
+<p class="empty" id="empty" hidden>Nothing matches those two filters — that combination is a coverage gap, listed at the bottom of the page.</p>
+<h2>Where the evidence actually is</h2>
+<p class="dfn">Findings per decision and army. Blank cells are honest gaps, not zero-importance: several armies have plenty of transcripts and still produced nothing decision-shaped.</p>
+<div class="tblwrap"><table><thead><tr><th>Army</th><th>Transcripts</th>
+<th>Where</th>
+<th>Screening</th>
+<th>What</th>
+<th>Objectives</th>
+<th>When</th>
+<th>When</th>
+<th>Staying</th>
+<th>Reserves</th>
+<th>When</th>
+<th>Who</th>
+<th>Turn</th>
+<th>Total</th></tr></thead><tbody>
+<tr><td>Holds for everyone</td><td class="n">1029</td>
+<td class="n has">5</td>
+<td class="n has">3</td>
+<td class="n has">5</td>
+<td class="n has">2</td>
+<td class="n">·</td>
+<td class="n has">2</td>
+<td class="n has">1</td>
+<td class="n has">2</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n has">1</td>
+<td class="n has">22</td>
+</tr>
+<tr><td>Adeptus Custodes</td><td class="n">54</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+</tr>
+<tr><td>Death Guard</td><td class="n">79</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+</tr>
+<tr><td>Drukhari</td><td class="n">46</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+</tr>
+<tr><td>Grey Knights</td><td class="n">60</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+</tr>
+<tr><td>Orks</td><td class="n">213</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">2</td>
+</tr>
+<tr><td>Space Marines</td><td class="n">214</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+</tr>
+<tr><td>Tyranids</td><td class="n">110</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">1</td>
+<td class="n">·</td>
+<td class="n">·</td>
+<td class="n has">2</td>
+</tr>
+</tbody></table></div>
+<h2>Where good players disagree</h2>
+<p class="dfn">Recorded rather than smoothed over. Where a disagreement has a resolving variable, it is named.</p>
+<div class="note"><h3>How much of the army to place in Strategic Reserves</h3><ul>
+<li>Keep at least one unit in reserve as a reactive answer / Rapid Ingress threat (40K Dirtbags, Enm67qaqHkU 04:00; Art of War 40k, ym0SnzF2ydg 162:00)</li>
+<li>Against high-pressure lists put nothing in reserve — you need every body on the table to hold the mid-board (Happy Krumping, pAk1YiuioNQ 09:00)</li>
+<li>Reserves are unnecessary when the army has a redeploy ability instead (Deploy on the Line 40K, gZWxrJy66nw 12:00)</li>
+</ul><p class="dfn" style="margin:12px 0 0">Not a contradiction so much as an unstated conditional: the resolving variable is the opponent&#x27;s turn-one threat range, which the AI can compute. Encoded that way in F014 rather than picking a side.</p></div>
+<div class="note"><h3>Whether the Disruption disposition is playable</h3><ul>
+<li>Disruption scores poorly, which frees you to ignore scoring and just kill (Happy Krumping, pAk1YiuioNQ 70:00)</li>
+<li>Disruption sucks, people know it&#x27;s awful (Deploy on the Line 40K, 14LSO7MS3QI 85:00)</li>
+<li>Disruption rewards movement and positioning and is about interfering with the opponent&#x27;s plan (Warpbane Tactics, ogMKXBVh4g0 02:00)</li>
+</ul><p class="dfn" style="margin:12px 0 0">Tournament data in the corpus (Warp Friends, PShNfK_IJAA 21:00) shows factions posting notably higher win rates INTO Disruption, supporting the &#x27;weak disposition&#x27; read. The AI should not be tuned to Disruption as a baseline.</p></div>
+<div class="note"><h3>Whether 11e Overwatch is oppressive or merely strong</h3><ul>
+<li>You can&#x27;t play around it any more — big squads just get overwatched (Deploy on the Line 40K, FT5JoL5Myis 05:00)</li>
+<li>It hits on sixes; it&#x27;s not &#x27;giga crazy&#x27; unless the volume is there (TacticalTortoise 40k, VqwMdS9MuIY 127:00)</li>
+</ul><p class="dfn" style="margin:12px 0 0">Both are consistent with the rule: snap shooting punishes volume/torrent shooters and is weak for elite guns. The AI&#x27;s exposure penalty should therefore scale with the watching unit&#x27;s shot count, not its damage quality — reflected in F004.</p></div>
+<div class="note"><h3>Whether World Eaters should still play maximum aggression in 11e</h3><ul>
+<li>11e removed the need to push everything onto objectives; hold home, take a couple of bricks, do actions (Exile Wargaming, mbNWzDn6Pu4 34:00)</li>
+<li>The faction&#x27;s identity and detachments remain melee-compulsion oriented (Tactical Sugar, uizU0NPlR14 10:00; WednesdayNightWarhammer, zVx7smZIRf0 04:00)</li>
+</ul><p class="dfn" style="margin:12px 0 0">The corpus does not support FACTION_AGGRESSION_WORLD_EATERS = 2.0 as a well-evidenced value — it is the highest constant in the file and rests on no corpus evidence at all. Flagged in gaps rather than changed.</p></div>
+<h2>What this corpus does not tell you</h2>
+<div class="note"><ul>
+<li>Necrons (101 transcripts, 56 in-title) yielded no high-confidence differentiated finding. Coverage is heavy but almost entirely list-review and battle-report play-by-play; the reanimation-vs-trade reasoning the AI would need is never stated explicitly. This is the largest coverage-to-findings gap in the corpus.</li>
+<li>World Eaters (58 transcripts): only one channel makes a decision-shaped claim, and it argues AGAINST the blanket aggression the code already encodes. No profile emitted; FACTION_AGGRESSION_WORLD_EATERS = 2.0 should be treated as unevidenced.</li>
+<li>Leagues of Votann (47 transcripts, 16 in-title): the judgement-token search returned zero hits in the title-attributed pool. Either the mechanic changed in 11e or the corpus does not discuss it — unresolved.</li>
+<li>Aeldari (50), Thousand Sons (48), Chaos Knights (43), Emperor&#x27;s Children (43): present in volume but discussion is list-composition and datasheet review, not decision reasoning. No actionable finding extracted.</li>
+<li>Adepta Sororitas (9), Agents of the Imperium (6), Ynnari (4), Harlequins (10): too thin to attribute anything safely.</li>
+<li>Imperial Knights and Chaos Knights: one channel notes they must pay CP to shoot and act in the same turn (Recon By Fire, 42CPnCfuCN8 01:00), which implies a distinctive action-economy problem for low-unit-count armies. Single-source, so recorded here rather than as a finding.</li>
+<li>The corpus is competitive/tournament-skewed and post-dates the late-July 2026 balance dataslate for only part of its range. Faction findings drawn on June/early-July material may already be stale; each finding&#x27;s evidence dates are given so this can be re-checked.</li>
+<li>Deployment as a decision (where to place units before turn one) is discussed constantly but almost always in terms of a specific board and layout, which does not generalise into a weight. No deployment finding survived.</li>
+<li>Secondary mission selection and discard is barely reasoned about on camera despite being a per-turn decision the AI makes; the SECONDARY_* constants have no corpus support either way.</li>
+</ul></div>
+<footer>Mined from auto-generated captions, so unit and army names are frequently mangled — no finding is assigned to an army on a single mis-hearable mention. Quotes are verbatim from the captions, including their errors. Rules claims were checked against the 11th-edition core rules; claims that are players&rsquo; judgement rather than rules are labelled as such. The corpus skews competitive and is a broad sweep, not a census.</footer>
+</div>
+<script>
+(function(){
+  var D='all', F='all';
+  function apply(){
+    var shown={};
+    document.querySelectorAll('article[data-d]').forEach(function(a){
+      var ok=(D==='all'||a.dataset.d===D)&&(F==='all'||a.dataset.f===F);
+      a.hidden=!ok; if(ok){shown[a.dataset.d]=(shown[a.dataset.d]||0)+1;}
+    });
+    var any=false;
+    document.querySelectorAll('section[data-d]').forEach(function(s){
+      var n=shown[s.dataset.d]||0; s.hidden=!n; if(n)any=true;
+      var c=s.querySelector('.n'); if(c)c.textContent=n===1?'1 finding':n+' findings';
+    });
+    document.getElementById('empty').hidden=any;
+  }
+  document.addEventListener('click',function(e){
+    var b=e.target.closest('button[data-k]'); if(!b)return;
+    var k=b.dataset.k, v=b.dataset.v;
+    if(k==='d'){D=v;} else if(k==='f'){F=v;} else if(k==='theme'){
+      var r=document.documentElement;
+      var cur=r.dataset.theme||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+      r.dataset.theme=cur==='dark'?'light':'dark'; return;
+    }
+    document.querySelectorAll('button[data-k="'+k+'"]').forEach(function(o){
+      o.setAttribute('aria-pressed', o.dataset.v===v?'true':'false');
+    });
+    apply();
+  });
+  apply();
+})();
+</script>

--- a/research/youtube/ai_learnings.json
+++ b/research/youtube/ai_learnings.json
@@ -1,0 +1,1750 @@
+{
+  "generated": "2026-08-05",
+  "corpus": {
+    "transcripts": 1029,
+    "channels": 90,
+    "date_range": "2026-04-04 to 2026-08-04 (68 transcripts carry no date field)",
+    "words": 10510642,
+    "note": "Auto-captioned (1027/1029). Heavily skewed to competitive/tournament content: 414 transcripts tagged Meta, 334 Batreps. 11th edition released June 2026, so ~92% of the corpus is June-August 2026 and post-dates the first big balance dataslate (late July 2026)."
+  },
+  "taxonomy": {
+    "decisions": [
+      {
+        "name": "positioning_and_concealment",
+        "definition": "Where a unit physically stands: what it can see, what can see it, what terrain state it ends its move in, and what that costs or buys.",
+        "finding_count": 5
+      },
+      {
+        "name": "screening_and_zoning",
+        "definition": "Using bodies to deny space — blocking deep strike arrival, blocking charge lanes, and blocking physical movement paths.",
+        "finding_count": 5
+      },
+      {
+        "name": "target_selection",
+        "definition": "Given a set of legal targets, which one to shoot or fight, and how much to commit to it.",
+        "finding_count": 5
+      },
+      {
+        "name": "objective_trade",
+        "definition": "Whether to take, hold, contest, or give up an objective, and what that is worth relative to killing something.",
+        "finding_count": 4
+      },
+      {
+        "name": "attrition_and_trades",
+        "definition": "Whether a unit's likely loss is acceptable for what it buys.",
+        "finding_count": 1
+      },
+      {
+        "name": "reserves_and_arrival",
+        "definition": "What to hold off the table, and when to bring it on.",
+        "finding_count": 2
+      },
+      {
+        "name": "melee_commitment",
+        "definition": "Whether to charge, what to charge, and what a charge is for when it is not for damage.",
+        "finding_count": 2
+      },
+      {
+        "name": "disengage_and_lock",
+        "definition": "Whether to fall back out of an engagement, or deliberately stay in one to deny the enemy its shooting.",
+        "finding_count": 2
+      },
+      {
+        "name": "ability_timing",
+        "definition": "When to fire a once-per-battle or once-per-turn army ability, stratagem, or command resource.",
+        "finding_count": 3
+      },
+      {
+        "name": "action_economy",
+        "definition": "Which unit spends its turn performing a mission action rather than fighting.",
+        "finding_count": 1
+      },
+      {
+        "name": "tempo_and_commitment",
+        "definition": "Which battle round to commit the army, and how much to hold back.",
+        "finding_count": 1
+      },
+      {
+        "name": "deployment",
+        "definition": "Where the army starts, and how that is shaped by what the opponent has put down.",
+        "finding_count": 0
+      }
+    ],
+    "factions": [
+      {
+        "name": "general",
+        "transcript_count": 1029,
+        "finding_count": 22
+      },
+      {
+        "name": "Orks",
+        "transcript_count": 213,
+        "finding_count": 2
+      },
+      {
+        "name": "Tyranids",
+        "transcript_count": 110,
+        "finding_count": 2
+      },
+      {
+        "name": "Space Marines",
+        "transcript_count": 214,
+        "finding_count": 1
+      },
+      {
+        "name": "Death Guard",
+        "transcript_count": 79,
+        "finding_count": 1
+      },
+      {
+        "name": "Grey Knights",
+        "transcript_count": 60,
+        "finding_count": 1
+      },
+      {
+        "name": "Adeptus Custodes",
+        "transcript_count": 54,
+        "finding_count": 1
+      },
+      {
+        "name": "Drukhari",
+        "transcript_count": 46,
+        "finding_count": 1
+      },
+      {
+        "name": "Necrons",
+        "transcript_count": 101,
+        "finding_count": 0
+      },
+      {
+        "name": "Dark Angels",
+        "transcript_count": 86,
+        "finding_count": 0
+      },
+      {
+        "name": "Chaos Space Marines",
+        "transcript_count": 65,
+        "finding_count": 0
+      },
+      {
+        "name": "T'au Empire",
+        "transcript_count": 65,
+        "finding_count": 0
+      },
+      {
+        "name": "World Eaters",
+        "transcript_count": 58,
+        "finding_count": 0
+      },
+      {
+        "name": "Blood Angels",
+        "transcript_count": 58,
+        "finding_count": 0
+      },
+      {
+        "name": "Space Wolves",
+        "transcript_count": 51,
+        "finding_count": 0
+      },
+      {
+        "name": "Aeldari",
+        "transcript_count": 50,
+        "finding_count": 0
+      },
+      {
+        "name": "Thousand Sons",
+        "transcript_count": 48,
+        "finding_count": 0
+      },
+      {
+        "name": "Leagues of Votann",
+        "transcript_count": 47,
+        "finding_count": 0
+      },
+      {
+        "name": "Chaos Knights",
+        "transcript_count": 43,
+        "finding_count": 0
+      },
+      {
+        "name": "Emperor's Children",
+        "transcript_count": 43,
+        "finding_count": 0
+      },
+      {
+        "name": "Genestealer Cults",
+        "transcript_count": 34,
+        "finding_count": 0
+      },
+      {
+        "name": "Astra Militarum",
+        "transcript_count": 32,
+        "finding_count": 0
+      },
+      {
+        "name": "Imperial Knights",
+        "transcript_count": 32,
+        "finding_count": 0
+      },
+      {
+        "name": "Adeptus Mechanicus",
+        "transcript_count": 31,
+        "finding_count": 0
+      },
+      {
+        "name": "Black Templars",
+        "transcript_count": 22,
+        "finding_count": 0
+      },
+      {
+        "name": "Deathwatch",
+        "transcript_count": 18,
+        "finding_count": 0
+      },
+      {
+        "name": "Chaos Daemons",
+        "transcript_count": 15,
+        "finding_count": 0
+      },
+      {
+        "name": "Harlequins",
+        "transcript_count": 10,
+        "finding_count": 0
+      },
+      {
+        "name": "Adepta Sororitas",
+        "transcript_count": 9,
+        "finding_count": 0
+      },
+      {
+        "name": "Agents of the Imperium",
+        "transcript_count": 6,
+        "finding_count": 0
+      },
+      {
+        "name": "Ynnari",
+        "transcript_count": 4,
+        "finding_count": 0
+      }
+    ],
+    "matrix": {
+      "positioning_and_concealment": {
+        "general": 5
+      },
+      "target_selection": {
+        "general": 5
+      },
+      "screening_and_zoning": {
+        "general": 3,
+        "Orks": 1,
+        "Tyranids": 1
+      },
+      "objective_trade": {
+        "general": 2,
+        "Adeptus Custodes": 1,
+        "Grey Knights": 1
+      },
+      "reserves_and_arrival": {
+        "general": 2
+      },
+      "melee_commitment": {
+        "general": 2
+      },
+      "disengage_and_lock": {
+        "general": 1,
+        "Death Guard": 1
+      },
+      "action_economy": {
+        "general": 1
+      },
+      "tempo_and_commitment": {
+        "general": 1
+      },
+      "ability_timing": {
+        "Orks": 1,
+        "Tyranids": 1,
+        "Space Marines": 1
+      },
+      "attrition_and_trades": {
+        "Drukhari": 1
+      }
+    }
+  },
+  "findings": [
+    {
+      "decision": "positioning_and_concealment",
+      "faction": "general",
+      "claim": "Infantry should end movement inside dense terrain so they gain Hidden, which makes them untargetable beyond 15\" (12\" when the shooter's view is broken by dense terrain).",
+      "detail": "11e's Hidden rule (core rules 13.09) gives INFANTRY/BEASTS/SWARM in a dense terrain area a detection range — enemies further away simply cannot target them, regardless of line of sight. Good players treat 'get to hidden 12' as the primary movement objective for infantry in the first two rounds, because it converts an entire enemy shooting phase into nothing. The 3\" reduction for being obscured by dense terrain is deliberately farmed, not incidental.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "0Gcpze1G4Lc",
+          "timestamp": "10:00",
+          "url": "https://youtube.com/watch?v=0Gcpze1G4Lc&t=600s",
+          "quote": "I try and get that dense cover for the hidden 12 ... How fast can I get to hidden 12"
+        },
+        {
+          "channel": "Happy Krumping",
+          "video_id": "SkaqF6vbCYA",
+          "timestamp": "12:00",
+          "url": "https://youtube.com/watch?v=SkaqF6vbCYA&t=720s",
+          "quote": "elite infantry is incredibly powerful, making use of the hidden rule ... can't be targeted outside of 15 or 12"
+        },
+        {
+          "channel": "Tabletop Titans",
+          "video_id": "dPFfT2IIlME",
+          "timestamp": "15:00",
+          "url": "https://youtube.com/watch?v=dPFfT2IIlME&t=900s",
+          "quote": "if you want to be a shooting army right now ... you have to be able to get within hidden range quickly"
+        },
+        {
+          "channel": "Planet 40K",
+          "video_id": "HQ0sQa37uHA",
+          "timestamp": "13:00",
+          "url": "https://youtube.com/watch?v=HQ0sQa37uHA&t=780s",
+          "quote": "as it's a monster, you're not going to be getting the hidden keyword"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "_score_movement_destination (movement scoring) — new WEIGHT_HIDDEN_GAINED constant",
+        "current_behaviour": "AIDecisionMaker.gd contains zero references to 'hidden' (grep -ci hidden = 0), while RulesEngine.gd fully implements 13.09 (hidden_model_visible_to, TerrainManager.detection_range_inches_for, 15\" base minus a 3\" dense penalty). The AI therefore benefits from Hidden only by accident when a destination happens to be in terrain.",
+        "suggested_change": "Add a movement-destination bonus (start ~4.0, comparable to SECONDARY_POSITIONAL_BONUS 4.0) when the destination puts an INFANTRY/BEASTS/SWARM unit inside a dense terrain area and the unit has not shot this turn. Scale by how many enemy units are further than the detection range returned by TerrainManager.detection_range_inches_for — a Hidden position that hides from nothing is worth nothing.",
+        "risk": "Over-weighting drags infantry into terrain and off objectives; Hidden does not stop charges or blast/indirect, so a Hidden unit can still be run down. Gate it against the objective VP estimator so it never outbids a scoring move."
+      },
+      "priority": "high",
+      "id": "F001",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "positioning_and_concealment",
+      "faction": "general",
+      "claim": "Shooting surrenders Hidden for this turn and the next, so a unit that cannot meaningfully hurt anything should hold its fire and stay untargetable.",
+      "detail": "Hidden requires that the unit made no ranged attacks this turn or last turn, so pulling the trigger is a two-turn commitment to being shootable. Players explicitly weigh a marginal shooting phase against a turn of immunity, and will decline shots with backfield or objective-holding infantry to keep the state. This is a genuine per-unit decision every shooting phase, not a list-building consideration.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Zeeto",
+          "video_id": "TJQWtTZiP1g",
+          "timestamp": "58:00",
+          "url": "https://youtube.com/watch?v=TJQWtTZiP1g&t=3480s",
+          "quote": "as soon as you give up hidden, you shoot a ball across the map ... you've got the 15 inch hidden anyway"
+        },
+        {
+          "channel": "Mid Table Tactics",
+          "video_id": "k-IMme1pngY",
+          "timestamp": "42:00",
+          "url": "https://youtube.com/watch?v=k-IMme1pngY&t=2520s",
+          "quote": "They're not going to be hidden though because they are probably going to shoot"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "VqwMdS9MuIY",
+          "timestamp": "186:00",
+          "url": "https://youtube.com/watch?v=VqwMdS9MuIY&t=11160s",
+          "quote": "I'm hidden in the line like this cuz I just got to shoot there ... not hidden cuz they're shooting"
+        },
+        {
+          "channel": "Proxy Hammer",
+          "video_id": "f_z0hvW0VMk",
+          "timestamp": "49:00",
+          "url": "https://youtube.com/watch?v=f_z0hvW0VMk&t=2940s",
+          "quote": "you don't have to move out into the open ... remain hidden even while shooting"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "shooting-phase target scoring — new HIDDEN_FORFEIT_PENALTY constant",
+        "current_behaviour": "The AI shoots whenever a legal shooting action scores above zero. It has no concept of a non-damage cost to firing, so it will trade two turns of untargetability for one low-value shooting action.",
+        "suggested_change": "When the shooter is currently Hidden, subtract a penalty from every shooting assignment for that unit — scale it by how many enemy units are outside detection range (i.e. how much immunity is being sold). Suggested start: 3.0, so the unit still fires when the expected damage is real but declines chip shots.",
+        "risk": "An over-large penalty produces a passive gunline that never shoots. The penalty must be zero for units that already shot this turn (Hidden is already lost) and for units with a 'remain hidden while shooting' ability."
+      },
+      "priority": "high",
+      "id": "F002",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "target_selection",
+      "faction": "general",
+      "claim": "Enemy infantry that is about to regain Hidden should be shot this turn, because next turn it may be untargetable.",
+      "detail": "Hidden returns once a unit goes a full turn without shooting, so an enemy unit that fired last turn but not this one is on a timer. Players consciously reprioritise onto those units while the window is open, rather than picking the highest-value target and finding it unshootable next turn. This is the mirror image of the decision to hold fire.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Boltgun Tactics",
+          "video_id": "gRQZh-QYBIQ",
+          "timestamp": "20:00",
+          "url": "https://youtube.com/watch?v=gRQZh-QYBIQ&t=1200s",
+          "quote": "I'm not going to shoot the raptors cuz they might get hidden um if I don't shoot"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "07:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=420s",
+          "quote": "these guys won't be able to shoot me turn one if everybody's hidden"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "_calculate_target_value — new HIDDEN_WINDOW_BONUS",
+        "current_behaviour": "Target value is computed from points, output, survivability and objective presence. Availability is treated as binary and permanent: there is no notion of a target that is legal now and illegal later.",
+        "suggested_change": "Multiply target value by ~1.25 when the target is an INFANTRY/BEASTS/SWARM unit standing in dense terrain that did not make ranged attacks this turn — it will be Hidden on the opponent's next turn. Read the same flags RulesEngine uses for 13.09.",
+        "risk": "Chasing the window can pull fire off a genuinely more dangerous target. Keep the multiplier modest so it breaks ties rather than overriding threat."
+      },
+      "priority": "medium",
+      "id": "F003",
+      "differs_from_general": null,
+      "corroborating_channels": 2
+    },
+    {
+      "decision": "positioning_and_concealment",
+      "faction": "general",
+      "claim": "Every move into enemy line of sight is taxed by Overwatch, which in 11e fires at the end of the opponent's Movement phase and can no longer be baited out with a single expendable model.",
+      "detail": "Overwatch moved to the end of the opponent's Movement phase and uses snap shooting (hits only on unmodified 6s, no re-rolls). Because the defender now watches the whole movement phase resolve before choosing a target, the old trick of pushing one cheap model out to draw the shot is dead — the defender simply waits and picks the best target. Players describe this as having to declare their whole movement plan to the opponent before paying for it.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Vanguard Tactics",
+          "video_id": "qahZnQPN8a8",
+          "timestamp": "27:00",
+          "url": "https://youtube.com/watch?v=qahZnQPN8a8&t=1620s",
+          "quote": "Overwatch is so powerful in this game now because you can't ... put one model out ... you can't bait them out anymore"
+        },
+        {
+          "channel": "StrikingScorpion82",
+          "video_id": "eUpeWbN7gF4",
+          "timestamp": "28:00",
+          "url": "https://youtube.com/watch?v=eUpeWbN7gF4&t=1680s",
+          "quote": "overwatch is done at the end of the opponent's movement phase ... it's a decision we can make uh once movement's done"
+        },
+        {
+          "channel": "Deploy on the Line 40K",
+          "video_id": "FT5JoL5Myis",
+          "timestamp": "05:00",
+          "url": "https://youtube.com/watch?v=FT5JoL5Myis&t=300s",
+          "quote": "it's just too easy to overwatch in 11th edition. You can't play around it anymore with these big squads"
+        },
+        {
+          "channel": "6 Plus Plus Gaming",
+          "video_id": "uKl8cEJlk0c",
+          "timestamp": "27:00",
+          "url": "https://youtube.com/watch?v=uKl8cEJlk0c&t=1620s",
+          "quote": "with how Overwatch is now, that's really really powerful to have a reactive move"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "THREAT_SHOOTING_PENALTY (currently 0.5)",
+        "current_behaviour": "THREAT_SHOOTING_PENALTY is 0.5 and commented 'Lighter penalty for moving into shooting range (reduced from 1.0 — often unavoidable)'. That reasoning was written for a shooting phase the mover could answer; 11e Overwatch is paid inside the mover's own turn, before it acts.",
+        "suggested_change": "Raise THREAT_SHOOTING_PENALTY to ~1.0 and add a separate OVERWATCH_EXPOSURE_PENALTY applied only when the destination is visible to an enemy unit that has not yet used Fire Overwatch this round, weighted by that unit's raw shot volume (snap shooting rewards volume and torrent, not quality). Do not apply it to destinations already inside enemy line of sight before the move.",
+        "risk": "Too high and the AI refuses to cross the board at all, which loses on primary. The penalty should be suppressed for melee-archetype units (they already discount threat via THREAT_MELEE_UNIT_IGNORE) and in rounds 4-5."
+      },
+      "priority": "high",
+      "id": "F004",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "positioning_and_concealment",
+      "faction": "general",
+      "claim": "The default opening is to stage the army out of line of sight behind mid-board terrain and physically occupy the staging point the opponent wants.",
+      "detail": "Because shooting is punishing and Hidden is available, the first-turn move is usually to get behind the centre ruin rather than onto the mid-board objectives. The refinement is that the terrain piece is a contested resource: putting bodies against it denies the opponent the same protection, so the move is simultaneously defensive and a denial play.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Fireside",
+          "video_id": "-Bh3n-_Tpfs",
+          "timestamp": "61:00",
+          "url": "https://youtube.com/watch?v=-Bh3n-_Tpfs&t=3660s",
+          "quote": "move block your opponent from touching the middle ruin and staging your army behind it"
+        },
+        {
+          "channel": "Master Crafted",
+          "video_id": "6Lgr1hUGsgw",
+          "timestamp": "14:00",
+          "url": "https://youtube.com/watch?v=6Lgr1hUGsgw&t=840s",
+          "quote": "we're behind it, we're hidden, they can't see us, but at least we know that we're taking up the space"
+        },
+        {
+          "channel": "Play On Tabletop",
+          "video_id": "1SRkN4Drhs4",
+          "timestamp": "18:00",
+          "url": "https://youtube.com/watch?v=1SRkN4Drhs4&t=1080s",
+          "quote": "my jumpack intercessors will move to stage behind this terrain ... I just don't want to be shot"
+        },
+        {
+          "channel": "Auspex Tactics",
+          "video_id": "mX7VBM9qJjY",
+          "timestamp": "07:00",
+          "url": "https://youtube.com/watch?v=mX7VBM9qJjY&t=420s",
+          "quote": "staged as far forward as possible but out of line of sight"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_POSITION_RATIO (0.55)",
+        "current_behaviour": "Corridor blocking already exists but is keyed to objectives — it places blockers 55% of the way from an objective toward a threatening enemy. It has no notion of terrain pieces as the thing worth denying.",
+        "suggested_change": "Extend the corridor-block candidate set with the mid-board dense terrain areas TerrainManager already exposes, scoring a blocking position that both breaks enemy line of sight to our army and sits against the terrain the enemy would otherwise stage in. Reuse CORRIDOR_BLOCK_SCORE_BASE so the two compete on one scale.",
+        "risk": "Terrain-hugging can strand units away from scoring positions in rounds 4-5, where STRATEGY_LATE_OBJECTIVE (1.6) should dominate. Gate to rounds 1-2."
+      },
+      "priority": "medium",
+      "id": "F005",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "screening_and_zoning",
+      "faction": "general",
+      "claim": "A screen is defined by the gaps between its models relative to the enemy's base size, not by the unit's overall position — gaps must be too narrow for an enemy base to pass through while staying more than 1\" away.",
+      "detail": "Models cannot move within Engagement Range of enemies during a normal move, so two screening models placed a base-width-plus-2\" apart form a wall; placed wider, they are decoration. Players talk in terms of the specific enemy base they are screening against (32mm, 2\"), and losing a game to a single unplanned gap is a recurring post-mortem. Consolidation compounds the error: a model that squeezes through kills the screen and then consolidates into whatever was behind it.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "6 Plus Plus Gaming",
+          "video_id": "gRqdSBkqVlA",
+          "timestamp": "22:00",
+          "url": "https://youtube.com/watch?v=gRqdSBkqVlA&t=1320s",
+          "quote": "What I didn't think of was leaving gaps between my models to screen a 32 mil base"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "VqwMdS9MuIY",
+          "timestamp": "514:00",
+          "url": "https://youtube.com/watch?v=VqwMdS9MuIY&t=30840s",
+          "quote": "create a gap that is less than 1 in between all of those models ... will prevent any orc model from going through"
+        },
+        {
+          "channel": "Proxy Hammer",
+          "video_id": "xFGyuYmXyJY",
+          "timestamp": "10:00",
+          "url": "https://youtube.com/watch?v=xFGyuYmXyJY&t=600s",
+          "quote": "you can have a little bit of space in between your models that they won't be able to actually fit through"
+        },
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "VPTL092E0VI",
+          "timestamp": "13:00",
+          "url": "https://youtube.com/watch?v=VPTL092E0VI&t=780s",
+          "quote": "The amount of times that I have tried to screen and there's a tiny hole"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "screening placement (SCREEN_SCORE_BASE path) — new SCREEN_MODEL_GAP logic",
+        "current_behaviour": "Screening is scored at unit granularity: SCREEN_SPACING_PX (18\") spaces whole screening units, and AI_B2B_GAP_PX (0.5px) is only used for base-to-base packing. Nothing checks whether the resulting model line has a passable gap.",
+        "suggested_change": "When laying out a unit flagged as a screener, cap inter-model spacing at (largest enemy base diameter + 2\") and validate the finished line against the widest enemy base on the board. Expose the cap as SCREEN_MAX_MODEL_GAP_PX so it is tunable per profile.",
+        "risk": "Tight spacing shortens the screen, so fewer inches are covered per unit and blast weapons get better value. It also interacts with unit coherency — the layout must still satisfy coherency after casualties."
+      },
+      "priority": "high",
+      "id": "F006",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "screening_and_zoning",
+      "faction": "general",
+      "claim": "Deep-strike denial must use the arriving unit's own minimum distance, because 6\" deep strike is common in 11e and a 9\"-spaced screen does not stop it.",
+      "detail": "Numerous 11e detachments and enhancements grant deep strike at 6\" rather than the core 9\", and players describe having to screen 'really aggressively' as a result. Denial geometry is the sum of two radii: to deny a 9\" arrival, screeners must be within 18\" of each other; to deny a 6\" arrival, within 12\". Using one fixed number under-screens against exactly the units most able to punish it.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Odyssey40k",
+          "video_id": "uYFHWwWSklU",
+          "timestamp": "87:00",
+          "url": "https://youtube.com/watch?v=uYFHWwWSklU&t=5220s",
+          "quote": "there's a 6-in deep strike in retaliation ... you have to screen really aggressively for it"
+        },
+        {
+          "channel": "Tactical Sugar",
+          "video_id": "SyVxk7EW_tI",
+          "timestamp": "132:00",
+          "url": "https://youtube.com/watch?v=SyVxk7EW_tI&t=7920s",
+          "quote": "it's so much harder screen out now in 11th and deep strikes are so much more important in 11th"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "nGqRAvAMTYA",
+          "timestamp": "66:00",
+          "url": "https://youtube.com/watch?v=nGqRAvAMTYA&t=3960s",
+          "quote": "He also can 6 in deep strike high OC onto an objective in order to grab it"
+        },
+        {
+          "channel": "The Tabletop Alliance 40K",
+          "video_id": "8_HAdKldvhs",
+          "timestamp": "20:00",
+          "url": "https://youtube.com/watch?v=8_HAdKldvhs&t=1200s",
+          "quote": "What do you have in reserve? Screamers ... 6 in deep strike now"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "DEEP_STRIKE_DENIAL_RANGE_PX (360.0 = 9\") and SCREEN_SPACING_PX (720.0 = 18\")",
+        "current_behaviour": "Both constants are hardcoded to the core-rules 9\" case. _find_screening_positions steps the board every SCREEN_SPACING_PX and treats any point further than DEEP_STRIKE_DENIAL_RANGE_PX from a friendly model as deniable.",
+        "suggested_change": "Derive the radius per threat: scan enemy units still in reserve for a deep-strike ability naming a distance, take the minimum across them, and use 2x that as the screen spacing for this game. Keep the current values as the fallback when no reserve unit advertises a shorter range.",
+        "risk": "A 12\" spacing needs ~50% more screening bodies to cover the same frontage; on low-model armies this will starve objectives. Pair with a cap on how many units may take screening assignments."
+      },
+      "priority": "high",
+      "id": "F007",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "target_selection",
+      "faction": "general",
+      "claim": "Clearing enemy screens is worth more than the screen's points, because the screen is what stops the rest of the army from scoring or charging.",
+      "detail": "Players routinely commit an expensive unit to kill a cheap one and describe it as a good decision, because the cheap unit is denying a charge lane, an objective, or a deep-strike landing zone. Points-per-wound efficiency scores this as a bad trade; the players' framing is that the screen's value is the value of everything it is blocking. The counterweight they also state is not to use your best melee unit on chaff when a cheaper one will do.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "VqwMdS9MuIY",
+          "timestamp": "62:00",
+          "url": "https://youtube.com/watch?v=VqwMdS9MuIY&t=3720s",
+          "quote": "it's absolutely worth a genailer squad to eviscerate one of those ranger squads even though it's a trade down"
+        },
+        {
+          "channel": "40K Fireside",
+          "video_id": "_xKjN6N1jT0",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=_xKjN6N1jT0&t=240s",
+          "quote": "you need to kill like I don't know, 10 guardsmen move blocking your big charges"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "7AgzQIEq3j4",
+          "timestamp": "93:00",
+          "url": "https://youtube.com/watch?v=7AgzQIEq3j4&t=5580s",
+          "quote": "you can clear screening units and infiltrators ... have to run 20 possessed into ... 10 commandos"
+        },
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "D5XVd0FRgK8",
+          "timestamp": "02:00",
+          "url": "https://youtube.com/watch?v=D5XVd0FRgK8&t=120s",
+          "quote": "unit left alive on one wood can still hold an objective, block our movement ... That is why finis"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "TRADE_PPW_WEIGHT (0.25) / TRADE_UNFAVORABLE_PENALTY (0.7)",
+        "current_behaviour": "Trade analysis penalises killing cheap units with expensive ones (TRADE_UNFAVORABLE_PENALTY 0.7), and is gated to Competitive difficulty only (use_trade_analysis). A screening unit is scored as its points and output, so it looks like a bad target.",
+        "suggested_change": "Add a positional-value term to _calculate_target_value: if the target is currently inside our own screening-denial evaluation (it is blocking a charge lane, sitting in a deep-strike landing zone we want, or contesting an objective our VP estimator prices), suppress the TRADE_UNFAVORABLE_PENALTY for that target rather than adding raw score. Suppression, not a bonus, keeps the existing scale intact.",
+        "risk": "Suppressing the penalty too broadly recreates the pre-trade-analysis behaviour of shooting lascannons at Grots. It must key off an explicit blocking role, not off cheapness."
+      },
+      "priority": "high",
+      "id": "F008",
+      "differs_from_general": null,
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "target_selection",
+      "faction": "general",
+      "claim": "Battle-shocking a unit strips its Objective Control to zero, so an objective can be flipped without killing anything.",
+      "detail": "A battle-shocked unit's models have OC '-', cannot be targeted by stratagems and cannot start actions. Players describe whole lists built around it ('battleshock OC denial') and use forced battle-shock tests specifically to deny a primary score in the opponent's command phase. Against durable objective-holders this is far cheaper than killing them, and it is the counter to armies that ignore attrition.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Zeeto",
+          "video_id": "TJQWtTZiP1g",
+          "timestamp": "02:00",
+          "url": "https://youtube.com/watch?v=TJQWtTZiP1g&t=120s",
+          "quote": "That sort of Battleshock um OC denial sort of list ... would probably work well in teams"
+        },
+        {
+          "channel": "6 Plus Plus Gaming",
+          "video_id": "eokQteHr0Fo",
+          "timestamp": "19:00",
+          "url": "https://youtube.com/watch?v=eokQteHr0Fo&t=1140s",
+          "quote": "if you really need them to not have a secondary uh primary point ... it's a really powerful strategy"
+        },
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "qwnHaQvzCq0",
+          "timestamp": "14:00",
+          "url": "https://youtube.com/watch?v=qwnHaQvzCq0&t=840s",
+          "quote": "If you Battle Shock me, I go to 1 OC instead of 0"
+        },
+        {
+          "channel": "The Six Machine",
+          "video_id": "ewxyBDMvC64",
+          "timestamp": "23:00",
+          "url": "https://youtube.com/watch?v=ewxyBDMvC64&t=1380s",
+          "quote": "it is more likely that you will get battleshocked and potentially stay battleshocked"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "objective contest evaluation + battle-shock-inflicting ability/stratagem scoring",
+        "current_behaviour": "The AI reads the battle_shocked flag defensively (it un-shocks its own units via 'Da Captain', and skips shocked enemies in some checks) but never evaluates inflicting battle-shock as a route to controlling an objective. Objective contest is computed from raw OC only.",
+        "suggested_change": "When scoring an ability or stratagem that forces a battle-shock test, add the VP the objective would be worth if the target's OC went to zero — reuse _estimate_objective_vp_value with the target's OC removed and score the delta. Same term should make a shocked enemy unit a lower-priority shooting target while it is shocked and already contributing nothing.",
+        "risk": "Battle-shock is a leadership roll and often fails; the score must be multiplied by the actual pass probability or the AI will spend CP on coin flips. It also lasts only until the next command phase, so it is worthless outside the scoring window."
+      },
+      "priority": "high",
+      "id": "F009",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "target_selection",
+      "faction": "general",
+      "claim": "Concentrate onto one target until it is destroyed rather than spreading damage; a unit left on one wound still holds objectives and blocks movement.",
+      "detail": "A surviving model retains full Objective Control and full blocking geometry, so partial damage buys almost nothing in a mission-scored edition. Players describe spreading fire as the specific mistake that cost them a game, and finishing targets as the corrective. This mostly corroborates what the AI already does, but the mechanism matters: the reason to finish is positional, not damage-economic.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "PWtaFLZYu_U",
+          "timestamp": "03:00",
+          "url": "https://youtube.com/watch?v=PWtaFLZYu_U&t=180s",
+          "quote": "spreading my damage across multiple units would have been a massive mistake. I focused on completely removing one unit at a time"
+        },
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "D5XVd0FRgK8",
+          "timestamp": "02:00",
+          "url": "https://youtube.com/watch?v=D5XVd0FRgK8&t=120s",
+          "quote": "unit left alive on one wood can still hold an objective, block our movement"
+        },
+        {
+          "channel": "Planet 40K",
+          "video_id": "lNn0zv_w8t8",
+          "timestamp": "05:00",
+          "url": "https://youtube.com/watch?v=lNn0zv_w8t8&t=300s",
+          "quote": "another bad priority target ... is just simply bad trades"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "MICRO_MARGINAL_KILL_BONUS (2.5) / MICRO_OVERKILL_DECAY (0.35) / OVERKILL_TOLERANCE (1.15)",
+        "current_behaviour": "Focus fire already exists at Normal+ and MICRO_MARGINAL_KILL_BONUS rewards the assignment that crosses the kill threshold. The weighting is damage-denominated, so a target holding an objective is not preferentially finished.",
+        "suggested_change": "Multiply MICRO_MARGINAL_KILL_BONUS by ~1.4 when the target currently contributes OC to an objective our VP estimator prices above zero, so finishing a scoring unit outbids starting on a fresh one.",
+        "risk": "Low. The main hazard is stacking with the disposition kill-pressure term and producing tunnel vision on one objective."
+      },
+      "priority": "medium",
+      "id": "F010",
+      "differs_from_general": null,
+      "corroborating_channels": 2
+    },
+    {
+      "decision": "objective_trade",
+      "faction": "general",
+      "claim": "Tabling the opponent is no longer a win condition in 11e; the AI should accept losing units it cannot save if the exchange keeps it ahead on primary.",
+      "detail": "Multiple channels contrast 11e with 10e explicitly: in 10e killing the opponent's army was a common route to victory, in 11e games are decided on accumulated primary and secondary VP with a 45-point primary cap. The practical consequence is that a durable army can lose the attrition war and still win, and an aggressive army that wins every fight can lose on points.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "MG546BN181w",
+          "timestamp": "47:00",
+          "url": "https://youtube.com/watch?v=MG546BN181w&t=2820s",
+          "quote": "You do not have to kill your opponent in 11th edition. A giant condition of winning was tableabling your opponent in 10th"
+        },
+        {
+          "channel": "Master Crafted",
+          "video_id": "9fuvetVLB3s",
+          "timestamp": "29:00",
+          "url": "https://youtube.com/watch?v=9fuvetVLB3s&t=1740s",
+          "quote": "they don't have to kill you. It's just going to take you five turns to kill their army and they're just going to keep scoring"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "EBJW0VDeT_Q",
+          "timestamp": "45:00",
+          "url": "https://youtube.com/watch?v=EBJW0VDeT_Q&t=2700s",
+          "quote": "win on primary by denying primary and stuff like that. It's really the only way to to win 40k"
+        },
+        {
+          "channel": "Deploy on the Line 40K",
+          "video_id": "VU4S_6e1NgE",
+          "timestamp": "24:00",
+          "url": "https://youtube.com/watch?v=VU4S_6e1NgE&t=1440s",
+          "quote": "you're just going to win on primary points as long as you don't burn out"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "STRATEGY_EARLY_AGGRESSION (1.3) / STRATEGY_EARLY_OBJECTIVE (0.95)",
+        "current_behaviour": "Rounds 1-2 boost kill-seeking 30% and hold objective weight just below full (0.95). The VP-denominated objective estimator already exists, so the framework is right, but the early-round modifiers still tilt toward damage.",
+        "suggested_change": "Bring STRATEGY_EARLY_AGGRESSION down toward 1.1 and STRATEGY_EARLY_OBJECTIVE up to 1.0, and A/B it the way orks_discipline_a.json A/B'd the Ork constant. Do not change the late modifiers — they already favour objectives.",
+        "risk": "Reduced early aggression can let an aggressive opponent establish the mid-board unopposed, which loses on primary for the opposite reason. This is a benchmark question, not a settled one — hence the profile arm rather than a constant edit."
+      },
+      "priority": "medium",
+      "id": "F011",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "objective_trade",
+      "faction": "general",
+      "claim": "The force disposition should modulate how much the AI values killing versus holding, not just which objectives it prices.",
+      "detail": "11e pairs each player's disposition deck against the opponent's, and the five dispositions reward very different behaviour: Purge the Foe pays for destroying units every turn, Take and Hold pays for straightforward objective control, Recon and Priority Assets pay for actions in specific places, and Disruption scores poorly overall — which players treat as licence to stop caring about scoring and simply attack. That last inversion is the clearest evidence that disposition should change aggression, not only objective pricing.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Happy Krumping",
+          "video_id": "pAk1YiuioNQ",
+          "timestamp": "70:00",
+          "url": "https://youtube.com/watch?v=pAk1YiuioNQ&t=4200s",
+          "quote": "disruption scores poorly, it kind of releases you to not have to worry about scoring ... you might as well just obliterate your opponents"
+        },
+        {
+          "channel": "Deploy on the Line 40K",
+          "video_id": "14LSO7MS3QI",
+          "timestamp": "85:00",
+          "url": "https://youtube.com/watch?v=14LSO7MS3QI&t=5100s",
+          "quote": "if they were taking recon they're just trying to kill people and say whatever you score your points later"
+        },
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "ogMKXBVh4g0",
+          "timestamp": "02:00",
+          "url": "https://youtube.com/watch?v=ogMKXBVh4g0&t=120s",
+          "quote": "Disruption is about interfering with your opponent's plans, it rewards movement, positioning"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "i7MkaccGXeA",
+          "timestamp": "25:00",
+          "url": "https://youtube.com/watch?v=i7MkaccGXeA&t=1500s",
+          "quote": "gives you points where you destroy enemies ... So it's a simply a race"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "_build_primary_awareness → feed kill_pressure into the aggression modifier stack",
+        "current_behaviour": "_build_primary_awareness already parses the player's own 11e primary card and sets objective_pressure, enemy_home_bonus, central_bonus and a boolean kill_pressure. objective_pressure feeds objective scoring, but kill_pressure is only recorded — it does not modify the aggression/charge-threshold modifiers.",
+        "suggested_change": "Multiply the aggression modifier by ~1.2 and the charge threshold by ~0.9 while awareness.kill_pressure is true, and apply the inverse when objective_pressure is high and kill_pressure false. This is a small change because the parsing already exists.",
+        "risk": "Double-counting: kill-based primary rules already raise the VP value of killing through the estimator, so a second multiplier can over-rotate. Cap the combined aggression modifier."
+      },
+      "priority": "medium",
+      "id": "F012",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "reserves_and_arrival",
+      "faction": "general",
+      "claim": "Keeping one unit in reserve as a reactive answer is standard, but committing the whole army to the table is correct against high-pressure lists — the corpus genuinely disagrees on how much to hold back.",
+      "detail": "One camp treats a reserve unit as a deliberate list slot: something held to answer whatever the opponent commits, or to Rapid Ingress into a gap. The other camp says that against lists which apply immediate pressure you need every body on the table from turn one, because arriving later means arriving after the mid-board is lost. Both are stated confidently by strong players; the resolving variable appears to be the opponent's speed, which the AI can measure.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=240s",
+          "quote": "at least one unit in reserves cuz you're making lists to have a reserve rapid ingress target"
+        },
+        {
+          "channel": "Art of War 40k",
+          "video_id": "ym0SnzF2ydg",
+          "timestamp": "162:00",
+          "url": "https://youtube.com/watch?v=ym0SnzF2ydg&t=9720s",
+          "quote": "maybe they should have just started the game in reserve so they could be a little bit more of a reactive answer"
+        },
+        {
+          "channel": "Happy Krumping",
+          "video_id": "pAk1YiuioNQ",
+          "timestamp": "09:00",
+          "url": "https://youtube.com/watch?v=pAk1YiuioNQ&t=540s",
+          "quote": "If you're ever going to play against it, don't start things in reserves. You need everything on the table"
+        },
+        {
+          "channel": "Deploy on the Line 40K",
+          "video_id": "gZWxrJy66nw",
+          "timestamp": "12:00",
+          "url": "https://youtube.com/watch?v=gZWxrJy66nw&t=720s",
+          "quote": "there's no reason to put anything in reserve because I have redeploy"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "_evaluate_reserves_declarations",
+        "current_behaviour": "Reserves selection puts melee-oriented and short-range deep-strike units into reserve up to the 50% points / 50% units cap, without reference to how fast the opponent's army is.",
+        "suggested_change": "Before declaring reserves, compute the opponent's effective turn-one threat range (max Move + Advance + charge across their deployed units, plus scout moves). Above a threshold (~20\"), reduce the reserve budget toward one unit; below it, keep the current behaviour. Expose the threshold as RESERVE_PRESSURE_THRESHOLD_INCHES.",
+        "risk": "Threat range is a crude proxy — an army can be fast and harmless. Getting it wrong in the aggressive direction leaves the AI with nothing in reserve against alpha strikes, which is the failure mode the second camp is warning about."
+      },
+      "priority": "medium",
+      "id": "F013",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "reserves_and_arrival",
+      "faction": "general",
+      "claim": "Reactive movement abilities are widespread enough in 11e that the AI cannot treat enemy positions as fixed between its own decisions.",
+      "detail": "Detachment rules, enhancements and stratagems across many factions grant a move triggered by an enemy action — being shot, or an enemy coming within a set distance. Players plan around it explicitly: they decline moves that would trigger a reactive escape, and they buy reactive-move abilities specifically as insurance against 11e's stronger Overwatch. Any AI plan that assumes the target stays put will systematically over-value long charges and precise blocking positions.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "PNW 40K",
+          "video_id": "ycW5l0xHp9s",
+          "timestamp": "08:00",
+          "url": "https://youtube.com/watch?v=ycW5l0xHp9s&t=480s",
+          "quote": "He can make a reactive move ... reactive moves in general are very powerful"
+        },
+        {
+          "channel": "HivemindHobbies",
+          "video_id": "Wm2Hd8h74_o",
+          "timestamp": "65:00",
+          "url": "https://youtube.com/watch?v=Wm2Hd8h74_o&t=3900s",
+          "quote": "if he moves up at all, then they will automatically reactive move behind this obscuring wall"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "20:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=1200s",
+          "quote": "he then reactive moves and kind of spreads out to stop Ghaz from moving this way"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "VqwMdS9MuIY",
+          "timestamp": "60:00",
+          "url": "https://youtube.com/watch?v=VqwMdS9MuIY&t=3600s",
+          "quote": "it has the ability to reactive move to enemies going close to it ... it may be able to jump away"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "difficulty_gate",
+        "target": "AIDifficultyConfig.use_look_ahead (Competitive only)",
+        "current_behaviour": "Look-ahead is Competitive-only and models opponent responses generically. Nothing detects that a specific enemy unit owns a reactive-move ability.",
+        "suggested_change": "Scan enemy datasheet abilities and the opponent's detachment stratagems for reactive-move wording, and discount blocking-position and marginal-charge scores against those units by ~30%. Gate to Hard+ rather than Competitive-only, since it is a defensive correction rather than deep search.",
+        "risk": "Ability-text scanning is brittle and will both miss and over-match. A false positive makes the AI refuse good charges. Prefer an explicit ability list over free-text matching."
+      },
+      "priority": "medium",
+      "id": "F014",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "melee_commitment",
+      "faction": "general",
+      "claim": "Charging purely to tie up a dangerous shooter is worth doing even when the charging unit expects to deal and receive negligible damage.",
+      "detail": "A unit locked in engagement generally cannot shoot, so a cheap charge can switch off an expensive gun for a full turn. Players make this charge knowing they will lose the melee, and specifically use it against vehicles and gunline units that would otherwise fire freely. The value is the enemy's forgone shooting phase, not the combat result.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "WednesdayNightWarhammer",
+          "video_id": "MkeH0tr1o_o",
+          "timestamp": "57:00",
+          "url": "https://youtube.com/watch?v=MkeH0tr1o_o&t=3420s",
+          "quote": "I guess I would attempt the charge to get just to tie you up"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "0Gcpze1G4Lc",
+          "timestamp": "14:00",
+          "url": "https://youtube.com/watch?v=0Gcpze1G4Lc&t=840s",
+          "quote": "this thing was within range to move up and shoot her. So, I needed to make this charge to stop this tank"
+        },
+        {
+          "channel": "WarGames Live",
+          "video_id": "HER6VzUGO60",
+          "timestamp": "658:00",
+          "url": "https://youtube.com/watch?v=HER6VzUGO60&t=39480s",
+          "quote": "We'll charge the truck in just to lock you in because we can still touch you and still be on the objective"
+        },
+        {
+          "channel": "Mordian Glory",
+          "video_id": "lp4j3iYlpQ4",
+          "timestamp": "25:00",
+          "url": "https://youtube.com/watch?v=lp4j3iYlpQ4&t=1500s",
+          "quote": "I charged up to the hell hound just to tie them up again"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / PHASE_PLAN_RANGED_STRENGTH_DANGEROUS (5.0)",
+        "current_behaviour": "The multi-phase planner already gives a 3.0 bonus for charging dangerous shooters, but it is gated behind use_multi_phase_planning (Hard+), and the charge must still clear the normal charge threshold that is driven by expected damage.",
+        "suggested_change": "Make the lock bonus able to carry a charge on its own: when the target exceeds PHASE_PLAN_RANGED_STRENGTH_DANGEROUS and the charger is cheap relative to it, bypass the expected-damage component of the charge threshold rather than adding to it. Consider lowering the gate to Normal, since players treat this as basic play.",
+        "risk": "Feeding cheap units into melee they lose can hand the opponent Purge-the-Foe VP and free consolidation moves toward objectives. Require that the charger is not currently contributing OC to a priced objective."
+      },
+      "priority": "medium",
+      "id": "F015",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "melee_commitment",
+      "faction": "general",
+      "claim": "Consolidation should be scored as a positioning move — onto an objective, into a new enemy unit, or backwards out of line of sight — not as a default 3\" shuffle.",
+      "detail": "After fighting, the 3\" consolidation is often the most valuable move of the turn: it can put a unit onto an objective it could not have charged, drag it into a second enemy unit to lock that one too, or pull it back behind terrain so it is not shot in the opponent's turn. Players choose deliberately between those three outcomes and name the reason each time.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "24:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=1440s",
+          "quote": "I picked this objective to cons consolidate backwards a little bit so he doesn't get shot"
+        },
+        {
+          "channel": "Maelstrom Gaming Studios - Tyranids",
+          "video_id": "aQsog-fkQJ8",
+          "timestamp": "71:00",
+          "url": "https://youtube.com/watch?v=aQsog-fkQJ8&t=4260s",
+          "quote": "I will tow this guy onto the objective ... get a tiny bit further away"
+        },
+        {
+          "channel": "Auspex Tactics",
+          "video_id": "YM1sRZGVOhw",
+          "timestamp": "12:00",
+          "url": "https://youtube.com/watch?v=YM1sRZGVOhw&t=720s",
+          "quote": "If you're able to hit something, destroy something, consolidate into something else"
+        },
+        {
+          "channel": "Boltgun Tactics",
+          "video_id": "6V8asnfgFUE",
+          "timestamp": "161:00",
+          "url": "https://youtube.com/watch?v=6V8asnfgFUE&t=9660s",
+          "quote": "We'll just consolidate into the middle"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "consolidation move selection in the FIGHT phase",
+        "current_behaviour": "Consolidation is resolved without a dedicated scoring pass comparable to _score_movement_destination; there is no explicit objective/LoS evaluation of the 3\" options.",
+        "suggested_change": "Score consolidation destinations with the same three terms used for movement — objective VP delta (via _estimate_objective_vp_value), number of additional enemy units brought into engagement, and whether the destination breaks enemy line of sight — and pick the max.",
+        "risk": "Consolidating out of line of sight can also leave an objective; the VP term must dominate. Rules constraints on consolidation (must end closer to the nearest enemy, or toward an objective) restrict the legal set and must be respected."
+      },
+      "priority": "medium",
+      "id": "F016",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "disengage_and_lock",
+      "faction": "general",
+      "claim": "Falling back is expensive: most vehicles cannot fall back and shoot, and a battle-shocked unit must make Desperate Escape rolls, so staying locked is often correct.",
+      "detail": "Fall Back normally forbids shooting and charging for the rest of the turn unless a specific ability says otherwise, and that ability is usually restricted to infantry. Players are caught out by this mid-game. The corollary drives the opposite decision too: armies that want the enemy stuck deliberately engage from multiple units so that falling back is unattractive.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "F5TL7LhZJlY",
+          "timestamp": "13:00",
+          "url": "https://youtube.com/watch?v=F5TL7LhZJlY&t=780s",
+          "quote": "He spends a CP realizing after the fact that you can't fall back and shoot with vehicles. It's only infantry"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "25:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=1500s",
+          "quote": "If they fall back and shoot, these guys could have fell back and shot. But that's only one unit of shooting"
+        },
+        {
+          "channel": "Maelstrom Gaming Studios - Tyranids",
+          "video_id": "aQsog-fkQJ8",
+          "timestamp": "98:00",
+          "url": "https://youtube.com/watch?v=aQsog-fkQJ8&t=5880s",
+          "quote": "no, we'll fall back and we'll take our hazardous roles. Ones and twos, they die"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "SURVIVAL_FALL_BACK_BONUS (2.0) / SURVIVAL_HOLD_BONUS (1.5)",
+        "current_behaviour": "Survival assessment (Normal+) compares expected damage against remaining wounds and adds a flat 2.0 toward falling back when the unit is threatened. The lost shooting phase is not priced.",
+        "suggested_change": "Subtract the unit's own expected ranged output from the fall-back score unless it has a fall-back-and-shoot ability, and subtract more when the unit is battle-shocked (Desperate Escape casualties). A VEHICLE without that ability should almost never fall back purely for survival.",
+        "risk": "Holding a losing combat can lose the unit outright. The change should only reweight, not veto — SURVIVAL_LETHAL_THRESHOLD (0.75) must still force the retreat when destruction is likely."
+      },
+      "priority": "medium",
+      "id": "F017",
+      "differs_from_general": null,
+      "corroborating_channels": 2
+    },
+    {
+      "decision": "action_economy",
+      "faction": "general",
+      "claim": "Mission actions consume the acting unit's shooting, so they should be assigned to the cheapest unit that can reach and survive, not to whatever is nearest.",
+      "detail": "Recon and Priority Assets dispositions are action-heavy, actions are limited to one per turn on some cards and cannot start before round two on others, and starting an action generally costs the unit its shooting phase. Players therefore build in small, cheap, mobile units whose whole job is to walk somewhere and press a button. Notable exception in 11e: Titanic units can shoot and perform actions.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "VPTL092E0VI",
+          "timestamp": "12:00",
+          "url": "https://youtube.com/watch?v=VPTL092E0VI&t=720s",
+          "quote": "They have very small bases and then put down somewhere else on the board to do the action"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "7AgzQIEq3j4",
+          "timestamp": "10:00",
+          "url": "https://youtube.com/watch?v=7AgzQIEq3j4&t=600s",
+          "quote": "Titanic units can shoot and perform actions. So, it's not actually like that bad"
+        },
+        {
+          "channel": "Recon By Fire",
+          "video_id": "42CPnCfuCN8",
+          "timestamp": "01:00",
+          "url": "https://youtube.com/watch?v=42CPnCfuCN8&t=60s",
+          "quote": "for one CP, they are capable of shooting and still being able to perform an action"
+        },
+        {
+          "channel": "Exile Wargaming",
+          "video_id": "mbNWzDn6Pu4",
+          "timestamp": "05:00",
+          "url": "https://youtube.com/watch?v=mbNWzDn6Pu4&t=300s",
+          "quote": "we have to triangulate objectives by doing actions on them. We can only do one a turn"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "action assignment (MissionManager._run_primary_auto_actions_11e is the backstop)",
+        "current_behaviour": "Primary-card marker/action mechanics are auto-resolved by MissionManager as a headless/AI backstop, and _build_primary_awareness gives those rule types a flat +1.0 generic objective pressure. There is no cost model for which unit performs the action.",
+        "suggested_change": "When an action is available, rank candidate units by (expected ranged output forgone + points at risk) ascending and pick the cheapest that can reach. Skip the forgone-output term for TITANIC units.",
+        "risk": "The cheapest unit is often the screening unit; pulling it off a screen to press a button can open a deep-strike lane. Exclude units currently holding a screening assignment."
+      },
+      "priority": "medium",
+      "id": "F018",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "tempo_and_commitment",
+      "faction": "general",
+      "claim": "In 11e the player who rolls highest must take the first turn, so deployment has to be robust to going either first or second rather than optimised for a choice.",
+      "detail": "Players describe not having to 'sweat' the first-turn roll because the choice is gone, and describe being forced into a first turn they did not want for their disposition. The planning consequence is that a deployment which is only good on the play, or only good on the draw, is a liability — and that counter-deployment against what the opponent has already put down matters more than turn-order gambling.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "MiniWarGaming",
+          "video_id": "dy1zEFAKLzk",
+          "timestamp": "03:00",
+          "url": "https://youtube.com/watch?v=dy1zEFAKLzk&t=180s",
+          "quote": "This is the nice thing about the whoever rolls highest has to go first. I do not have to sweat about who gets first turn"
+        },
+        {
+          "channel": "Exile Wargaming",
+          "video_id": "mbNWzDn6Pu4",
+          "timestamp": "10:00",
+          "url": "https://youtube.com/watch?v=mbNWzDn6Pu4&t=600s",
+          "quote": "we did win the dice roll and had to go first, which I don't really like in recon"
+        }
+      ],
+      "rules_status": "unverified",
+      "ai_impact": {
+        "seam": "difficulty_gate",
+        "target": "AIDifficultyConfig.use_counter_deployment (Normal+)",
+        "current_behaviour": "Counter-deployment is already enabled from Normal upward, which is the right call under this rule. No change is strictly required.",
+        "suggested_change": "No weight change. Record the rule so that any future 'choose to go second' logic is not written, and so deployment scoring is not tuned on an assumed turn order. Verify against the 11e core rules before relying on it.",
+        "risk": "None — this finding is informational. It is marked unverified because it rests on two channels' asides rather than a rules quotation."
+      },
+      "priority": "low",
+      "id": "F019",
+      "differs_from_general": null,
+      "corroborating_channels": 2
+    },
+    {
+      "decision": "ability_timing",
+      "faction": "Orks",
+      "claim": "Waaagh! should not be called in round 1, nor the moment a single unit can reach something — it wants several units simultaneously in advance-and-charge range, and its 5+ invulnerable is worth calling for on its own when crossing open ground.",
+      "detail": "Waaagh! is once per battle and grants advance-and-charge, +1 Strength and Attacks in melee, and a 5+ invulnerable save to the whole army for one battle round. Because it is a single one-shot, the payoff is the number of units that convert it into a charge at once; spending it to reach one target wastes the army-wide component. Players also call it purely defensively, to survive a turn of shooting while advancing — which means 'how many units can charge' is not the only trigger.",
+      "differs_from_general": "The general-case AI fires a once-per-battle offensive buff as early as it can be used, on the reasoning that more turns benefit. Waaagh! does not work that way: it lasts one battle round, so early use is pure waste, and its value is the count of units that benefit simultaneously plus the defensive save for the turn the army is most exposed.",
+      "confidence": "high",
+      "evidence": [
+        {
+          "channel": "Tabletop Nexus",
+          "video_id": "QZ9wggn2oUo",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=QZ9wggn2oUo&t=240s",
+          "quote": "Don't call it turn one, though. Don't call it the moment you can reach something"
+        },
+        {
+          "channel": "Tabletop Nexus",
+          "video_id": "QZ9wggn2oUo",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=QZ9wggn2oUo&t=240s",
+          "quote": "A strong Waaagh! turn has several units positioned to benefit at once"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "DHVBk9vnR8w",
+          "timestamp": "07:00",
+          "url": "https://youtube.com/watch?v=DHVBk9vnR8w&t=420s",
+          "quote": "moved up a little bit like two extra inches forward uh to plan for turn two Waagh"
+        },
+        {
+          "channel": "Hubtown Hammer",
+          "video_id": "vLQTE5P6pJg",
+          "timestamp": "03:00",
+          "url": "https://youtube.com/watch?v=vLQTE5P6pJg&t=180s",
+          "quote": "Turn two, the Orks used the Waagh, which turned out to be a great choice ... blunted by some hot five plus invulnerable"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "33:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=1980s",
+          "quote": "if I give up Zod turn one with a Waagh, I spent my Waagh and now I gave up Zod"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "faction_ability",
+        "target": "AIDecisionMaker.gd:4481 CALL_WAAAGH block",
+        "current_behaviour": "Round 1: calls Waaagh! if ANY single unit is within 22\" of an enemy (units_in_range >= 1). Round 2+: calls it unconditionally, with the comment 'Round 2+: always use it — waiting loses turns of benefit'. The unit count is computed but only used for the log line from round 2 onward, and the 5+ invulnerable is never considered.",
+        "suggested_change": "Replace the round-1 gate with a units_in_range threshold of 3+, and replace the unconditional round-2 fire with 'units_in_range >= 3, or round >= 4 (use-it-or-lose-it)'. Add a defensive trigger: fire it regardless of charge count when more than half the army is inside enemy threat range and lacks an invulnerable save. Expose the threshold as WAAAGH_MIN_UNITS_IN_RANGE.",
+        "risk": "A threshold set too high never fires the ability, which is strictly worse than firing it late — hence the round-4 backstop. The 22\" advance-and-charge estimate is centroid-based and optimistic; 3 units at 22\" may be 1 unit in practice."
+      },
+      "priority": "high",
+      "id": "F020",
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "screening_and_zoning",
+      "faction": "Orks",
+      "claim": "Gretchin exist to absorb the screening and home-objective jobs so Boyz mobs are never assigned to them.",
+      "detail": "Ork lists carry multiple cheap Gretchin units specifically as job-units: sit on home, screen the deployment zone, and block deep strike, leaving the 20-model Boyz mobs free to be the offensive units the army actually wins with. The failure mode players describe is a Boyz mob that ends up babysitting an objective — a 200-point unit doing a 40-point unit's job.",
+      "differs_from_general": "The general AI picks screeners by cost threshold (SCREEN_CHEAP_UNIT_POINTS 100) and would happily assign a cheap-ish melee unit to a screen. For Orks the assignment should be near-absolute: Gretchin take these roles first and Boyz take them only when no Gretchin remain, even if the Boyz mob is closer.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Tabletop Nexus",
+          "video_id": "QZ9wggn2oUo",
+          "timestamp": "07:00",
+          "url": "https://youtube.com/watch?v=QZ9wggn2oUo&t=420s",
+          "quote": "Gretchen handle the boring jobs, your home objectives, more screening so boys don't have to"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "05:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=300s",
+          "quote": "we have three units of Gretchen, 120 men, two 10 mans"
+        },
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "DHVBk9vnR8w",
+          "timestamp": "02:00",
+          "url": "https://youtube.com/watch?v=DHVBk9vnR8w&t=120s",
+          "quote": "20-man gretchin with Zagdrod, two 10-man gretchin which I really liked having extra gretchin unit"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "profile_rule",
+        "target": "SCREEN_CHEAP_UNIT_POINTS (100) / SCREEN_SCORE_BASE (8.0)",
+        "current_behaviour": "Any unit at or below 100 points is a screening candidate, scored at SCREEN_SCORE_BASE 8.0 against objective priorities. Ork Boyz mobs are above the threshold so they are not screen candidates, but they are still eligible for home-objective assignments.",
+        "suggested_change": "Ork profile: lower SCREEN_CHEAP_UNIT_POINTS to ~60 so only Gretchin-class units qualify, and raise SCREEN_SCORE_BASE to ~10.0 so those units take screening over a marginal objective push. Pair with a rule that raises WEIGHT_ALREADY_HELD_OBJ for melee units so Boyz leave held objectives.",
+        "risk": "If the army has lost its Gretchin, a 60-point threshold leaves nothing eligible to screen at all. Needs a fallback to the default threshold when no candidate exists."
+      },
+      "priority": "medium",
+      "id": "F021",
+      "corroborating_channels": 2
+    },
+    {
+      "decision": "objective_trade",
+      "faction": "Adeptus Custodes",
+      "claim": "Custodes cannot screen and score simultaneously; they should concentrate into one or two bricks and concede board area rather than spreading to cover objectives.",
+      "detail": "With roughly a third of a normal army's unit count, every Custodes unit split off to hold a marker is a unit missing from the one place the army can win a fight. Players describe the army as wanting to move as a wrecking ball, and describe splitting as the mistake. The army's compensation is that its units are individually hard enough to hold an objective against a much larger force, so it can arrive late and still take the ground.",
+      "differs_from_general": "The general AI spreads units across objectives by score, using SUPPORT_STACK_PENALTY (3.5) to actively discourage stacking. For Custodes that penalty is backwards: concentration is the plan, and the army should accept holding fewer objectives for longer rather than contesting more of them briefly.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Tabletop Titans",
+          "video_id": "EAqaLgAudQo",
+          "timestamp": "216:00",
+          "url": "https://youtube.com/watch?v=EAqaLgAudQo&t=12960s",
+          "quote": "custodians are just not designed that way. They want to be hanging out together just few units but just wrecking ball"
+        },
+        {
+          "channel": "Master Crafted",
+          "video_id": "9fuvetVLB3s",
+          "timestamp": "63:00",
+          "url": "https://youtube.com/watch?v=9fuvetVLB3s&t=3780s",
+          "quote": "it still just didn't feel great as a custod player to have to uh be playing might with purge"
+        },
+        {
+          "channel": "Hubtown Hammer",
+          "video_id": "ET9gYSgKRfs",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=ET9gYSgKRfs&t=240s",
+          "quote": "we will always have minus one to hit in the fight phase since they will be within 12 in with the hidden rule"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "faction_constant",
+        "target": "FACTION_AGGRESSION_CUSTODES (1.5) — plus SUPPORT_STACK_PENALTY in the profile",
+        "current_behaviour": "Custodes get a single scalar aggression of 1.5, which raises kill-seeking and lowers the charge threshold. Nothing changes how widely the army spreads; SUPPORT_STACK_PENALTY 3.5 applies as normal and pushes units apart.",
+        "suggested_change": "This is the clearest evidence that a single 'aggression' scalar is the wrong model. For Custodes the differentiating parameter is concentration, not aggression: drop SUPPORT_STACK_PENALTY to ~1.5 in the Custodes profile and raise WEIGHT_ALREADY_HELD_OBJ toward -1.0 so units stay on ground they already hold, while leaving FACTION_AGGRESSION_CUSTODES at 1.5.",
+        "risk": "Concentration loses to mission formats that reward spread (Recon table quarters, Priority Assets actions). The profile should be benchmarked per disposition, not adopted globally."
+      },
+      "priority": "medium",
+      "id": "F022",
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "ability_timing",
+      "faction": "Tyranids",
+      "claim": "Tyranid battle-shock output is an offensive tempo tool used to strip OC and enable precision kills, not a passive debuff — the units carrying it should be positioned aggressively to keep enemies inside its range.",
+      "detail": "Shadow in the Warp and unit-level shock effects turn enemy objective-holders into OC-0 passengers and open up follow-up plays: players describe shocking a target and then charging in to precision out the character. That makes the delivery units (Neurolictors and similar) forward-positioned pieces whose range band matters more than their survival, which is the opposite of how a support unit is normally played.",
+      "differs_from_general": "The general AI treats support and buff units as things to protect, applying THREAT_FRAGILE_BONUS (1.3) to keep high-value fragile units out of danger. Tyranid shock-delivery units need to be inside their aura range of the enemy's scoring units, which means deliberately accepting threat that the general model penalises.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Maelstrom Gaming Studios - Tyranids",
+          "video_id": "efeKiBbPUPM",
+          "timestamp": "09:00",
+          "url": "https://youtube.com/watch?v=efeKiBbPUPM&t=540s",
+          "quote": "My Neurolictor battleshocked Volus and the Paladins, which allowed both the Neurolictor and the Hive turret to charge in and precision out"
+        },
+        {
+          "channel": "Factions&Fate",
+          "video_id": "OKoDYKdWm1E",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=OKoDYKdWm1E&t=240s",
+          "quote": "infiltrated up here just a little bit past my deployment line, but still within range to hand out battle shocks"
+        },
+        {
+          "channel": "winters SEO",
+          "video_id": "uAmbb_rrUvM",
+          "timestamp": "15:00",
+          "url": "https://youtube.com/watch?v=uAmbb_rrUvM&t=900s",
+          "quote": "shadow in the warp and signapse ... hurts the enemy when they're in range of signapse"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "7AgzQIEq3j4",
+          "timestamp": "121:00",
+          "url": "https://youtube.com/watch?v=7AgzQIEq3j4&t=7260s",
+          "quote": "force the battle the um shadow in the warp battle shock at a higher penalty"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "profile_rule",
+        "target": "THREAT_FRAGILE_BONUS (1.3) / WEIGHT_OC_EFFICIENCY (2.0)",
+        "current_behaviour": "Fragile high-value units get an extra threat multiplier and are steered away from the enemy. Nothing values keeping an aura source within range of enemy units.",
+        "suggested_change": "Tyranid profile: reduce THREAT_FRAGILE_BONUS toward 1.0 and add a movement term that rewards destinations keeping enemy scoring units inside the shock aura's range — mirroring the AAO_RADIUS_INCHES / WEIGHT_AAO_ISOLATION pattern already used for Against All Odds.",
+        "risk": "Neurolictor-class units are cheap but not expendable; walking them into charge range hands over kill VP under Purge the Foe. Bound the exposure to units the enemy cannot reach with a charge this turn."
+      },
+      "priority": "medium",
+      "id": "F023",
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "disengage_and_lock",
+      "faction": "Death Guard",
+      "claim": "Death Guard win by making disengagement expensive rather than by killing — they should seek to engage multiple enemy units at once and hold them there.",
+      "detail": "Death Guard stack leadership penalties and fall-back punishment, so a unit engaged by them faces a hard Desperate Escape roll to leave. Players deliberately engage one enemy unit with two of their own so that the opponent must pass multiple tests, and describe the army as low-damage but very hard to get away from. The scoring consequence is that a locked enemy is not shooting and not scoring, which is the army's whole engine.",
+      "differs_from_general": "The general AI evaluates melee by expected damage and uses SURVIVAL_FALL_BACK_BONUS to leave losing fights. Death Guard should prefer engagements it does not win on damage, and should value multi-unit engagement (more fall-back tests) that the general model treats as inefficient over-commitment.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "F5TL7LhZJlY",
+          "timestamp": "23:00",
+          "url": "https://youtube.com/watch?v=F5TL7LhZJlY&t=1380s",
+          "quote": "If both of these guys were in combat with the death shroud ... both of them would have to pass a seven up to fall back"
+        },
+        {
+          "channel": "Factions&Fate",
+          "video_id": "OKoDYKdWm1E",
+          "timestamp": "06:00",
+          "url": "https://youtube.com/watch?v=OKoDYKdWm1E&t=360s",
+          "quote": "against you you want to be in melee, so that might benefit me the most"
+        },
+        {
+          "channel": "40K Fireside",
+          "video_id": "u8fm403MGtg",
+          "timestamp": "08:00",
+          "url": "https://youtube.com/watch?v=u8fm403MGtg&t=480s",
+          "quote": "Plague Legion it gets stuck in combat a lot and it's really hard to get out of combat"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "profile_rule",
+        "target": "PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / SURVIVAL_HOLD_BONUS (1.5)",
+        "current_behaviour": "Locking bonuses only apply to targets classed as dangerous shooters (PHASE_PLAN_RANGED_STRENGTH_DANGEROUS 5.0), and survival assessment pulls the AI out of losing fights from Normal upward.",
+        "suggested_change": "Death Guard profile: raise PHASE_PLAN_LOCK_SHOOTER_BONUS to ~5.0, raise SURVIVAL_HOLD_BONUS to ~3.0 so the AI stays in combats it is losing on damage, and lower SURVIVAL_FALL_BACK_BONUS to ~1.0.",
+        "risk": "Staying in fights it loses is exactly the failure mode survival assessment was added to fix; if the enemy can simply kill the engaged unit, this profile feeds it. Needs benchmarking against a high-damage melee opponent specifically."
+      },
+      "priority": "medium",
+      "id": "F024",
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "attrition_and_trades",
+      "faction": "Drukhari",
+      "claim": "Drukhari should fight out of transports and treat committed squads as expendable — a squad that disembarks, kills, and dies has done its job.",
+      "detail": "Drukhari infantry are fast and lethal but do not survive being shot, so the transport is not a delivery convenience but the unit's durability. Players describe squads as explicitly suicidal — sent to remove a key piece with no expectation of returning — and describe leaving a unit outside its transport as the error. The army's economy assumes it trades its units away and keeps scoring with what is left.",
+      "differs_from_general": "The general AI protects expensive and fragile units (THREAT_FRAGILE_BONUS 1.3, ARCHETYPE_ELITE_SURVIVAL 1.25) and penalises trading an expensive unit into a cheaper one. Drukhari should accept those trades when the target is a key enabler, and should weight embarkation far more heavily than a general army would.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Deploy on the Line 40K",
+          "video_id": "jJwrYZs3l-I",
+          "timestamp": "11:00",
+          "url": "https://youtube.com/watch?v=jJwrYZs3l-I&t=660s",
+          "quote": "squad in transport. They're going to suicide themselves"
+        },
+        {
+          "channel": "SkaredCast",
+          "video_id": "nCQuNE_8V44",
+          "timestamp": "19:00",
+          "url": "https://youtube.com/watch?v=nCQuNE_8V44&t=1140s",
+          "quote": "you didn't need the entire unit to kill them. They died very fast. Should have kept them in the transport"
+        },
+        {
+          "channel": "6 Plus Plus Gaming",
+          "video_id": "gRqdSBkqVlA",
+          "timestamp": "07:00",
+          "url": "https://youtube.com/watch?v=gRqdSBkqVlA&t=420s",
+          "quote": "Drukhari really love it in Sky Splinter Assault ... it gives them that bit of protection"
+        },
+        {
+          "channel": "MiniWarGaming",
+          "video_id": "3lwK9jAR0RM",
+          "timestamp": "23:00",
+          "url": "https://youtube.com/watch?v=3lwK9jAR0RM&t=1380s",
+          "quote": "going to pick Drazar up to protect Drazar from at least a round of shooting"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "profile_rule",
+        "target": "TRADE_UNFAVORABLE_PENALTY (0.7) / THREAT_FRAGILE_BONUS (1.3)",
+        "current_behaviour": "Trade analysis penalises expensive-kills-cheap down to 0.7, and fragile high-value units get a 1.3x threat multiplier steering them away from danger. Both push against the Drukhari pattern.",
+        "suggested_change": "Drukhari profile: raise TRADE_UNFAVORABLE_PENALTY to ~0.9 (nearly neutral) and lower THREAT_FRAGILE_BONUS to ~1.0, so committed units accept exposure. Add a rule that restores caution in rounds 4-5 (round_gte 4 → multiply THREAT_FRAGILE_BONUS by 1.3) so the AI stops throwing units away once the trades no longer buy anything.",
+        "risk": "Under Purge the Foe the opponent is paid for every unit destroyed, so an expendable-units profile actively feeds their primary. Benchmark specifically against a Purge opponent before adopting."
+      },
+      "priority": "medium",
+      "id": "F025",
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "ability_timing",
+      "faction": "Space Marines",
+      "claim": "Oath of Moment should be discounted against targets that our own shooters can already re-roll into — its value is the re-roll it adds, not the target's threat.",
+      "detail": "Oath grants re-rolls against one enemy unit, so its marginal value collapses when the units that will actually shoot the target already re-roll hits from another source. Players state this directly when reviewing lists — a unit hitting on 2s with re-roll 1s 'does not need Oath of Moment'. The corollary is that Oath goes on the target the unbuffed portion of the army must kill.",
+      "differs_from_general": "This is a refinement rather than a reversal: the general logic of 'mark what you most want dead' is right, but for Space Marines specifically the score must be computed against the shooters that will use it, not against the target in isolation.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Happy Krumping",
+          "video_id": "pAk1YiuioNQ",
+          "timestamp": "22:00",
+          "url": "https://youtube.com/watch?v=pAk1YiuioNQ&t=1320s",
+          "quote": "They already hit on twos ... re-rolling hit rolls of one. They do not need oath of moment"
+        },
+        {
+          "channel": "Tabletop Tactics",
+          "video_id": "eUQmB4CTKlk",
+          "timestamp": "21:00",
+          "url": "https://youtube.com/watch?v=eUQmB4CTKlk&t=1260s",
+          "quote": "I'm going to put Oath of Moment on that big brain bug ... he's super tough"
+        },
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "qwnHaQvzCq0",
+          "timestamp": "14:00",
+          "url": "https://youtube.com/watch?v=qwnHaQvzCq0&t=840s",
+          "quote": "the only thing you have to remember to do in your Command phase then is ... That's my Oath of Moment target"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "faction_ability",
+        "target": "_select_oath_of_moment_target (AIDecisionMaker.gd:4844)",
+        "current_behaviour": "Scores each candidate from _calculate_target_value plus target-side modifiers: toughness, save, remaining wounds, below-half-strength, invulnerable discount, leader-buff bonus, and a 0.5x penalty when the army lacks weapons that can hurt it. All modifiers are properties of the target; none look at the shooters' existing re-rolls.",
+        "suggested_change": "Weight each candidate by the expected damage the army would gain from the re-roll, computed over the units likely to shoot it — i.e. sum over candidate shooters of (damage with re-roll − damage without), and skip shooters that already re-roll hits. This reuses the existing _check_army_can_damage_target traversal.",
+        "risk": "More expensive to compute each command phase, and it can pick a soft target the army would have killed anyway. Keep the existing target-side terms as a tiebreak."
+      },
+      "priority": "medium",
+      "id": "F026",
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "objective_trade",
+      "faction": "Grey Knights",
+      "claim": "Grey Knights teleport (pick a unit up and redeploy it) costs objective control, so its value is disposition-dependent — under Take and Hold, teleporting a scoring unit is usually a net loss.",
+      "detail": "Repositioning a unit off an objective removes its OC contribution for the scoring window, so the same ability that is a free reposition under a kill-oriented card is a self-inflicted VP loss under an objective-oriented one. The arrival-turn buffs that reward teleporting are also limited to the turn the unit arrives, so the benefit is one turn while the objective loss can span two.",
+      "differs_from_general": "A general AI treats a free reposition as unambiguously good. For Grey Knights the ability has to be priced against the VP estimator before use, and its worth swings with the primary card.",
+      "confidence": "low",
+      "evidence": [
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "veM7sLjtdIw",
+          "timestamp": "01:00",
+          "url": "https://youtube.com/watch?v=veM7sLjtdIw&t=60s",
+          "quote": "being careful about when we use our teleportation. Picking a unit up is incredibly useful, but under Take and Hold, that decision becomes more costly"
+        },
+        {
+          "channel": "Warpbane Tactics",
+          "video_id": "D5XVd0FRgK8",
+          "timestamp": "03:00",
+          "url": "https://youtube.com/watch?v=D5XVd0FRgK8&t=180s",
+          "quote": "Fury of the Titan. Each time one of our units is set up using the deep strike ability until the end of that turn"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "faction_ability",
+        "target": "teleport / redeploy ability scoring",
+        "current_behaviour": "Repositioning abilities are scored on the destination's movement value. The VP the unit was contributing at its origin is not subtracted.",
+        "suggested_change": "Subtract _estimate_objective_vp_value for the origin objective from the score of any pick-up-and-place ability, so the decision is a net VP comparison. This is a general improvement that Grey Knights make most visible.",
+        "risk": "Low confidence — a single channel. Implement the VP subtraction as general logic rather than as a Grey Knights special case, and do not ship a Grey Knights profile on this evidence."
+      },
+      "priority": "low",
+      "id": "F027",
+      "corroborating_channels": 1
+    },
+    {
+      "decision": "target_selection",
+      "faction": "general",
+      "claim": "Units standing on objectives are premium targets in every round, not just rounds 4-5, because several common secondaries pay for killing them.",
+      "detail": "'Kill things on objectives' recurs as a secondary across the corpus, and players reshuffle their whole shooting plan when they draw it — sometimes needing two kills on markers for full value. Combined with the primary card, an enemy unit on a marker is being paid for twice: once by removing its OC, once by the secondary. This is a scoring decision dressed as a target-priority decision.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Tabletop Titans",
+          "video_id": "Krfpc2el0cA",
+          "timestamp": "25:00",
+          "url": "https://youtube.com/watch?v=Krfpc2el0cA&t=1500s",
+          "quote": "Overwhelming is good. This is kill things on objectives. It's what I want to do ... you really want to try to get two kills"
+        },
+        {
+          "channel": "MiniWarGaming",
+          "video_id": "VvZD_rjUBjE",
+          "timestamp": "19:00",
+          "url": "https://youtube.com/watch?v=VvZD_rjUBjE&t=1140s",
+          "quote": "Kill things on the critical objectives with overwhelming force"
+        },
+        {
+          "channel": "Play On Tabletop",
+          "video_id": "TPV3hVKSUxw",
+          "timestamp": "42:00",
+          "url": "https://youtube.com/watch?v=TPV3hVKSUxw&t=2520s",
+          "quote": "we've got overwhelming force. So, kill things on objectives"
+        },
+        {
+          "channel": "WarGames Live",
+          "video_id": "1AwnDclFviQ",
+          "timestamp": "552:00",
+          "url": "https://youtube.com/watch?v=1AwnDclFviQ&t=33120s",
+          "quote": "Kill things on objectives. Easy. And do actions"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "STRATEGY_LATE_OBJ_TARGET_BONUS (1.3)",
+        "current_behaviour": "The bonus for shooting units on objectives is part of the rounds-4-5 strategy block only. In rounds 1-3 an enemy unit on a marker is valued the same as one in the open.",
+        "suggested_change": "Move the objective-occupancy bonus out of the late-game block and apply it whenever the active secondary or primary card pays for kills on objectives — the SecondaryMissionManager hints already surface this. Keep the extra late-game multiplier on top.",
+        "risk": "Applied unconditionally it double-counts with the OC-denial value of the same kill and can pull fire off genuinely dangerous units early. Gate it on the mission actually paying for it."
+      },
+      "priority": "medium",
+      "id": "F028",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "screening_and_zoning",
+      "faction": "general",
+      "claim": "A screen must still be intact during the opponent's turn, because Rapid Ingress lets reserves arrive in the opponent's Movement phase.",
+      "detail": "Rapid Ingress moves a reserve unit onto the table during the opponent's movement phase, so a screen evaluated only at the end of the AI's own turn can be bypassed the moment it takes casualties or moves. Players build lists specifically around having a Rapid Ingress target and describe screening against it as a distinct obligation from screening against normal deep strike.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "40K Dirtbags",
+          "video_id": "Enm67qaqHkU",
+          "timestamp": "04:00",
+          "url": "https://youtube.com/watch?v=Enm67qaqHkU&t=240s",
+          "quote": "at least one unit in reserves cuz you're making lists to have a reserve rapid ingress target"
+        },
+        {
+          "channel": "WarGames Live",
+          "video_id": "1AwnDclFviQ",
+          "timestamp": "159:00",
+          "url": "https://youtube.com/watch?v=1AwnDclFviQ&t=9540s",
+          "quote": "this dog is doing some rapid ingress screening which is nice ... Deep strike denying"
+        },
+        {
+          "channel": "Happy Krumping",
+          "video_id": "pAk1YiuioNQ",
+          "timestamp": "57:00",
+          "url": "https://youtube.com/watch?v=pAk1YiuioNQ&t=3420s",
+          "quote": "You don't have to screen the rapid ingress. You don't have to worry about screening"
+        },
+        {
+          "channel": "6 Plus Plus Gaming",
+          "video_id": "gRqdSBkqVlA",
+          "timestamp": "06:00",
+          "url": "https://youtube.com/watch?v=gRqdSBkqVlA&t=360s",
+          "quote": "a big Helion Brick for rapid ingress threats ... I needed a infiltrate screen unit against things like Emperor's Children"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "new_heuristic",
+        "target": "screening assignment validity window",
+        "current_behaviour": "Screening positions are chosen during the AI's movement phase and evaluated against the board as it stands then. Nothing re-checks coverage after the AI's own shooting/charge phases move or lose the screening unit.",
+        "suggested_change": "Re-validate screening coverage at the end of the AI's turn and, when a gap has opened, prefer keeping a screening unit stationary over using it in a charge. Simplest form: mark units holding a screening assignment as ineligible for charges unless the charge itself closes the gap.",
+        "risk": "Locking screeners out of charges wastes them when no reserves remain. Skip the restriction entirely once the opponent has nothing left in reserve — the AI can see reserve counts in the snapshot."
+      },
+      "priority": "medium",
+      "id": "F029",
+      "differs_from_general": null,
+      "corroborating_channels": 4
+    },
+    {
+      "decision": "positioning_and_concealment",
+      "faction": "general",
+      "claim": "Cover in 11e worsens the attacker's Ballistic Skill by 1 rather than improving the defender's save, so seeking cover degrades incoming fire and ignore-cover weapons are worth aiming deliberately.",
+      "detail": "Benefit of Cover (13.08) applies a -1 to hit rather than a save bonus, which is a different shape of protection: it scales with the number of shots rather than with AP, and it stacks differently with re-rolls. Players call it out in play as 'your storm bolters will be at minus one to hit', and treat ignore-cover as a targeting consideration rather than a list-building nicety.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Maelstrom Gaming Studios - Tyranids",
+          "video_id": "aQsog-fkQJ8",
+          "timestamp": "85:00",
+          "url": "https://youtube.com/watch?v=aQsog-fkQJ8&t=5100s",
+          "quote": "partially obscured ... your storm bolters will be at minus one to hit"
+        },
+        {
+          "channel": "TacticalTortoise 40k",
+          "video_id": "VqwMdS9MuIY",
+          "timestamp": "171:00",
+          "url": "https://youtube.com/watch?v=VqwMdS9MuIY&t=10260s",
+          "quote": "Don't get cover, right? Yeah. No, it's ignore cover for all"
+        },
+        {
+          "channel": "Play On Tabletop",
+          "video_id": "1SRkN4Drhs4",
+          "timestamp": "52:00",
+          "url": "https://youtube.com/watch?v=1SRkN4Drhs4&t=3120s",
+          "quote": "because you're not an infantry, so you have to be obscured by the terrain itself"
+        }
+      ],
+      "rules_status": "confirmed",
+      "ai_impact": {
+        "seam": "weight_constant",
+        "target": "movement destination scoring + EFFICIENCY_* target matching",
+        "current_behaviour": "Cover terrain types are enumerated (COVER_TERRAIN_WITHIN_AND_BEHIND, COVER_TERRAIN_WITHIN_ONLY) and RulesEngine resolves the modifier, but movement scoring has no explicit term for ending in cover, and target scoring has no term for the target being in cover.",
+        "suggested_change": "Add a modest movement bonus for destinations granting Benefit of Cover (smaller than the Hidden bonus in F001 — cover is a -1, Hidden is immunity), and reduce a target's efficiency multiplier when it has cover against the shooter unless the weapon ignores cover.",
+        "risk": "Cover and Hidden are sought in the same terrain, so the two bonuses can double-count and over-concentrate the army into one ruin. Apply cover only when Hidden does not already apply."
+      },
+      "priority": "medium",
+      "id": "F030",
+      "differs_from_general": null,
+      "corroborating_channels": 3
+    },
+    {
+      "decision": "screening_and_zoning",
+      "faction": "Tyranids",
+      "claim": "Tyranids should spend cheap broods and spore mines as disposable movement blockers placed in the enemy's path, not as objective holders held back safely.",
+      "detail": "Tyranid screening pieces are cheap enough to be spent every turn and are placed specifically to force the opponent to go around — the value is the movement tax, not the bodies. Players describe placing spore mines downfield turn after turn to close deep-strike lanes, and describe a single unscreened gap as what lets the opponent through.",
+      "differs_from_general": "The general AI picks screeners by cost threshold and places them to cover deep-strike arrival zones near its own objectives. Tyranids should also project blockers forward into the enemy's approach lanes and treat them as consumable each turn, which the general threat model would penalise as walking into danger.",
+      "confidence": "medium",
+      "evidence": [
+        {
+          "channel": "Into the Hive Mind",
+          "video_id": "K8OD14Mz6N4",
+          "timestamp": "09:00",
+          "url": "https://youtube.com/watch?v=K8OD14Mz6N4&t=540s",
+          "quote": "putting these spore mines out that screen out deep strikers or any kind of reserve"
+        },
+        {
+          "channel": "Grimdark Breakdown",
+          "video_id": "VPTL092E0VI",
+          "timestamp": "13:00",
+          "url": "https://youtube.com/watch?v=VPTL092E0VI&t=780s",
+          "quote": "you could put things in their way to block their easy path"
+        },
+        {
+          "channel": "StrikingScorpion82",
+          "video_id": "sPWC5HujB_Y",
+          "timestamp": "19:00",
+          "url": "https://youtube.com/watch?v=sPWC5HujB_Y&t=1140s",
+          "quote": "holding objectives, picking on isolated, tying units down, blocking movements ... it's no big deal if they're slain"
+        }
+      ],
+      "rules_status": "player_opinion",
+      "ai_impact": {
+        "seam": "profile_rule",
+        "target": "CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_MAX_POSITIONS (4)",
+        "current_behaviour": "Corridor blocking exists at 7.0 base priority — below screening's 8.0 — capped at 4 positions, and requires an enemy within 30\" of the objective being protected.",
+        "suggested_change": "Tyranid profile: raise CORRIDOR_BLOCK_SCORE_BASE to ~9.0 so blocking outbids screening for cheap broods, and raise CORRIDOR_BLOCK_MAX_POSITIONS to 6. Lower THREAT_FRAGILE_BONUS so the blockers accept being killed.",
+        "risk": "Cheap Tyranid units are also the army's OC on objectives; spending them all as blockers can leave nothing scoring. Cap the number of units that may take a blocking assignment as a fraction of the army."
+      },
+      "priority": "medium",
+      "id": "F031",
+      "corroborating_channels": 3
+    }
+  ],
+  "disagreements": [
+    {
+      "topic": "How much of the army to place in Strategic Reserves",
+      "positions": [
+        "Keep at least one unit in reserve as a reactive answer / Rapid Ingress threat (40K Dirtbags, Enm67qaqHkU 04:00; Art of War 40k, ym0SnzF2ydg 162:00)",
+        "Against high-pressure lists put nothing in reserve — you need every body on the table to hold the mid-board (Happy Krumping, pAk1YiuioNQ 09:00)",
+        "Reserves are unnecessary when the army has a redeploy ability instead (Deploy on the Line 40K, gZWxrJy66nw 12:00)"
+      ],
+      "note": "Not a contradiction so much as an unstated conditional: the resolving variable is the opponent's turn-one threat range, which the AI can compute. Encoded that way in F014 rather than picking a side."
+    },
+    {
+      "topic": "Whether the Disruption disposition is playable",
+      "positions": [
+        "Disruption scores poorly, which frees you to ignore scoring and just kill (Happy Krumping, pAk1YiuioNQ 70:00)",
+        "Disruption sucks, people know it's awful (Deploy on the Line 40K, 14LSO7MS3QI 85:00)",
+        "Disruption rewards movement and positioning and is about interfering with the opponent's plan (Warpbane Tactics, ogMKXBVh4g0 02:00)"
+      ],
+      "note": "Tournament data in the corpus (Warp Friends, PShNfK_IJAA 21:00) shows factions posting notably higher win rates INTO Disruption, supporting the 'weak disposition' read. The AI should not be tuned to Disruption as a baseline."
+    },
+    {
+      "topic": "Whether 11e Overwatch is oppressive or merely strong",
+      "positions": [
+        "You can't play around it any more — big squads just get overwatched (Deploy on the Line 40K, FT5JoL5Myis 05:00)",
+        "It hits on sixes; it's not 'giga crazy' unless the volume is there (TacticalTortoise 40k, VqwMdS9MuIY 127:00)"
+      ],
+      "note": "Both are consistent with the rule: snap shooting punishes volume/torrent shooters and is weak for elite guns. The AI's exposure penalty should therefore scale with the watching unit's shot count, not its damage quality — reflected in F004."
+    },
+    {
+      "topic": "Whether World Eaters should still play maximum aggression in 11e",
+      "positions": [
+        "11e removed the need to push everything onto objectives; hold home, take a couple of bricks, do actions (Exile Wargaming, mbNWzDn6Pu4 34:00)",
+        "The faction's identity and detachments remain melee-compulsion oriented (Tactical Sugar, uizU0NPlR14 10:00; WednesdayNightWarhammer, zVx7smZIRf0 04:00)"
+      ],
+      "note": "The corpus does not support FACTION_AGGRESSION_WORLD_EATERS = 2.0 as a well-evidenced value — it is the highest constant in the file and rests on no corpus evidence at all. Flagged in gaps rather than changed."
+    }
+  ],
+  "gaps": [
+    "Necrons (101 transcripts, 56 in-title) yielded no high-confidence differentiated finding. Coverage is heavy but almost entirely list-review and battle-report play-by-play; the reanimation-vs-trade reasoning the AI would need is never stated explicitly. This is the largest coverage-to-findings gap in the corpus.",
+    "World Eaters (58 transcripts): only one channel makes a decision-shaped claim, and it argues AGAINST the blanket aggression the code already encodes. No profile emitted; FACTION_AGGRESSION_WORLD_EATERS = 2.0 should be treated as unevidenced.",
+    "Leagues of Votann (47 transcripts, 16 in-title): the judgement-token search returned zero hits in the title-attributed pool. Either the mechanic changed in 11e or the corpus does not discuss it — unresolved.",
+    "Aeldari (50), Thousand Sons (48), Chaos Knights (43), Emperor's Children (43): present in volume but discussion is list-composition and datasheet review, not decision reasoning. No actionable finding extracted.",
+    "Adepta Sororitas (9), Agents of the Imperium (6), Ynnari (4), Harlequins (10): too thin to attribute anything safely.",
+    "Imperial Knights and Chaos Knights: one channel notes they must pay CP to shoot and act in the same turn (Recon By Fire, 42CPnCfuCN8 01:00), which implies a distinctive action-economy problem for low-unit-count armies. Single-source, so recorded here rather than as a finding.",
+    "The corpus is competitive/tournament-skewed and post-dates the late-July 2026 balance dataslate for only part of its range. Faction findings drawn on June/early-July material may already be stale; each finding's evidence dates are given so this can be re-checked.",
+    "Deployment as a decision (where to place units before turn one) is discussed constantly but almost always in terms of a specific board and layout, which does not generalise into a weight. No deployment finding survived.",
+    "Secondary mission selection and discard is barely reasoned about on camera despite being a per-turn decision the AI makes; the SECONDARY_* constants have no corpus support either way."
+  ]
+}

--- a/research/youtube/batch.py
+++ b/research/youtube/batch.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run a named batch of themed regexes over the corpus in one pass.
+
+Batches are declared in BATCHES below so a scan is reproducible and reviewable:
+each theme is a decision the AI has to make, and the regex is the phrasing
+players use when they talk about making it.
+
+    python3 batch.py general_a [--max 8] [--width 190]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from search_transcripts import load
+from mine import run
+
+BATCHES = {
+    "positioning": [
+        ("OVERWATCH-move-cost", r"(before|worry|scared|afraid|because) .{0,30}overwatch|overwatch .{0,25}(punish|tax|threat|deterrent)"),
+        ("STAGING-out-of-los", r"stag(e|ing).{0,40}(out of|behind|hidden|los|line of sight)|out of (line of sight|los).{0,30}stag"),
+        ("OBSCURING-play", r"obscur\w+.{0,60}(so|because|means|can'?t see)"),
+        ("MOVE-BLOCK", r"(block|blocking).{0,30}(charge|the charge|movement|lane|path)"),
+    ],
+    "objectives": [
+        ("HOLD-vs-PUSH", r"(don'?t|do not) (need to |have to )?(push|overextend|over.commit)|overextend\w*"),
+        ("STICKY", r"sticky.{0,80}"),
+        ("OC-battleshock", r"battle.?shock\w*.{0,60}(o\.?c\.?|objective|control|score|scoring)"),
+        ("SECURE-then-leave", r"(score|secure|hold) (it|the objective).{0,30}(then|and) (leave|move off|walk off)"),
+    ],
+    "targeting": [
+        ("KILL-SCREEN-FIRST", r"(kill|clear|remove|shoot).{0,25}(the )?(screen|screens|chaff|gret?ch?in|grots)"),
+        ("PRIORITY-TARGET", r"(priority|primary) target|target priority"),
+        ("DONT-OVERKILL", r"overkill|waste (the|those|my) (shots|shooting|attacks)"),
+        ("KILL-THE-SCORER", r"kill.{0,30}(what'?s|the unit|things) (on|holding).{0,15}objective"),
+    ],
+    "commit": [
+        ("TURN-TO-COMMIT", r"(turn|round) (two|2|three|3).{0,40}(commit|push|go for it|alpha|strike)"),
+        ("PATIENCE", r"(be |stay |play )?patient|don'?t (rush|over.?commit)|wait (a turn|until|for)"),
+        ("GO-FIRST-SECOND", r"(want|prefer|choose|rather) (to )?(go|going) (first|second)"),
+        ("DOUBLE-DIP", r"(score|scoring) (on|in) (both|two) (turns|rounds)"),
+    ],
+    "combat": [
+        ("FALLBACK-DECIDE", r"fall(ing)? back.{0,60}(because|so|instead|rather|to )"),
+        ("STAY-IN-COMBAT", r"(stay|stuck|keep).{0,20}(in|locked in) (combat|melee|engagement)|tie (them|it|him) up"),
+        ("CONSOLIDATE-INTO", r"consolidat\w+.{0,60}(onto|into|objective|another unit)"),
+        ("CHARGE-TO-LOCK", r"charge.{0,40}(to (tie|lock|stop|shut)|so (they|he) can'?t shoot)"),
+    ],
+    "abilities": [
+        ("WAAAGH-TIMING", r"waaa+gh.{0,80}(turn|round|when|timing|save|hold)"),
+        ("OATH-TIMING", r"oath of moment.{0,70}"),
+        ("CP-SPEND", r"(save|saving|spend|spending) (my |your |the )?c\.?p\.?|command points? (for|on)"),
+        ("ONCE-PER-BATTLE", r"once per (battle|game).{0,60}(save|wait|hold|timing|use it)"),
+    ],
+    "screening": [
+        ("SCREEN-SPACING", r"(spac|space|gap|inch).{0,40}(between|apart).{0,40}(model|unit|screen)"),
+        ("SIX-INCH-DS", r"6.?(in|inch|\")? deep ?strike|six inch deep ?strike"),
+        ("SCREEN-COST", r"screen.{0,60}(cost|worth|cheap|expensive|points)"),
+        ("RAPID-INGRESS", r"rapid ingress"),
+    ],
+}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("batch", choices=sorted(BATCHES))
+    ap.add_argument("--max", type=int, default=8)
+    ap.add_argument("--width", type=int, default=190)
+    ap.add_argument("--per-video", type=int, default=1)
+    args = ap.parse_args()
+
+    recs = list(load())
+    for theme, rx in BATCHES[args.batch]:
+        hits = run(rx, recs, args.width, args.per_video, args.max)
+        print("### %s (%d)" % (theme, len(hits)))
+        for h in hits:
+            print("- [%s|%s|%s|%s] %s" % (h["channel"][:22], h["date"][5:], h["ts"],
+                                          h["video_id"], h["snip"]))
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/build_html.py
+++ b/research/youtube/build_html.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""Render ai_learnings.json into a self-contained, filterable HTML page.
+
+No external CSS, JS, fonts or images — everything is inlined so the file works
+from disk with no network. Light and dark themes follow the OS by default with a
+manual toggle. Written for a player who wants to learn how strong 40k players
+think; the AI-engineering notes are present but secondary and collapsed.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import os
+from collections import defaultdict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SRC = os.path.join(HERE, "ai_learnings.json")
+OUT = os.path.join(HERE, "ai_learnings.html")
+
+# Player-facing names for the decision axis. The JSON keeps the machine keys.
+DECISION_LABEL = {
+    "positioning_and_concealment": "Where to stand",
+    "screening_and_zoning": "Screening and denying space",
+    "target_selection": "What to shoot",
+    "objective_trade": "Objectives and scoring",
+    "attrition_and_trades": "When to accept a bad trade",
+    "reserves_and_arrival": "Reserves and arrival",
+    "melee_commitment": "When to charge",
+    "disengage_and_lock": "Staying in combat, or getting out",
+    "ability_timing": "When to spend your big ability",
+    "action_economy": "Who performs the actions",
+    "tempo_and_commitment": "Turn order and commitment",
+    "deployment": "Deployment",
+}
+
+DECISION_ORDER = [
+    "positioning_and_concealment", "screening_and_zoning", "target_selection",
+    "objective_trade", "attrition_and_trades", "melee_commitment",
+    "disengage_and_lock", "reserves_and_arrival", "ability_timing",
+    "action_economy", "tempo_and_commitment", "deployment",
+]
+
+CSS = """
+:root{
+  --bg:#fbfaf8; --panel:#ffffff; --ink:#1c1a17; --muted:#6a6560; --line:#e4e0da;
+  --accent:#8a2f24; --accent-soft:#f3e6e3; --chip:#f1eee9;
+  --hi:#2f6b4f; --hi-soft:#e6f0ea; --mid:#8a6a1f; --mid-soft:#f6efdd;
+  --lo:#6a6560; --lo-soft:#efedea;
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#16151a; --panel:#1e1d23; --ink:#eceaf0; --muted:#9a95a3; --line:#302e38;
+    --accent:#e0857a; --accent-soft:#33232a; --chip:#282730;
+    --hi:#7fd0a5; --hi-soft:#1b2f26; --mid:#e3c274; --mid-soft:#332c1c;
+    --lo:#9a95a3; --lo-soft:#26252c;
+  }
+}
+:root[data-theme=light]{
+  --bg:#fbfaf8; --panel:#ffffff; --ink:#1c1a17; --muted:#6a6560; --line:#e4e0da;
+  --accent:#8a2f24; --accent-soft:#f3e6e3; --chip:#f1eee9;
+  --hi:#2f6b4f; --hi-soft:#e6f0ea; --mid:#8a6a1f; --mid-soft:#f6efdd;
+  --lo:#6a6560; --lo-soft:#efedea;
+}
+:root[data-theme=dark]{
+  --bg:#16151a; --panel:#1e1d23; --ink:#eceaf0; --muted:#9a95a3; --line:#302e38;
+  --accent:#e0857a; --accent-soft:#33232a; --chip:#282730;
+  --hi:#7fd0a5; --hi-soft:#1b2f26; --mid:#e3c274; --mid-soft:#332c1c;
+  --lo:#9a95a3; --lo-soft:#26252c;
+}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);
+  font:16px/1.6 ui-serif,Georgia,'Iowan Old Style','Times New Roman',serif;
+  -webkit-text-size-adjust:100%}
+.wrap{max-width:920px;margin:0 auto;padding:0 20px 96px}
+header{padding:56px 0 8px;border-bottom:1px solid var(--line);margin-bottom:28px}
+h1{font-size:2.1rem;line-height:1.15;margin:0 0 10px;letter-spacing:-.01em}
+.sub{color:var(--muted);margin:0;max-width:62ch}
+.meta{color:var(--muted);font-size:.85rem;margin-top:14px}
+.sans{font-family:ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif}
+h2{font-size:1.32rem;margin:44px 0 4px;letter-spacing:-.01em;scroll-margin-top:16px}
+h2 .n{color:var(--muted);font-size:.8rem;font-weight:400;margin-left:8px;
+  font-family:ui-sans-serif,system-ui,sans-serif}
+.dfn{color:var(--muted);font-size:.92rem;margin:0 0 18px;max-width:64ch}
+.controls{position:sticky;top:0;z-index:5;background:var(--bg);
+  border-bottom:1px solid var(--line);padding:12px 0 12px;margin-bottom:6px}
+.row{display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin-bottom:7px}
+.row:last-child{margin-bottom:0}
+.lbl{font-size:.72rem;text-transform:uppercase;letter-spacing:.09em;color:var(--muted);
+  font-family:ui-sans-serif,system-ui,sans-serif;margin-right:6px;min-width:66px}
+button{font:inherit;font-family:ui-sans-serif,system-ui,sans-serif;font-size:.8rem;
+  background:var(--chip);color:var(--ink);border:1px solid transparent;
+  border-radius:999px;padding:4px 11px;cursor:pointer;line-height:1.4}
+button:hover{border-color:var(--line)}
+button[aria-pressed=true]{background:var(--accent-soft);border-color:var(--accent);
+  color:var(--accent);font-weight:600}
+.theme{margin-left:auto}
+article{background:var(--panel);border:1px solid var(--line);border-radius:12px;
+  padding:20px 22px;margin:0 0 14px}
+.claim{font-size:1.06rem;font-weight:600;margin:0 0 10px;line-height:1.45}
+.tags{display:flex;flex-wrap:wrap;gap:6px;margin:0 0 12px}
+.tag{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.7rem;
+  letter-spacing:.03em;padding:2px 9px;border-radius:999px;background:var(--chip);
+  color:var(--muted);white-space:nowrap}
+.tag.fac{background:var(--accent-soft);color:var(--accent);font-weight:600}
+.tag.high{background:var(--hi-soft);color:var(--hi)}
+.tag.medium{background:var(--mid-soft);color:var(--mid)}
+.tag.low{background:var(--lo-soft);color:var(--lo)}
+.tag.warn{background:var(--accent-soft);color:var(--accent);font-weight:600}
+p.detail{margin:0 0 12px}
+.diff{margin:0 0 12px;padding:10px 14px;border-left:3px solid var(--accent);
+  background:var(--accent-soft);border-radius:0 8px 8px 0;font-size:.94rem}
+.diff b{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.7rem;
+  text-transform:uppercase;letter-spacing:.08em;display:block;margin-bottom:3px;
+  color:var(--accent)}
+.src{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.85rem;
+  color:var(--muted);margin-top:12px}
+.src li{margin-bottom:5px}
+.src ul{margin:6px 0 0;padding-left:18px}
+.src a{color:var(--accent);text-decoration:none;border-bottom:1px solid transparent}
+.src a:hover{border-bottom-color:var(--accent)}
+.q{color:var(--ink);opacity:.85}
+details{margin-top:14px;border-top:1px dashed var(--line);padding-top:10px}
+summary{cursor:pointer;font-family:ui-sans-serif,system-ui,sans-serif;
+  font-size:.78rem;color:var(--muted);letter-spacing:.03em;list-style:none}
+summary::-webkit-details-marker{display:none}
+summary::before{content:"▸ ";color:var(--accent)}
+details[open] summary::before{content:"▾ "}
+details .body{font-family:ui-sans-serif,system-ui,sans-serif;font-size:.85rem;
+  color:var(--muted);margin-top:10px}
+details .body div{margin-bottom:7px}
+details .body b{color:var(--ink);font-weight:600}
+code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.85em;
+  background:var(--chip);padding:1px 5px;border-radius:4px}
+.tblwrap{overflow-x:auto;border:1px solid var(--line);border-radius:12px;
+  background:var(--panel)}
+table{border-collapse:collapse;font-family:ui-sans-serif,system-ui,sans-serif;
+  font-size:.8rem;width:100%}
+th,td{padding:7px 10px;text-align:left;border-bottom:1px solid var(--line);
+  white-space:nowrap}
+th{color:var(--muted);font-weight:600;font-size:.72rem;text-transform:uppercase;
+  letter-spacing:.05em}
+td.n{text-align:center;color:var(--muted)}
+td.n.has{color:var(--accent);font-weight:700}
+tr:last-child td{border-bottom:none}
+.note{background:var(--panel);border:1px solid var(--line);border-radius:12px;
+  padding:18px 22px;margin-bottom:14px}
+.note h3{margin:0 0 8px;font-size:1rem}
+.note ul{margin:0;padding-left:20px;font-size:.94rem}
+.note li{margin-bottom:7px}
+.empty{color:var(--muted);font-style:italic;padding:26px 0}
+footer{margin-top:56px;padding-top:20px;border-top:1px solid var(--line);
+  color:var(--muted);font-size:.82rem;font-family:ui-sans-serif,system-ui,sans-serif}
+@media(max-width:620px){
+  h1{font-size:1.6rem} .wrap{padding:0 14px 64px} header{padding-top:32px}
+  article{padding:16px 15px} .lbl{min-width:100%;margin-bottom:2px}
+}
+"""
+
+JS = """
+(function(){
+  var D='all', F='all';
+  function apply(){
+    var shown={};
+    document.querySelectorAll('article[data-d]').forEach(function(a){
+      var ok=(D==='all'||a.dataset.d===D)&&(F==='all'||a.dataset.f===F);
+      a.hidden=!ok; if(ok){shown[a.dataset.d]=(shown[a.dataset.d]||0)+1;}
+    });
+    var any=false;
+    document.querySelectorAll('section[data-d]').forEach(function(s){
+      var n=shown[s.dataset.d]||0; s.hidden=!n; if(n)any=true;
+      var c=s.querySelector('.n'); if(c)c.textContent=n===1?'1 finding':n+' findings';
+    });
+    document.getElementById('empty').hidden=any;
+  }
+  document.addEventListener('click',function(e){
+    var b=e.target.closest('button[data-k]'); if(!b)return;
+    var k=b.dataset.k, v=b.dataset.v;
+    if(k==='d'){D=v;} else if(k==='f'){F=v;} else if(k==='theme'){
+      var r=document.documentElement;
+      var cur=r.dataset.theme||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');
+      r.dataset.theme=cur==='dark'?'light':'dark'; return;
+    }
+    document.querySelectorAll('button[data-k="'+k+'"]').forEach(function(o){
+      o.setAttribute('aria-pressed', o.dataset.v===v?'true':'false');
+    });
+    apply();
+  });
+  apply();
+})();
+"""
+
+
+def esc(s):
+    return html.escape(str(s), quote=True)
+
+
+def build():
+    doc = json.load(open(SRC))
+    findings = doc["findings"]
+    by_decision = defaultdict(list)
+    for f in findings:
+        by_decision[f["decision"]].append(f)
+    defs = {d["name"]: d["definition"] for d in doc["taxonomy"]["decisions"]}
+    order = [d for d in DECISION_ORDER if by_decision.get(d)]
+    order += [d for d in by_decision if d not in order]
+
+    factions = sorted({f["faction"] for f in findings if f["faction"] != "general"})
+    fcount = {f["name"]: f["finding_count"] for f in doc["taxonomy"]["factions"]}
+    tcount = {f["name"]: f["transcript_count"] for f in doc["taxonomy"]["factions"]}
+
+    P = []
+    a = P.append
+    a('<title>How good 40k players think — mined from 1,029 YouTube transcripts</title>')
+    a('<meta name="viewport" content="width=device-width,initial-scale=1">')
+    a('<style>%s</style>' % CSS)
+    a('<div class="wrap">')
+
+    # ---- header
+    c = doc["corpus"]
+    a('<header>')
+    a('<h1>How good 40k players actually think</h1>')
+    a('<p class="sub">%d decision patterns pulled out of roughly %s hours of '
+      '11th-edition Warhammer 40,000 talk — tournament coverage, battle reports and '
+      'list reviews — organised by the decision you are making, not by the video it '
+      'came from. Every claim links to the moment somebody said it.</p>'
+      % (len(findings), "{:,}".format(int(round(c["words"] / 9000, -2)))))
+    a('<p class="meta sans">%s transcripts · %s channels · %s · generated %s</p>'
+      % (esc(c["transcripts"]), esc(c["channels"]), esc(c["date_range"]), esc(doc["generated"])))
+    a('</header>')
+
+    # ---- controls
+    a('<div class="controls sans">')
+    a('<div class="row"><span class="lbl">Decision</span>')
+    a('<button data-k="d" data-v="all" aria-pressed="true">Everything</button>')
+    for d in order:
+        a('<button data-k="d" data-v="%s" aria-pressed="false">%s</button>'
+          % (esc(d), esc(DECISION_LABEL.get(d, d))))
+    a('</div>')
+    a('<div class="row"><span class="lbl">Army</span>')
+    a('<button data-k="f" data-v="all" aria-pressed="true">All armies</button>')
+    a('<button data-k="f" data-v="general" aria-pressed="false">Holds for everyone</button>')
+    for fa in factions:
+        a('<button data-k="f" data-v="%s" aria-pressed="false">%s</button>' % (esc(fa), esc(fa)))
+    a('<button class="theme" data-k="theme" data-v="t">Light / dark</button>')
+    a('</div></div>')
+
+    # ---- findings
+    for d in order:
+        a('<section data-d="%s">' % esc(d))
+        a('<h2>%s<span class="n"></span></h2>' % esc(DECISION_LABEL.get(d, d)))
+        a('<p class="dfn">%s</p>' % esc(defs.get(d, "")))
+        for f in by_decision[d]:
+            a('<article data-d="%s" data-f="%s">' % (esc(d), esc(f["faction"])))
+            a('<p class="claim">%s</p>' % esc(f["claim"]))
+            a('<div class="tags">')
+            if f["faction"] != "general":
+                a('<span class="tag fac">%s</span>' % esc(f["faction"]))
+            else:
+                a('<span class="tag">every army</span>')
+            a('<span class="tag %s">%s confidence</span>' % (esc(f["confidence"]), esc(f["confidence"])))
+            a('<span class="tag">%d channel%s agree</span>'
+              % (f["corroborating_channels"], "" if f["corroborating_channels"] == 1 else "s"))
+            rs = f["rules_status"]
+            label = {"confirmed": "matches the rules", "player_opinion": "player judgement",
+                     "contradicts_rules": "CONTRADICTS THE RULES",
+                     "unverified": "unverified against the rules"}.get(rs, rs)
+            a('<span class="tag%s">%s</span>'
+              % (" warn" if rs == "contradicts_rules" else "", esc(label)))
+            a('</div>')
+            a('<p class="detail">%s</p>' % esc(f["detail"]))
+            if f.get("differs_from_general"):
+                a('<div class="diff"><b>Why this army is different</b>%s</div>'
+                  % esc(f["differs_from_general"]))
+            a('<div class="src"><ul>')
+            for e in f["evidence"]:
+                a('<li><a href="%s" target="_blank" rel="noopener">%s @ %s</a> — '
+                  '<span class="q">&ldquo;%s&rdquo;</span></li>'
+                  % (esc(e["url"]), esc(e["channel"]), esc(e["timestamp"]), esc(e["quote"])))
+            a('</ul></div>')
+            im = f["ai_impact"]
+            a('<details><summary>What this means for the game&rsquo;s AI</summary>'
+              '<div class="body">')
+            a('<div><b>Today:</b> %s</div>' % esc(im["current_behaviour"]))
+            a('<div><b>Change:</b> %s</div>' % esc(im["suggested_change"]))
+            a('<div><b>Risk:</b> %s</div>' % esc(im["risk"]))
+            a('<div><b>Where:</b> <code>%s</code> &middot; %s &middot; %s priority</div>'
+              % (esc(im.get("target") or "n/a"), esc(im["seam"]), esc(f["priority"])))
+            a('</div></details>')
+            a('</article>')
+        a('</section>')
+    a('<p class="empty" id="empty" hidden>Nothing matches those two filters — '
+      'that combination is a coverage gap, listed at the bottom of the page.</p>')
+
+    # ---- coverage matrix
+    a('<h2>Where the evidence actually is</h2>')
+    a('<p class="dfn">Findings per decision and army. Blank cells are honest gaps, '
+      'not zero-importance: several armies have plenty of transcripts and still '
+      'produced nothing decision-shaped.</p>')
+    a('<div class="tblwrap"><table><thead><tr><th>Army</th><th>Transcripts</th>')
+    for d in order:
+        a('<th>%s</th>' % esc(DECISION_LABEL.get(d, d).split()[0]))
+    a('<th>Total</th></tr></thead><tbody>')
+    matrix = doc["taxonomy"]["matrix"]
+    rows = ["general"] + [f for f in factions]
+    for fa in rows:
+        a('<tr><td>%s</td><td class="n">%s</td>'
+          % (esc("Holds for everyone" if fa == "general" else fa), esc(tcount.get(fa, "—"))))
+        for d in order:
+            n = matrix.get(d, {}).get(fa, 0)
+            a('<td class="n%s">%s</td>' % (" has" if n else "", n or "·"))
+        a('<td class="n%s">%d</td>' % (" has" if fcount.get(fa) else "", fcount.get(fa, 0)))
+        a('</tr>')
+    a('</tbody></table></div>')
+
+    # ---- disagreements
+    a('<h2>Where good players disagree</h2>')
+    a('<p class="dfn">Recorded rather than smoothed over. Where a disagreement has a '
+      'resolving variable, it is named.</p>')
+    for dis in doc["disagreements"]:
+        a('<div class="note"><h3>%s</h3><ul>' % esc(dis["topic"]))
+        for pos in dis["positions"]:
+            a('<li>%s</li>' % esc(pos))
+        a('</ul><p class="dfn" style="margin:12px 0 0">%s</p></div>' % esc(dis["note"]))
+
+    # ---- gaps
+    a('<h2>What this corpus does not tell you</h2>')
+    a('<div class="note"><ul>')
+    for g in doc["gaps"]:
+        a('<li>%s</li>' % esc(g))
+    a('</ul></div>')
+
+    a('<footer>Mined from auto-generated captions, so unit and army names are '
+      'frequently mangled — no finding is assigned to an army on a single '
+      'mis-hearable mention. Quotes are verbatim from the captions, including their '
+      'errors. Rules claims were checked against the 11th-edition core rules; claims '
+      'that are players&rsquo; judgement rather than rules are labelled as such. '
+      'The corpus skews competitive and is a broad sweep, not a census.</footer>')
+    a('</div>')
+    a('<script>%s</script>' % JS)
+
+    with open(OUT, "w") as fh:
+        fh.write("\n".join(P))
+    print("wrote %s (%d KB, %d findings)"
+          % (OUT, os.path.getsize(OUT) // 1024, len(findings)))
+
+
+if __name__ == "__main__":
+    build()

--- a/research/youtube/build_learnings.py
+++ b/research/youtube/build_learnings.py
@@ -1,0 +1,1494 @@
+#!/usr/bin/env python3
+"""Single source of truth for the mined findings.
+
+Emits research/youtube/ai_learnings.json (machine-readable, for the LLM that
+implements the changes). The HTML page is rendered from that JSON by
+build_html.py, so the two can never drift.
+
+Every evidence entry below was produced by search_transcripts.py / mine.py /
+faction_mine.py against research/youtube/transcripts_text.jsonl.gz; the
+timestamp is the [MM:00] caption marker preceding the quoted line.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from collections import Counter, defaultdict
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT = os.path.join(HERE, "ai_learnings.json")
+
+GENERATED = "2026-08-05"
+
+CORPUS = {
+    "transcripts": 1029,
+    "channels": 90,
+    "date_range": "2026-04-04 to 2026-08-04 (68 transcripts carry no date field)",
+    "words": 10510642,
+    "note": ("Auto-captioned (1027/1029). Heavily skewed to competitive/tournament "
+             "content: 414 transcripts tagged Meta, 334 Batreps. 11th edition released "
+             "June 2026, so ~92% of the corpus is June-August 2026 and post-dates the "
+             "first big balance dataslate (late July 2026)."),
+}
+
+DECISIONS = {
+    "positioning_and_concealment": (
+        "Where a unit physically stands: what it can see, what can see it, what "
+        "terrain state it ends its move in, and what that costs or buys."),
+    "screening_and_zoning": (
+        "Using bodies to deny space — blocking deep strike arrival, blocking charge "
+        "lanes, and blocking physical movement paths."),
+    "target_selection": (
+        "Given a set of legal targets, which one to shoot or fight, and how much to "
+        "commit to it."),
+    "objective_trade": (
+        "Whether to take, hold, contest, or give up an objective, and what that is "
+        "worth relative to killing something."),
+    "attrition_and_trades": (
+        "Whether a unit's likely loss is acceptable for what it buys."),
+    "reserves_and_arrival": (
+        "What to hold off the table, and when to bring it on."),
+    "melee_commitment": (
+        "Whether to charge, what to charge, and what a charge is for when it is not "
+        "for damage."),
+    "disengage_and_lock": (
+        "Whether to fall back out of an engagement, or deliberately stay in one to "
+        "deny the enemy its shooting."),
+    "ability_timing": (
+        "When to fire a once-per-battle or once-per-turn army ability, stratagem, or "
+        "command resource."),
+    "action_economy": (
+        "Which unit spends its turn performing a mission action rather than fighting."),
+    "tempo_and_commitment": (
+        "Which battle round to commit the army, and how much to hold back."),
+    "deployment": (
+        "Where the army starts, and how that is shaped by what the opponent has put "
+        "down."),
+}
+
+# Transcript counts from faction_index.py (title match OR >=6 in-body alias hits).
+FACTION_TRANSCRIPTS = {
+    "general": 1029,
+    "Space Marines": 214, "Orks": 213, "Tyranids": 110, "Necrons": 101,
+    "Dark Angels": 86, "Death Guard": 79, "Chaos Space Marines": 65,
+    "T'au Empire": 65, "Grey Knights": 60, "World Eaters": 58,
+    "Blood Angels": 58, "Adeptus Custodes": 54, "Space Wolves": 51,
+    "Aeldari": 50, "Thousand Sons": 48, "Leagues of Votann": 47,
+    "Drukhari": 46, "Chaos Knights": 43, "Emperor's Children": 43,
+    "Genestealer Cults": 34, "Astra Militarum": 32, "Imperial Knights": 32,
+    "Adeptus Mechanicus": 31, "Black Templars": 22, "Deathwatch": 18,
+    "Chaos Daemons": 15, "Harlequins": 10, "Adepta Sororitas": 9,
+    "Agents of the Imperium": 6, "Ynnari": 4,
+}
+
+
+def ev(channel, vid, ts, quote):
+    """Evidence row. ts is 'MM:SS'; the deep link seeks to that second."""
+    mm, ss = ts.split(":")
+    secs = int(mm) * 60 + int(ss)
+    return {"channel": channel, "video_id": vid, "timestamp": ts,
+            "url": "https://youtube.com/watch?v=%s&t=%ds" % (vid, secs),
+            "quote": quote}
+
+
+F = []
+
+
+def add(**kw):
+    kw["id"] = "F%03d" % (len(F) + 1)
+    kw.setdefault("differs_from_general", None)
+    kw["corroborating_channels"] = len({e["channel"] for e in kw["evidence"]})
+    F.append(kw)
+
+
+# ---------------------------------------------------------------- positioning
+add(
+    decision="positioning_and_concealment", faction="general",
+    claim="Infantry should end movement inside dense terrain so they gain Hidden, "
+          "which makes them untargetable beyond 15\" (12\" when the shooter's view is "
+          "broken by dense terrain).",
+    detail="11e's Hidden rule (core rules 13.09) gives INFANTRY/BEASTS/SWARM in a "
+           "dense terrain area a detection range — enemies further away simply cannot "
+           "target them, regardless of line of sight. Good players treat 'get to hidden "
+           "12' as the primary movement objective for infantry in the first two rounds, "
+           "because it converts an entire enemy shooting phase into nothing. The 3\" "
+           "reduction for being obscured by dense terrain is deliberately farmed, not "
+           "incidental.",
+    confidence="high",
+    evidence=[
+        ev("40K Dirtbags", "0Gcpze1G4Lc", "10:00",
+           "I try and get that dense cover for the hidden 12 ... How fast can I get to hidden 12"),
+        ev("Happy Krumping", "SkaqF6vbCYA", "12:00",
+           "elite infantry is incredibly powerful, making use of the hidden rule ... can't be targeted outside of 15 or 12"),
+        ev("Tabletop Titans", "dPFfT2IIlME", "15:00",
+           "if you want to be a shooting army right now ... you have to be able to get within hidden range quickly"),
+        ev("Planet 40K", "HQ0sQa37uHA", "13:00",
+           "as it's a monster, you're not going to be getting the hidden keyword"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "_score_movement_destination (movement scoring) — new WEIGHT_HIDDEN_GAINED constant",
+        "current_behaviour": "AIDecisionMaker.gd contains zero references to 'hidden' "
+                             "(grep -ci hidden = 0), while RulesEngine.gd fully implements 13.09 "
+                             "(hidden_model_visible_to, TerrainManager.detection_range_inches_for, "
+                             "15\" base minus a 3\" dense penalty). The AI therefore benefits from "
+                             "Hidden only by accident when a destination happens to be in terrain.",
+        "suggested_change": "Add a movement-destination bonus (start ~4.0, comparable to "
+                            "SECONDARY_POSITIONAL_BONUS 4.0) when the destination puts an "
+                            "INFANTRY/BEASTS/SWARM unit inside a dense terrain area and the unit "
+                            "has not shot this turn. Scale by how many enemy units are further "
+                            "than the detection range returned by "
+                            "TerrainManager.detection_range_inches_for — a Hidden position that "
+                            "hides from nothing is worth nothing.",
+        "risk": "Over-weighting drags infantry into terrain and off objectives; Hidden does "
+                "not stop charges or blast/indirect, so a Hidden unit can still be run down. "
+                "Gate it against the objective VP estimator so it never outbids a scoring move.",
+    },
+    priority="high",
+)
+
+add(
+    decision="positioning_and_concealment", faction="general",
+    claim="Shooting surrenders Hidden for this turn and the next, so a unit that "
+          "cannot meaningfully hurt anything should hold its fire and stay untargetable.",
+    detail="Hidden requires that the unit made no ranged attacks this turn or last turn, "
+           "so pulling the trigger is a two-turn commitment to being shootable. Players "
+           "explicitly weigh a marginal shooting phase against a turn of immunity, and "
+           "will decline shots with backfield or objective-holding infantry to keep the "
+           "state. This is a genuine per-unit decision every shooting phase, not a "
+           "list-building consideration.",
+    confidence="high",
+    evidence=[
+        ev("Zeeto", "TJQWtTZiP1g", "58:00",
+           "as soon as you give up hidden, you shoot a ball across the map ... you've got the 15 inch hidden anyway"),
+        ev("Mid Table Tactics", "k-IMme1pngY", "42:00",
+           "They're not going to be hidden though because they are probably going to shoot"),
+        ev("TacticalTortoise 40k", "VqwMdS9MuIY", "186:00",
+           "I'm hidden in the line like this cuz I just got to shoot there ... not hidden cuz they're shooting"),
+        ev("Proxy Hammer", "f_z0hvW0VMk", "49:00",
+           "you don't have to move out into the open ... remain hidden even while shooting"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "shooting-phase target scoring — new HIDDEN_FORFEIT_PENALTY constant",
+        "current_behaviour": "The AI shoots whenever a legal shooting action scores above "
+                             "zero. It has no concept of a non-damage cost to firing, so it will "
+                             "trade two turns of untargetability for one low-value shooting action.",
+        "suggested_change": "When the shooter is currently Hidden, subtract a penalty from every "
+                            "shooting assignment for that unit — scale it by how many enemy units "
+                            "are outside detection range (i.e. how much immunity is being sold). "
+                            "Suggested start: 3.0, so the unit still fires when the expected "
+                            "damage is real but declines chip shots.",
+        "risk": "An over-large penalty produces a passive gunline that never shoots. The penalty "
+                "must be zero for units that already shot this turn (Hidden is already lost) and "
+                "for units with a 'remain hidden while shooting' ability.",
+    },
+    priority="high",
+)
+
+add(
+    decision="target_selection", faction="general",
+    claim="Enemy infantry that is about to regain Hidden should be shot this turn, "
+          "because next turn it may be untargetable.",
+    detail="Hidden returns once a unit goes a full turn without shooting, so an enemy "
+           "unit that fired last turn but not this one is on a timer. Players consciously "
+           "reprioritise onto those units while the window is open, rather than picking "
+           "the highest-value target and finding it unshootable next turn. This is the "
+           "mirror image of the decision to hold fire.",
+    confidence="medium",
+    evidence=[
+        ev("Boltgun Tactics", "gRQZh-QYBIQ", "20:00",
+           "I'm not going to shoot the raptors cuz they might get hidden um if I don't shoot"),
+        ev("40K Dirtbags", "Enm67qaqHkU", "07:00",
+           "these guys won't be able to shoot me turn one if everybody's hidden"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "_calculate_target_value — new HIDDEN_WINDOW_BONUS",
+        "current_behaviour": "Target value is computed from points, output, survivability and "
+                             "objective presence. Availability is treated as binary and permanent: "
+                             "there is no notion of a target that is legal now and illegal later.",
+        "suggested_change": "Multiply target value by ~1.25 when the target is an "
+                            "INFANTRY/BEASTS/SWARM unit standing in dense terrain that did not "
+                            "make ranged attacks this turn — it will be Hidden on the opponent's "
+                            "next turn. Read the same flags RulesEngine uses for 13.09.",
+        "risk": "Chasing the window can pull fire off a genuinely more dangerous target. Keep the "
+                "multiplier modest so it breaks ties rather than overriding threat.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="positioning_and_concealment", faction="general",
+    claim="Every move into enemy line of sight is taxed by Overwatch, which in 11e "
+          "fires at the end of the opponent's Movement phase and can no longer be baited "
+          "out with a single expendable model.",
+    detail="Overwatch moved to the end of the opponent's Movement phase and uses snap "
+           "shooting (hits only on unmodified 6s, no re-rolls). Because the defender now "
+           "watches the whole movement phase resolve before choosing a target, the old "
+           "trick of pushing one cheap model out to draw the shot is dead — the defender "
+           "simply waits and picks the best target. Players describe this as having to "
+           "declare their whole movement plan to the opponent before paying for it.",
+    confidence="high",
+    evidence=[
+        ev("Vanguard Tactics", "qahZnQPN8a8", "27:00",
+           "Overwatch is so powerful in this game now because you can't ... put one model out ... you can't bait them out anymore"),
+        ev("StrikingScorpion82", "eUpeWbN7gF4", "28:00",
+           "overwatch is done at the end of the opponent's movement phase ... it's a decision we can make uh once movement's done"),
+        ev("Deploy on the Line 40K", "FT5JoL5Myis", "05:00",
+           "it's just too easy to overwatch in 11th edition. You can't play around it anymore with these big squads"),
+        ev("6 Plus Plus Gaming", "uKl8cEJlk0c", "27:00",
+           "with how Overwatch is now, that's really really powerful to have a reactive move"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "THREAT_SHOOTING_PENALTY (currently 0.5)",
+        "current_behaviour": "THREAT_SHOOTING_PENALTY is 0.5 and commented 'Lighter penalty for "
+                             "moving into shooting range (reduced from 1.0 — often unavoidable)'. "
+                             "That reasoning was written for a shooting phase the mover could "
+                             "answer; 11e Overwatch is paid inside the mover's own turn, before "
+                             "it acts.",
+        "suggested_change": "Raise THREAT_SHOOTING_PENALTY to ~1.0 and add a separate "
+                            "OVERWATCH_EXPOSURE_PENALTY applied only when the destination is "
+                            "visible to an enemy unit that has not yet used Fire Overwatch this "
+                            "round, weighted by that unit's raw shot volume (snap shooting rewards "
+                            "volume and torrent, not quality). Do not apply it to destinations "
+                            "already inside enemy line of sight before the move.",
+        "risk": "Too high and the AI refuses to cross the board at all, which loses on primary. "
+                "The penalty should be suppressed for melee-archetype units (they already "
+                "discount threat via THREAT_MELEE_UNIT_IGNORE) and in rounds 4-5.",
+    },
+    priority="high",
+)
+
+add(
+    decision="positioning_and_concealment", faction="general",
+    claim="The default opening is to stage the army out of line of sight behind mid-board "
+          "terrain and physically occupy the staging point the opponent wants.",
+    detail="Because shooting is punishing and Hidden is available, the first-turn move is "
+           "usually to get behind the centre ruin rather than onto the mid-board objectives. "
+           "The refinement is that the terrain piece is a contested resource: putting bodies "
+           "against it denies the opponent the same protection, so the move is simultaneously "
+           "defensive and a denial play.",
+    confidence="medium",
+    evidence=[
+        ev("40K Fireside", "-Bh3n-_Tpfs", "61:00",
+           "move block your opponent from touching the middle ruin and staging your army behind it"),
+        ev("Master Crafted", "6Lgr1hUGsgw", "14:00",
+           "we're behind it, we're hidden, they can't see us, but at least we know that we're taking up the space"),
+        ev("Play On Tabletop", "1SRkN4Drhs4", "18:00",
+           "my jumpack intercessors will move to stage behind this terrain ... I just don't want to be shot"),
+        ev("Auspex Tactics", "mX7VBM9qJjY", "07:00",
+           "staged as far forward as possible but out of line of sight"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_POSITION_RATIO (0.55)",
+        "current_behaviour": "Corridor blocking already exists but is keyed to objectives — it "
+                             "places blockers 55% of the way from an objective toward a threatening "
+                             "enemy. It has no notion of terrain pieces as the thing worth denying.",
+        "suggested_change": "Extend the corridor-block candidate set with the mid-board dense "
+                            "terrain areas TerrainManager already exposes, scoring a blocking "
+                            "position that both breaks enemy line of sight to our army and sits "
+                            "against the terrain the enemy would otherwise stage in. Reuse "
+                            "CORRIDOR_BLOCK_SCORE_BASE so the two compete on one scale.",
+        "risk": "Terrain-hugging can strand units away from scoring positions in rounds 4-5, where "
+                "STRATEGY_LATE_OBJECTIVE (1.6) should dominate. Gate to rounds 1-2.",
+    },
+    priority="medium",
+)
+
+# ------------------------------------------------------------------ screening
+add(
+    decision="screening_and_zoning", faction="general",
+    claim="A screen is defined by the gaps between its models relative to the enemy's "
+          "base size, not by the unit's overall position — gaps must be too narrow for an "
+          "enemy base to pass through while staying more than 1\" away.",
+    detail="Models cannot move within Engagement Range of enemies during a normal move, so "
+           "two screening models placed a base-width-plus-2\" apart form a wall; placed wider, "
+           "they are decoration. Players talk in terms of the specific enemy base they are "
+           "screening against (32mm, 2\"), and losing a game to a single unplanned gap is a "
+           "recurring post-mortem. Consolidation compounds the error: a model that squeezes "
+           "through kills the screen and then consolidates into whatever was behind it.",
+    confidence="high",
+    evidence=[
+        ev("6 Plus Plus Gaming", "gRqdSBkqVlA", "22:00",
+           "What I didn't think of was leaving gaps between my models to screen a 32 mil base"),
+        ev("TacticalTortoise 40k", "VqwMdS9MuIY", "514:00",
+           "create a gap that is less than 1 in between all of those models ... will prevent any orc model from going through"),
+        ev("Proxy Hammer", "xFGyuYmXyJY", "10:00",
+           "you can have a little bit of space in between your models that they won't be able to actually fit through"),
+        ev("Grimdark Breakdown", "VPTL092E0VI", "13:00",
+           "The amount of times that I have tried to screen and there's a tiny hole"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "screening placement (SCREEN_SCORE_BASE path) — new SCREEN_MODEL_GAP logic",
+        "current_behaviour": "Screening is scored at unit granularity: SCREEN_SPACING_PX (18\") "
+                             "spaces whole screening units, and AI_B2B_GAP_PX (0.5px) is only used "
+                             "for base-to-base packing. Nothing checks whether the resulting model "
+                             "line has a passable gap.",
+        "suggested_change": "When laying out a unit flagged as a screener, cap inter-model spacing "
+                            "at (largest enemy base diameter + 2\") and validate the finished line "
+                            "against the widest enemy base on the board. Expose the cap as "
+                            "SCREEN_MAX_MODEL_GAP_PX so it is tunable per profile.",
+        "risk": "Tight spacing shortens the screen, so fewer inches are covered per unit and "
+                "blast weapons get better value. It also interacts with unit coherency — the "
+                "layout must still satisfy coherency after casualties.",
+    },
+    priority="high",
+)
+
+add(
+    decision="screening_and_zoning", faction="general",
+    claim="Deep-strike denial must use the arriving unit's own minimum distance, because "
+          "6\" deep strike is common in 11e and a 9\"-spaced screen does not stop it.",
+    detail="Numerous 11e detachments and enhancements grant deep strike at 6\" rather than "
+           "the core 9\", and players describe having to screen 'really aggressively' as a "
+           "result. Denial geometry is the sum of two radii: to deny a 9\" arrival, screeners "
+           "must be within 18\" of each other; to deny a 6\" arrival, within 12\". Using one "
+           "fixed number under-screens against exactly the units most able to punish it.",
+    confidence="high",
+    evidence=[
+        ev("Odyssey40k", "uYFHWwWSklU", "87:00",
+           "there's a 6-in deep strike in retaliation ... you have to screen really aggressively for it"),
+        ev("Tactical Sugar", "SyVxk7EW_tI", "132:00",
+           "it's so much harder screen out now in 11th and deep strikes are so much more important in 11th"),
+        ev("TacticalTortoise 40k", "nGqRAvAMTYA", "66:00",
+           "He also can 6 in deep strike high OC onto an objective in order to grab it"),
+        ev("The Tabletop Alliance 40K", "8_HAdKldvhs", "20:00",
+           "What do you have in reserve? Screamers ... 6 in deep strike now"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "DEEP_STRIKE_DENIAL_RANGE_PX (360.0 = 9\") and SCREEN_SPACING_PX (720.0 = 18\")",
+        "current_behaviour": "Both constants are hardcoded to the core-rules 9\" case. "
+                             "_find_screening_positions steps the board every SCREEN_SPACING_PX and "
+                             "treats any point further than DEEP_STRIKE_DENIAL_RANGE_PX from a "
+                             "friendly model as deniable.",
+        "suggested_change": "Derive the radius per threat: scan enemy units still in reserve for a "
+                            "deep-strike ability naming a distance, take the minimum across them, "
+                            "and use 2x that as the screen spacing for this game. Keep the current "
+                            "values as the fallback when no reserve unit advertises a shorter range.",
+        "risk": "A 12\" spacing needs ~50% more screening bodies to cover the same frontage; on "
+                "low-model armies this will starve objectives. Pair with a cap on how many units "
+                "may take screening assignments.",
+    },
+    priority="high",
+)
+
+# ------------------------------------------------------------ target selection
+add(
+    decision="target_selection", faction="general",
+    claim="Clearing enemy screens is worth more than the screen's points, because the "
+          "screen is what stops the rest of the army from scoring or charging.",
+    detail="Players routinely commit an expensive unit to kill a cheap one and describe it "
+           "as a good decision, because the cheap unit is denying a charge lane, an objective, "
+           "or a deep-strike landing zone. Points-per-wound efficiency scores this as a bad "
+           "trade; the players' framing is that the screen's value is the value of everything "
+           "it is blocking. The counterweight they also state is not to use your best melee "
+           "unit on chaff when a cheaper one will do.",
+    confidence="high",
+    evidence=[
+        ev("TacticalTortoise 40k", "VqwMdS9MuIY", "62:00",
+           "it's absolutely worth a genailer squad to eviscerate one of those ranger squads even though it's a trade down"),
+        ev("40K Fireside", "_xKjN6N1jT0", "04:00",
+           "you need to kill like I don't know, 10 guardsmen move blocking your big charges"),
+        ev("TacticalTortoise 40k", "7AgzQIEq3j4", "93:00",
+           "you can clear screening units and infiltrators ... have to run 20 possessed into ... 10 commandos"),
+        ev("Warpbane Tactics", "D5XVd0FRgK8", "02:00",
+           "unit left alive on one wood can still hold an objective, block our movement ... That is why finis"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "TRADE_PPW_WEIGHT (0.25) / TRADE_UNFAVORABLE_PENALTY (0.7)",
+        "current_behaviour": "Trade analysis penalises killing cheap units with expensive ones "
+                             "(TRADE_UNFAVORABLE_PENALTY 0.7), and is gated to Competitive "
+                             "difficulty only (use_trade_analysis). A screening unit is scored as "
+                             "its points and output, so it looks like a bad target.",
+        "suggested_change": "Add a positional-value term to _calculate_target_value: if the target "
+                            "is currently inside our own screening-denial evaluation (it is blocking "
+                            "a charge lane, sitting in a deep-strike landing zone we want, or "
+                            "contesting an objective our VP estimator prices), suppress the "
+                            "TRADE_UNFAVORABLE_PENALTY for that target rather than adding raw score. "
+                            "Suppression, not a bonus, keeps the existing scale intact.",
+        "risk": "Suppressing the penalty too broadly recreates the pre-trade-analysis behaviour of "
+                "shooting lascannons at Grots. It must key off an explicit blocking role, not off "
+                "cheapness.",
+    },
+    priority="high",
+)
+
+add(
+    decision="target_selection", faction="general",
+    claim="Battle-shocking a unit strips its Objective Control to zero, so an objective can "
+          "be flipped without killing anything.",
+    detail="A battle-shocked unit's models have OC '-', cannot be targeted by stratagems and "
+           "cannot start actions. Players describe whole lists built around it ('battleshock OC "
+           "denial') and use forced battle-shock tests specifically to deny a primary score in "
+           "the opponent's command phase. Against durable objective-holders this is far cheaper "
+           "than killing them, and it is the counter to armies that ignore attrition.",
+    confidence="high",
+    evidence=[
+        ev("Zeeto", "TJQWtTZiP1g", "02:00",
+           "That sort of Battleshock um OC denial sort of list ... would probably work well in teams"),
+        ev("6 Plus Plus Gaming", "eokQteHr0Fo", "19:00",
+           "if you really need them to not have a secondary uh primary point ... it's a really powerful strategy"),
+        ev("Grimdark Breakdown", "qwnHaQvzCq0", "14:00",
+           "If you Battle Shock me, I go to 1 OC instead of 0"),
+        ev("The Six Machine", "ewxyBDMvC64", "23:00",
+           "it is more likely that you will get battleshocked and potentially stay battleshocked"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "objective contest evaluation + battle-shock-inflicting ability/stratagem scoring",
+        "current_behaviour": "The AI reads the battle_shocked flag defensively (it un-shocks its "
+                             "own units via 'Da Captain', and skips shocked enemies in some checks) "
+                             "but never evaluates inflicting battle-shock as a route to controlling "
+                             "an objective. Objective contest is computed from raw OC only.",
+        "suggested_change": "When scoring an ability or stratagem that forces a battle-shock test, "
+                            "add the VP the objective would be worth if the target's OC went to "
+                            "zero — reuse _estimate_objective_vp_value with the target's OC removed "
+                            "and score the delta. Same term should make a shocked enemy unit a "
+                            "lower-priority shooting target while it is shocked and already "
+                            "contributing nothing.",
+        "risk": "Battle-shock is a leadership roll and often fails; the score must be multiplied by "
+                "the actual pass probability or the AI will spend CP on coin flips. It also lasts "
+                "only until the next command phase, so it is worthless outside the scoring window.",
+    },
+    priority="high",
+)
+
+add(
+    decision="target_selection", faction="general",
+    claim="Concentrate onto one target until it is destroyed rather than spreading damage; "
+          "a unit left on one wound still holds objectives and blocks movement.",
+    detail="A surviving model retains full Objective Control and full blocking geometry, so "
+           "partial damage buys almost nothing in a mission-scored edition. Players describe "
+           "spreading fire as the specific mistake that cost them a game, and finishing "
+           "targets as the corrective. This mostly corroborates what the AI already does, but "
+           "the mechanism matters: the reason to finish is positional, not damage-economic.",
+    confidence="medium",
+    evidence=[
+        ev("Warpbane Tactics", "PWtaFLZYu_U", "03:00",
+           "spreading my damage across multiple units would have been a massive mistake. I focused on completely removing one unit at a time"),
+        ev("Warpbane Tactics", "D5XVd0FRgK8", "02:00",
+           "unit left alive on one wood can still hold an objective, block our movement"),
+        ev("Planet 40K", "lNn0zv_w8t8", "05:00",
+           "another bad priority target ... is just simply bad trades"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "MICRO_MARGINAL_KILL_BONUS (2.5) / MICRO_OVERKILL_DECAY (0.35) / OVERKILL_TOLERANCE (1.15)",
+        "current_behaviour": "Focus fire already exists at Normal+ and MICRO_MARGINAL_KILL_BONUS "
+                             "rewards the assignment that crosses the kill threshold. The weighting "
+                             "is damage-denominated, so a target holding an objective is not "
+                             "preferentially finished.",
+        "suggested_change": "Multiply MICRO_MARGINAL_KILL_BONUS by ~1.4 when the target currently "
+                            "contributes OC to an objective our VP estimator prices above zero, so "
+                            "finishing a scoring unit outbids starting on a fresh one.",
+        "risk": "Low. The main hazard is stacking with the disposition kill-pressure term and "
+                "producing tunnel vision on one objective.",
+    },
+    priority="medium",
+)
+
+# --------------------------------------------------------------- objectives
+add(
+    decision="objective_trade", faction="general",
+    claim="Tabling the opponent is no longer a win condition in 11e; the AI should accept "
+          "losing units it cannot save if the exchange keeps it ahead on primary.",
+    detail="Multiple channels contrast 11e with 10e explicitly: in 10e killing the opponent's "
+           "army was a common route to victory, in 11e games are decided on accumulated primary "
+           "and secondary VP with a 45-point primary cap. The practical consequence is that a "
+           "durable army can lose the attrition war and still win, and an aggressive army that "
+           "wins every fight can lose on points.",
+    confidence="high",
+    evidence=[
+        ev("Grimdark Breakdown", "MG546BN181w", "47:00",
+           "You do not have to kill your opponent in 11th edition. A giant condition of winning was tableabling your opponent in 10th"),
+        ev("Master Crafted", "9fuvetVLB3s", "29:00",
+           "they don't have to kill you. It's just going to take you five turns to kill their army and they're just going to keep scoring"),
+        ev("40K Dirtbags", "EBJW0VDeT_Q", "45:00",
+           "win on primary by denying primary and stuff like that. It's really the only way to to win 40k"),
+        ev("Deploy on the Line 40K", "VU4S_6e1NgE", "24:00",
+           "you're just going to win on primary points as long as you don't burn out"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "STRATEGY_EARLY_AGGRESSION (1.3) / STRATEGY_EARLY_OBJECTIVE (0.95)",
+        "current_behaviour": "Rounds 1-2 boost kill-seeking 30% and hold objective weight just "
+                             "below full (0.95). The VP-denominated objective estimator already "
+                             "exists, so the framework is right, but the early-round modifiers "
+                             "still tilt toward damage.",
+        "suggested_change": "Bring STRATEGY_EARLY_AGGRESSION down toward 1.1 and "
+                            "STRATEGY_EARLY_OBJECTIVE up to 1.0, and A/B it the way "
+                            "orks_discipline_a.json A/B'd the Ork constant. Do not change the late "
+                            "modifiers — they already favour objectives.",
+        "risk": "Reduced early aggression can let an aggressive opponent establish the mid-board "
+                "unopposed, which loses on primary for the opposite reason. This is a benchmark "
+                "question, not a settled one — hence the profile arm rather than a constant edit.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="objective_trade", faction="general",
+    claim="The force disposition should modulate how much the AI values killing versus "
+          "holding, not just which objectives it prices.",
+    detail="11e pairs each player's disposition deck against the opponent's, and the five "
+           "dispositions reward very different behaviour: Purge the Foe pays for destroying "
+           "units every turn, Take and Hold pays for straightforward objective control, "
+           "Recon and Priority Assets pay for actions in specific places, and Disruption "
+           "scores poorly overall — which players treat as licence to stop caring about "
+           "scoring and simply attack. That last inversion is the clearest evidence that "
+           "disposition should change aggression, not only objective pricing.",
+    confidence="medium",
+    evidence=[
+        ev("Happy Krumping", "pAk1YiuioNQ", "70:00",
+           "disruption scores poorly, it kind of releases you to not have to worry about scoring ... you might as well just obliterate your opponents"),
+        ev("Deploy on the Line 40K", "14LSO7MS3QI", "85:00",
+           "if they were taking recon they're just trying to kill people and say whatever you score your points later"),
+        ev("Warpbane Tactics", "ogMKXBVh4g0", "02:00",
+           "Disruption is about interfering with your opponent's plans, it rewards movement, positioning"),
+        ev("TacticalTortoise 40k", "i7MkaccGXeA", "25:00",
+           "gives you points where you destroy enemies ... So it's a simply a race"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "_build_primary_awareness → feed kill_pressure into the aggression modifier stack",
+        "current_behaviour": "_build_primary_awareness already parses the player's own 11e primary "
+                             "card and sets objective_pressure, enemy_home_bonus, central_bonus and "
+                             "a boolean kill_pressure. objective_pressure feeds objective scoring, "
+                             "but kill_pressure is only recorded — it does not modify the "
+                             "aggression/charge-threshold modifiers.",
+        "suggested_change": "Multiply the aggression modifier by ~1.2 and the charge threshold by "
+                            "~0.9 while awareness.kill_pressure is true, and apply the inverse when "
+                            "objective_pressure is high and kill_pressure false. This is a small "
+                            "change because the parsing already exists.",
+        "risk": "Double-counting: kill-based primary rules already raise the VP value of killing "
+                "through the estimator, so a second multiplier can over-rotate. Cap the combined "
+                "aggression modifier.",
+    },
+    priority="medium",
+)
+
+# ----------------------------------------------------------------- reserves
+add(
+    decision="reserves_and_arrival", faction="general",
+    claim="Keeping one unit in reserve as a reactive answer is standard, but committing "
+          "the whole army to the table is correct against high-pressure lists — the corpus "
+          "genuinely disagrees on how much to hold back.",
+    detail="One camp treats a reserve unit as a deliberate list slot: something held to "
+           "answer whatever the opponent commits, or to Rapid Ingress into a gap. The other "
+           "camp says that against lists which apply immediate pressure you need every body "
+           "on the table from turn one, because arriving later means arriving after the "
+           "mid-board is lost. Both are stated confidently by strong players; the resolving "
+           "variable appears to be the opponent's speed, which the AI can measure.",
+    confidence="medium",
+    evidence=[
+        ev("40K Dirtbags", "Enm67qaqHkU", "04:00",
+           "at least one unit in reserves cuz you're making lists to have a reserve rapid ingress target"),
+        ev("Art of War 40k", "ym0SnzF2ydg", "162:00",
+           "maybe they should have just started the game in reserve so they could be a little bit more of a reactive answer"),
+        ev("Happy Krumping", "pAk1YiuioNQ", "09:00",
+           "If you're ever going to play against it, don't start things in reserves. You need everything on the table"),
+        ev("Deploy on the Line 40K", "gZWxrJy66nw", "12:00",
+           "there's no reason to put anything in reserve because I have redeploy"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "_evaluate_reserves_declarations",
+        "current_behaviour": "Reserves selection puts melee-oriented and short-range deep-strike "
+                             "units into reserve up to the 50% points / 50% units cap, without "
+                             "reference to how fast the opponent's army is.",
+        "suggested_change": "Before declaring reserves, compute the opponent's effective turn-one "
+                            "threat range (max Move + Advance + charge across their deployed units, "
+                            "plus scout moves). Above a threshold (~20\"), reduce the reserve budget "
+                            "toward one unit; below it, keep the current behaviour. Expose the "
+                            "threshold as RESERVE_PRESSURE_THRESHOLD_INCHES.",
+        "risk": "Threat range is a crude proxy — an army can be fast and harmless. Getting it wrong "
+                "in the aggressive direction leaves the AI with nothing in reserve against alpha "
+                "strikes, which is the failure mode the second camp is warning about.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="reserves_and_arrival", faction="general",
+    claim="Reactive movement abilities are widespread enough in 11e that the AI cannot "
+          "treat enemy positions as fixed between its own decisions.",
+    detail="Detachment rules, enhancements and stratagems across many factions grant a move "
+           "triggered by an enemy action — being shot, or an enemy coming within a set "
+           "distance. Players plan around it explicitly: they decline moves that would trigger "
+           "a reactive escape, and they buy reactive-move abilities specifically as insurance "
+           "against 11e's stronger Overwatch. Any AI plan that assumes the target stays put "
+           "will systematically over-value long charges and precise blocking positions.",
+    confidence="medium",
+    evidence=[
+        ev("PNW 40K", "ycW5l0xHp9s", "08:00",
+           "He can make a reactive move ... reactive moves in general are very powerful"),
+        ev("HivemindHobbies", "Wm2Hd8h74_o", "65:00",
+           "if he moves up at all, then they will automatically reactive move behind this obscuring wall"),
+        ev("40K Dirtbags", "Enm67qaqHkU", "20:00",
+           "he then reactive moves and kind of spreads out to stop Ghaz from moving this way"),
+        ev("TacticalTortoise 40k", "VqwMdS9MuIY", "60:00",
+           "it has the ability to reactive move to enemies going close to it ... it may be able to jump away"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "difficulty_gate",
+        "target": "AIDifficultyConfig.use_look_ahead (Competitive only)",
+        "current_behaviour": "Look-ahead is Competitive-only and models opponent responses "
+                             "generically. Nothing detects that a specific enemy unit owns a "
+                             "reactive-move ability.",
+        "suggested_change": "Scan enemy datasheet abilities and the opponent's detachment "
+                            "stratagems for reactive-move wording, and discount blocking-position "
+                            "and marginal-charge scores against those units by ~30%. Gate to "
+                            "Hard+ rather than Competitive-only, since it is a defensive "
+                            "correction rather than deep search.",
+        "risk": "Ability-text scanning is brittle and will both miss and over-match. A false "
+                "positive makes the AI refuse good charges. Prefer an explicit ability list over "
+                "free-text matching.",
+    },
+    priority="medium",
+)
+
+# ------------------------------------------------------- melee / lock / actions
+add(
+    decision="melee_commitment", faction="general",
+    claim="Charging purely to tie up a dangerous shooter is worth doing even when the "
+          "charging unit expects to deal and receive negligible damage.",
+    detail="A unit locked in engagement generally cannot shoot, so a cheap charge can switch "
+           "off an expensive gun for a full turn. Players make this charge knowing they will "
+           "lose the melee, and specifically use it against vehicles and gunline units that "
+           "would otherwise fire freely. The value is the enemy's forgone shooting phase, not "
+           "the combat result.",
+    confidence="medium",
+    evidence=[
+        ev("WednesdayNightWarhammer", "MkeH0tr1o_o", "57:00",
+           "I guess I would attempt the charge to get just to tie you up"),
+        ev("40K Dirtbags", "0Gcpze1G4Lc", "14:00",
+           "this thing was within range to move up and shoot her. So, I needed to make this charge to stop this tank"),
+        ev("WarGames Live", "HER6VzUGO60", "658:00",
+           "We'll charge the truck in just to lock you in because we can still touch you and still be on the objective"),
+        ev("Mordian Glory", "lp4j3iYlpQ4", "25:00",
+           "I charged up to the hell hound just to tie them up again"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / PHASE_PLAN_RANGED_STRENGTH_DANGEROUS (5.0)",
+        "current_behaviour": "The multi-phase planner already gives a 3.0 bonus for charging "
+                             "dangerous shooters, but it is gated behind use_multi_phase_planning "
+                             "(Hard+), and the charge must still clear the normal charge threshold "
+                             "that is driven by expected damage.",
+        "suggested_change": "Make the lock bonus able to carry a charge on its own: when the target "
+                            "exceeds PHASE_PLAN_RANGED_STRENGTH_DANGEROUS and the charger is cheap "
+                            "relative to it, bypass the expected-damage component of the charge "
+                            "threshold rather than adding to it. Consider lowering the gate to "
+                            "Normal, since players treat this as basic play.",
+        "risk": "Feeding cheap units into melee they lose can hand the opponent Purge-the-Foe VP "
+                "and free consolidation moves toward objectives. Require that the charger is not "
+                "currently contributing OC to a priced objective.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="melee_commitment", faction="general",
+    claim="Consolidation should be scored as a positioning move — onto an objective, into "
+          "a new enemy unit, or backwards out of line of sight — not as a default 3\" shuffle.",
+    detail="After fighting, the 3\" consolidation is often the most valuable move of the turn: "
+           "it can put a unit onto an objective it could not have charged, drag it into a "
+           "second enemy unit to lock that one too, or pull it back behind terrain so it is "
+           "not shot in the opponent's turn. Players choose deliberately between those three "
+           "outcomes and name the reason each time.",
+    confidence="medium",
+    evidence=[
+        ev("40K Dirtbags", "Enm67qaqHkU", "24:00",
+           "I picked this objective to cons consolidate backwards a little bit so he doesn't get shot"),
+        ev("Maelstrom Gaming Studios - Tyranids", "aQsog-fkQJ8", "71:00",
+           "I will tow this guy onto the objective ... get a tiny bit further away"),
+        ev("Auspex Tactics", "YM1sRZGVOhw", "12:00",
+           "If you're able to hit something, destroy something, consolidate into something else"),
+        ev("Boltgun Tactics", "6V8asnfgFUE", "161:00",
+           "We'll just consolidate into the middle"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "consolidation move selection in the FIGHT phase",
+        "current_behaviour": "Consolidation is resolved without a dedicated scoring pass "
+                             "comparable to _score_movement_destination; there is no explicit "
+                             "objective/LoS evaluation of the 3\" options.",
+        "suggested_change": "Score consolidation destinations with the same three terms used for "
+                            "movement — objective VP delta (via _estimate_objective_vp_value), "
+                            "number of additional enemy units brought into engagement, and whether "
+                            "the destination breaks enemy line of sight — and pick the max.",
+        "risk": "Consolidating out of line of sight can also leave an objective; the VP term must "
+                "dominate. Rules constraints on consolidation (must end closer to the nearest "
+                "enemy, or toward an objective) restrict the legal set and must be respected.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="disengage_and_lock", faction="general",
+    claim="Falling back is expensive: most vehicles cannot fall back and shoot, and a "
+          "battle-shocked unit must make Desperate Escape rolls, so staying locked is often "
+          "correct.",
+    detail="Fall Back normally forbids shooting and charging for the rest of the turn unless "
+           "a specific ability says otherwise, and that ability is usually restricted to "
+           "infantry. Players are caught out by this mid-game. The corollary drives the "
+           "opposite decision too: armies that want the enemy stuck deliberately engage from "
+           "multiple units so that falling back is unattractive.",
+    confidence="medium",
+    evidence=[
+        ev("40K Dirtbags", "F5TL7LhZJlY", "13:00",
+           "He spends a CP realizing after the fact that you can't fall back and shoot with vehicles. It's only infantry"),
+        ev("40K Dirtbags", "Enm67qaqHkU", "25:00",
+           "If they fall back and shoot, these guys could have fell back and shot. But that's only one unit of shooting"),
+        ev("Maelstrom Gaming Studios - Tyranids", "aQsog-fkQJ8", "98:00",
+           "no, we'll fall back and we'll take our hazardous roles. Ones and twos, they die"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "SURVIVAL_FALL_BACK_BONUS (2.0) / SURVIVAL_HOLD_BONUS (1.5)",
+        "current_behaviour": "Survival assessment (Normal+) compares expected damage against "
+                             "remaining wounds and adds a flat 2.0 toward falling back when the "
+                             "unit is threatened. The lost shooting phase is not priced.",
+        "suggested_change": "Subtract the unit's own expected ranged output from the fall-back "
+                            "score unless it has a fall-back-and-shoot ability, and subtract more "
+                            "when the unit is battle-shocked (Desperate Escape casualties). A "
+                            "VEHICLE without that ability should almost never fall back purely for "
+                            "survival.",
+        "risk": "Holding a losing combat can lose the unit outright. The change should only "
+                "reweight, not veto — SURVIVAL_LETHAL_THRESHOLD (0.75) must still force the "
+                "retreat when destruction is likely.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="action_economy", faction="general",
+    claim="Mission actions consume the acting unit's shooting, so they should be assigned "
+          "to the cheapest unit that can reach and survive, not to whatever is nearest.",
+    detail="Recon and Priority Assets dispositions are action-heavy, actions are limited to "
+           "one per turn on some cards and cannot start before round two on others, and "
+           "starting an action generally costs the unit its shooting phase. Players therefore "
+           "build in small, cheap, mobile units whose whole job is to walk somewhere and press "
+           "a button. Notable exception in 11e: Titanic units can shoot and perform actions.",
+    confidence="medium",
+    evidence=[
+        ev("Grimdark Breakdown", "VPTL092E0VI", "12:00",
+           "They have very small bases and then put down somewhere else on the board to do the action"),
+        ev("TacticalTortoise 40k", "7AgzQIEq3j4", "10:00",
+           "Titanic units can shoot and perform actions. So, it's not actually like that bad"),
+        ev("Recon By Fire", "42CPnCfuCN8", "01:00",
+           "for one CP, they are capable of shooting and still being able to perform an action"),
+        ev("Exile Wargaming", "mbNWzDn6Pu4", "05:00",
+           "we have to triangulate objectives by doing actions on them. We can only do one a turn"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "action assignment (MissionManager._run_primary_auto_actions_11e is the backstop)",
+        "current_behaviour": "Primary-card marker/action mechanics are auto-resolved by "
+                             "MissionManager as a headless/AI backstop, and _build_primary_awareness "
+                             "gives those rule types a flat +1.0 generic objective pressure. There "
+                             "is no cost model for which unit performs the action.",
+        "suggested_change": "When an action is available, rank candidate units by (expected ranged "
+                            "output forgone + points at risk) ascending and pick the cheapest that "
+                            "can reach. Skip the forgone-output term for TITANIC units.",
+        "risk": "The cheapest unit is often the screening unit; pulling it off a screen to press a "
+                "button can open a deep-strike lane. Exclude units currently holding a screening "
+                "assignment.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="tempo_and_commitment", faction="general",
+    claim="In 11e the player who rolls highest must take the first turn, so deployment has "
+          "to be robust to going either first or second rather than optimised for a choice.",
+    detail="Players describe not having to 'sweat' the first-turn roll because the choice is "
+           "gone, and describe being forced into a first turn they did not want for their "
+           "disposition. The planning consequence is that a deployment which is only good on "
+           "the play, or only good on the draw, is a liability — and that counter-deployment "
+           "against what the opponent has already put down matters more than turn-order "
+           "gambling.",
+    confidence="medium",
+    evidence=[
+        ev("MiniWarGaming", "dy1zEFAKLzk", "03:00",
+           "This is the nice thing about the whoever rolls highest has to go first. I do not have to sweat about who gets first turn"),
+        ev("Exile Wargaming", "mbNWzDn6Pu4", "10:00",
+           "we did win the dice roll and had to go first, which I don't really like in recon"),
+    ],
+    rules_status="unverified",
+    ai_impact={
+        "seam": "difficulty_gate",
+        "target": "AIDifficultyConfig.use_counter_deployment (Normal+)",
+        "current_behaviour": "Counter-deployment is already enabled from Normal upward, which is "
+                             "the right call under this rule. No change is strictly required.",
+        "suggested_change": "No weight change. Record the rule so that any future 'choose to go "
+                            "second' logic is not written, and so deployment scoring is not tuned "
+                            "on an assumed turn order. Verify against the 11e core rules before "
+                            "relying on it.",
+        "risk": "None — this finding is informational. It is marked unverified because it rests on "
+                "two channels' asides rather than a rules quotation.",
+    },
+    priority="low",
+)
+
+# --------------------------------------------------------------- FACTION: Orks
+add(
+    decision="ability_timing", faction="Orks",
+    claim="Waaagh! should not be called in round 1, nor the moment a single unit can reach "
+          "something — it wants several units simultaneously in advance-and-charge range, and "
+          "its 5+ invulnerable is worth calling for on its own when crossing open ground.",
+    detail="Waaagh! is once per battle and grants advance-and-charge, +1 Strength and Attacks "
+           "in melee, and a 5+ invulnerable save to the whole army for one battle round. "
+           "Because it is a single one-shot, the payoff is the number of units that convert it "
+           "into a charge at once; spending it to reach one target wastes the army-wide "
+           "component. Players also call it purely defensively, to survive a turn of shooting "
+           "while advancing — which means 'how many units can charge' is not the only trigger.",
+    differs_from_general="The general-case AI fires a once-per-battle offensive buff as early "
+                         "as it can be used, on the reasoning that more turns benefit. Waaagh! "
+                         "does not work that way: it lasts one battle round, so early use is "
+                         "pure waste, and its value is the count of units that benefit "
+                         "simultaneously plus the defensive save for the turn the army is most "
+                         "exposed.",
+    confidence="high",
+    evidence=[
+        ev("Tabletop Nexus", "QZ9wggn2oUo", "04:00",
+           "Don't call it turn one, though. Don't call it the moment you can reach something"),
+        ev("Tabletop Nexus", "QZ9wggn2oUo", "04:00",
+           "A strong Waaagh! turn has several units positioned to benefit at once"),
+        ev("40K Dirtbags", "DHVBk9vnR8w", "07:00",
+           "moved up a little bit like two extra inches forward uh to plan for turn two Waagh"),
+        ev("Hubtown Hammer", "vLQTE5P6pJg", "03:00",
+           "Turn two, the Orks used the Waagh, which turned out to be a great choice ... blunted by some hot five plus invulnerable"),
+        ev("40K Dirtbags", "Enm67qaqHkU", "33:00",
+           "if I give up Zod turn one with a Waagh, I spent my Waagh and now I gave up Zod"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "faction_ability",
+        "target": "AIDecisionMaker.gd:4481 CALL_WAAAGH block",
+        "current_behaviour": "Round 1: calls Waaagh! if ANY single unit is within 22\" of an enemy "
+                             "(units_in_range >= 1). Round 2+: calls it unconditionally, with the "
+                             "comment 'Round 2+: always use it — waiting loses turns of benefit'. "
+                             "The unit count is computed but only used for the log line from round "
+                             "2 onward, and the 5+ invulnerable is never considered.",
+        "suggested_change": "Replace the round-1 gate with a units_in_range threshold of 3+, and "
+                            "replace the unconditional round-2 fire with 'units_in_range >= 3, or "
+                            "round >= 4 (use-it-or-lose-it)'. Add a defensive trigger: fire it "
+                            "regardless of charge count when more than half the army is inside "
+                            "enemy threat range and lacks an invulnerable save. Expose the "
+                            "threshold as WAAAGH_MIN_UNITS_IN_RANGE.",
+        "risk": "A threshold set too high never fires the ability, which is strictly worse than "
+                "firing it late — hence the round-4 backstop. The 22\" advance-and-charge estimate "
+                "is centroid-based and optimistic; 3 units at 22\" may be 1 unit in practice.",
+    },
+    priority="high",
+)
+
+add(
+    decision="screening_and_zoning", faction="Orks",
+    claim="Gretchin exist to absorb the screening and home-objective jobs so Boyz mobs are "
+          "never assigned to them.",
+    detail="Ork lists carry multiple cheap Gretchin units specifically as job-units: sit on "
+           "home, screen the deployment zone, and block deep strike, leaving the 20-model Boyz "
+           "mobs free to be the offensive units the army actually wins with. The failure mode "
+           "players describe is a Boyz mob that ends up babysitting an objective — a 200-point "
+           "unit doing a 40-point unit's job.",
+    differs_from_general="The general AI picks screeners by cost threshold "
+                         "(SCREEN_CHEAP_UNIT_POINTS 100) and would happily assign a cheap-ish "
+                         "melee unit to a screen. For Orks the assignment should be near-absolute: "
+                         "Gretchin take these roles first and Boyz take them only when no "
+                         "Gretchin remain, even if the Boyz mob is closer.",
+    confidence="medium",
+    evidence=[
+        ev("Tabletop Nexus", "QZ9wggn2oUo", "07:00",
+           "Gretchen handle the boring jobs, your home objectives, more screening so boys don't have to"),
+        ev("40K Dirtbags", "Enm67qaqHkU", "05:00",
+           "we have three units of Gretchen, 120 men, two 10 mans"),
+        ev("40K Dirtbags", "DHVBk9vnR8w", "02:00",
+           "20-man gretchin with Zagdrod, two 10-man gretchin which I really liked having extra gretchin unit"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "profile_rule",
+        "target": "SCREEN_CHEAP_UNIT_POINTS (100) / SCREEN_SCORE_BASE (8.0)",
+        "current_behaviour": "Any unit at or below 100 points is a screening candidate, scored at "
+                             "SCREEN_SCORE_BASE 8.0 against objective priorities. Ork Boyz mobs are "
+                             "above the threshold so they are not screen candidates, but they are "
+                             "still eligible for home-objective assignments.",
+        "suggested_change": "Ork profile: lower SCREEN_CHEAP_UNIT_POINTS to ~60 so only Gretchin-"
+                            "class units qualify, and raise SCREEN_SCORE_BASE to ~10.0 so those "
+                            "units take screening over a marginal objective push. Pair with a rule "
+                            "that raises WEIGHT_ALREADY_HELD_OBJ for melee units so Boyz leave held "
+                            "objectives.",
+        "risk": "If the army has lost its Gretchin, a 60-point threshold leaves nothing eligible "
+                "to screen at all. Needs a fallback to the default threshold when no candidate "
+                "exists.",
+    },
+    priority="medium",
+)
+
+# ---------------------------------------------------------- FACTION: Custodes
+add(
+    decision="objective_trade", faction="Adeptus Custodes",
+    claim="Custodes cannot screen and score simultaneously; they should concentrate into one "
+          "or two bricks and concede board area rather than spreading to cover objectives.",
+    detail="With roughly a third of a normal army's unit count, every Custodes unit split off "
+           "to hold a marker is a unit missing from the one place the army can win a fight. "
+           "Players describe the army as wanting to move as a wrecking ball, and describe "
+           "splitting as the mistake. The army's compensation is that its units are individually "
+           "hard enough to hold an objective against a much larger force, so it can arrive late "
+           "and still take the ground.",
+    differs_from_general="The general AI spreads units across objectives by score, using "
+                         "SUPPORT_STACK_PENALTY (3.5) to actively discourage stacking. For "
+                         "Custodes that penalty is backwards: concentration is the plan, and the "
+                         "army should accept holding fewer objectives for longer rather than "
+                         "contesting more of them briefly.",
+    confidence="medium",
+    evidence=[
+        ev("Tabletop Titans", "EAqaLgAudQo", "216:00",
+           "custodians are just not designed that way. They want to be hanging out together just few units but just wrecking ball"),
+        ev("Master Crafted", "9fuvetVLB3s", "63:00",
+           "it still just didn't feel great as a custod player to have to uh be playing might with purge"),
+        ev("Hubtown Hammer", "ET9gYSgKRfs", "04:00",
+           "we will always have minus one to hit in the fight phase since they will be within 12 in with the hidden rule"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "faction_constant",
+        "target": "FACTION_AGGRESSION_CUSTODES (1.5) — plus SUPPORT_STACK_PENALTY in the profile",
+        "current_behaviour": "Custodes get a single scalar aggression of 1.5, which raises "
+                             "kill-seeking and lowers the charge threshold. Nothing changes how "
+                             "widely the army spreads; SUPPORT_STACK_PENALTY 3.5 applies as normal "
+                             "and pushes units apart.",
+        "suggested_change": "This is the clearest evidence that a single 'aggression' scalar is the "
+                            "wrong model. For Custodes the differentiating parameter is "
+                            "concentration, not aggression: drop SUPPORT_STACK_PENALTY to ~1.5 in "
+                            "the Custodes profile and raise WEIGHT_ALREADY_HELD_OBJ toward -1.0 so "
+                            "units stay on ground they already hold, while leaving "
+                            "FACTION_AGGRESSION_CUSTODES at 1.5.",
+        "risk": "Concentration loses to mission formats that reward spread (Recon table quarters, "
+                "Priority Assets actions). The profile should be benchmarked per disposition, not "
+                "adopted globally.",
+    },
+    priority="medium",
+)
+
+# ---------------------------------------------------------- FACTION: Tyranids
+add(
+    decision="ability_timing", faction="Tyranids",
+    claim="Tyranid battle-shock output is an offensive tempo tool used to strip OC and enable "
+          "precision kills, not a passive debuff — the units carrying it should be positioned "
+          "aggressively to keep enemies inside its range.",
+    detail="Shadow in the Warp and unit-level shock effects turn enemy objective-holders into "
+           "OC-0 passengers and open up follow-up plays: players describe shocking a target and "
+           "then charging in to precision out the character. That makes the delivery units "
+           "(Neurolictors and similar) forward-positioned pieces whose range band matters more "
+           "than their survival, which is the opposite of how a support unit is normally played.",
+    differs_from_general="The general AI treats support and buff units as things to protect, "
+                         "applying THREAT_FRAGILE_BONUS (1.3) to keep high-value fragile units out "
+                         "of danger. Tyranid shock-delivery units need to be inside their aura "
+                         "range of the enemy's scoring units, which means deliberately accepting "
+                         "threat that the general model penalises.",
+    confidence="medium",
+    evidence=[
+        ev("Maelstrom Gaming Studios - Tyranids", "efeKiBbPUPM", "09:00",
+           "My Neurolictor battleshocked Volus and the Paladins, which allowed both the Neurolictor and the Hive turret to charge in and precision out"),
+        ev("Factions&Fate", "OKoDYKdWm1E", "04:00",
+           "infiltrated up here just a little bit past my deployment line, but still within range to hand out battle shocks"),
+        ev("winters SEO", "uAmbb_rrUvM", "15:00",
+           "shadow in the warp and signapse ... hurts the enemy when they're in range of signapse"),
+        ev("TacticalTortoise 40k", "7AgzQIEq3j4", "121:00",
+           "force the battle the um shadow in the warp battle shock at a higher penalty"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "profile_rule",
+        "target": "THREAT_FRAGILE_BONUS (1.3) / WEIGHT_OC_EFFICIENCY (2.0)",
+        "current_behaviour": "Fragile high-value units get an extra threat multiplier and are "
+                             "steered away from the enemy. Nothing values keeping an aura source "
+                             "within range of enemy units.",
+        "suggested_change": "Tyranid profile: reduce THREAT_FRAGILE_BONUS toward 1.0 and add a "
+                            "movement term that rewards destinations keeping enemy scoring units "
+                            "inside the shock aura's range — mirroring the AAO_RADIUS_INCHES / "
+                            "WEIGHT_AAO_ISOLATION pattern already used for Against All Odds.",
+        "risk": "Neurolictor-class units are cheap but not expendable; walking them into charge "
+                "range hands over kill VP under Purge the Foe. Bound the exposure to units the "
+                "enemy cannot reach with a charge this turn.",
+    },
+    priority="medium",
+)
+
+# ------------------------------------------------------- FACTION: Death Guard
+add(
+    decision="disengage_and_lock", faction="Death Guard",
+    claim="Death Guard win by making disengagement expensive rather than by killing — they "
+          "should seek to engage multiple enemy units at once and hold them there.",
+    detail="Death Guard stack leadership penalties and fall-back punishment, so a unit engaged "
+           "by them faces a hard Desperate Escape roll to leave. Players deliberately engage "
+           "one enemy unit with two of their own so that the opponent must pass multiple tests, "
+           "and describe the army as low-damage but very hard to get away from. The scoring "
+           "consequence is that a locked enemy is not shooting and not scoring, which is the "
+           "army's whole engine.",
+    differs_from_general="The general AI evaluates melee by expected damage and uses "
+                         "SURVIVAL_FALL_BACK_BONUS to leave losing fights. Death Guard should "
+                         "prefer engagements it does not win on damage, and should value multi-unit "
+                         "engagement (more fall-back tests) that the general model treats as "
+                         "inefficient over-commitment.",
+    confidence="medium",
+    evidence=[
+        ev("40K Dirtbags", "F5TL7LhZJlY", "23:00",
+           "If both of these guys were in combat with the death shroud ... both of them would have to pass a seven up to fall back"),
+        ev("Factions&Fate", "OKoDYKdWm1E", "06:00",
+           "against you you want to be in melee, so that might benefit me the most"),
+        ev("40K Fireside", "u8fm403MGtg", "08:00",
+           "Plague Legion it gets stuck in combat a lot and it's really hard to get out of combat"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "profile_rule",
+        "target": "PHASE_PLAN_LOCK_SHOOTER_BONUS (3.0) / SURVIVAL_HOLD_BONUS (1.5)",
+        "current_behaviour": "Locking bonuses only apply to targets classed as dangerous shooters "
+                             "(PHASE_PLAN_RANGED_STRENGTH_DANGEROUS 5.0), and survival assessment "
+                             "pulls the AI out of losing fights from Normal upward.",
+        "suggested_change": "Death Guard profile: raise PHASE_PLAN_LOCK_SHOOTER_BONUS to ~5.0, "
+                            "raise SURVIVAL_HOLD_BONUS to ~3.0 so the AI stays in combats it is "
+                            "losing on damage, and lower SURVIVAL_FALL_BACK_BONUS to ~1.0.",
+        "risk": "Staying in fights it loses is exactly the failure mode survival assessment was "
+                "added to fix; if the enemy can simply kill the engaged unit, this profile feeds "
+                "it. Needs benchmarking against a high-damage melee opponent specifically.",
+    },
+    priority="medium",
+)
+
+# --------------------------------------------------------- FACTION: Drukhari
+add(
+    decision="attrition_and_trades", faction="Drukhari",
+    claim="Drukhari should fight out of transports and treat committed squads as expendable — "
+          "a squad that disembarks, kills, and dies has done its job.",
+    detail="Drukhari infantry are fast and lethal but do not survive being shot, so the "
+           "transport is not a delivery convenience but the unit's durability. Players describe "
+           "squads as explicitly suicidal — sent to remove a key piece with no expectation of "
+           "returning — and describe leaving a unit outside its transport as the error. The "
+           "army's economy assumes it trades its units away and keeps scoring with what is left.",
+    differs_from_general="The general AI protects expensive and fragile units "
+                         "(THREAT_FRAGILE_BONUS 1.3, ARCHETYPE_ELITE_SURVIVAL 1.25) and penalises "
+                         "trading an expensive unit into a cheaper one. Drukhari should accept "
+                         "those trades when the target is a key enabler, and should weight "
+                         "embarkation far more heavily than a general army would.",
+    confidence="medium",
+    evidence=[
+        ev("Deploy on the Line 40K", "jJwrYZs3l-I", "11:00",
+           "squad in transport. They're going to suicide themselves"),
+        ev("SkaredCast", "nCQuNE_8V44", "19:00",
+           "you didn't need the entire unit to kill them. They died very fast. Should have kept them in the transport"),
+        ev("6 Plus Plus Gaming", "gRqdSBkqVlA", "07:00",
+           "Drukhari really love it in Sky Splinter Assault ... it gives them that bit of protection"),
+        ev("MiniWarGaming", "3lwK9jAR0RM", "23:00",
+           "going to pick Drazar up to protect Drazar from at least a round of shooting"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "profile_rule",
+        "target": "TRADE_UNFAVORABLE_PENALTY (0.7) / THREAT_FRAGILE_BONUS (1.3)",
+        "current_behaviour": "Trade analysis penalises expensive-kills-cheap down to 0.7, and "
+                             "fragile high-value units get a 1.3x threat multiplier steering them "
+                             "away from danger. Both push against the Drukhari pattern.",
+        "suggested_change": "Drukhari profile: raise TRADE_UNFAVORABLE_PENALTY to ~0.9 (nearly "
+                            "neutral) and lower THREAT_FRAGILE_BONUS to ~1.0, so committed units "
+                            "accept exposure. Add a rule that restores caution in rounds 4-5 "
+                            "(round_gte 4 → multiply THREAT_FRAGILE_BONUS by 1.3) so the AI stops "
+                            "throwing units away once the trades no longer buy anything.",
+        "risk": "Under Purge the Foe the opponent is paid for every unit destroyed, so an "
+                "expendable-units profile actively feeds their primary. Benchmark specifically "
+                "against a Purge opponent before adopting.",
+    },
+    priority="medium",
+)
+
+# ---------------------------------------------------- FACTION: Space Marines
+add(
+    decision="ability_timing", faction="Space Marines",
+    claim="Oath of Moment should be discounted against targets that our own shooters can "
+          "already re-roll into — its value is the re-roll it adds, not the target's threat.",
+    detail="Oath grants re-rolls against one enemy unit, so its marginal value collapses when "
+           "the units that will actually shoot the target already re-roll hits from another "
+           "source. Players state this directly when reviewing lists — a unit hitting on 2s "
+           "with re-roll 1s 'does not need Oath of Moment'. The corollary is that Oath goes on "
+           "the target the unbuffed portion of the army must kill.",
+    differs_from_general="This is a refinement rather than a reversal: the general logic of "
+                         "'mark what you most want dead' is right, but for Space Marines "
+                         "specifically the score must be computed against the shooters that will "
+                         "use it, not against the target in isolation.",
+    confidence="medium",
+    evidence=[
+        ev("Happy Krumping", "pAk1YiuioNQ", "22:00",
+           "They already hit on twos ... re-rolling hit rolls of one. They do not need oath of moment"),
+        ev("Tabletop Tactics", "eUQmB4CTKlk", "21:00",
+           "I'm going to put Oath of Moment on that big brain bug ... he's super tough"),
+        ev("Grimdark Breakdown", "qwnHaQvzCq0", "14:00",
+           "the only thing you have to remember to do in your Command phase then is ... That's my Oath of Moment target"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "faction_ability",
+        "target": "_select_oath_of_moment_target (AIDecisionMaker.gd:4844)",
+        "current_behaviour": "Scores each candidate from _calculate_target_value plus target-side "
+                             "modifiers: toughness, save, remaining wounds, below-half-strength, "
+                             "invulnerable discount, leader-buff bonus, and a 0.5x penalty when the "
+                             "army lacks weapons that can hurt it. All modifiers are properties of "
+                             "the target; none look at the shooters' existing re-rolls.",
+        "suggested_change": "Weight each candidate by the expected damage the army would gain from "
+                            "the re-roll, computed over the units likely to shoot it — i.e. sum "
+                            "over candidate shooters of (damage with re-roll − damage without), "
+                            "and skip shooters that already re-roll hits. This reuses the existing "
+                            "_check_army_can_damage_target traversal.",
+        "risk": "More expensive to compute each command phase, and it can pick a soft target the "
+                "army would have killed anyway. Keep the existing target-side terms as a tiebreak.",
+    },
+    priority="medium",
+)
+
+# ------------------------------------------------------ FACTION: Grey Knights
+add(
+    decision="objective_trade", faction="Grey Knights",
+    claim="Grey Knights teleport (pick a unit up and redeploy it) costs objective control, so "
+          "its value is disposition-dependent — under Take and Hold, teleporting a scoring unit "
+          "is usually a net loss.",
+    detail="Repositioning a unit off an objective removes its OC contribution for the scoring "
+           "window, so the same ability that is a free reposition under a kill-oriented card is "
+           "a self-inflicted VP loss under an objective-oriented one. The arrival-turn buffs "
+           "that reward teleporting are also limited to the turn the unit arrives, so the "
+           "benefit is one turn while the objective loss can span two.",
+    differs_from_general="A general AI treats a free reposition as unambiguously good. For Grey "
+                         "Knights the ability has to be priced against the VP estimator before "
+                         "use, and its worth swings with the primary card.",
+    confidence="low",
+    evidence=[
+        ev("Warpbane Tactics", "veM7sLjtdIw", "01:00",
+           "being careful about when we use our teleportation. Picking a unit up is incredibly useful, but under Take and Hold, that decision becomes more costly"),
+        ev("Warpbane Tactics", "D5XVd0FRgK8", "03:00",
+           "Fury of the Titan. Each time one of our units is set up using the deep strike ability until the end of that turn"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "faction_ability",
+        "target": "teleport / redeploy ability scoring",
+        "current_behaviour": "Repositioning abilities are scored on the destination's movement "
+                             "value. The VP the unit was contributing at its origin is not "
+                             "subtracted.",
+        "suggested_change": "Subtract _estimate_objective_vp_value for the origin objective from "
+                            "the score of any pick-up-and-place ability, so the decision is a net "
+                            "VP comparison. This is a general improvement that Grey Knights make "
+                            "most visible.",
+        "risk": "Low confidence — a single channel. Implement the VP subtraction as general logic "
+                "rather than as a Grey Knights special case, and do not ship a Grey Knights "
+                "profile on this evidence.",
+    },
+    priority="low",
+)
+
+add(
+    decision="target_selection", faction="general",
+    claim="Units standing on objectives are premium targets in every round, not just "
+          "rounds 4-5, because several common secondaries pay for killing them.",
+    detail="'Kill things on objectives' recurs as a secondary across the corpus, and players "
+           "reshuffle their whole shooting plan when they draw it — sometimes needing two kills "
+           "on markers for full value. Combined with the primary card, an enemy unit on a "
+           "marker is being paid for twice: once by removing its OC, once by the secondary. "
+           "This is a scoring decision dressed as a target-priority decision.",
+    confidence="medium",
+    evidence=[
+        ev("Tabletop Titans", "Krfpc2el0cA", "25:00",
+           "Overwhelming is good. This is kill things on objectives. It's what I want to do ... you really want to try to get two kills"),
+        ev("MiniWarGaming", "VvZD_rjUBjE", "19:00",
+           "Kill things on the critical objectives with overwhelming force"),
+        ev("Play On Tabletop", "TPV3hVKSUxw", "42:00",
+           "we've got overwhelming force. So, kill things on objectives"),
+        ev("WarGames Live", "1AwnDclFviQ", "552:00",
+           "Kill things on objectives. Easy. And do actions"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "STRATEGY_LATE_OBJ_TARGET_BONUS (1.3)",
+        "current_behaviour": "The bonus for shooting units on objectives is part of the rounds-4-5 "
+                             "strategy block only. In rounds 1-3 an enemy unit on a marker is "
+                             "valued the same as one in the open.",
+        "suggested_change": "Move the objective-occupancy bonus out of the late-game block and "
+                            "apply it whenever the active secondary or primary card pays for kills "
+                            "on objectives — the SecondaryMissionManager hints already surface "
+                            "this. Keep the extra late-game multiplier on top.",
+        "risk": "Applied unconditionally it double-counts with the OC-denial value of the same "
+                "kill and can pull fire off genuinely dangerous units early. Gate it on the "
+                "mission actually paying for it.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="screening_and_zoning", faction="general",
+    claim="A screen must still be intact during the opponent's turn, because Rapid Ingress "
+          "lets reserves arrive in the opponent's Movement phase.",
+    detail="Rapid Ingress moves a reserve unit onto the table during the opponent's movement "
+           "phase, so a screen evaluated only at the end of the AI's own turn can be bypassed "
+           "the moment it takes casualties or moves. Players build lists specifically around "
+           "having a Rapid Ingress target and describe screening against it as a distinct "
+           "obligation from screening against normal deep strike.",
+    confidence="medium",
+    evidence=[
+        ev("40K Dirtbags", "Enm67qaqHkU", "04:00",
+           "at least one unit in reserves cuz you're making lists to have a reserve rapid ingress target"),
+        ev("WarGames Live", "1AwnDclFviQ", "159:00",
+           "this dog is doing some rapid ingress screening which is nice ... Deep strike denying"),
+        ev("Happy Krumping", "pAk1YiuioNQ", "57:00",
+           "You don't have to screen the rapid ingress. You don't have to worry about screening"),
+        ev("6 Plus Plus Gaming", "gRqdSBkqVlA", "06:00",
+           "a big Helion Brick for rapid ingress threats ... I needed a infiltrate screen unit against things like Emperor's Children"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "new_heuristic",
+        "target": "screening assignment validity window",
+        "current_behaviour": "Screening positions are chosen during the AI's movement phase and "
+                             "evaluated against the board as it stands then. Nothing re-checks "
+                             "coverage after the AI's own shooting/charge phases move or lose the "
+                             "screening unit.",
+        "suggested_change": "Re-validate screening coverage at the end of the AI's turn and, when "
+                            "a gap has opened, prefer keeping a screening unit stationary over "
+                            "using it in a charge. Simplest form: mark units holding a screening "
+                            "assignment as ineligible for charges unless the charge itself closes "
+                            "the gap.",
+        "risk": "Locking screeners out of charges wastes them when no reserves remain. Skip the "
+                "restriction entirely once the opponent has nothing left in reserve — the AI can "
+                "see reserve counts in the snapshot.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="positioning_and_concealment", faction="general",
+    claim="Cover in 11e worsens the attacker's Ballistic Skill by 1 rather than improving the "
+          "defender's save, so seeking cover degrades incoming fire and ignore-cover weapons "
+          "are worth aiming deliberately.",
+    detail="Benefit of Cover (13.08) applies a -1 to hit rather than a save bonus, which is a "
+           "different shape of protection: it scales with the number of shots rather than with "
+           "AP, and it stacks differently with re-rolls. Players call it out in play as 'your "
+           "storm bolters will be at minus one to hit', and treat ignore-cover as a targeting "
+           "consideration rather than a list-building nicety.",
+    confidence="medium",
+    evidence=[
+        ev("Maelstrom Gaming Studios - Tyranids", "aQsog-fkQJ8", "85:00",
+           "partially obscured ... your storm bolters will be at minus one to hit"),
+        ev("TacticalTortoise 40k", "VqwMdS9MuIY", "171:00",
+           "Don't get cover, right? Yeah. No, it's ignore cover for all"),
+        ev("Play On Tabletop", "1SRkN4Drhs4", "52:00",
+           "because you're not an infantry, so you have to be obscured by the terrain itself"),
+    ],
+    rules_status="confirmed",
+    ai_impact={
+        "seam": "weight_constant",
+        "target": "movement destination scoring + EFFICIENCY_* target matching",
+        "current_behaviour": "Cover terrain types are enumerated (COVER_TERRAIN_WITHIN_AND_BEHIND, "
+                             "COVER_TERRAIN_WITHIN_ONLY) and RulesEngine resolves the modifier, but "
+                             "movement scoring has no explicit term for ending in cover, and target "
+                             "scoring has no term for the target being in cover.",
+        "suggested_change": "Add a modest movement bonus for destinations granting Benefit of Cover "
+                            "(smaller than the Hidden bonus in F001 — cover is a -1, Hidden is "
+                            "immunity), and reduce a target's efficiency multiplier when it has "
+                            "cover against the shooter unless the weapon ignores cover.",
+        "risk": "Cover and Hidden are sought in the same terrain, so the two bonuses can "
+                "double-count and over-concentrate the army into one ruin. Apply cover only when "
+                "Hidden does not already apply.",
+    },
+    priority="medium",
+)
+
+add(
+    decision="screening_and_zoning", faction="Tyranids",
+    claim="Tyranids should spend cheap broods and spore mines as disposable movement blockers "
+          "placed in the enemy's path, not as objective holders held back safely.",
+    detail="Tyranid screening pieces are cheap enough to be spent every turn and are placed "
+           "specifically to force the opponent to go around — the value is the movement tax, "
+           "not the bodies. Players describe placing spore mines downfield turn after turn to "
+           "close deep-strike lanes, and describe a single unscreened gap as what lets the "
+           "opponent through.",
+    differs_from_general="The general AI picks screeners by cost threshold and places them to "
+                         "cover deep-strike arrival zones near its own objectives. Tyranids should "
+                         "also project blockers forward into the enemy's approach lanes and treat "
+                         "them as consumable each turn, which the general threat model would "
+                         "penalise as walking into danger.",
+    confidence="medium",
+    evidence=[
+        ev("Into the Hive Mind", "K8OD14Mz6N4", "09:00",
+           "putting these spore mines out that screen out deep strikers or any kind of reserve"),
+        ev("Grimdark Breakdown", "VPTL092E0VI", "13:00",
+           "you could put things in their way to block their easy path"),
+        ev("StrikingScorpion82", "sPWC5HujB_Y", "19:00",
+           "holding objectives, picking on isolated, tying units down, blocking movements ... it's no big deal if they're slain"),
+    ],
+    rules_status="player_opinion",
+    ai_impact={
+        "seam": "profile_rule",
+        "target": "CORRIDOR_BLOCK_SCORE_BASE (7.0) / CORRIDOR_BLOCK_MAX_POSITIONS (4)",
+        "current_behaviour": "Corridor blocking exists at 7.0 base priority — below screening's "
+                             "8.0 — capped at 4 positions, and requires an enemy within 30\" of the "
+                             "objective being protected.",
+        "suggested_change": "Tyranid profile: raise CORRIDOR_BLOCK_SCORE_BASE to ~9.0 so blocking "
+                            "outbids screening for cheap broods, and raise "
+                            "CORRIDOR_BLOCK_MAX_POSITIONS to 6. Lower THREAT_FRAGILE_BONUS so the "
+                            "blockers accept being killed.",
+        "risk": "Cheap Tyranid units are also the army's OC on objectives; spending them all as "
+                "blockers can leave nothing scoring. Cap the number of units that may take a "
+                "blocking assignment as a fraction of the army.",
+    },
+    priority="medium",
+)
+
+# --------------------------------------------------------------- disagreements
+DISAGREEMENTS = [
+    {
+        "topic": "How much of the army to place in Strategic Reserves",
+        "positions": [
+            "Keep at least one unit in reserve as a reactive answer / Rapid Ingress threat "
+            "(40K Dirtbags, Enm67qaqHkU 04:00; Art of War 40k, ym0SnzF2ydg 162:00)",
+            "Against high-pressure lists put nothing in reserve — you need every body on the "
+            "table to hold the mid-board (Happy Krumping, pAk1YiuioNQ 09:00)",
+            "Reserves are unnecessary when the army has a redeploy ability instead "
+            "(Deploy on the Line 40K, gZWxrJy66nw 12:00)",
+        ],
+        "note": "Not a contradiction so much as an unstated conditional: the resolving variable "
+                "is the opponent's turn-one threat range, which the AI can compute. Encoded that "
+                "way in F014 rather than picking a side.",
+    },
+    {
+        "topic": "Whether the Disruption disposition is playable",
+        "positions": [
+            "Disruption scores poorly, which frees you to ignore scoring and just kill "
+            "(Happy Krumping, pAk1YiuioNQ 70:00)",
+            "Disruption sucks, people know it's awful (Deploy on the Line 40K, 14LSO7MS3QI 85:00)",
+            "Disruption rewards movement and positioning and is about interfering with the "
+            "opponent's plan (Warpbane Tactics, ogMKXBVh4g0 02:00)",
+        ],
+        "note": "Tournament data in the corpus (Warp Friends, PShNfK_IJAA 21:00) shows factions "
+                "posting notably higher win rates INTO Disruption, supporting the 'weak "
+                "disposition' read. The AI should not be tuned to Disruption as a baseline.",
+    },
+    {
+        "topic": "Whether 11e Overwatch is oppressive or merely strong",
+        "positions": [
+            "You can't play around it any more — big squads just get overwatched "
+            "(Deploy on the Line 40K, FT5JoL5Myis 05:00)",
+            "It hits on sixes; it's not 'giga crazy' unless the volume is there "
+            "(TacticalTortoise 40k, VqwMdS9MuIY 127:00)",
+        ],
+        "note": "Both are consistent with the rule: snap shooting punishes volume/torrent shooters "
+                "and is weak for elite guns. The AI's exposure penalty should therefore scale with "
+                "the watching unit's shot count, not its damage quality — reflected in F004.",
+    },
+    {
+        "topic": "Whether World Eaters should still play maximum aggression in 11e",
+        "positions": [
+            "11e removed the need to push everything onto objectives; hold home, take a couple "
+            "of bricks, do actions (Exile Wargaming, mbNWzDn6Pu4 34:00)",
+            "The faction's identity and detachments remain melee-compulsion oriented "
+            "(Tactical Sugar, uizU0NPlR14 10:00; WednesdayNightWarhammer, zVx7smZIRf0 04:00)",
+        ],
+        "note": "The corpus does not support FACTION_AGGRESSION_WORLD_EATERS = 2.0 as a "
+                "well-evidenced value — it is the highest constant in the file and rests on no "
+                "corpus evidence at all. Flagged in gaps rather than changed.",
+    },
+]
+
+GAPS = [
+    "Necrons (101 transcripts, 56 in-title) yielded no high-confidence differentiated finding. "
+    "Coverage is heavy but almost entirely list-review and battle-report play-by-play; the "
+    "reanimation-vs-trade reasoning the AI would need is never stated explicitly. This is the "
+    "largest coverage-to-findings gap in the corpus.",
+    "World Eaters (58 transcripts): only one channel makes a decision-shaped claim, and it "
+    "argues AGAINST the blanket aggression the code already encodes. No profile emitted; "
+    "FACTION_AGGRESSION_WORLD_EATERS = 2.0 should be treated as unevidenced.",
+    "Leagues of Votann (47 transcripts, 16 in-title): the judgement-token search returned zero "
+    "hits in the title-attributed pool. Either the mechanic changed in 11e or the corpus does "
+    "not discuss it — unresolved.",
+    "Aeldari (50), Thousand Sons (48), Chaos Knights (43), Emperor's Children (43): present in "
+    "volume but discussion is list-composition and datasheet review, not decision reasoning. No "
+    "actionable finding extracted.",
+    "Adepta Sororitas (9), Agents of the Imperium (6), Ynnari (4), Harlequins (10): too thin to "
+    "attribute anything safely.",
+    "Imperial Knights and Chaos Knights: one channel notes they must pay CP to shoot and act in "
+    "the same turn (Recon By Fire, 42CPnCfuCN8 01:00), which implies a distinctive action-economy "
+    "problem for low-unit-count armies. Single-source, so recorded here rather than as a finding.",
+    "The corpus is competitive/tournament-skewed and post-dates the late-July 2026 balance "
+    "dataslate for only part of its range. Faction findings drawn on June/early-July material "
+    "may already be stale; each finding's evidence dates are given so this can be re-checked.",
+    "Deployment as a decision (where to place units before turn one) is discussed constantly but "
+    "almost always in terms of a specific board and layout, which does not generalise into a "
+    "weight. No deployment finding survived.",
+    "Secondary mission selection and discard is barely reasoned about on camera despite being a "
+    "per-turn decision the AI makes; the SECONDARY_* constants have no corpus support either way.",
+]
+
+
+def build():
+    matrix = defaultdict(lambda: defaultdict(int))
+    dcount = Counter()
+    fcount = Counter()
+    for f in F:
+        matrix[f["decision"]][f["faction"]] += 1
+        dcount[f["decision"]] += 1
+        fcount[f["faction"]] += 1
+
+    doc = {
+        "generated": GENERATED,
+        "corpus": CORPUS,
+        "taxonomy": {
+            "decisions": [
+                {"name": k, "definition": v, "finding_count": dcount.get(k, 0)}
+                for k, v in DECISIONS.items()
+            ],
+            "factions": [
+                {"name": k, "transcript_count": FACTION_TRANSCRIPTS.get(k, 0),
+                 "finding_count": fcount.get(k, 0)}
+                for k in sorted(FACTION_TRANSCRIPTS,
+                                key=lambda n: (-fcount.get(n, 0), -FACTION_TRANSCRIPTS[n]))
+            ],
+            "matrix": {d: dict(m) for d, m in matrix.items()},
+        },
+        "findings": F,
+        "disagreements": DISAGREEMENTS,
+        "gaps": GAPS,
+    }
+    with open(OUT, "w") as fh:
+        json.dump(doc, fh, indent=2, ensure_ascii=False)
+    print("wrote %s — %d findings, %d decisions, %d factions with findings"
+          % (OUT, len(F), len(dcount), len(fcount)))
+    return doc
+
+
+if __name__ == "__main__":
+    build()

--- a/research/youtube/build_profiles.py
+++ b/research/youtube/build_profiles.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Emit draft AI profiles in the ProfileManager format (40k/scripts/ProfileManager.gd).
+
+These are DRAFTS FOR REVIEW, not tuned values. Every parameter and rule carries
+the finding IDs that motivated it in the profile description, so a reviewer can
+trace each number back to research/youtube/ai_learnings.json and from there to a
+timestamped quote.
+
+Two mechanics of the rule engine constrain what can be written here
+(AIDecisionMaker.evaluate_rules / _apply_rule_actions / _get_base_param_value):
+
+  * "multiply" and "add" actions resolve the base value from the profile's own
+    `parameters` block or from ai_config.json overrides — NOT from the GDScript
+    const. _get_base_param_value returns 0.0 when the parameter is absent, so a
+    multiply against an undeclared parameter silently yields 0. Every parameter a
+    rule multiplies is therefore declared in `parameters` at its current const
+    value.
+  * Rule conditions may only use the context keys the engine populates: phase,
+    round, vp_diff, units_remaining_pct, nearest_enemy_inches, on_objective,
+    is_melee_unit, is_vehicle, unit_points. Phase strings are the enum names
+    (FORMATIONS, DEPLOYMENT, SCOUT, COMMAND, MOVEMENT, SHOOTING, CHARGE, FIGHT,
+    SCORING).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUTDIR = os.path.join(HERE, "profiles")
+
+PROFILES = [
+    {
+        "file": "orks.json",
+        "profile_name": "Orks — Waaagh! discipline and Gretchin job-units (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json (corpus 2026-04..2026-08). "
+            "F019 (Waaagh! timing, high confidence, 3 channels): the code at "
+            "AIDecisionMaker.gd:4481 fires Waaagh! in round 1 on a single unit within 22\" "
+            "and unconditionally from round 2. Players say the opposite — don't call it turn "
+            "one, don't call it to reach one thing, want several units benefiting at once. "
+            "WAAAGH_MIN_UNITS_IN_RANGE does not exist yet; it is declared here as the "
+            "parameter the code change in F019 should read. "
+            "F020 (Gretchin job-units, medium): SCREEN_CHEAP_UNIT_POINTS 100 -> 60 so only "
+            "Gretchin-class units are screen candidates, SCREEN_SCORE_BASE 8.0 -> 10.0 so "
+            "they take those jobs over a marginal objective push. "
+            "FACTION_AGGRESSION_ORKS is left at the benchmark-tuned 1.2 "
+            "(tests/bench_baselines/2026-07-10_ork_discipline_ab.md) — the corpus gives no "
+            "reason to move a value that was settled by benchmark.",
+        "parameters": {
+            "FACTION_AGGRESSION_ORKS": 1.2,
+            "WAAAGH_MIN_UNITS_IN_RANGE": 3,
+            "SCREEN_CHEAP_UNIT_POINTS": 60,
+            "SCREEN_SCORE_BASE": 10.0,
+            "WEIGHT_ALREADY_HELD_OBJ": -3.0,
+        },
+        "rules": [
+            {
+                "id": "ork_waaagh_backstop",
+                "name": "Waaagh! use-it-or-lose-it from round 4 (F019)",
+                "priority": 10,
+                "enabled": True,
+                "conditions": [{"type": "phase", "value": "COMMAND"},
+                               {"type": "round_gte", "value": 4}],
+                "actions": [{"type": "override", "param": "WAAAGH_MIN_UNITS_IN_RANGE",
+                             "value": 1}],
+            },
+            {
+                "id": "ork_boyz_off_held_objectives",
+                "name": "Melee units leave objectives already held — Gretchin hold them (F020)",
+                "priority": 20,
+                "enabled": True,
+                "conditions": [{"type": "phase", "value": "MOVEMENT"},
+                               {"type": "is_melee_unit"},
+                               {"type": "on_objective"},
+                               {"type": "unit_points_gte", "value": 150}],
+                "actions": [{"type": "override", "param": "WEIGHT_ALREADY_HELD_OBJ",
+                             "value": -7.0}],
+            },
+        ],
+    },
+    {
+        "file": "adeptus_custodes.json",
+        "profile_name": "Adeptus Custodes — concentrate, do not spread (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json. F022 (medium confidence, 3 "
+            "channels): Custodes have too few units to screen and score at once; players "
+            "describe the army as wanting to move as one wrecking ball and describe "
+            "splitting as the mistake. The differentiating parameter is CONCENTRATION, not "
+            "aggression — SUPPORT_STACK_PENALTY 3.5 -> 1.5 stops the AI pushing units apart, "
+            "and WEIGHT_ALREADY_HELD_OBJ -3.0 -> -1.0 stops it abandoning ground it holds. "
+            "FACTION_AGGRESSION_CUSTODES stays at 1.5: the corpus supports the army being "
+            "fight-oriented, it does not support changing that number. "
+            "This profile is the concrete argument that a single per-faction aggression "
+            "scalar is too coarse — nothing about Custodes identity is expressible as "
+            "'more or less aggressive'.",
+        "parameters": {
+            "FACTION_AGGRESSION_CUSTODES": 1.5,
+            "SUPPORT_STACK_PENALTY": 1.5,
+            "WEIGHT_ALREADY_HELD_OBJ": -1.0,
+            "SCREEN_SCORE_BASE": 4.0,
+        },
+        "rules": [
+            {
+                "id": "custodes_late_spread",
+                "name": "Rounds 4-5: allow spreading again for end-game objectives (F022)",
+                "priority": 10,
+                "enabled": True,
+                "conditions": [{"type": "round_gte", "value": 4}],
+                "actions": [
+                    {"type": "override", "param": "SUPPORT_STACK_PENALTY", "value": 3.5},
+                    {"type": "override", "param": "WEIGHT_ALREADY_HELD_OBJ", "value": -3.0},
+                ],
+            },
+        ],
+    },
+    {
+        "file": "tyranids.json",
+        "profile_name": "Tyranids — forward shock delivery and disposable blockers (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json. F023 (medium, 4 channels): "
+            "Tyranid battle-shock output is offensive tempo — shock a holder, strip its OC, "
+            "then charge in and precision the character out. That means the aura carriers "
+            "must be forward, so THREAT_FRAGILE_BONUS 1.3 -> 1.0 stops the AI treating them "
+            "as things to hide. F031 (medium, 3 channels): cheap broods and spore mines are "
+            "spent as movement blockers in the enemy's path, so CORRIDOR_BLOCK_SCORE_BASE "
+            "7.0 -> 9.0 (above SCREEN_SCORE_BASE 8.0, so blocking outbids screening) and "
+            "CORRIDOR_BLOCK_MAX_POSITIONS 4 -> 6. "
+            "F009 (battle-shock OC denial) is a GENERAL finding and is deliberately NOT "
+            "encoded here — it should land as core logic, not as a Tyranid quirk.",
+        "parameters": {
+            "THREAT_FRAGILE_BONUS": 1.0,
+            "CORRIDOR_BLOCK_SCORE_BASE": 9.0,
+            "CORRIDOR_BLOCK_MAX_POSITIONS": 6,
+            "SCREEN_CHEAP_UNIT_POINTS": 120,
+        },
+        "rules": [
+            {
+                "id": "nids_protect_when_thin",
+                "name": "Below 40% of the army, stop spending blockers (F031 risk note)",
+                "priority": 10,
+                "enabled": True,
+                "conditions": [{"type": "units_remaining_pct_lte", "value": 40.0}],
+                "actions": [
+                    {"type": "override", "param": "CORRIDOR_BLOCK_SCORE_BASE", "value": 5.0},
+                    {"type": "override", "param": "THREAT_FRAGILE_BONUS", "value": 1.3},
+                ],
+            },
+        ],
+    },
+    {
+        "file": "death_guard.json",
+        "profile_name": "Death Guard — lock the enemy in, win by denial (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json. F024 (medium, 3 channels): "
+            "Death Guard are described as low-damage and very hard to disengage from; the "
+            "play is to engage and stay engaged so the enemy neither shoots nor scores, "
+            "ideally with two units on one target so multiple fall-back tests are needed. "
+            "PHASE_PLAN_LOCK_SHOOTER_BONUS 3.0 -> 5.0 makes lock-down charges compete, "
+            "SURVIVAL_HOLD_BONUS 1.5 -> 3.0 and SURVIVAL_FALL_BACK_BONUS 2.0 -> 1.0 keep the "
+            "AI in combats it is losing on damage. "
+            "HIGHEST-RISK PROFILE IN THIS SET: staying in losing fights is exactly what "
+            "survival assessment was added to prevent. Benchmark against a high-damage melee "
+            "opponent before adopting anything here.",
+        "parameters": {
+            "PHASE_PLAN_LOCK_SHOOTER_BONUS": 5.0,
+            "SURVIVAL_HOLD_BONUS": 3.0,
+            "SURVIVAL_FALL_BACK_BONUS": 1.0,
+            "PHASE_PLAN_RANGED_STRENGTH_DANGEROUS": 3.5,
+        },
+        "rules": [
+            {
+                "id": "dg_release_when_dying",
+                "name": "Restore normal fall-back once the army is being ground down (F024 risk)",
+                "priority": 10,
+                "enabled": True,
+                "conditions": [{"type": "units_remaining_pct_lte", "value": 50.0}],
+                "actions": [
+                    {"type": "override", "param": "SURVIVAL_FALL_BACK_BONUS", "value": 2.0},
+                    {"type": "override", "param": "SURVIVAL_HOLD_BONUS", "value": 1.5},
+                ],
+            },
+        ],
+    },
+    {
+        "file": "drukhari.json",
+        "profile_name": "Drukhari — expendable strike squads, transports as durability (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json. F025 (medium, 4 channels): "
+            "Drukhari squads are sent to kill a key piece with no expectation of surviving, "
+            "and leaving a squad outside its transport is named as the error. "
+            "TRADE_UNFAVORABLE_PENALTY 0.7 -> 0.9 lets an expensive squad kill a cheaper key "
+            "target, THREAT_FRAGILE_BONUS 1.3 -> 1.0 stops the AI refusing the exposure. "
+            "The round-4 rule restores caution once trades stop buying anything. "
+            "RISK: under a Purge the Foe opponent this profile feeds their primary directly "
+            "— benchmark against Purge specifically.",
+        "parameters": {
+            "TRADE_UNFAVORABLE_PENALTY": 0.9,
+            "THREAT_FRAGILE_BONUS": 1.0,
+            "TRADE_FAVORABLE_BONUS": 1.3,
+            "THREAT_CHARGE_PENALTY": 1.2,
+        },
+        "rules": [
+            {
+                "id": "drukhari_late_caution",
+                "name": "Rounds 4-5: stop spending units, protect what scores (F025)",
+                "priority": 10,
+                "enabled": True,
+                "conditions": [{"type": "round_gte", "value": 4}],
+                "actions": [
+                    {"type": "multiply", "param": "THREAT_FRAGILE_BONUS", "value": 1.3},
+                    {"type": "override", "param": "TRADE_UNFAVORABLE_PENALTY", "value": 0.7},
+                ],
+            },
+            {
+                "id": "drukhari_commit_when_behind",
+                "name": "Behind on VP: accept worse trades to break a stalemate (F025)",
+                "priority": 20,
+                "enabled": True,
+                "conditions": [{"type": "vp_behind"}, {"type": "round_lte", "value": 3}],
+                "actions": [{"type": "override", "param": "TRADE_UNFAVORABLE_PENALTY",
+                             "value": 1.0}],
+            },
+        ],
+    },
+    {
+        "file": "space_marines.json",
+        "profile_name": "Space Marines — Oath valued by re-roll gain (draft)",
+        "description":
+            "DRAFT from research/youtube/ai_learnings.json. F026 (medium, 3 channels): "
+            "Oath of Moment's value is the re-roll it ADDS, so it is wasted on a target our "
+            "already-re-rolling units will shoot. The real fix is a code change in "
+            "_select_oath_of_moment_target (AIDecisionMaker.gd:4844) to weight candidates by "
+            "expected damage gained rather than by target properties — no existing constant "
+            "expresses it, so OATH_REROLL_GAIN_WEIGHT is declared here as the parameter that "
+            "change should read. "
+            "This profile is therefore thinner than the others ON PURPOSE: the finding is a "
+            "logic change, not a tuning change, and inventing constants to fake it would "
+            "misrepresent the evidence.",
+        "parameters": {
+            "OATH_REROLL_GAIN_WEIGHT": 1.0,
+            "MACRO_LEADER_BUFF_BONUS": 1.5,
+        },
+        "rules": [],
+    },
+]
+
+
+def main():
+    os.makedirs(OUTDIR, exist_ok=True)
+    for p in PROFILES:
+        doc = {
+            "format": "wh40k_ai_profile",
+            "version": 1,
+            "profile_name": p["profile_name"],
+            "description": p["description"],
+            "parameters": p["parameters"],
+        }
+        if p["rules"]:
+            doc["rules"] = p["rules"]
+        path = os.path.join(OUTDIR, p["file"])
+        with open(path, "w") as fh:
+            json.dump(doc, fh, indent="\t", ensure_ascii=False)
+            fh.write("\n")
+        print("wrote", path)
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/exact_quote.py
+++ b/research/youtube/exact_quote.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Print the verbatim corpus span around a probe phrase, with its true timestamp.
+
+Used to replace hand-typed (and therefore paraphrased) quotes in
+build_learnings.py with text that actually appears in the transcript.
+
+    python3 exact_quote.py <video_id> '<probe words>' [chars]
+"""
+import re, sys
+from search_transcripts import load, marker_index, seconds_at, fmt_ts, MARKER_RE
+
+vid, probe = sys.argv[1], sys.argv[2]
+width = int(sys.argv[3]) if len(sys.argv) > 3 else 200
+rec = next(r for r in load() if r["video_id"] == vid)
+raw = rec["text"]
+flat = re.sub(r"\s+", " ", MARKER_RE.sub(" ", raw))
+rx = re.compile(r"\s*".join(re.escape(c) for c in probe.lower().replace(" ", "")), re.I)
+m = rx.search(re.sub(r"\s+", "", flat))
+# simpler: search word-wise on the flattened text
+words = probe.split()
+rx2 = re.compile(r"[^a-zA-Z0-9]+".join(re.escape(w) for w in words), re.I)
+m2 = rx2.search(flat)
+if not m2:
+    print("NOT FOUND in flattened text"); sys.exit(1)
+# recover timestamp by finding the same span in raw
+markers = marker_index(raw)
+rx3 = re.compile(r"[^a-zA-Z0-9]+".join(re.escape(w) for w in words), re.I)
+m3 = rx3.search(raw)
+ts = fmt_ts(seconds_at(markers, m3.start())) if m3 else "??"
+lo, hi = max(0, m2.start()-40), min(len(flat), m2.end()+width)
+print("TS", ts, "|", rec["channel"])
+print(flat[lo:hi])

--- a/research/youtube/faction_index.py
+++ b/research/youtube/faction_index.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Faction attribution over the transcript corpus.
+
+Auto-captions mangle proper nouns constantly ("orks" -> "orcs", "Votann" ->
+"voltan", "Aeldari" -> "eldari"), so faction attribution never rests on a single
+mention. Each faction has a set of aliases; a transcript is attributed to a
+faction when EITHER the title names it (strong signal, human-written) OR the
+body mentions it repeatedly (>= MIN_BODY_HITS distinct alias hits).
+
+Usage:
+    python3 faction_index.py                 # table of per-faction transcript counts
+    python3 faction_index.py --faction Orks  # list transcripts attributed to a faction
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections import Counter, defaultdict
+
+from search_transcripts import load
+
+MIN_BODY_HITS = 6  # distinct in-body alias mentions before body-only attribution
+
+# alias -> regex fragments. Deliberately conservative: ambiguous fragments
+# ("guard" alone, "marines" alone, "demons" alone) are excluded or paired.
+FACTIONS = {
+    "Space Marines": r"space marines?|astartes|adeptus astartes|codex marines?|gladius",
+    "Blood Angels": r"blood angels?",
+    "Dark Angels": r"dark angels?|deathwing|ravenwing",
+    "Space Wolves": r"space wolves|space wolf",
+    "Black Templars": r"black templars?",
+    "Deathwatch": r"deathwatch",
+    "Grey Knights": r"gr[ea]y knights?",
+    "Adeptus Custodes": r"custod[ei]s|custodian guard|allarus|adeptus custodes",
+    "Adepta Sororitas": r"sororitas|sisters of battle|adepta sororitas",
+    "Astra Militarum": r"astra militarum|imperial guard|guardsmen|leman russ|catachan|cadian",
+    "Adeptus Mechanicus": r"ad[- ]?mech|mechanicus|skitarii|kataphron",
+    "Imperial Knights": r"imperial knights?|knight paladin|knight castellan|questoris",
+    "Agents of the Imperium": r"agents of the imperium|assassinorum|callidus|vindicare|eversor",
+    "Chaos Space Marines": r"chaos space marines?|c\.?s\.?m\.?\b|legionaries|heretic astartes",
+    "World Eaters": r"world eaters?|khorne berzerkers?|angron",
+    "Death Guard": r"death guard|plague marines?|mortarion",
+    "Thousand Sons": r"thousand sons|rubric marines?|magnus the red",
+    "Emperor's Children": r"emperor'?s children|fulgrim|noise marines?",
+    "Chaos Daemons": r"chaos daemons|chaos demons|daemon prince|bloodletters|plaguebearers",
+    "Chaos Knights": r"chaos knights?|knight desecrator|knight rampager|war dog",
+    "Aeldari": r"aeldari|eldari|craftworld|asuryani|wraithknight|farseer|guardian defenders",
+    "Drukhari": r"drukhari|dark eldar|drukari|kabalite|wych|haemonculus",
+    "Harlequins": r"harlequins?|troupe master|solitaire",
+    "Ynnari": r"ynnari|yncarne",
+    "Necrons": r"necrons?|lychguard|canoptek|szarekh|silent king|immortals",
+    "Orks": r"\borks?\b|\borcs?\b|waaagh|boyz|meganobz|nobz|deffkopta|warboss|beast snagga",
+    "T'au Empire": r"t'?au empire|\bt'?au\b|tau empire|fire warriors?|crisis suits?|riptide|battlesuit",
+    "Tyranids": r"tyranids?|\bnids\b|hormagaunts?|termagants?|carnifex|hive tyrant|synapse",
+    "Genestealer Cults": r"genestealer cults?|\bg\.?s\.?c\.?\b|neophyte|acolyte hybrids?|cult ambush",
+    "Leagues of Votann": r"votann|votan\b|hearthkyn|hearthguard|kin\b.{0,20}votann|sagitaur",
+    "Sisters of Silence": r"sisters of silence|prosecutors|vigilators",
+}
+
+COMPILED = {name: re.compile(rx, re.IGNORECASE) for name, rx in FACTIONS.items()}
+
+
+def attribute(rec):
+    """Return {faction: {'title': bool, 'hits': int}} for one transcript."""
+    out = {}
+    title = rec["title"]
+    text = rec["text"]
+    for name, rx in COMPILED.items():
+        in_title = bool(rx.search(title))
+        hits = len(rx.findall(text))
+        if in_title or hits >= MIN_BODY_HITS:
+            out[name] = {"title": in_title, "hits": hits}
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--faction", default="")
+    ap.add_argument("--min-hits", type=int, default=MIN_BODY_HITS)
+    args = ap.parse_args()
+
+    recs = list(load())
+    counts = Counter()
+    title_counts = Counter()
+    per_faction = defaultdict(list)
+    for rec in recs:
+        for name, info in attribute(rec).items():
+            counts[name] += 1
+            if info["title"]:
+                title_counts[name] += 1
+            per_faction[name].append((info["hits"], info["title"], rec))
+
+    if args.faction:
+        rows = sorted(per_faction[args.faction], key=lambda r: -r[0])
+        for hits, in_title, rec in rows[:60]:
+            print("%4d %s %-28s %s | %s" % (
+                hits, "T" if in_title else " ", rec["channel"][:28],
+                rec.get("date", ""), rec["title"][:70]))
+        print("total attributed:", len(rows))
+        return
+
+    print("%-24s %8s %8s" % ("faction", "attrib", "in-title"))
+    for name, n in counts.most_common():
+        print("%-24s %8d %8d" % (name, n, title_counts[name]))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/faction_mine.py
+++ b/research/youtube/faction_mine.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Mine one faction's transcripts for decision-shaped statements.
+
+Attribution guard: by default only transcripts whose TITLE names the faction are
+searched. Titles are human-written, so they survive the caption errors that make
+in-body proper nouns unreliable ("Votann" -> "voltan", "Orks" -> "orcs"). Use
+--body to relax to body-attributed transcripts when the title-only pool is thin;
+findings drawn from that pool must be marked lower confidence.
+
+    python3 faction_mine.py Orks 'waaagh.{0,80}' --max 12
+    python3 faction_mine.py Necrons 'reanimat\\w+' --body
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from search_transcripts import load
+from faction_index import COMPILED, MIN_BODY_HITS
+from mine import run
+
+
+def pool(faction, body=False):
+    rx = COMPILED[faction]
+    out = []
+    for rec in load():
+        if rx.search(rec["title"]):
+            out.append(rec)
+        elif body and len(rx.findall(rec["text"])) >= MIN_BODY_HITS:
+            out.append(rec)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("faction", choices=sorted(COMPILED))
+    ap.add_argument("pattern")
+    ap.add_argument("--body", action="store_true")
+    ap.add_argument("--max", type=int, default=12)
+    ap.add_argument("--width", type=int, default=200)
+    ap.add_argument("--per-video", type=int, default=1)
+    args = ap.parse_args()
+
+    recs = pool(args.faction, args.body)
+    hits = run(args.pattern, recs, args.width, args.per_video, args.max)
+    print("### %s (pool=%d transcripts, %d channels) — %d hits shown"
+          % (args.faction, len(recs), len({r["channel"] for r in recs}), len(hits)))
+    for h in hits:
+        print("- [%s|%s|%s|%s] %s" % (h["channel"][:22], h["date"][5:], h["ts"],
+                                      h["video_id"], h["snip"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/mine.py
+++ b/research/youtube/mine.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Compact batch miner — run many themed regexes and print one line per hit.
+
+Built for scanning breadth before deep-diving: each hit is trimmed to a short
+window so hundreds of hits stay readable, and every line carries the channel and
+timestamp needed to cite it.
+
+    python3 mine.py THEME 'regex' [--width 180] [--per-video 1] [--max 30]
+                    [--channel S] [--title S] [--faction NAME]
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+from search_transcripts import load, marker_index, seconds_at, fmt_ts, clean
+
+
+def run(pattern, recs, width=180, per_video=1, max_hits=30, require=None):
+    rx = re.compile(pattern, re.IGNORECASE)
+    req = re.compile(require, re.IGNORECASE) if require else None
+    out = []
+    for rec in recs:
+        text = rec["text"]
+        if req and not req.search(text):
+            continue
+        markers = marker_index(text)
+        found = 0
+        for m in rx.finditer(text):
+            if found >= per_video:
+                break
+            found += 1
+            secs = seconds_at(markers, m.start())
+            lo = max(0, m.start() - width // 2)
+            hi = min(len(text), m.end() + width)
+            out.append({
+                "channel": rec["channel"], "date": rec.get("date", ""),
+                "video_id": rec["video_id"], "title": rec["title"],
+                "ts": fmt_ts(secs), "secs": secs,
+                "snip": clean(text[lo:hi]),
+            })
+    return out[:max_hits]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("theme")
+    ap.add_argument("pattern")
+    ap.add_argument("--width", type=int, default=180)
+    ap.add_argument("--per-video", type=int, default=1)
+    ap.add_argument("--max", type=int, default=30)
+    ap.add_argument("--channel", default="")
+    ap.add_argument("--title", default="")
+    ap.add_argument("--require", default="")
+    args = ap.parse_args()
+
+    recs = [r for r in load()
+            if args.channel.lower() in r["channel"].lower()
+            and args.title.lower() in r["title"].lower()]
+    hits = run(args.pattern, recs, args.width, args.per_video, args.max,
+               args.require or None)
+    print("### %s — %d shown" % (args.theme, len(hits)))
+    for h in hits:
+        print("- [%s|%s|%s|%s] %s" % (h["channel"][:22], h["date"][5:], h["ts"],
+                                      h["video_id"], h["snip"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/profiles/adeptus_custodes.json
+++ b/research/youtube/profiles/adeptus_custodes.json
@@ -1,0 +1,38 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Adeptus Custodes — concentrate, do not spread (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json. F022 (medium confidence, 3 channels): Custodes have too few units to screen and score at once; players describe the army as wanting to move as one wrecking ball and describe splitting as the mistake. The differentiating parameter is CONCENTRATION, not aggression — SUPPORT_STACK_PENALTY 3.5 -> 1.5 stops the AI pushing units apart, and WEIGHT_ALREADY_HELD_OBJ -3.0 -> -1.0 stops it abandoning ground it holds. FACTION_AGGRESSION_CUSTODES stays at 1.5: the corpus supports the army being fight-oriented, it does not support changing that number. This profile is the concrete argument that a single per-faction aggression scalar is too coarse — nothing about Custodes identity is expressible as 'more or less aggressive'.",
+	"parameters": {
+		"FACTION_AGGRESSION_CUSTODES": 1.5,
+		"SUPPORT_STACK_PENALTY": 1.5,
+		"WEIGHT_ALREADY_HELD_OBJ": -1.0,
+		"SCREEN_SCORE_BASE": 4.0
+	},
+	"rules": [
+		{
+			"id": "custodes_late_spread",
+			"name": "Rounds 4-5: allow spreading again for end-game objectives (F022)",
+			"priority": 10,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "round_gte",
+					"value": 4
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "SUPPORT_STACK_PENALTY",
+					"value": 3.5
+				},
+				{
+					"type": "override",
+					"param": "WEIGHT_ALREADY_HELD_OBJ",
+					"value": -3.0
+				}
+			]
+		}
+	]
+}

--- a/research/youtube/profiles/death_guard.json
+++ b/research/youtube/profiles/death_guard.json
@@ -1,0 +1,38 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Death Guard — lock the enemy in, win by denial (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json. F024 (medium, 3 channels): Death Guard are described as low-damage and very hard to disengage from; the play is to engage and stay engaged so the enemy neither shoots nor scores, ideally with two units on one target so multiple fall-back tests are needed. PHASE_PLAN_LOCK_SHOOTER_BONUS 3.0 -> 5.0 makes lock-down charges compete, SURVIVAL_HOLD_BONUS 1.5 -> 3.0 and SURVIVAL_FALL_BACK_BONUS 2.0 -> 1.0 keep the AI in combats it is losing on damage. HIGHEST-RISK PROFILE IN THIS SET: staying in losing fights is exactly what survival assessment was added to prevent. Benchmark against a high-damage melee opponent before adopting anything here.",
+	"parameters": {
+		"PHASE_PLAN_LOCK_SHOOTER_BONUS": 5.0,
+		"SURVIVAL_HOLD_BONUS": 3.0,
+		"SURVIVAL_FALL_BACK_BONUS": 1.0,
+		"PHASE_PLAN_RANGED_STRENGTH_DANGEROUS": 3.5
+	},
+	"rules": [
+		{
+			"id": "dg_release_when_dying",
+			"name": "Restore normal fall-back once the army is being ground down (F024 risk)",
+			"priority": 10,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "units_remaining_pct_lte",
+					"value": 50.0
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "SURVIVAL_FALL_BACK_BONUS",
+					"value": 2.0
+				},
+				{
+					"type": "override",
+					"param": "SURVIVAL_HOLD_BONUS",
+					"value": 1.5
+				}
+			]
+		}
+	]
+}

--- a/research/youtube/profiles/drukhari.json
+++ b/research/youtube/profiles/drukhari.json
@@ -1,0 +1,60 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Drukhari — expendable strike squads, transports as durability (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json. F025 (medium, 4 channels): Drukhari squads are sent to kill a key piece with no expectation of surviving, and leaving a squad outside its transport is named as the error. TRADE_UNFAVORABLE_PENALTY 0.7 -> 0.9 lets an expensive squad kill a cheaper key target, THREAT_FRAGILE_BONUS 1.3 -> 1.0 stops the AI refusing the exposure. The round-4 rule restores caution once trades stop buying anything. RISK: under a Purge the Foe opponent this profile feeds their primary directly — benchmark against Purge specifically.",
+	"parameters": {
+		"TRADE_UNFAVORABLE_PENALTY": 0.9,
+		"THREAT_FRAGILE_BONUS": 1.0,
+		"TRADE_FAVORABLE_BONUS": 1.3,
+		"THREAT_CHARGE_PENALTY": 1.2
+	},
+	"rules": [
+		{
+			"id": "drukhari_late_caution",
+			"name": "Rounds 4-5: stop spending units, protect what scores (F025)",
+			"priority": 10,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "round_gte",
+					"value": 4
+				}
+			],
+			"actions": [
+				{
+					"type": "multiply",
+					"param": "THREAT_FRAGILE_BONUS",
+					"value": 1.3
+				},
+				{
+					"type": "override",
+					"param": "TRADE_UNFAVORABLE_PENALTY",
+					"value": 0.7
+				}
+			]
+		},
+		{
+			"id": "drukhari_commit_when_behind",
+			"name": "Behind on VP: accept worse trades to break a stalemate (F025)",
+			"priority": 20,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "vp_behind"
+				},
+				{
+					"type": "round_lte",
+					"value": 3
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "TRADE_UNFAVORABLE_PENALTY",
+					"value": 1.0
+				}
+			]
+		}
+	]
+}

--- a/research/youtube/profiles/orks.json
+++ b/research/youtube/profiles/orks.json
@@ -1,0 +1,67 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Orks — Waaagh! discipline and Gretchin job-units (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json (corpus 2026-04..2026-08). F019 (Waaagh! timing, high confidence, 3 channels): the code at AIDecisionMaker.gd:4481 fires Waaagh! in round 1 on a single unit within 22\" and unconditionally from round 2. Players say the opposite — don't call it turn one, don't call it to reach one thing, want several units benefiting at once. WAAAGH_MIN_UNITS_IN_RANGE does not exist yet; it is declared here as the parameter the code change in F019 should read. F020 (Gretchin job-units, medium): SCREEN_CHEAP_UNIT_POINTS 100 -> 60 so only Gretchin-class units are screen candidates, SCREEN_SCORE_BASE 8.0 -> 10.0 so they take those jobs over a marginal objective push. FACTION_AGGRESSION_ORKS is left at the benchmark-tuned 1.2 (tests/bench_baselines/2026-07-10_ork_discipline_ab.md) — the corpus gives no reason to move a value that was settled by benchmark.",
+	"parameters": {
+		"FACTION_AGGRESSION_ORKS": 1.2,
+		"WAAAGH_MIN_UNITS_IN_RANGE": 3,
+		"SCREEN_CHEAP_UNIT_POINTS": 60,
+		"SCREEN_SCORE_BASE": 10.0,
+		"WEIGHT_ALREADY_HELD_OBJ": -3.0
+	},
+	"rules": [
+		{
+			"id": "ork_waaagh_backstop",
+			"name": "Waaagh! use-it-or-lose-it from round 4 (F019)",
+			"priority": 10,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "phase",
+					"value": "COMMAND"
+				},
+				{
+					"type": "round_gte",
+					"value": 4
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "WAAAGH_MIN_UNITS_IN_RANGE",
+					"value": 1
+				}
+			]
+		},
+		{
+			"id": "ork_boyz_off_held_objectives",
+			"name": "Melee units leave objectives already held — Gretchin hold them (F020)",
+			"priority": 20,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "phase",
+					"value": "MOVEMENT"
+				},
+				{
+					"type": "is_melee_unit"
+				},
+				{
+					"type": "on_objective"
+				},
+				{
+					"type": "unit_points_gte",
+					"value": 150
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "WEIGHT_ALREADY_HELD_OBJ",
+					"value": -7.0
+				}
+			]
+		}
+	]
+}

--- a/research/youtube/profiles/space_marines.json
+++ b/research/youtube/profiles/space_marines.json
@@ -1,0 +1,10 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Space Marines — Oath valued by re-roll gain (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json. F026 (medium, 3 channels): Oath of Moment's value is the re-roll it ADDS, so it is wasted on a target our already-re-rolling units will shoot. The real fix is a code change in _select_oath_of_moment_target (AIDecisionMaker.gd:4844) to weight candidates by expected damage gained rather than by target properties — no existing constant expresses it, so OATH_REROLL_GAIN_WEIGHT is declared here as the parameter that change should read. This profile is therefore thinner than the others ON PURPOSE: the finding is a logic change, not a tuning change, and inventing constants to fake it would misrepresent the evidence.",
+	"parameters": {
+		"OATH_REROLL_GAIN_WEIGHT": 1.0,
+		"MACRO_LEADER_BUFF_BONUS": 1.5
+	}
+}

--- a/research/youtube/profiles/tyranids.json
+++ b/research/youtube/profiles/tyranids.json
@@ -1,0 +1,38 @@
+{
+	"format": "wh40k_ai_profile",
+	"version": 1,
+	"profile_name": "Tyranids — forward shock delivery and disposable blockers (draft)",
+	"description": "DRAFT from research/youtube/ai_learnings.json. F023 (medium, 4 channels): Tyranid battle-shock output is offensive tempo — shock a holder, strip its OC, then charge in and precision the character out. That means the aura carriers must be forward, so THREAT_FRAGILE_BONUS 1.3 -> 1.0 stops the AI treating them as things to hide. F031 (medium, 3 channels): cheap broods and spore mines are spent as movement blockers in the enemy's path, so CORRIDOR_BLOCK_SCORE_BASE 7.0 -> 9.0 (above SCREEN_SCORE_BASE 8.0, so blocking outbids screening) and CORRIDOR_BLOCK_MAX_POSITIONS 4 -> 6. F009 (battle-shock OC denial) is a GENERAL finding and is deliberately NOT encoded here — it should land as core logic, not as a Tyranid quirk.",
+	"parameters": {
+		"THREAT_FRAGILE_BONUS": 1.0,
+		"CORRIDOR_BLOCK_SCORE_BASE": 9.0,
+		"CORRIDOR_BLOCK_MAX_POSITIONS": 6,
+		"SCREEN_CHEAP_UNIT_POINTS": 120
+	},
+	"rules": [
+		{
+			"id": "nids_protect_when_thin",
+			"name": "Below 40% of the army, stop spending blockers (F031 risk note)",
+			"priority": 10,
+			"enabled": true,
+			"conditions": [
+				{
+					"type": "units_remaining_pct_lte",
+					"value": 40.0
+				}
+			],
+			"actions": [
+				{
+					"type": "override",
+					"param": "CORRIDOR_BLOCK_SCORE_BASE",
+					"value": 5.0
+				},
+				{
+					"type": "override",
+					"param": "THREAT_FRAGILE_BONUS",
+					"value": 1.3
+				}
+			]
+		}
+	]
+}

--- a/research/youtube/search_transcripts.py
+++ b/research/youtube/search_transcripts.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Filtered / regex search over the Warhammer 40k YouTube transcript corpus.
+
+The corpus (research/youtube/transcripts_text.jsonl.gz, gitignored) is one JSON
+object per line with the fields:
+    video_id, title, channel, date, cats, url, auto, words, text
+
+`text` carries per-minute markers of the form ``[MM:00]``, so every hit can be
+cited back to a timestamp and a deep link.
+
+Usage
+-----
+    python3 search_transcripts.py 'reactive move' --window 220
+    python3 search_transcripts.py 'oath of moment' --channel 'Vanguard' --limit 20
+    python3 search_transcripts.py 'secondar\\w+ scor\\w+' --cat Missions --json
+
+Options
+-------
+    --window N      characters of context around the hit (default 200)
+    --channel S     substring filter on channel name (case-insensitive)
+    --title S       substring filter on video title (case-insensitive)
+    --cat S         require this tag in `cats`
+    --since / --until  YYYY-MM-DD date bounds
+    --limit N       max hits to print (default 40)
+    --per-video N   max hits from any single video (default 2)
+    --json          emit JSON instead of human-readable text
+    --count-only    just report hits per channel / per video
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+DEFAULT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "transcripts_text.jsonl.gz")
+
+MARKER_RE = re.compile(r"\[(\d+):(\d+)\]")
+
+
+def load(path: str = DEFAULT_PATH):
+    """Yield every transcript record. Fails loudly if the corpus is missing."""
+    if not os.path.exists(path):
+        sys.exit(
+            "Corpus not found at %s.\n"
+            "It is gitignored on purpose (19MB). Restore it before running "
+            "any analysis - do not substitute invented data." % path
+        )
+    with gzip.open(path, "rt") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def marker_index(text: str):
+    """Return [(char_offset, seconds)] for every [MM:00] marker, in order."""
+    out = []
+    for m in MARKER_RE.finditer(text):
+        out.append((m.start(), int(m.group(1)) * 60 + int(m.group(2))))
+    return out
+
+
+def seconds_at(markers, offset: int) -> int:
+    """Seconds of the last marker at or before `offset` (binary search)."""
+    lo, hi, best = 0, len(markers) - 1, 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if markers[mid][0] <= offset:
+            best = markers[mid][1]
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return best
+
+
+def fmt_ts(seconds: int) -> str:
+    return "%02d:%02d" % (seconds // 60, seconds % 60)
+
+
+def clean(snippet: str) -> str:
+    """Strip markers and collapse whitespace so quotes read as prose."""
+    return re.sub(r"\s+", " ", MARKER_RE.sub(" ", snippet)).strip()
+
+
+def search(pattern, records, window=200, per_video=2, ignore_case=True):
+    """Yield hit dicts for `pattern` (regex) over `records`."""
+    flags = re.IGNORECASE if ignore_case else 0
+    rx = re.compile(pattern, flags)
+    for rec in records:
+        text = rec["text"]
+        markers = marker_index(text)
+        found = 0
+        for m in rx.finditer(text):
+            if per_video and found >= per_video:
+                break
+            found += 1
+            secs = seconds_at(markers, m.start())
+            lo = max(0, m.start() - window)
+            hi = min(len(text), m.end() + window)
+            yield {
+                "video_id": rec["video_id"],
+                "channel": rec["channel"],
+                "title": rec["title"],
+                "date": rec.get("date", ""),
+                "cats": rec.get("cats", []),
+                "timestamp": fmt_ts(secs),
+                "seconds": secs,
+                "url": "https://youtube.com/watch?v=%s&t=%ds" % (rec["video_id"], secs),
+                "match": m.group(0),
+                "snippet": clean(text[lo:hi]),
+            }
+
+
+def matching_records(args, records):
+    for rec in records:
+        if args.channel and args.channel.lower() not in rec["channel"].lower():
+            continue
+        if args.title and args.title.lower() not in rec["title"].lower():
+            continue
+        if args.cat and args.cat not in rec.get("cats", []):
+            continue
+        date = rec.get("date", "")
+        if args.since and (not date or date < args.since):
+            continue
+        if args.until and (not date or date > args.until):
+            continue
+        yield rec
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pattern", help="regex, case-insensitive by default")
+    ap.add_argument("--path", default=DEFAULT_PATH)
+    ap.add_argument("--window", type=int, default=200)
+    ap.add_argument("--channel", default="")
+    ap.add_argument("--title", default="")
+    ap.add_argument("--cat", default="")
+    ap.add_argument("--since", default="")
+    ap.add_argument("--until", default="")
+    ap.add_argument("--limit", type=int, default=40)
+    ap.add_argument("--per-video", type=int, default=2)
+    ap.add_argument("--case-sensitive", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--count-only", action="store_true")
+    args = ap.parse_args()
+
+    records = list(matching_records(args, load(args.path)))
+    hits = list(search(args.pattern, records, window=args.window,
+                       per_video=args.per_video,
+                       ignore_case=not args.case_sensitive))
+
+    if args.count_only:
+        by_channel = Counter(h["channel"] for h in hits)
+        vids = {h["video_id"] for h in hits}
+        print("%d hits across %d videos / %d channels (of %d records searched)"
+              % (len(hits), len(vids), len(by_channel), len(records)))
+        for ch, n in by_channel.most_common(30):
+            print("%5d  %s" % (n, ch))
+        return
+
+    hits = hits[: args.limit]
+    if args.json:
+        print(json.dumps(hits, indent=2))
+        return
+    for h in hits:
+        print("=" * 100)
+        print("%s | %s | %s | %s" % (h["channel"], h["date"], h["timestamp"], h["title"][:70]))
+        print(h["url"])
+        print(h["snippet"])
+
+
+if __name__ == "__main__":
+    main()

--- a/research/youtube/verify_evidence.py
+++ b/research/youtube/verify_evidence.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Verify every evidence quote in ai_learnings.json against the corpus.
+
+Checks, per evidence row:
+  1. the video_id exists in the corpus
+  2. the channel name matches that video's channel
+  3. each fragment of the quote (split on the ellipsis used to elide) appears in
+     the transcript, normalised for whitespace and case
+  4. the first fragment sits within +/-TOLERANCE minutes of the cited timestamp
+
+Exit code is non-zero if anything fails, so this can gate a commit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+from search_transcripts import load, marker_index, seconds_at, MARKER_RE
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOLERANCE_MIN = 2
+
+
+def norm(s: str) -> str:
+    s = MARKER_RE.sub(" ", s)
+    s = s.replace("’", "'").replace("“", '"').replace("”", '"')
+    s = re.sub(r"[^a-z0-9' ]+", " ", s.lower())
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def main():
+    doc = json.load(open(os.path.join(HERE, "ai_learnings.json")))
+    corpus = {r["video_id"]: r for r in load()}
+    fails, checked = [], 0
+
+    for finding in doc["findings"]:
+        for e in finding["evidence"]:
+            checked += 1
+            tag = "%s %s %s" % (finding["id"], e["video_id"], e["timestamp"])
+            rec = corpus.get(e["video_id"])
+            if rec is None:
+                fails.append("%s: video_id not in corpus" % tag)
+                continue
+            if rec["channel"] != e["channel"]:
+                fails.append("%s: channel %r != corpus %r"
+                             % (tag, e["channel"], rec["channel"]))
+            raw = rec["text"]
+            markers = marker_index(raw)
+            # Blank out [MM:00] markers in place (same length) so offsets into
+            # `raw` stay valid while the marker digits stop polluting the text.
+            masked = MARKER_RE.sub(lambda m: " " * len(m.group(0)), raw)
+            # Map every raw-text offset onto its offset in the normalised string,
+            # so a match in normalised space can be traced back to a timestamp.
+            back = []
+            buf = []
+            prev_space = True
+            for i, ch in enumerate(masked):
+                c = norm(ch)
+                if c == "":
+                    if not prev_space and buf and buf[-1] != " ":
+                        buf.append(" ")
+                        back.append(i)
+                    prev_space = True
+                    continue
+                prev_space = False
+                buf.append(c)
+                back.append(i)
+            hay = "".join(buf)
+            first_at = None
+            for frag in [f for f in e["quote"].split("...") if norm(f)]:
+                nf = norm(frag)
+                pos = hay.find(nf)
+                if pos < 0:
+                    fails.append("%s: fragment not found: %r" % (tag, frag.strip()))
+                    continue
+                if first_at is None:
+                    first_at = seconds_at(markers, back[pos])
+            if first_at is not None:
+                cited = int(e["timestamp"].split(":")[0]) * 60
+                if abs(first_at - cited) > TOLERANCE_MIN * 60:
+                    fails.append("%s: quote near %02d:00 but cited %s"
+                                 % (tag, first_at // 60, e["timestamp"]))
+
+    print("checked %d evidence rows across %d findings" % (checked, len(doc["findings"])))
+    if fails:
+        print("\n%d PROBLEM(S):" % len(fails))
+        for f in fails:
+            print("  -", f)
+        sys.exit(1)
+    print("all quotes verified against the corpus")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Mines the 11th-edition YouTube corpus (1,029 transcripts, 10.5M words, 90 channels, Apr–Aug 2026) into changes the AI opponent can actually adopt. Every finding is tagged on two axes — the **decision** being made, and the **faction** (or `general`).

Nothing under `40k/` changes. This is research plus its tooling; no player-facing behaviour, so no `version_history.json` entry.

## Outputs

| file | what it is |
|---|---|
| `research/youtube/ai_learnings.json` | primary machine-readable output — 31 findings across 11 decisions and 7 factions |
| `research/youtube/profiles/*.json` | six draft AI profiles in the `ProfileManager` format |
| `research/youtube/ai_learnings.html` | self-contained reader-facing page, filterable on both axes, light + dark |
| `research/youtube/*.py` + `README.md` | the mining tooling and its provenance notes |

Each finding carries a falsifiable claim, the mechanism, timestamped evidence, a rules status checked against the 11e core rules, and a concrete change named against a real seam — `weight_constant`, `faction_constant`, `profile_rule`, `difficulty_gate`, `faction_ability` or `new_heuristic` — with `current_behaviour` written from reading the code rather than guessed.

## The four biggest gaps this surfaces

1. **The Hidden rule (13.09) is invisible to the AI.** `RulesEngine.gd` implements it fully — detection range, the 3" dense-terrain penalty, the "hasn't shot this turn or last" condition. `AIDecisionMaker.gd` has *zero* occurrences of `hidden`. So the AI never seeks the state, and never weighs that shooting surrenders it for two turns. Five channels treat "get to hidden 12" as the primary early-game movement goal.
2. **Overwatch moved to the end of the opponent's Movement phase** (snap shooting, 6s only). `THREAT_SHOOTING_PENALTY` is `0.5`, commented as lenient because moving into range is "often unavoidable" — that reasoning predates a cost paid inside the mover's own turn.
3. **`DEEP_STRIKE_DENIAL_RANGE_PX` is hardcoded to 9"** while 6" deep strike is common in 11e, so screens are systematically 6" too loose against exactly the units that punish it.
4. **Waaagh! fires on round 2 unconditionally** (`AIDecisionMaker.gd:4481`), and on round 1 if *one* unit is within 22". Players say the opposite, explicitly: don't call it turn one, don't call it to reach one thing.

## On the single-scalar faction model

The evidence says `_get_faction_aggression` is too coarse. The Custodes profile is the clearest case: their identity is **concentration** (`SUPPORT_STACK_PENALTY`), not aggression, and no value of `FACTION_AGGRESSION_CUSTODES` expresses it.

Separately — `FACTION_AGGRESSION_WORLD_EATERS = 2.0` is the highest constant in the file and has **no** corpus support. The one channel making a decision-shaped claim about 11e World Eaters argues *against* blanket aggression. Flagged under `gaps`, not changed.

## Evidence integrity

`verify_evidence.py` mechanically checks all 111 quotes exist in the corpus, on the right channel, within two minutes of the cited timestamp; it exits non-zero otherwise. It caught 24 paraphrases in the first pass — all now verbatim, caption errors included (`genailer`, `signapse`, `orc`).

Confidence rules: `high` needs multiple independent channels. Single-channel claims are `low` and get no profile — they are listed under `gaps` instead. The corpus is competitive-skewed and is a broad sweep, not a census.

## Caveats

- All six profiles are **drafts, none benchmarked**. Death Guard is riskiest: it deliberately keeps the AI in fights it loses on damage, which is what survival assessment exists to prevent.
- `multiply`/`add` rule actions resolve their base from the profile's own `parameters` — `_get_base_param_value` returns `0.0` otherwise — so every multiplied parameter is declared explicitly. Worth knowing before writing more profiles.
- One finding (first turn is not a choice in 11e) is marked `unverified` — two channels' asides, no rules quotation. Not acted on.
- Necrons are the largest coverage gap: 101 transcripts, zero differentiated findings.
- The corpus itself (19 MB) stays gitignored; `research/youtube/README.md` documents how to restore it.

## Validation

- `verify_evidence.py` — 111/111 evidence rows verified against the corpus
- profiles validated against `ProfileManager.validate_profile` **and** the rule engine's condition vocabulary and phase-name enum
- HTML rendered live in Chromium: 31 findings, filters and empty state exercised, theme toggle, no console errors, no horizontal scroll at 390px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Aa8MFeHsS7nPDJT3v97yP

---
_Generated by [Claude Code](https://claude.ai/code/session_018Aa8MFeHsS7nPDJT3v97yP)_