### PR TITLE
Vision Map: per-unit whole-board visibility shading with ray-cast shadow geometry

### DIFF
--- a/40k/autoloads/KeybindingManager.gd
+++ b/40k/autoloads/KeybindingManager.gd
@@ -70,6 +70,10 @@ func _register_defaults() -> void:
 	# killed this tool's earlier V and G bindings.
 	_register("los_check", "Check Line of Sight (hold)", CATEGORY_GAMEPLAY, KEY_X)
 	_register("los_debug", "Sight-Line Overlay (hold)", CATEGORY_GAMEPLAY, KEY_L)
+	# Whole-board "what can this unit see" shading, per selected unit. Shift+L:
+	# the toggle sibling of the held-L sight lines — same mnemonic family, and
+	# Shift+L is unclaimed (plain L is the hold overlay, Ctrl+L nothing).
+	_register("los_vision_map", "Vision Map (unit visibility shading)", CATEGORY_GAMEPLAY, KEY_L, {"shift": true})
 
 	# Shooting phase (T5-UX12 → KeybindingManager registration 2026-05-05)
 	# These were previously hardcoded keycode matches in ShootingController; promoting

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.28.1",
+      "date": "2026-08-06",
+      "summary": "Vision Map v2: the shading is now true ray-cast geometry — smooth shadow wedges that snap to the terrain, instead of the blocky 1\" squares.",
+      "changes": [
+        "Fixed (requested): the Vision Map's shading was built from 1\" grid cells and read as blocky stair-steps. It is now computed by casting rays from each model of the chosen unit — one ray at every terrain corner — so the seen/hidden boundary is smooth geometry that follows the ruins' actual silhouettes exactly.",
+        "Same rules underneath, now sharper to look at: obscuring ruins with the stand-inside exception, solid walls, elevated models seeing over Solid features — all unchanged, and still continuously cross-checked against the game's own targeting maths (plus a new check that what is DRAWN matches what the rules say).",
+        "The panel now reports what share of the board the unit can see; everything else — the 👁 Vision button, Shift+L, the per-unit picker, auto-recompute when models move — works as before."
+      ]
+    },
+    {
       "version": "1.28.0",
       "date": "2026-08-06",
       "summary": "New: Vision Map — pick any unit and the board shades everything that unit can see, so you can tell at a glance whether a deploy spot is hidden or exposed.",

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,17 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.28.0",
+      "date": "2026-08-06",
+      "summary": "New: Vision Map — pick any unit and the board shades everything that unit can see, so you can tell at a glance whether a deploy spot is hidden or exposed.",
+      "changes": [
+        "New (requested): a whole-board visibility view to complement the model-to-model sight lines — open it with the 👁 Vision button on the bottom bar or Shift+L, pick a unit from the panel, and every spot that unit can see is washed warm red while hidden ground stays cool blue. Weapon range is ignored on purpose: it answers \"can I be SEEN here\", not \"can I be shot\".",
+        "One unit at a time, by design — the panel lists every unit on the board (yours and theirs) and a single click switches whose eyes you are looking through; gold rings mark the chosen unit's models. Deployment is the intended home: select an enemy unit that just deployed, then drop your own models in the blue.",
+        "The shading uses the same terrain rules as targeting itself (obscuring ruins with the stand-inside exception, solid walls, barricades), it recomputes automatically as models are placed, moved or slain, and it works in every phase.",
+        "Precision is 1\" squares judged at ground level from each model's base — the last blue cell before a corner may still let a base edge peek out, and upper-floor sight is approximated."
+      ]
+    },
+    {
       "version": "1.27.4",
       "date": "2026-08-05",
       "summary": "New setting: let the line-of-sight overlay skip enemies none of your guns could reach, for a quieter and faster board.",

--- a/40k/scripts/Main.gd
+++ b/40k/scripts/Main.gd
@@ -132,6 +132,11 @@ var camera_gestures_used: Dictionary = {}
 # top-bar toggle. los_debug_active mirrors the debug state for scenarios.
 var los_debug_active: bool = false
 
+# Vision map: whole-board visibility shading for one selected unit
+# (VisionMapOverlay in BoardRoot + VisionMapPanel selector, toggled by the
+# bottom-bar 👁 button or Shift+L).
+var _vision_map_panel: VisionMapPanel = null
+
 # Replay mode
 var is_replay_mode: bool = false
 var replay_ui: Node = null
@@ -4862,6 +4867,28 @@ func _setup_terrain() -> void:
 		$BoardRoot.add_child(los_dbg)
 		print("Added persistent LoSDebugVisual to BoardRoot")
 
+	# Vision map — whole-board "what can this unit see" shading, selected
+	# unit-by-unit from the Vision panel (bottom-bar button / Shift+L). Lives
+	# all game long like LoSDebugVisual; earns its keep during deployment.
+	if not $BoardRoot.has_node("VisionMapOverlay"):
+		var vision_overlay = preload("res://scripts/VisionMapOverlay.gd").new()
+		$BoardRoot.add_child(vision_overlay)
+		print("Added persistent VisionMapOverlay to BoardRoot")
+
+	# Vision map toggle — a PLAYER tool (not dev-gated): deployment is where it
+	# matters most and Shift+D dev tools are invisible to a normal player.
+	var hud_container_vision = $HUD_Bottom/HBoxContainer
+	if hud_container_vision and not hud_container_vision.has_node("VisionMapButton"):
+		var vision_btn := Button.new()
+		vision_btn.name = "VisionMapButton"
+		vision_btn.text = "👁 Vision"
+		vision_btn.toggle_mode = true
+		vision_btn.tooltip_text = "Vision Map (%s): shade everything one chosen unit can see — check deploy spots for cover" \
+			% (KeybindingManager.get_primary_key_display("los_vision_map") if KeybindingManager else "Shift+L")
+		vision_btn.toggled.connect(_on_vision_map_button_toggled)
+		hud_container_vision.add_child(vision_btn)
+		print("Added VisionMapButton to HUD")
+
 	# Dev tools — hidden by default, toggled with Shift+D
 	var hud_container2 = $HUD_Bottom/HBoxContainer
 	if hud_container2:
@@ -5242,6 +5269,67 @@ func _toggle_los_debug() -> void:
 				los_debug.show_overview(_selected_unit_id_or_empty())
 	else:
 		print("LoS debug visual not found")
+
+# ═══ Vision map (unit visibility shading) ═══
+
+func get_vision_map_overlay() -> VisionMapOverlay:
+	return get_node_or_null("BoardRoot/VisionMapOverlay") as VisionMapOverlay
+
+func _toggle_vision_map_panel() -> void:
+	if _vision_map_panel and is_instance_valid(_vision_map_panel) and _vision_map_panel.visible:
+		_close_vision_map_panel()
+		return
+	var overlay := get_vision_map_overlay()
+	if overlay == null:
+		# Save loaded straight into a phase before _setup_terrain? Create on
+		# demand, same guarantee _toggle_los_debug makes for its layer.
+		if not has_node("BoardRoot"):
+			print("Vision map: no BoardRoot, cannot open")
+			return
+		overlay = preload("res://scripts/VisionMapOverlay.gd").new()
+		$BoardRoot.add_child(overlay)
+		print("Vision map: created BoardRoot overlay on demand")
+	if _vision_map_panel == null or not is_instance_valid(_vision_map_panel):
+		_vision_map_panel = preload("res://scripts/VisionMapPanel.gd").new()
+		_vision_map_panel.overlay = overlay
+		# Left side: the right edge belongs to the phase unit list / unit card,
+		# which deployment needs visible WHILE this panel is open.
+		_vision_map_panel.anchor_left = 0.0
+		_vision_map_panel.anchor_right = 0.0
+		_vision_map_panel.anchor_top = 0.16
+		_vision_map_panel.anchor_bottom = 0.16
+		_vision_map_panel.offset_left = 16
+		_vision_map_panel.offset_right = 312
+		_vision_map_panel.grow_vertical = Control.GROW_DIRECTION_END
+		_vision_map_panel.close_requested.connect(_close_vision_map_panel)
+		add_child(_vision_map_panel)
+		_vision_map_panel.z_index = UI_OVERLAY_Z
+	else:
+		_vision_map_panel.visible = true
+		_vision_map_panel.rebuild_unit_list()
+	_sync_vision_map_button(true)
+	print("Vision map panel opened")
+
+func _close_vision_map_panel() -> void:
+	# Closing the picker also drops the shading — an unlabelled full-board wash
+	# with no visible control to switch it off would read as a rendering bug.
+	var overlay := get_vision_map_overlay()
+	if overlay:
+		overlay.clear_map()
+	if _vision_map_panel and is_instance_valid(_vision_map_panel):
+		_vision_map_panel.visible = false
+	_sync_vision_map_button(false)
+	print("Vision map panel closed")
+
+func _on_vision_map_button_toggled(pressed: bool) -> void:
+	var open := _vision_map_panel != null and is_instance_valid(_vision_map_panel) and _vision_map_panel.visible
+	if pressed != open:
+		_toggle_vision_map_panel()
+
+func _sync_vision_map_button(pressed: bool) -> void:
+	var btn := get_node_or_null("HUD_Bottom/HBoxContainer/VisionMapButton") as Button
+	if btn:
+		btn.set_pressed_no_signal(pressed)
 
 func _show_toast(message: String, duration: float = 2.0) -> void:
 	# Route through global ToastManager for consistent on-screen display
@@ -6841,6 +6929,16 @@ func _input(event: InputEvent) -> void:
 			return
 		print("Debug mode key (9) pressed!")
 		DebugManager.toggle_debug_mode()
+		get_viewport().set_input_as_handled()
+		return
+
+	# Vision map panel (rebindable: los_vision_map, default Shift+L — the
+	# toggle sibling of held-L). Checked BEFORE the los_debug block: that
+	# block's release branch deliberately ignores modifiers, so it would
+	# swallow the Shift+L release; the press is what toggles here.
+	if event is InputEventKey and event.pressed and not event.echo \
+			and KeybindingManager.matches_action(event, "los_vision_map"):
+		_toggle_vision_map_panel()
 		get_viewport().set_input_as_handled()
 		return
 
@@ -10897,6 +10995,14 @@ func _clear_debug_visualizations() -> void:
 	var los_debug = board_root.get_node_or_null("LoSDebugVisual")
 	if los_debug and is_instance_valid(los_debug) and los_debug.has_method("clear_all_debug_visuals"):
 		los_debug.clear_all_debug_visuals()
+
+	# Vision map: the loaded game has different units, so the shading (and the
+	# selector panel, if open) is stale — drop both.
+	var vision_overlay = board_root.get_node_or_null("VisionMapOverlay")
+	if vision_overlay and is_instance_valid(vision_overlay) and vision_overlay.has_method("clear_map"):
+		vision_overlay.clear_map()
+	if _vision_map_panel and is_instance_valid(_vision_map_panel) and _vision_map_panel.visible:
+		_close_vision_map_panel()
 
 func _on_save_failed(error: String) -> void:
 	print("Save failed: %s" % error)

--- a/40k/scripts/VisionMapOverlay.gd
+++ b/40k/scripts/VisionMapOverlay.gd
@@ -1,111 +1,120 @@
 extends Node2D
 class_name VisionMapOverlay
 
-# VisionMapOverlay — whole-board visibility shading for ONE chosen unit.
+# VisionMapOverlay — whole-board visibility shading for ONE chosen unit,
+# rendered as TRUE RAY-CAST GEOMETRY (v2).
 #
-# The existing LoS debug tools answer "can A see B?" for two units that are
-# already on the table. During deployment the player's real question is the
-# inverse: "if I put a model HERE, is it seen?" — which needs the whole board
-# classified, not a line between two tokens. This overlay grid-samples the
-# board (CELL_INCHES resolution) and shades every cell the chosen unit can see,
-# ignoring weapon range entirely, so hideable real estate is readable at a
-# glance in any phase. One unit at a time by design: overlapping several units'
-# vision fields is unreadable (the user report asking for this said exactly
-# that), so the selector (VisionMapPanel) applies it unit-by-unit.
+# v1 classified a 1" grid of cells, which read as blocky stair-steps (user
+# report 2026-08-06: "very blocky — can't you project, almost ray casting,
+# from the models?"). v2 does exactly that: from every observer point it runs
+# an angular visibility sweep — one ray AT every terrain vertex (±ε twin rays,
+# the classic trick that makes corners crisp) plus a sparse uniform fill — and
+# computes the exact blocked/visible intervals along each ray. Adjacent rays
+# are stitched into triangle fans, so shadow boundaries land ON the terrain
+# silhouettes: between two vertex-targeted rays every visibility boundary
+# follows a straight polygon edge, which the stitched quad reproduces
+# EXACTLY. No cells, no steps.
 #
-# ── Semantics ──────────────────────────────────────────────────────────────
-# Per sight line this mirrors EnhancedLineOfSight._check_single_line_of_sight_11e
-# — the SAME per-line judge the eligibility path uses (via RulesEngine.
-# _check_line_of_sight → check_enhanced_visibility) — with the piece list,
-# bboxes and exclusion sets precomputed so a few thousand cells are affordable:
-#   ▪ 13.10 Obscuring: light/dense terrain AREAS block unless the observer or
-#     the probed point is within that area group;
-#   ▪ 13.11 Solid: dense FEATURES block ground-level lines except the piece a
-#     model occupies;
-#   ▪ explicit wall segments block when no polygon already did.
-# run_self_check() re-judges sampled cells straight through the canonical
-# EnhancedLineOfSight function to prove the mirror never drifts — the L-overlay
-# taught us (2026-08) that a debug view with its own private LoS logic WILL
-# eventually contradict the rules engine.
+# ── Rules semantics (unchanged from v1, and still held to canon) ───────────
+# Per sight line this implements the SAME 11e judgement as
+# EnhancedLineOfSight._check_single_line_of_sight_11e — the per-line judge the
+# targeting engine itself uses:
+#   ▪ 13.10 Obscuring: light/dense terrain AREAS block from the point the ray
+#     first crosses them, EXCEPT where the target point stands within that
+#     area's group (windows of visibility inside the group's own footprints —
+#     you can be seen while standing in a ruin) or the observer is within it.
+#   ▪ 13.11 Solid: dense FEATURES block ground-level rays the same way, with
+#     the piece's own footprint as the exception, and not at all for elevated
+#     observers.
+#   ▪ Explicit wall segments block outright.
+# Along a ray these become interval operations: a blocker contributes
+# [first_crossing, ∞) minus its exclusion windows; the union over blockers,
+# inverted, is the visible set. run_self_check() still re-judges sampled
+# points straight through the canonical EnhancedLineOfSight function AND
+# cross-checks the rendered fan geometry against the per-point judge — the
+# L-overlay lesson (a debug view with private LoS logic WILL drift) applies
+# to a renderer too.
 #
-# ── Approximations (documented, deliberate) ────────────────────────────────
-#   ▪ The probed point is a point target at ground level, not a based model:
-#     verdicts are exact for the cell CENTRE; a real model's base edge can peek
-#     around a corner from within a "hidden" cell. Precision = cell size.
-#   ▪ Observer rays: base centre + OBSERVER_EDGE_RAYS points on the base rim
-#     (all base shapes approximated by their base_mm circle, matching
-#     TerrainManager._sight_points). The rules' full base-to-base sampling can
-#     rarely find a line these rays miss — sub-cell effect at shadow edges.
-#   ▪ 13.09 HIDDEN is a property of a real target unit's recent actions, not of
-#     a board position, so it is intentionally NOT part of this map.
+# ── Remaining approximations (documented, deliberate) ──────────────────────
+#   ▪ The probed point is a point target at ground level: a real model's base
+#     edge can peek past a corner from just inside the shadow. Rays from each
+#     model's base rim (small units get rim points, see _prepare_observers)
+#     show this as a soft fringe where fans from one base disagree.
+#   ▪ 13.09 HIDDEN is a property of a real target unit's recent actions, not
+#     of a board position, so it is intentionally NOT part of this map.
+#   ▪ Requires the 11e ruleset (the game always plays 11e; only the legacy
+#     test harness pins 10e — the map reports itself unavailable there).
 
 signal vision_map_updated
 
-const CELL_UNKNOWN := 0
-const CELL_VISIBLE := 1
-const CELL_HIDDEN := 2
+const STATE_UNKNOWN := 0
+const STATE_VISIBLE := 1
+const STATE_HIDDEN := 2
 
-# 1" cells: 2640 cells on a 44"x60" board — fills in about a second, and
-# matches the precision a deployment decision actually needs.
-const CELL_INCHES := 1.0
-# Per-frame compute budget (ms). Keeps the UI at full framerate while the map
-# fills in progressively.
-const FRAME_BUDGET_MS := 6.0
-# Observer rays per model beyond the centre ray (points on the base rim).
-const OBSERVER_EDGE_RAYS := 8
-# Re-check the world signature at this interval while active, so the map tracks
-# deployments/moves/casualties without recomputing every frame.
-const REFRESH_POLL_SEC := 0.5
-
-# Visible = warm "you are exposed here" wash; hidden = cool "safe shadow".
-# Both translucent enough that terrain, zones and tokens stay readable. The
-# hidden blue is picked for how it COMPOSITES, not how it looks as a swatch
-# (2026-08-06 windowed runs): at 0.38 alpha a dark navy multiplies into the
-# khaki board as a neutral dark grey — the "hidden" read disappeared outside
-# the pale-blue deployment-zone tint. A high blue channel keeps the composite
-# unmistakably blue over khaki ground, terrain fills AND the zone tints.
+# Base hues (shared with the panel legend). The map is drawn as OPAQUE fills
+# inside a CanvasGroup that is then faded as ONE layer (GROUP_ALPHA), so
+# overlapping fans from different models never double-darken — the flattened
+# composite matches the v1 look that was validated for legibility over the
+# khaki board, terrain fills and the pale deployment-zone tints.
 const COLOR_VISIBLE := Color(1.0, 0.42, 0.16, 0.32)
 const COLOR_HIDDEN := Color(0.05, 0.12, 0.55, 0.40)
+const GROUP_ALPHA := 0.36
 const SOURCE_RING_COLOR := Color(1.0, 0.85, 0.2, 0.95)
+
+# Twin-ray offset around each vertex angle: at 3000px range this is ~0.6px of
+# arc — the sliver between the twins is where a corner transition lives.
+const EPS_ANG := 0.0002
+# Sparse uniform fill on top of the vertex-targeted rays — belt and braces
+# for numeric edge cases; the vertex rays carry all the real geometry.
+const UNIFORM_FILL_RAYS := 96
+const EPS_T := 0.05
+# Per-frame compute budget (ms) while filling in progressively.
+const FRAME_BUDGET_MS := 6.0
+const REFRESH_POLL_SEC := 0.5
 
 var source_unit_id: String = ""
 
-# ── grid state ──
-var _cols: int = 0
-var _rows: int = 0
-var _cell_px: float = 40.0
-var _board_px: Vector2 = Vector2.ZERO
-var _cells: PackedByteArray = PackedByteArray()
-var _pending_idx: int = 0
-var _image: Image = null
-var _texture: ImageTexture = null
-
 # ── precomputed world data ──
-# Terrain pieces: {id, polygon, bbox, cat, pclass, group_key, legacy walls[]}
+# Terrain pieces: {id, polygon, bbox, cat, pclass, group_key}
 var _pieces: Array = []
 var _walls: Array = []  # {a: Vector2, b: Vector2, bbox: Rect2}
 var _group_map: Dictionary = {}
+# group_key -> Array of {polygon, bbox} (every footprint of that area group)
+var _group_polys: Dictionary = {}
 var _raw_features: Array = []
-# Observer models: {model, pos, ground, groups, feats, ruins (pre-11e), points: Array[Vector2]}
+var _board_px: Vector2 = Vector2.ZERO
+# Observer points: {model, pos, ground, groups, feats}
 var _observers: Array = []
-# Flattened try-order: centre rays of every model first (cheap early-exit for
-# open ground), then the rim rays. Entries are [point: Vector2, observer_idx].
-var _obs_points: Array = []
+
+# ── sweep state ──
+# Per observer: {obs, blockers, angles: PackedFloat64Array, intervals: Array,
+#                next_ray: int, tris: PackedVector2Array,
+#                gap_ranges: PackedInt32Array (per-gap start index into tris,
+#                length n+1 — the fan is queried by ANGLE, not spatially)}
+var _sweeps: Array = []
+var _pending_observer: int = 0
+var _total_rays: int = 0
+var _done_rays: int = 0
+var _compute_done: bool = false
+var _no_models_reason: String = ""
+var _seen_ratio_cache: float = -1.0
 
 var _poll_accum: float = 0.0
 var _world_sig: int = 0
-var _compute_done: bool = false
-var _no_models_reason: String = ""
+
+# ── render nodes ──
+var _map_group: CanvasGroup = null
+var _base_rect: Polygon2D = null
+var _fan_meshes: Array = []
 
 func _ready() -> void:
 	name = "VisionMapOverlay"
 	z_index = -3  # above board(-10)/terrain(-8)/zones(-5), below tokens(10)
-	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	set_process(false)
 	var tm = get_node_or_null("/root/TerrainManager")
 	if tm and tm.has_signal("terrain_loaded"):
 		tm.terrain_loaded.connect(func(_features): if is_active(): _restart_compute())
-	print("[VisionMapOverlay] Initialized")
+	print("[VisionMapOverlay] Initialized (ray-cast sweep renderer)")
 
 # ═══════════════════════════════ public API ═══════════════════════════════
 
@@ -120,13 +129,12 @@ func show_for_unit(unit_id: String) -> void:
 
 func clear_map() -> void:
 	source_unit_id = ""
-	_cells = PackedByteArray()
 	_observers.clear()
-	_obs_points.clear()
-	_image = null
-	_texture = null
+	_sweeps.clear()
 	_compute_done = false
 	_no_models_reason = ""
+	_seen_ratio_cache = -1.0
+	_clear_render_nodes()
 	set_process(false)
 	queue_redraw()
 	emit_signal("vision_map_updated")
@@ -139,39 +147,96 @@ func is_compute_done() -> bool:
 	return _compute_done
 
 func compute_progress() -> float:
-	if _cells.is_empty():
-		return 0.0
-	return float(_pending_idx) / float(_cells.size())
+	if _total_rays <= 0:
+		return 1.0 if _compute_done else 0.0
+	return float(_done_rays) / float(_total_rays)
 
-## "" when the map is drawable; otherwise why it is not (e.g. the chosen unit
-## has nothing on the board yet — legal to select during deployment, the map
-## auto-fills the moment its first model is placed).
+## "" when the map is drawable; otherwise why it is not.
 func status_reason() -> String:
 	return _no_models_reason
 
-func visible_cell_count() -> int:
-	return _count_state(CELL_VISIBLE)
+## Synchronous full compute — tests and scenario asserts use this to avoid
+## racing the frame-sliced path.
+func compute_now() -> void:
+	if not is_active() or _no_models_reason != "":
+		return
+	while not _compute_done:
+		_advance_sweep(1_000_000_000)
 
-func hidden_cell_count() -> int:
-	return _count_state(CELL_HIDDEN)
+## Fraction of the board the unit can see, by seeded point sampling through
+## the exact per-point judge. Cached per compute; cheap, deterministic.
+func seen_ratio(samples: int = 500, seed_value: int = 1337) -> float:
+	if not is_active() or _observers.is_empty():
+		return 0.0
+	if _seen_ratio_cache >= 0.0:
+		return _seen_ratio_cache
+	var rng := RandomNumberGenerator.new()
+	rng.seed = seed_value
+	var seen := 0
+	for i in range(samples):
+		var p := Vector2(rng.randf() * _board_px.x, rng.randf() * _board_px.y)
+		if point_state_at(p) == STATE_VISIBLE:
+			seen += 1
+	_seen_ratio_cache = float(seen) / float(samples)
+	return _seen_ratio_cache
 
-func _count_state(state: int) -> int:
-	var n := 0
-	for c in _cells:
-		if c == state:
-			n += 1
-	return n
+# ═════════════════════════ exact per-point judge ═══════════════════════════
+# The same segment judgement v1 used (mirrors the canonical
+# _check_single_line_of_sight_11e branch for branch) — the sweep RENDERS the
+# map, this ANSWERS point queries and anchors the self-checks.
 
-## Cell verdict at a board position (CELL_* constants; CELL_UNKNOWN when the
-## map is off, still computing that cell, or pos is off-board).
-func cell_state_at(pos: Vector2) -> int:
-	if _cells.is_empty() or _cell_px <= 0.0:
-		return CELL_UNKNOWN
-	var cx := int(pos.x / _cell_px)
-	var cy := int(pos.y / _cell_px)
-	if cx < 0 or cy < 0 or cx >= _cols or cy >= _rows:
-		return CELL_UNKNOWN
-	return _cells[cy * _cols + cx]
+func point_state_at(pos: Vector2) -> int:
+	if not is_active() or _observers.is_empty() or _no_models_reason != "":
+		return STATE_UNKNOWN
+	if pos.x < 0.0 or pos.y < 0.0 or pos.x > _board_px.x or pos.y > _board_px.y:
+		return STATE_UNKNOWN
+	var cell_groups := {}
+	var cell_feats := {}
+	for piece in _pieces:
+		if piece.bbox.grow(0.01).has_point(pos) and Geometry2D.is_point_in_polygon(pos, piece.polygon):
+			cell_groups[piece.group_key] = true
+			cell_feats[piece.id] = true
+	for obs in _observers:
+		if not _line_blocked_11e_fast(obs.pos, pos, obs.groups, cell_groups, obs.feats, cell_feats, obs.ground):
+			return STATE_VISIBLE
+	return STATE_HIDDEN
+
+# Fast mirror of EnhancedLineOfSight._check_single_line_of_sight_11e for a
+# point target: identical branch structure over precomputed piece data, plus a
+# bbox reject. run_self_check() holds it to the canonical function.
+func _line_blocked_11e_fast(a: Vector2, b: Vector2, obs_groups: Dictionary, cell_groups: Dictionary, obs_feats: Dictionary, cell_feats: Dictionary, ground_level: bool) -> bool:
+	var seg_min := a.min(b)
+	var seg_bbox := Rect2(seg_min, a.max(b) - seg_min)
+	for piece in _pieces:
+		if not seg_bbox.intersects(piece.bbox, true):
+			continue
+		if not _segment_hits_polygon(a, b, piece.polygon):
+			continue
+		# 13.10 Obscuring — terrain areas (authored boundaries + legacy pieces).
+		if piece.pclass != "feature":
+			if (piece.cat == TerrainManager.CATEGORY_LIGHT or piece.cat == TerrainManager.CATEGORY_DENSE) \
+					and not obs_groups.has(piece.group_key) and not cell_groups.has(piece.group_key):
+				return true
+		# 13.11 Solid — dense physical structures (features + legacy pieces).
+		if piece.pclass != "area":
+			if piece.cat == TerrainManager.CATEGORY_DENSE and ground_level \
+					and not obs_feats.has(piece.id) and not cell_feats.has(piece.id):
+				return true
+	for wall in _walls:
+		if not seg_bbox.intersects(wall.bbox, true):
+			continue
+		if Geometry2D.segment_intersects_segment(a, b, wall.a, wall.b) != null:
+			return true
+	return false
+
+static func _segment_hits_polygon(a: Vector2, b: Vector2, poly: PackedVector2Array) -> bool:
+	var n := poly.size()
+	for i in range(n):
+		if Geometry2D.segment_intersects_segment(a, b, poly[i], poly[(i + 1) % n]) != null:
+			return true
+	if Geometry2D.is_point_in_polygon(a, poly):
+		return true
+	return Geometry2D.is_point_in_polygon(b, poly)
 
 # ═════════════════════════════ world signature ═════════════════════════════
 
@@ -186,8 +251,8 @@ func _process(delta: float) -> void:
 		if sig != _world_sig:
 			_restart_compute()
 			return
-	if not _compute_done and not _cells.is_empty():
-		_compute_chunk()
+	if not _compute_done and _no_models_reason == "":
+		_advance_sweep(int(FRAME_BUDGET_MS * 1000.0))
 
 func _world_signature() -> int:
 	var parts: Array = [source_unit_id, GameConstants.edition]
@@ -219,39 +284,44 @@ static func _model_pos(model: Dictionary) -> Vector2:
 func _restart_compute() -> void:
 	_world_sig = _world_signature()
 	_compute_done = false
-	_pending_idx = 0
 	_no_models_reason = ""
+	_seen_ratio_cache = -1.0
+	_sweeps.clear()
+	_pending_observer = 0
+	_total_rays = 0
+	_done_rays = 0
 
 	var board_size: Dictionary = GameState.state.get("board", {}).get("size", {"width": 44, "height": 60})
 	_board_px = Vector2(
 		float(board_size.get("width", 44)) * Measurement.PX_PER_INCH,
 		float(board_size.get("height", 60)) * Measurement.PX_PER_INCH)
-	_cell_px = CELL_INCHES * Measurement.PX_PER_INCH
-	_cols = int(ceil(_board_px.x / _cell_px))
-	_rows = int(ceil(_board_px.y / _cell_px))
 
 	_prepare_terrain()
 	_prepare_observers()
-
-	_cells = PackedByteArray()
-	_cells.resize(_cols * _rows)
-	_image = Image.create(_cols, _rows, false, Image.FORMAT_RGBA8)
-	_image.fill(Color(0, 0, 0, 0))
-	_texture = ImageTexture.create_from_image(_image)
+	_rebuild_render_nodes()
 
 	var unit: Dictionary = GameState.state.get("units", {}).get(source_unit_id, {})
-	if unit.is_empty():
+	if GameConstants.edition < 11:
+		_no_models_reason = "Vision Map needs the 11e ruleset"
+		_compute_done = true
+	elif unit.is_empty():
 		_no_models_reason = "Unit not found"
 		_compute_done = true
 	elif _observers.is_empty():
 		_no_models_reason = "No models on the board yet"
 		_compute_done = true
+	else:
+		for obs in _observers:
+			_sweeps.append(_new_sweep(obs))
+		for sweep in _sweeps:
+			_total_rays += sweep.angles.size()
 	queue_redraw()
 	emit_signal("vision_map_updated")
 
 func _prepare_terrain() -> void:
 	_pieces.clear()
 	_walls.clear()
+	_group_polys.clear()
 	_raw_features = []
 	var tm = get_node_or_null("/root/TerrainManager")
 	if tm:
@@ -266,16 +336,19 @@ func _prepare_terrain() -> void:
 			for v in poly:
 				bb_min = bb_min.min(v)
 				bb_max = bb_max.max(v)
-			_pieces.append({
+			var gk: String = _group_map.get(pid, "id:" + pid)
+			var entry := {
 				"id": pid,
 				"polygon": poly,
 				"bbox": Rect2(bb_min, bb_max - bb_min),
 				"cat": TerrainManager.category_of(piece),
 				"pclass": str(piece.get("piece_class", "")),
-				"group_key": _group_map.get(pid, "id:" + pid),
-			})
-		# Legacy/custom wall segments (11e layouts author walls as feature
-		# pieces, so these arrays are normally empty).
+				"group_key": gk,
+			}
+			_pieces.append(entry)
+			if not _group_polys.has(gk):
+				_group_polys[gk] = []
+			_group_polys[gk].append({"polygon": poly, "bbox": entry.bbox})
 		for wall in piece.get("walls", []):
 			if not wall.get("blocks_los", true):
 				continue
@@ -286,202 +359,457 @@ func _prepare_terrain() -> void:
 
 func _prepare_observers() -> void:
 	_observers.clear()
-	_obs_points.clear()
 	var unit: Dictionary = GameState.state.get("units", {}).get(source_unit_id, {})
-	var board_stub := {"terrain_features": _raw_features}
+	var models: Array = []
 	for m in unit.get("models", []):
 		if typeof(m) != TYPE_DICTIONARY or not m.get("alive", true):
 			continue
-		var pos := _model_pos(m)
-		if pos == Vector2.ZERO:
+		if _model_pos(m) == Vector2.ZERO:
 			continue
+		models.append(m)
+	# Rim rays reveal base-edge peeking, but every extra observer point is a
+	# full sweep — spend them where they matter (small elite units) and fall
+	# back to centre-only for mobs, whose many bases cover each other anyway.
+	var rim_points := 0
+	if models.size() <= 2:
+		rim_points = 8
+	elif models.size() <= 5:
+		rim_points = 4
+	for m in models:
+		var pos := _model_pos(m)
 		var radius: float = Measurement.base_radius_px(int(m.get("base_mm", 32)))
 		var points: Array = [pos]
-		for i in range(OBSERVER_EDGE_RAYS):
-			var ang := TAU * float(i) / float(OBSERVER_EDGE_RAYS)
+		for i in range(rim_points):
+			var ang := TAU * float(i) / float(rim_points)
 			points.append(pos + Vector2(cos(ang), sin(ang)) * radius)
-		var ctx := {
-			"model": m,
-			"pos": pos,
-			"ground": float(m.get("elevation_inches", 0.0)) < 3.0,
-			"groups": {},
-			"feats": {},
-			"ruins": [],
-			"points": points,
-		}
-		if GameConstants.edition >= 11:
-			# Same "within"/"occupies" split visibility_exclusions_for applies:
-			# any base overlap excuses the piece's obscuring GROUP; only centre-
-			# inside excuses a Solid feature (13.10/13.11 via 01.04).
-			for piece in _pieces:
-				if not _circle_overlaps_bbox(pos, radius, piece.bbox):
-					continue
-				var center_in: bool = Geometry2D.is_point_in_polygon(pos, piece.polygon)
-				if center_in or TerrainManager._circle_overlaps_polygon(pos, radius, piece.polygon):
-					ctx.groups[piece.group_key] = true
-					if center_in:
-						ctx.feats[piece.id] = true
-		else:
-			ctx.ruins = EnhancedLineOfSight._get_ruins_model_wholly_within(points, pos, m, board_stub)
-		_observers.append(ctx)
-	# Try-order: every model's centre ray first, then the rim rays — open
-	# ground resolves on the first probe, and only genuinely contested cells
-	# pay for the full fan.
-	for oi in range(_observers.size()):
-		_obs_points.append([_observers[oi].points[0], oi])
-	for oi in range(_observers.size()):
-		var pts: Array = _observers[oi].points
-		for pi in range(1, pts.size()):
-			_obs_points.append([pts[pi], oi])
-
-static func _circle_overlaps_bbox(center: Vector2, radius: float, bbox: Rect2) -> bool:
-	return bbox.grow(radius).has_point(center)
-
-# ═══════════════════════════════ chunked compute ═══════════════════════════
-
-func _compute_chunk() -> void:
-	var deadline := Time.get_ticks_usec() + int(FRAME_BUDGET_MS * 1000.0)
-	var total := _cells.size()
-	while _pending_idx < total and Time.get_ticks_usec() < deadline:
-		_compute_cell(_pending_idx)
-		_pending_idx += 1
-	_texture.update(_image)
-	queue_redraw()
-	if _pending_idx >= total:
-		_compute_done = true
-		emit_signal("vision_map_updated")
-		print("[VisionMapOverlay] Map complete for %s: %d visible / %d hidden cells" % [
-			source_unit_id, visible_cell_count(), hidden_cell_count()])
-
-func _compute_cell(idx: int) -> void:
-	var cx := idx % _cols
-	var cy := int(float(idx) / float(_cols))
-	var target := Vector2((float(cx) + 0.5) * _cell_px, (float(cy) + 0.5) * _cell_px)
-
-	var state := CELL_HIDDEN
-	if GameConstants.edition >= 11:
-		# Target-side exclusions: the areas/pieces the probed point sits in
-		# (a point target is "within" and "occupies" the same set). bbox grown
-		# a hair so the precheck can never exclude an exact-boundary point the
-		# polygon test would accept.
-		var cell_groups := {}
-		var cell_feats := {}
+		# Exclusions are per MODEL (base overlap), applied to all its points —
+		# the same "within"/"occupies" split visibility_exclusions_for uses.
+		var groups := {}
+		var feats := {}
 		for piece in _pieces:
-			if piece.bbox.grow(0.01).has_point(target) and Geometry2D.is_point_in_polygon(target, piece.polygon):
-				cell_groups[piece.group_key] = true
-				cell_feats[piece.id] = true
-		for op in _obs_points:
-			var obs: Dictionary = _observers[op[1]]
-			if not _line_blocked_11e_fast(op[0], target, obs.groups, cell_groups, obs.feats, cell_feats, obs.ground):
-				state = CELL_VISIBLE
-				break
-	else:
-		# Pre-11e fallback: judge each ray with the canonical 10e per-line
-		# function directly (no fast mirror — this path is not hot for us).
-		var board_stub := {"terrain_features": _raw_features}
-		var fake_target := {"position": {"x": target.x, "y": target.y}, "base_mm": 32, "alive": true}
-		for op in _obs_points:
-			var obs: Dictionary = _observers[op[1]]
-			var res: Dictionary = EnhancedLineOfSight._check_single_line_of_sight(
-				op[0], target, board_stub, obs.model, fake_target, obs.ruins, {}, false)
-			if res.has_los:
-				state = CELL_VISIBLE
-				break
+			if not piece.bbox.grow(radius).has_point(pos):
+				continue
+			var center_in: bool = Geometry2D.is_point_in_polygon(pos, piece.polygon)
+			if center_in or TerrainManager._circle_overlaps_polygon(pos, radius, piece.polygon):
+				groups[piece.group_key] = true
+				if center_in:
+					feats[piece.id] = true
+		var ground := float(m.get("elevation_inches", 0.0)) < 3.0
+		for p in points:
+			_observers.append({"model": m, "pos": p, "ground": ground, "groups": groups, "feats": feats})
 
-	_cells[idx] = state
-	_image.set_pixel(cx, cy, COLOR_VISIBLE if state == CELL_VISIBLE else COLOR_HIDDEN)
+# ═══════════════════════════════ the sweep ═════════════════════════════════
 
-# Fast mirror of EnhancedLineOfSight._check_single_line_of_sight_11e for a
-# point target: identical branch structure over precomputed piece data, plus a
-# bbox reject. run_self_check() holds it to the canonical function — change one
-# without the other and the self-check fails.
-func _line_blocked_11e_fast(a: Vector2, b: Vector2, obs_groups: Dictionary, cell_groups: Dictionary, obs_feats: Dictionary, cell_feats: Dictionary, ground_level: bool) -> bool:
-	var seg_min := a.min(b)
-	var seg_bbox := Rect2(seg_min, a.max(b) - seg_min)
+func _new_sweep(obs: Dictionary) -> Dictionary:
+	# Blocker entries for THIS observer. A legacy piece (no piece_class) can
+	# block in BOTH roles — two entries with different exclusion sets, exactly
+	# like the two branches of the canonical judge. Each entry carries its
+	# angular span from the observer so a ray only pays for blockers that can
+	# actually lie in its direction.
+	var blockers: Array = []
 	for piece in _pieces:
-		if not seg_bbox.intersects(piece.bbox, true):
-			continue
-		if not _segment_hits_polygon(a, b, piece.polygon):
-			continue
-		# 13.10 Obscuring — terrain areas (authored boundaries + legacy pieces).
-		if piece.pclass != "feature":
-			if (piece.cat == TerrainManager.CATEGORY_LIGHT or piece.cat == TerrainManager.CATEGORY_DENSE) \
-					and not obs_groups.has(piece.group_key) and not cell_groups.has(piece.group_key):
-				return true
-		# 13.11 Solid — dense physical structures (features + legacy pieces).
-		if piece.pclass != "area":
-			if piece.cat == TerrainManager.CATEGORY_DENSE and ground_level \
-					and not obs_feats.has(piece.id) and not cell_feats.has(piece.id):
-				return true
-	# Wall segments only matter when no polygon already blocked (mirrors the
-	# canonical ordering; the answer is the same either way for a bool).
+		if piece.pclass != "feature" \
+				and (piece.cat == TerrainManager.CATEGORY_LIGHT or piece.cat == TerrainManager.CATEGORY_DENSE) \
+				and not obs.groups.has(piece.group_key):
+			var e := {"polygon": piece.polygon, "bbox": piece.bbox,
+				"excl": _group_polys.get(piece.group_key, [])}
+			_stamp_angular_span(e, obs.pos, piece.polygon)
+			blockers.append(e)
+		if piece.pclass != "area" \
+				and piece.cat == TerrainManager.CATEGORY_DENSE and obs.ground \
+				and not obs.feats.has(piece.id):
+			var e2 := {"polygon": piece.polygon, "bbox": piece.bbox,
+				"excl": [{"polygon": piece.polygon, "bbox": piece.bbox}]}
+			_stamp_angular_span(e2, obs.pos, piece.polygon)
+			blockers.append(e2)
 	for wall in _walls:
-		if not seg_bbox.intersects(wall.bbox, true):
-			continue
-		if Geometry2D.segment_intersects_segment(a, b, wall.a, wall.b) != null:
-			return true
-	return false
+		var we := {"wall": true, "a": wall.a, "b": wall.b, "bbox": wall.bbox, "excl": []}
+		_stamp_angular_span(we, obs.pos, PackedVector2Array([wall.a, wall.b]))
+		blockers.append(we)
 
-# _segment_intersects_polygon semantics (edges OR either endpoint inside),
-# minus the coercion — polygons were packed once in _prepare_terrain.
-static func _segment_hits_polygon(a: Vector2, b: Vector2, poly: PackedVector2Array) -> bool:
+	# Ray fan: every terrain vertex (±ε twins) — INCLUDING vertices of pieces
+	# that do not block this observer, because excluded footprints still shape
+	# the visibility windows inside other blockers' shadows — plus wall ends,
+	# board corners, and a sparse uniform fill.
+	var angles_raw: Array = []
+	var o: Vector2 = obs.pos
+	for piece in _pieces:
+		for v in piece.polygon:
+			var ang: float = (v - o).angle()
+			angles_raw.append(ang - EPS_ANG)
+			angles_raw.append(ang + EPS_ANG)
+	for wall in _walls:
+		for v in [wall.a, wall.b]:
+			var wang: float = (v - o).angle()
+			angles_raw.append(wang - EPS_ANG)
+			angles_raw.append(wang + EPS_ANG)
+	for corner in [Vector2.ZERO, Vector2(_board_px.x, 0), _board_px, Vector2(0, _board_px.y)]:
+		angles_raw.append((corner - o).angle())
+	for i in range(UNIFORM_FILL_RAYS):
+		angles_raw.append(-PI + TAU * float(i) / float(UNIFORM_FILL_RAYS))
+	angles_raw.sort()
+	var angles := PackedFloat64Array()
+	var last := INF
+	for ang in angles_raw:
+		if last == INF or absf(ang - last) > 0.00001:
+			angles.append(ang)
+			last = ang
+	return {"obs": obs, "blockers": blockers, "angles": angles,
+		"intervals": [], "next_ray": 0, "tris": PackedVector2Array(),
+		"gap_ranges": PackedInt32Array()}
+
+## Precompute the blocker's angular extent as seen from `o`: a reference
+## direction plus min/max offsets. A ray whose offset falls outside the span
+## cannot touch the blocker — the cheap reject that keeps a ray from paying
+## the slab+edge tests for all ~60 blockers. A shape subtending more than a
+## half-turn (possible only for something wrapped AROUND the observer) is
+## marked full and never filtered.
+static func _stamp_angular_span(entry: Dictionary, o: Vector2, verts: PackedVector2Array) -> void:
+	if verts.is_empty():
+		entry["span_full"] = true
+		return
+	var ref := (verts[0] - o).angle()
+	var lo := 0.0
+	var hi := 0.0
+	for v in verts:
+		var d := wrapf((v - o).angle() - ref, -PI, PI)
+		lo = minf(lo, d)
+		hi = maxf(hi, d)
+	if hi - lo > PI:
+		entry["span_full"] = true
+		return
+	entry["span_full"] = false
+	entry["span_ref"] = ref
+	entry["span_lo"] = lo - EPS_ANG * 8.0
+	entry["span_hi"] = hi + EPS_ANG * 8.0
+
+func _advance_sweep(budget_usec: int) -> void:
+	var deadline := Time.get_ticks_usec() + budget_usec
+	while _pending_observer < _sweeps.size():
+		var sweep: Dictionary = _sweeps[_pending_observer]
+		var n: int = sweep.angles.size()
+		while sweep.next_ray < n:
+			sweep.intervals.append(_cast_ray(sweep, sweep.angles[sweep.next_ray]))
+			sweep.next_ray += 1
+			_done_rays += 1
+			if Time.get_ticks_usec() >= deadline:
+				return
+		_finish_observer(sweep, _pending_observer)
+		_pending_observer += 1
+		if Time.get_ticks_usec() >= deadline:
+			break
+	if _pending_observer >= _sweeps.size() and not _compute_done:
+		_compute_done = true
+		queue_redraw()
+		emit_signal("vision_map_updated")
+		print("[VisionMapOverlay] Sweep complete for %s: %d observers, %d rays, ~%d%% of board in sight" % [
+			source_unit_id, _sweeps.size(), _total_rays, int(seen_ratio() * 100.0)])
+
+## Visible intervals [t0, t1] along the ray from sweep.obs.pos at angle `ang`,
+## capped at the board edge. Exact interval algebra over the blocker set.
+func _cast_ray(sweep: Dictionary, ang: float) -> Array:
+	var o: Vector2 = sweep.obs.pos
+	var dir := Vector2(cos(ang), sin(ang))
+	var t_max := _board_exit_t(o, dir)
+	if t_max <= 0.0:
+		return []
+	var seg_end := o + dir * t_max
+
+	var blocked: Array = []  # [t0, t1] pairs, unsorted
+	for blocker in sweep.blockers:
+		if not blocker.span_full:
+			var d := wrapf(ang - blocker.span_ref, -PI, PI)
+			if d < blocker.span_lo or d > blocker.span_hi:
+				continue
+		if not _ray_hits_rect(o, dir, t_max, blocker.bbox):
+			continue
+		if blocker.has("wall"):
+			var hit = Geometry2D.segment_intersects_segment(o, seg_end, blocker.a, blocker.b)
+			if hit != null:
+				blocked.append([maxf((hit - o).dot(dir), 0.0), t_max])
+			continue
+		var ts := _polygon_crossings(o, seg_end, dir, blocker.polygon)
+		if ts.is_empty():
+			continue
+		var t_enter: float = ts[0]
+		# Exclusion windows: stretches of this blocker's shadow where the
+		# target point stands within the excused footprints (13.10 group /
+		# 13.11 own piece) — visible islands INSIDE the shadow.
+		var windows: Array = []
+		for ex in blocker.excl:
+			if not _ray_hits_rect(o, dir, t_max, ex.bbox):
+				continue
+			var ets := _polygon_crossings(o, seg_end, dir, ex.polygon)
+			if ets.is_empty():
+				continue
+			# Pair up in/out by midpoint containment — robust against grazes.
+			var bounds: Array = [0.0]
+			bounds.append_array(ets)
+			bounds.append(t_max)
+			for i in range(bounds.size() - 1):
+				var lo: float = bounds[i]
+				var hi: float = bounds[i + 1]
+				if hi - lo < EPS_T:
+					continue
+				if Geometry2D.is_point_in_polygon(o + dir * ((lo + hi) * 0.5), ex.polygon):
+					windows.append([lo, hi])
+		if windows.is_empty():
+			blocked.append([t_enter, t_max])
+		else:
+			windows.sort_custom(func(x, y): return x[0] < y[0])
+			var cursor := t_enter
+			for w in windows:
+				if w[1] <= cursor:
+					continue
+				if w[0] > cursor:
+					blocked.append([cursor, minf(w[0], t_max)])
+				cursor = maxf(cursor, w[1])
+				if cursor >= t_max:
+					break
+			if cursor < t_max:
+				blocked.append([cursor, t_max])
+
+	if blocked.is_empty():
+		return [[0.0, t_max]]
+	blocked.sort_custom(func(x, y): return x[0] < y[0])
+	# Merge blocked, then invert into visible.
+	var visible: Array = []
+	var open := 0.0
+	for b in blocked:
+		if b[0] - open > EPS_T:
+			visible.append([open, b[0]])
+		open = maxf(open, b[1])
+	if t_max - open > EPS_T:
+		visible.append([open, t_max])
+	return visible
+
+## Sorted distances along o→dir at which the ray crosses the polygon outline.
+func _polygon_crossings(o: Vector2, seg_end: Vector2, dir: Vector2, poly: PackedVector2Array) -> Array:
+	var ts: Array = []
 	var n := poly.size()
 	for i in range(n):
-		if Geometry2D.segment_intersects_segment(a, b, poly[i], poly[(i + 1) % n]) != null:
-			return true
-	if Geometry2D.is_point_in_polygon(a, poly):
-		return true
-	return Geometry2D.is_point_in_polygon(b, poly)
+		var hit = Geometry2D.segment_intersects_segment(o, seg_end, poly[i], poly[(i + 1) % n])
+		if hit != null:
+			ts.append(maxf((hit - o).dot(dir), 0.0))
+	ts.sort()
+	# Dedupe shared-vertex double hits.
+	var out: Array = []
+	for t in ts:
+		if out.is_empty() or t - out[out.size() - 1] > EPS_T:
+			out.append(t)
+	return out
+
+func _board_exit_t(o: Vector2, dir: Vector2) -> float:
+	var t := INF
+	if dir.x > 0.00001:
+		t = minf(t, (_board_px.x - o.x) / dir.x)
+	elif dir.x < -0.00001:
+		t = minf(t, -o.x / dir.x)
+	if dir.y > 0.00001:
+		t = minf(t, (_board_px.y - o.y) / dir.y)
+	elif dir.y < -0.00001:
+		t = minf(t, -o.y / dir.y)
+	return maxf(t, 0.0) if t != INF else 0.0
+
+static func _ray_hits_rect(o: Vector2, dir: Vector2, t_max: float, rect: Rect2) -> bool:
+	# Classic slab test for the segment o → o+dir*t_max.
+	var t0 := 0.0
+	var t1 := t_max
+	for axis in 2:
+		var d := dir.x if axis == 0 else dir.y
+		var start := o.x if axis == 0 else o.y
+		var lo := rect.position.x if axis == 0 else rect.position.y
+		var hi := lo + (rect.size.x if axis == 0 else rect.size.y)
+		if absf(d) < 0.0000001:
+			if start < lo or start > hi:
+				return false
+		else:
+			var ta := (lo - start) / d
+			var tb := (hi - start) / d
+			if ta > tb:
+				var tmp := ta
+				ta = tb
+				tb = tmp
+			t0 = maxf(t0, ta)
+			t1 = minf(t1, tb)
+			if t0 > t1:
+				return false
+	return true
+
+# ═══════════════════════ fan stitching + rendering ═════════════════════════
+
+func _finish_observer(sweep: Dictionary, observer_idx: int) -> void:
+	var o: Vector2 = sweep.obs.pos
+	var angles: PackedFloat64Array = sweep.angles
+	var n := angles.size()
+	var tris := PackedVector2Array()
+	# gap_ranges[i] = first triangle index of gap i (the wedge between ray i
+	# and ray i+1, wrapping); length n+1. Point queries binary-search the
+	# angle to its gap and test only that wedge's few triangles.
+	var gap_ranges := PackedInt32Array()
+	for i in range(n):
+		gap_ranges.append(tris.size() / 3)
+		var j := (i + 1) % n
+		var dir_i := Vector2(cos(angles[i]), sin(angles[i]))
+		var dir_j := Vector2(cos(angles[j]), sin(angles[j]))
+		var list_i: Array = sweep.intervals[i]
+		var list_j: Array = sweep.intervals[j]
+		# Stitch every overlapping interval pair into a quad using each ray's
+		# OWN endpoints: between vertex-twin rays each boundary follows one
+		# straight polygon edge, so the quad reproduces it exactly. The rare
+		# many-to-one overlap at a corner lives inside the ±ε sliver and the
+		# extra overlapping quads collapse invisibly (flat colour, union
+		# rendering).
+		for a in list_i:
+			for b in list_j:
+				if a[0] >= b[1] - EPS_T or b[0] >= a[1] - EPS_T:
+					continue
+				var a0: Vector2 = o + dir_i * a[0]
+				var a1: Vector2 = o + dir_i * a[1]
+				var b0: Vector2 = o + dir_j * b[0]
+				var b1: Vector2 = o + dir_j * b[1]
+				# Skip zero-area triangles: every quad rooted at the observer
+				# has a0 == b0, and point_is_inside_triangle answers TRUE for
+				# any COLLINEAR point against a degenerate triangle — which
+				# made sweep_point_visible hallucinate visibility along exact
+				# ray bearings (all sign tests are 0). Invisible when drawn,
+				# poisonous when queried.
+				if absf((a1 - a0).cross(b1 - a0)) > 0.5:
+					tris.append(a0); tris.append(a1); tris.append(b1)
+				if absf((b1 - a0).cross(b0 - a0)) > 0.5:
+					tris.append(a0); tris.append(b1); tris.append(b0)
+	gap_ranges.append(tris.size() / 3)
+	sweep.tris = tris
+	sweep.gap_ranges = gap_ranges
+	_attach_fan_mesh(observer_idx, tris)
+	queue_redraw()
+
+## Is P inside this unit's RENDERED visible geometry? (What the player sees —
+## cross-checked against the per-point judge by run_self_check part B.)
+## Angle-indexed: binary-search the ray pair bracketing P's bearing, then test
+## only that wedge's triangles.
+func sweep_point_visible(p: Vector2) -> bool:
+	for sweep in _sweeps:
+		var n: int = sweep.angles.size()
+		if n < 2 or sweep.next_ray < n or sweep.gap_ranges.is_empty():
+			continue
+		var theta: float = (p - sweep.obs.pos).angle()
+		var gap: int
+		if theta < sweep.angles[0] or theta >= sweep.angles[n - 1]:
+			gap = n - 1  # the wrap wedge between the last and first rays
+		else:
+			var lo := 0
+			var hi := n - 1
+			while hi - lo > 1:
+				var mid := (lo + hi) >> 1
+				if sweep.angles[mid] <= theta:
+					lo = mid
+				else:
+					hi = mid
+			gap = lo
+		for t in range(sweep.gap_ranges[gap], sweep.gap_ranges[gap + 1]):
+			if Geometry2D.point_is_inside_triangle(p, sweep.tris[t * 3], sweep.tris[t * 3 + 1], sweep.tris[t * 3 + 2]):
+				return true
+	return false
+
+func _rebuild_render_nodes() -> void:
+	_clear_render_nodes()
+	_map_group = CanvasGroup.new()
+	_map_group.name = "MapGroup"
+	# One flattened layer: opaque hidden base + opaque visible fans, faded
+	# together — overlapping fans can never double-darken.
+	_map_group.self_modulate = Color(1, 1, 1, GROUP_ALPHA)
+	add_child(_map_group)
+	_base_rect = Polygon2D.new()
+	_base_rect.name = "HiddenBase"
+	_base_rect.polygon = PackedVector2Array([
+		Vector2.ZERO, Vector2(_board_px.x, 0), _board_px, Vector2(0, _board_px.y)])
+	_base_rect.color = Color(COLOR_HIDDEN.r, COLOR_HIDDEN.g, COLOR_HIDDEN.b, 1.0)
+	_map_group.add_child(_base_rect)
+	_fan_meshes.clear()
+
+func _clear_render_nodes() -> void:
+	if _map_group and is_instance_valid(_map_group):
+		_map_group.queue_free()
+	_map_group = null
+	_base_rect = null
+	_fan_meshes.clear()
+
+func _attach_fan_mesh(observer_idx: int, tris: PackedVector2Array) -> void:
+	if _map_group == null or tris.is_empty():
+		return
+	var mesh := ArrayMesh.new()
+	var arrays := []
+	arrays.resize(Mesh.ARRAY_MAX)
+	arrays[Mesh.ARRAY_VERTEX] = tris
+	mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, arrays)
+	var mi := MeshInstance2D.new()
+	mi.name = "Fan%d" % observer_idx
+	mi.mesh = mesh
+	mi.modulate = Color(COLOR_VISIBLE.r, COLOR_VISIBLE.g, COLOR_VISIBLE.b, 1.0)
+	_map_group.add_child(mi)
+	_fan_meshes.append(mi)
 
 # ═══════════════════════════════ self check ═══════════════════════════════
 
-## Re-judge `samples` random computed cells straight through the CANONICAL
-## per-line function (EnhancedLineOfSight._check_single_line_of_sight_11e) with
-## the same exclusion contexts, and count disagreements with the stored grid.
-## 0 mismatches proves the fast mirror + chunked bookkeeping preserve rules
-## semantics on this exact board. Scenario- and test-callable.
+## Two-part agreement audit over `samples` seeded random board points:
+##   A) the per-point judge vs the CANONICAL EnhancedLineOfSight per-line
+##      function with identical exclusion contexts (mismatches must be 0);
+##   B) the RENDERED fan geometry vs the per-point judge — points within a
+##      hair of a shadow boundary (where ±ε stitching lives) are detected by
+##      offset probing and skipped; everything else must agree exactly.
 func run_self_check(samples: int = 100, seed_value: int = 1337) -> Dictionary:
-	var out := {"checked": 0, "mismatches": 0, "examples": []}
-	if _cells.is_empty() or _observers.is_empty():
-		return out
-	if GameConstants.edition < 11:
-		# The pre-11e path already computes through the canonical function.
-		out["note"] = "edition<11 computes via canonical path; nothing to cross-check"
+	var out := {"checked": 0, "mismatches": 0, "render_checked": 0, "render_mismatches": 0, "examples": []}
+	if _observers.is_empty() or not _compute_done or _no_models_reason != "":
 		return out
 	var rng := RandomNumberGenerator.new()
 	rng.seed = seed_value
 	for s in range(samples):
-		var idx := rng.randi_range(0, _cells.size() - 1)
-		if _cells[idx] == CELL_UNKNOWN:
-			continue
-		var cx := idx % _cols
-		var cy := int(float(idx) / float(_cols))
-		var target := Vector2((float(cx) + 0.5) * _cell_px, (float(cy) + 0.5) * _cell_px)
+		var p := Vector2(rng.randf() * _board_px.x, rng.randf() * _board_px.y)
+		var judge_visible := point_state_at(p) == STATE_VISIBLE
+
+		# Part A — judge vs canonical rules engine.
 		var cell_groups := {}
 		var cell_feats := {}
 		for piece in _pieces:
-			if piece.bbox.grow(0.01).has_point(target) and Geometry2D.is_point_in_polygon(target, piece.polygon):
+			if piece.bbox.grow(0.01).has_point(p) and Geometry2D.is_point_in_polygon(p, piece.polygon):
 				cell_groups[piece.group_key] = true
 				cell_feats[piece.id] = true
 		var canonical_visible := false
-		for op in _obs_points:
-			var obs: Dictionary = _observers[op[1]]
+		for obs in _observers:
 			var e11 := {
 				"group_map": _group_map,
 				"exclude_groups": _merged(obs.groups, cell_groups),
 				"exclude_feature_ids": _merged(obs.feats, cell_feats),
 				"ground_level": obs.ground,
 			}
-			var res: Dictionary = EnhancedLineOfSight._check_single_line_of_sight_11e(op[0], target, _raw_features, e11)
+			var res: Dictionary = EnhancedLineOfSight._check_single_line_of_sight_11e(obs.pos, p, _raw_features, e11)
 			if res.has_los:
 				canonical_visible = true
 				break
-		var stored_visible: bool = _cells[idx] == CELL_VISIBLE
 		out.checked += 1
-		if canonical_visible != stored_visible:
+		if canonical_visible != judge_visible:
 			out.mismatches += 1
 			if out.examples.size() < 5:
-				out.examples.append({"cell": Vector2i(cx, cy), "stored": _cells[idx], "canonical_visible": canonical_visible})
+				out.examples.append({"at": p, "kind": "judge_vs_canonical", "judge": judge_visible, "canonical": canonical_visible})
+
+		# Part B — rendered geometry vs judge, boundary points skipped.
+		var near_boundary := false
+		for off in [Vector2(1.5, 0), Vector2(-1.5, 0), Vector2(0, 1.5), Vector2(0, -1.5)]:
+			var q: Vector2 = p + off
+			if q.x < 0 or q.y < 0 or q.x > _board_px.x or q.y > _board_px.y:
+				near_boundary = true
+				break
+			if (point_state_at(q) == STATE_VISIBLE) != judge_visible:
+				near_boundary = true
+				break
+		if near_boundary:
+			continue
+		out.render_checked += 1
+		if sweep_point_visible(p) != judge_visible:
+			out.render_mismatches += 1
+			if out.examples.size() < 5:
+				out.examples.append({"at": p, "kind": "render_vs_judge", "judge": judge_visible})
 	return out
 
 static func _merged(a: Dictionary, b: Dictionary) -> Dictionary:
@@ -494,10 +822,17 @@ static func _merged(a: Dictionary, b: Dictionary) -> Dictionary:
 func _draw() -> void:
 	if not is_active():
 		return
-	if _texture != null and _no_models_reason == "":
-		draw_texture_rect(_texture, Rect2(Vector2.ZERO, _board_px), false)
-	# Gold rings mark WHOSE vision is being shaded.
+	if _map_group:
+		_map_group.visible = _no_models_reason == ""
+	# Gold rings mark WHOSE vision is being shaded (one ring per model, not
+	# per rim point).
+	var ringed := {}
 	for obs in _observers:
+		var mid: String = str(obs.model.get("id", ""))
+		if ringed.has(mid):
+			continue
+		ringed[mid] = true
+		var center := _model_pos(obs.model)
 		var radius: float = Measurement.base_radius_px(int(obs.model.get("base_mm", 32)))
-		draw_arc(obs.pos, radius + 6.0, 0, TAU, 48, SOURCE_RING_COLOR, 3.0, true)
-		draw_arc(obs.pos, radius + 10.0, 0, TAU, 48, Color(SOURCE_RING_COLOR.r, SOURCE_RING_COLOR.g, SOURCE_RING_COLOR.b, 0.35), 1.5, true)
+		draw_arc(center, radius + 6.0, 0, TAU, 48, SOURCE_RING_COLOR, 3.0, true)
+		draw_arc(center, radius + 10.0, 0, TAU, 48, Color(SOURCE_RING_COLOR.r, SOURCE_RING_COLOR.g, SOURCE_RING_COLOR.b, 0.35), 1.5, true)

--- a/40k/scripts/VisionMapOverlay.gd
+++ b/40k/scripts/VisionMapOverlay.gd
@@ -1,0 +1,503 @@
+extends Node2D
+class_name VisionMapOverlay
+
+# VisionMapOverlay — whole-board visibility shading for ONE chosen unit.
+#
+# The existing LoS debug tools answer "can A see B?" for two units that are
+# already on the table. During deployment the player's real question is the
+# inverse: "if I put a model HERE, is it seen?" — which needs the whole board
+# classified, not a line between two tokens. This overlay grid-samples the
+# board (CELL_INCHES resolution) and shades every cell the chosen unit can see,
+# ignoring weapon range entirely, so hideable real estate is readable at a
+# glance in any phase. One unit at a time by design: overlapping several units'
+# vision fields is unreadable (the user report asking for this said exactly
+# that), so the selector (VisionMapPanel) applies it unit-by-unit.
+#
+# ── Semantics ──────────────────────────────────────────────────────────────
+# Per sight line this mirrors EnhancedLineOfSight._check_single_line_of_sight_11e
+# — the SAME per-line judge the eligibility path uses (via RulesEngine.
+# _check_line_of_sight → check_enhanced_visibility) — with the piece list,
+# bboxes and exclusion sets precomputed so a few thousand cells are affordable:
+#   ▪ 13.10 Obscuring: light/dense terrain AREAS block unless the observer or
+#     the probed point is within that area group;
+#   ▪ 13.11 Solid: dense FEATURES block ground-level lines except the piece a
+#     model occupies;
+#   ▪ explicit wall segments block when no polygon already did.
+# run_self_check() re-judges sampled cells straight through the canonical
+# EnhancedLineOfSight function to prove the mirror never drifts — the L-overlay
+# taught us (2026-08) that a debug view with its own private LoS logic WILL
+# eventually contradict the rules engine.
+#
+# ── Approximations (documented, deliberate) ────────────────────────────────
+#   ▪ The probed point is a point target at ground level, not a based model:
+#     verdicts are exact for the cell CENTRE; a real model's base edge can peek
+#     around a corner from within a "hidden" cell. Precision = cell size.
+#   ▪ Observer rays: base centre + OBSERVER_EDGE_RAYS points on the base rim
+#     (all base shapes approximated by their base_mm circle, matching
+#     TerrainManager._sight_points). The rules' full base-to-base sampling can
+#     rarely find a line these rays miss — sub-cell effect at shadow edges.
+#   ▪ 13.09 HIDDEN is a property of a real target unit's recent actions, not of
+#     a board position, so it is intentionally NOT part of this map.
+
+signal vision_map_updated
+
+const CELL_UNKNOWN := 0
+const CELL_VISIBLE := 1
+const CELL_HIDDEN := 2
+
+# 1" cells: 2640 cells on a 44"x60" board — fills in about a second, and
+# matches the precision a deployment decision actually needs.
+const CELL_INCHES := 1.0
+# Per-frame compute budget (ms). Keeps the UI at full framerate while the map
+# fills in progressively.
+const FRAME_BUDGET_MS := 6.0
+# Observer rays per model beyond the centre ray (points on the base rim).
+const OBSERVER_EDGE_RAYS := 8
+# Re-check the world signature at this interval while active, so the map tracks
+# deployments/moves/casualties without recomputing every frame.
+const REFRESH_POLL_SEC := 0.5
+
+# Visible = warm "you are exposed here" wash; hidden = cool "safe shadow".
+# Both translucent enough that terrain, zones and tokens stay readable. The
+# hidden blue is picked for how it COMPOSITES, not how it looks as a swatch
+# (2026-08-06 windowed runs): at 0.38 alpha a dark navy multiplies into the
+# khaki board as a neutral dark grey — the "hidden" read disappeared outside
+# the pale-blue deployment-zone tint. A high blue channel keeps the composite
+# unmistakably blue over khaki ground, terrain fills AND the zone tints.
+const COLOR_VISIBLE := Color(1.0, 0.42, 0.16, 0.32)
+const COLOR_HIDDEN := Color(0.05, 0.12, 0.55, 0.40)
+const SOURCE_RING_COLOR := Color(1.0, 0.85, 0.2, 0.95)
+
+var source_unit_id: String = ""
+
+# ── grid state ──
+var _cols: int = 0
+var _rows: int = 0
+var _cell_px: float = 40.0
+var _board_px: Vector2 = Vector2.ZERO
+var _cells: PackedByteArray = PackedByteArray()
+var _pending_idx: int = 0
+var _image: Image = null
+var _texture: ImageTexture = null
+
+# ── precomputed world data ──
+# Terrain pieces: {id, polygon, bbox, cat, pclass, group_key, legacy walls[]}
+var _pieces: Array = []
+var _walls: Array = []  # {a: Vector2, b: Vector2, bbox: Rect2}
+var _group_map: Dictionary = {}
+var _raw_features: Array = []
+# Observer models: {model, pos, ground, groups, feats, ruins (pre-11e), points: Array[Vector2]}
+var _observers: Array = []
+# Flattened try-order: centre rays of every model first (cheap early-exit for
+# open ground), then the rim rays. Entries are [point: Vector2, observer_idx].
+var _obs_points: Array = []
+
+var _poll_accum: float = 0.0
+var _world_sig: int = 0
+var _compute_done: bool = false
+var _no_models_reason: String = ""
+
+func _ready() -> void:
+	name = "VisionMapOverlay"
+	z_index = -3  # above board(-10)/terrain(-8)/zones(-5), below tokens(10)
+	texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
+	set_process(false)
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm and tm.has_signal("terrain_loaded"):
+		tm.terrain_loaded.connect(func(_features): if is_active(): _restart_compute())
+	print("[VisionMapOverlay] Initialized")
+
+# ═══════════════════════════════ public API ═══════════════════════════════
+
+func show_for_unit(unit_id: String) -> void:
+	source_unit_id = unit_id
+	if unit_id == "":
+		clear_map()
+		return
+	print("[VisionMapOverlay] Vision map ON for unit %s" % unit_id)
+	_restart_compute()
+	set_process(true)
+
+func clear_map() -> void:
+	source_unit_id = ""
+	_cells = PackedByteArray()
+	_observers.clear()
+	_obs_points.clear()
+	_image = null
+	_texture = null
+	_compute_done = false
+	_no_models_reason = ""
+	set_process(false)
+	queue_redraw()
+	emit_signal("vision_map_updated")
+	print("[VisionMapOverlay] Vision map cleared")
+
+func is_active() -> bool:
+	return source_unit_id != ""
+
+func is_compute_done() -> bool:
+	return _compute_done
+
+func compute_progress() -> float:
+	if _cells.is_empty():
+		return 0.0
+	return float(_pending_idx) / float(_cells.size())
+
+## "" when the map is drawable; otherwise why it is not (e.g. the chosen unit
+## has nothing on the board yet — legal to select during deployment, the map
+## auto-fills the moment its first model is placed).
+func status_reason() -> String:
+	return _no_models_reason
+
+func visible_cell_count() -> int:
+	return _count_state(CELL_VISIBLE)
+
+func hidden_cell_count() -> int:
+	return _count_state(CELL_HIDDEN)
+
+func _count_state(state: int) -> int:
+	var n := 0
+	for c in _cells:
+		if c == state:
+			n += 1
+	return n
+
+## Cell verdict at a board position (CELL_* constants; CELL_UNKNOWN when the
+## map is off, still computing that cell, or pos is off-board).
+func cell_state_at(pos: Vector2) -> int:
+	if _cells.is_empty() or _cell_px <= 0.0:
+		return CELL_UNKNOWN
+	var cx := int(pos.x / _cell_px)
+	var cy := int(pos.y / _cell_px)
+	if cx < 0 or cy < 0 or cx >= _cols or cy >= _rows:
+		return CELL_UNKNOWN
+	return _cells[cy * _cols + cx]
+
+# ═════════════════════════════ world signature ═════════════════════════════
+
+func _process(delta: float) -> void:
+	if not is_active():
+		set_process(false)
+		return
+	_poll_accum += delta
+	if _poll_accum >= REFRESH_POLL_SEC:
+		_poll_accum = 0.0
+		var sig := _world_signature()
+		if sig != _world_sig:
+			_restart_compute()
+			return
+	if not _compute_done and not _cells.is_empty():
+		_compute_chunk()
+
+func _world_signature() -> int:
+	var parts: Array = [source_unit_id, GameConstants.edition]
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm:
+		parts.append(tm.terrain_features.size())
+		parts.append(tm.current_layout)
+	var unit: Dictionary = GameState.state.get("units", {}).get(source_unit_id, {})
+	for m in unit.get("models", []):
+		if typeof(m) != TYPE_DICTIONARY:
+			continue
+		parts.append(bool(m.get("alive", true)))
+		var p := _model_pos(m)
+		parts.append(int(p.x))
+		parts.append(int(p.y))
+		parts.append(float(m.get("elevation_inches", 0.0)))
+	return hash(parts)
+
+static func _model_pos(model: Dictionary) -> Vector2:
+	var pos = model.get("position")
+	if pos is Dictionary:
+		return Vector2(float(pos.get("x", 0)), float(pos.get("y", 0)))
+	elif pos is Vector2:
+		return pos
+	return Vector2.ZERO
+
+# ═══════════════════════════════ compute prep ═══════════════════════════════
+
+func _restart_compute() -> void:
+	_world_sig = _world_signature()
+	_compute_done = false
+	_pending_idx = 0
+	_no_models_reason = ""
+
+	var board_size: Dictionary = GameState.state.get("board", {}).get("size", {"width": 44, "height": 60})
+	_board_px = Vector2(
+		float(board_size.get("width", 44)) * Measurement.PX_PER_INCH,
+		float(board_size.get("height", 60)) * Measurement.PX_PER_INCH)
+	_cell_px = CELL_INCHES * Measurement.PX_PER_INCH
+	_cols = int(ceil(_board_px.x / _cell_px))
+	_rows = int(ceil(_board_px.y / _cell_px))
+
+	_prepare_terrain()
+	_prepare_observers()
+
+	_cells = PackedByteArray()
+	_cells.resize(_cols * _rows)
+	_image = Image.create(_cols, _rows, false, Image.FORMAT_RGBA8)
+	_image.fill(Color(0, 0, 0, 0))
+	_texture = ImageTexture.create_from_image(_image)
+
+	var unit: Dictionary = GameState.state.get("units", {}).get(source_unit_id, {})
+	if unit.is_empty():
+		_no_models_reason = "Unit not found"
+		_compute_done = true
+	elif _observers.is_empty():
+		_no_models_reason = "No models on the board yet"
+		_compute_done = true
+	queue_redraw()
+	emit_signal("vision_map_updated")
+
+func _prepare_terrain() -> void:
+	_pieces.clear()
+	_walls.clear()
+	_raw_features = []
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm:
+		_raw_features = tm.terrain_features
+	_group_map = TerrainManager.build_area_group_map(_raw_features)
+	for piece in _raw_features:
+		var poly: PackedVector2Array = EnhancedLineOfSight._to_packed_polygon(piece.get("polygon", PackedVector2Array()))
+		var pid := str(piece.get("id", ""))
+		if poly.size() >= 3:
+			var bb_min := poly[0]
+			var bb_max := poly[0]
+			for v in poly:
+				bb_min = bb_min.min(v)
+				bb_max = bb_max.max(v)
+			_pieces.append({
+				"id": pid,
+				"polygon": poly,
+				"bbox": Rect2(bb_min, bb_max - bb_min),
+				"cat": TerrainManager.category_of(piece),
+				"pclass": str(piece.get("piece_class", "")),
+				"group_key": _group_map.get(pid, "id:" + pid),
+			})
+		# Legacy/custom wall segments (11e layouts author walls as feature
+		# pieces, so these arrays are normally empty).
+		for wall in piece.get("walls", []):
+			if not wall.get("blocks_los", true):
+				continue
+			var a: Vector2 = TerrainManager._wall_point_to_vec2(wall.get("start", Vector2.ZERO))
+			var b: Vector2 = TerrainManager._wall_point_to_vec2(wall.get("end", Vector2.ZERO))
+			var w_min := a.min(b)
+			_walls.append({"a": a, "b": b, "bbox": Rect2(w_min, a.max(b) - w_min)})
+
+func _prepare_observers() -> void:
+	_observers.clear()
+	_obs_points.clear()
+	var unit: Dictionary = GameState.state.get("units", {}).get(source_unit_id, {})
+	var board_stub := {"terrain_features": _raw_features}
+	for m in unit.get("models", []):
+		if typeof(m) != TYPE_DICTIONARY or not m.get("alive", true):
+			continue
+		var pos := _model_pos(m)
+		if pos == Vector2.ZERO:
+			continue
+		var radius: float = Measurement.base_radius_px(int(m.get("base_mm", 32)))
+		var points: Array = [pos]
+		for i in range(OBSERVER_EDGE_RAYS):
+			var ang := TAU * float(i) / float(OBSERVER_EDGE_RAYS)
+			points.append(pos + Vector2(cos(ang), sin(ang)) * radius)
+		var ctx := {
+			"model": m,
+			"pos": pos,
+			"ground": float(m.get("elevation_inches", 0.0)) < 3.0,
+			"groups": {},
+			"feats": {},
+			"ruins": [],
+			"points": points,
+		}
+		if GameConstants.edition >= 11:
+			# Same "within"/"occupies" split visibility_exclusions_for applies:
+			# any base overlap excuses the piece's obscuring GROUP; only centre-
+			# inside excuses a Solid feature (13.10/13.11 via 01.04).
+			for piece in _pieces:
+				if not _circle_overlaps_bbox(pos, radius, piece.bbox):
+					continue
+				var center_in: bool = Geometry2D.is_point_in_polygon(pos, piece.polygon)
+				if center_in or TerrainManager._circle_overlaps_polygon(pos, radius, piece.polygon):
+					ctx.groups[piece.group_key] = true
+					if center_in:
+						ctx.feats[piece.id] = true
+		else:
+			ctx.ruins = EnhancedLineOfSight._get_ruins_model_wholly_within(points, pos, m, board_stub)
+		_observers.append(ctx)
+	# Try-order: every model's centre ray first, then the rim rays — open
+	# ground resolves on the first probe, and only genuinely contested cells
+	# pay for the full fan.
+	for oi in range(_observers.size()):
+		_obs_points.append([_observers[oi].points[0], oi])
+	for oi in range(_observers.size()):
+		var pts: Array = _observers[oi].points
+		for pi in range(1, pts.size()):
+			_obs_points.append([pts[pi], oi])
+
+static func _circle_overlaps_bbox(center: Vector2, radius: float, bbox: Rect2) -> bool:
+	return bbox.grow(radius).has_point(center)
+
+# ═══════════════════════════════ chunked compute ═══════════════════════════
+
+func _compute_chunk() -> void:
+	var deadline := Time.get_ticks_usec() + int(FRAME_BUDGET_MS * 1000.0)
+	var total := _cells.size()
+	while _pending_idx < total and Time.get_ticks_usec() < deadline:
+		_compute_cell(_pending_idx)
+		_pending_idx += 1
+	_texture.update(_image)
+	queue_redraw()
+	if _pending_idx >= total:
+		_compute_done = true
+		emit_signal("vision_map_updated")
+		print("[VisionMapOverlay] Map complete for %s: %d visible / %d hidden cells" % [
+			source_unit_id, visible_cell_count(), hidden_cell_count()])
+
+func _compute_cell(idx: int) -> void:
+	var cx := idx % _cols
+	var cy := int(float(idx) / float(_cols))
+	var target := Vector2((float(cx) + 0.5) * _cell_px, (float(cy) + 0.5) * _cell_px)
+
+	var state := CELL_HIDDEN
+	if GameConstants.edition >= 11:
+		# Target-side exclusions: the areas/pieces the probed point sits in
+		# (a point target is "within" and "occupies" the same set). bbox grown
+		# a hair so the precheck can never exclude an exact-boundary point the
+		# polygon test would accept.
+		var cell_groups := {}
+		var cell_feats := {}
+		for piece in _pieces:
+			if piece.bbox.grow(0.01).has_point(target) and Geometry2D.is_point_in_polygon(target, piece.polygon):
+				cell_groups[piece.group_key] = true
+				cell_feats[piece.id] = true
+		for op in _obs_points:
+			var obs: Dictionary = _observers[op[1]]
+			if not _line_blocked_11e_fast(op[0], target, obs.groups, cell_groups, obs.feats, cell_feats, obs.ground):
+				state = CELL_VISIBLE
+				break
+	else:
+		# Pre-11e fallback: judge each ray with the canonical 10e per-line
+		# function directly (no fast mirror — this path is not hot for us).
+		var board_stub := {"terrain_features": _raw_features}
+		var fake_target := {"position": {"x": target.x, "y": target.y}, "base_mm": 32, "alive": true}
+		for op in _obs_points:
+			var obs: Dictionary = _observers[op[1]]
+			var res: Dictionary = EnhancedLineOfSight._check_single_line_of_sight(
+				op[0], target, board_stub, obs.model, fake_target, obs.ruins, {}, false)
+			if res.has_los:
+				state = CELL_VISIBLE
+				break
+
+	_cells[idx] = state
+	_image.set_pixel(cx, cy, COLOR_VISIBLE if state == CELL_VISIBLE else COLOR_HIDDEN)
+
+# Fast mirror of EnhancedLineOfSight._check_single_line_of_sight_11e for a
+# point target: identical branch structure over precomputed piece data, plus a
+# bbox reject. run_self_check() holds it to the canonical function — change one
+# without the other and the self-check fails.
+func _line_blocked_11e_fast(a: Vector2, b: Vector2, obs_groups: Dictionary, cell_groups: Dictionary, obs_feats: Dictionary, cell_feats: Dictionary, ground_level: bool) -> bool:
+	var seg_min := a.min(b)
+	var seg_bbox := Rect2(seg_min, a.max(b) - seg_min)
+	for piece in _pieces:
+		if not seg_bbox.intersects(piece.bbox, true):
+			continue
+		if not _segment_hits_polygon(a, b, piece.polygon):
+			continue
+		# 13.10 Obscuring — terrain areas (authored boundaries + legacy pieces).
+		if piece.pclass != "feature":
+			if (piece.cat == TerrainManager.CATEGORY_LIGHT or piece.cat == TerrainManager.CATEGORY_DENSE) \
+					and not obs_groups.has(piece.group_key) and not cell_groups.has(piece.group_key):
+				return true
+		# 13.11 Solid — dense physical structures (features + legacy pieces).
+		if piece.pclass != "area":
+			if piece.cat == TerrainManager.CATEGORY_DENSE and ground_level \
+					and not obs_feats.has(piece.id) and not cell_feats.has(piece.id):
+				return true
+	# Wall segments only matter when no polygon already blocked (mirrors the
+	# canonical ordering; the answer is the same either way for a bool).
+	for wall in _walls:
+		if not seg_bbox.intersects(wall.bbox, true):
+			continue
+		if Geometry2D.segment_intersects_segment(a, b, wall.a, wall.b) != null:
+			return true
+	return false
+
+# _segment_intersects_polygon semantics (edges OR either endpoint inside),
+# minus the coercion — polygons were packed once in _prepare_terrain.
+static func _segment_hits_polygon(a: Vector2, b: Vector2, poly: PackedVector2Array) -> bool:
+	var n := poly.size()
+	for i in range(n):
+		if Geometry2D.segment_intersects_segment(a, b, poly[i], poly[(i + 1) % n]) != null:
+			return true
+	if Geometry2D.is_point_in_polygon(a, poly):
+		return true
+	return Geometry2D.is_point_in_polygon(b, poly)
+
+# ═══════════════════════════════ self check ═══════════════════════════════
+
+## Re-judge `samples` random computed cells straight through the CANONICAL
+## per-line function (EnhancedLineOfSight._check_single_line_of_sight_11e) with
+## the same exclusion contexts, and count disagreements with the stored grid.
+## 0 mismatches proves the fast mirror + chunked bookkeeping preserve rules
+## semantics on this exact board. Scenario- and test-callable.
+func run_self_check(samples: int = 100, seed_value: int = 1337) -> Dictionary:
+	var out := {"checked": 0, "mismatches": 0, "examples": []}
+	if _cells.is_empty() or _observers.is_empty():
+		return out
+	if GameConstants.edition < 11:
+		# The pre-11e path already computes through the canonical function.
+		out["note"] = "edition<11 computes via canonical path; nothing to cross-check"
+		return out
+	var rng := RandomNumberGenerator.new()
+	rng.seed = seed_value
+	for s in range(samples):
+		var idx := rng.randi_range(0, _cells.size() - 1)
+		if _cells[idx] == CELL_UNKNOWN:
+			continue
+		var cx := idx % _cols
+		var cy := int(float(idx) / float(_cols))
+		var target := Vector2((float(cx) + 0.5) * _cell_px, (float(cy) + 0.5) * _cell_px)
+		var cell_groups := {}
+		var cell_feats := {}
+		for piece in _pieces:
+			if piece.bbox.grow(0.01).has_point(target) and Geometry2D.is_point_in_polygon(target, piece.polygon):
+				cell_groups[piece.group_key] = true
+				cell_feats[piece.id] = true
+		var canonical_visible := false
+		for op in _obs_points:
+			var obs: Dictionary = _observers[op[1]]
+			var e11 := {
+				"group_map": _group_map,
+				"exclude_groups": _merged(obs.groups, cell_groups),
+				"exclude_feature_ids": _merged(obs.feats, cell_feats),
+				"ground_level": obs.ground,
+			}
+			var res: Dictionary = EnhancedLineOfSight._check_single_line_of_sight_11e(op[0], target, _raw_features, e11)
+			if res.has_los:
+				canonical_visible = true
+				break
+		var stored_visible: bool = _cells[idx] == CELL_VISIBLE
+		out.checked += 1
+		if canonical_visible != stored_visible:
+			out.mismatches += 1
+			if out.examples.size() < 5:
+				out.examples.append({"cell": Vector2i(cx, cy), "stored": _cells[idx], "canonical_visible": canonical_visible})
+	return out
+
+static func _merged(a: Dictionary, b: Dictionary) -> Dictionary:
+	var m := a.duplicate()
+	m.merge(b)
+	return m
+
+# ═══════════════════════════════ drawing ═══════════════════════════════
+
+func _draw() -> void:
+	if not is_active():
+		return
+	if _texture != null and _no_models_reason == "":
+		draw_texture_rect(_texture, Rect2(Vector2.ZERO, _board_px), false)
+	# Gold rings mark WHOSE vision is being shaded.
+	for obs in _observers:
+		var radius: float = Measurement.base_radius_px(int(obs.model.get("base_mm", 32)))
+		draw_arc(obs.pos, radius + 6.0, 0, TAU, 48, SOURCE_RING_COLOR, 3.0, true)
+		draw_arc(obs.pos, radius + 10.0, 0, TAU, 48, Color(SOURCE_RING_COLOR.r, SOURCE_RING_COLOR.g, SOURCE_RING_COLOR.b, 0.35), 1.5, true)

--- a/40k/scripts/VisionMapOverlay.gd.uid
+++ b/40k/scripts/VisionMapOverlay.gd.uid
@@ -1,0 +1,1 @@
+uid://df3wrbtrp44s3

--- a/40k/scripts/VisionMapPanel.gd
+++ b/40k/scripts/VisionMapPanel.gd
@@ -76,7 +76,7 @@ func _ready() -> void:
 	vbox.add_child(status_label)
 
 	var footnote := Label.new()
-	footnote.text = "Cell precision 1\"; a base edge can peek past a corner from the last hidden cell."
+	footnote.text = "Ray-cast from each model at ground level; shadow edges follow the terrain exactly. A base edge can still peek out from just inside a shadow."
 	footnote.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	footnote.add_theme_font_size_override("font_size", 12)
 	footnote.modulate = Color(1, 1, 1, 0.5)
@@ -193,7 +193,6 @@ func _update_status() -> void:
 		status_label.text = overlay.status_reason()
 		return
 	if not overlay.is_compute_done():
-		status_label.text = "Mapping vision… %d%%" % int(overlay.compute_progress() * 100.0)
+		status_label.text = "Casting rays… %d%%" % int(overlay.compute_progress() * 100.0)
 		return
-	status_label.text = "%d\" cells seen: %d · hidden: %d" % [
-		int(VisionMapOverlay.CELL_INCHES), overlay.visible_cell_count(), overlay.hidden_cell_count()]
+	status_label.text = "≈%d%% of the board in this unit's sight" % int(overlay.seen_ratio() * 100.0)

--- a/40k/scripts/VisionMapPanel.gd
+++ b/40k/scripts/VisionMapPanel.gd
@@ -1,0 +1,199 @@
+extends PanelContainer
+class_name VisionMapPanel
+
+# VisionMapPanel — the unit selector for VisionMapOverlay.
+#
+# The vision map is deliberately unit-by-unit (a multi-unit overlay is soup),
+# so the tool needs an explicit "whose eyes?" picker that works in EVERY phase
+# — during deployment the interesting unit is usually an ENEMY one, which the
+# phase UI offers no way to select. An ItemList (not an OptionButton) so a
+# single click switches units while browsing, and so windowed scenarios can
+# drive it with real clicks (click_item_list).
+
+signal close_requested
+
+const ROW_OFF_LABEL := "— Off —"
+const P1_COLOR := Color(0.45, 0.65, 1.0)
+const P2_COLOR := Color(1.0, 0.45, 0.4)
+const POLL_SEC := 0.5
+
+var overlay: VisionMapOverlay = null
+
+var unit_list: ItemList = null
+var status_label: Label = null
+var _poll_accum: float = 0.0
+var _roster_sig: int = 0
+
+func _ready() -> void:
+	name = "VisionMapPanel"
+	custom_minimum_size = Vector2(280, 0)
+
+	# Stable node names so windowed scenarios can target children by NodePath.
+	var vbox := VBoxContainer.new()
+	vbox.name = "VBox"
+	vbox.add_theme_constant_override("separation", 6)
+	add_child(vbox)
+
+	var header := HBoxContainer.new()
+	header.name = "Header"
+	vbox.add_child(header)
+	var title := Label.new()
+	title.text = "👁 Vision Map"
+	title.add_theme_font_size_override("font_size", 20)
+	title.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	header.add_child(title)
+	var close_btn := Button.new()
+	close_btn.name = "CloseButton"
+	close_btn.text = "✕"
+	close_btn.tooltip_text = "Close (clears the shading)"
+	close_btn.pressed.connect(func(): emit_signal("close_requested"))
+	header.add_child(close_btn)
+
+	var info := Label.new()
+	info.text = "Shades every spot the chosen unit can see — any range, terrain only. Pick a unit:"
+	info.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	info.add_theme_font_size_override("font_size", 14)
+	info.modulate = Color(1, 1, 1, 0.75)
+	vbox.add_child(info)
+
+	unit_list = ItemList.new()
+	unit_list.name = "UnitList"
+	unit_list.custom_minimum_size = Vector2(0, 300)
+	unit_list.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	unit_list.add_theme_font_size_override("font_size", 15)
+	unit_list.item_selected.connect(_on_row_selected)
+	vbox.add_child(unit_list)
+
+	_add_legend_row(vbox, VisionMapOverlay.COLOR_VISIBLE, "Seen by the unit")
+	_add_legend_row(vbox, VisionMapOverlay.COLOR_HIDDEN, "Hidden from the unit")
+
+	status_label = Label.new()
+	status_label.name = "StatusLabel"
+	status_label.text = "Off — pick a unit"
+	status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	status_label.add_theme_font_size_override("font_size", 14)
+	status_label.add_theme_color_override("font_color", Color(1.0, 0.85, 0.3))
+	vbox.add_child(status_label)
+
+	var footnote := Label.new()
+	footnote.text = "Cell precision 1\"; a base edge can peek past a corner from the last hidden cell."
+	footnote.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	footnote.add_theme_font_size_override("font_size", 12)
+	footnote.modulate = Color(1, 1, 1, 0.5)
+	vbox.add_child(footnote)
+
+	rebuild_unit_list()
+
+func _add_legend_row(vbox: VBoxContainer, color: Color, text: String) -> void:
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 8)
+	var swatch := ColorRect.new()
+	# Legend swatches show the wash at full readability, not board alpha.
+	swatch.color = Color(color.r, color.g, color.b, 0.85)
+	swatch.custom_minimum_size = Vector2(18, 18)
+	row.add_child(swatch)
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 14)
+	row.add_child(lbl)
+	vbox.add_child(row)
+
+func _process(delta: float) -> void:
+	if not visible:
+		return
+	_poll_accum += delta
+	if _poll_accum < POLL_SEC:
+		_update_status()
+		return
+	_poll_accum = 0.0
+	var sig := _compute_roster_sig()
+	if sig != _roster_sig:
+		rebuild_unit_list()
+	_update_status()
+
+# ── unit roster ──
+
+## Units that have vision to map: at least one alive model actually standing on
+## the board (undeployed, reserves and embarked units see nothing yet).
+func _on_board_units() -> Array:
+	var rows: Array = []
+	var units: Dictionary = GameState.state.get("units", {})
+	for uid in units:
+		var u = units[uid]
+		if typeof(u) != TYPE_DICTIONARY:
+			continue
+		var status := int(u.get("status", 0))
+		if status == GameStateData.UnitStatus.UNDEPLOYED or status == GameStateData.UnitStatus.IN_RESERVES:
+			continue
+		if u.get("embarked_in", null) != null:
+			continue
+		var positioned := false
+		for m in u.get("models", []):
+			if typeof(m) != TYPE_DICTIONARY or not m.get("alive", true):
+				continue
+			if VisionMapOverlay._model_pos(m) != Vector2.ZERO:
+				positioned = true
+				break
+		if not positioned:
+			continue
+		rows.append({
+			"uid": str(uid),
+			"owner": int(u.get("owner", 0)),
+			"name": str(u.get("meta", {}).get("name", uid)),
+		})
+	rows.sort_custom(func(a, b):
+		if a.owner != b.owner:
+			return a.owner < b.owner
+		if a.name != b.name:
+			return a.name < b.name
+		return a.uid < b.uid)
+	return rows
+
+func _compute_roster_sig() -> int:
+	var parts: Array = []
+	for row in _on_board_units():
+		parts.append(row.uid)
+	return hash(parts)
+
+func rebuild_unit_list() -> void:
+	var rows := _on_board_units()
+	_roster_sig = _compute_roster_sig()
+	unit_list.clear()
+	unit_list.add_item(ROW_OFF_LABEL)
+	unit_list.set_item_metadata(0, "")
+	var selected_idx := 0
+	for row in rows:
+		var idx := unit_list.add_item("P%d · %s" % [row.owner, row.name])
+		unit_list.set_item_metadata(idx, row.uid)
+		unit_list.set_item_custom_fg_color(idx, P1_COLOR if row.owner == 1 else P2_COLOR)
+		if overlay and overlay.source_unit_id == row.uid:
+			selected_idx = idx
+	unit_list.select(selected_idx)
+	# The overlay may be shading a unit that just left the board (died/undo) —
+	# selection falls back to Off, and the overlay clears itself via its own
+	# signature poll; nothing to force here.
+
+func _on_row_selected(idx: int) -> void:
+	if overlay == null:
+		return
+	var uid := str(unit_list.get_item_metadata(idx))
+	if uid == "":
+		overlay.clear_map()
+	else:
+		overlay.show_for_unit(uid)
+	_update_status()
+
+# ── status line ──
+
+func _update_status() -> void:
+	if overlay == null or not overlay.is_active():
+		status_label.text = "Off — pick a unit"
+		return
+	if overlay.status_reason() != "":
+		status_label.text = overlay.status_reason()
+		return
+	if not overlay.is_compute_done():
+		status_label.text = "Mapping vision… %d%%" % int(overlay.compute_progress() * 100.0)
+		return
+	status_label.text = "%d\" cells seen: %d · hidden: %d" % [
+		int(VisionMapOverlay.CELL_INCHES), overlay.visible_cell_count(), overlay.hidden_cell_count()]

--- a/40k/scripts/VisionMapPanel.gd.uid
+++ b/40k/scripts/VisionMapPanel.gd.uid
@@ -1,0 +1,1 @@
+uid://d3fpy7fjktm43

--- a/40k/tests/scenarios/sp/los_vision_map_deployment.json
+++ b/40k/tests/scenarios/sp/los_vision_map_deployment.json
@@ -8,66 +8,214 @@
   "transition_to_phase": 1,
   "edition": 11,
   "disable_ai": true,
-  "description": "Vision Map (whole-board visibility shading, per selected unit) drives end-to-end during DEPLOYMENT — the phase it was requested for: deploy one unit per side, open the panel with the real bottom-bar 👁 button, pick the ENEMY Warboss from the unit list with a real click, and the board shades everything that Warboss can see (warm = seen, cool = hidden), ignoring weapon range. Asserts the overlay computes a full grid with BOTH visible and hidden cells on the 44-piece default layout, that run_self_check re-judges sampled cells through the CANONICAL EnhancedLineOfSight._check_single_line_of_sight_11e with zero disagreements (the L-overlay lesson: a debug view with private LoS logic will drift from the rules engine), that a single click re-targets the map to another unit, and that the Off row + Close button clear the shading.",
+  "description": "Vision Map v2 (ray-cast visibility fans, per selected unit) drives end-to-end during DEPLOYMENT — the phase it was requested for: deploy one unit per side, open the panel with the real bottom-bar 👁 button, pick the ENEMY Warboss from the unit list with a real click, and the board shades everything that Warboss can see with smooth ray-cast shadow geometry (warm = seen, cool = hidden), ignoring weapon range. After the real click, compute_now() fast-forwards the frame-sliced sweep so asserts are deterministic. Asserts the sweep completes with a genuine seen/hidden mix, and that run_self_check holds BOTH agreements at zero mismatches: the per-point judge vs the CANONICAL EnhancedLineOfSight._check_single_line_of_sight_11e, and the RENDERED fan geometry vs that judge (the L-overlay lesson: a debug view with private LoS logic will drift — a renderer can too). Also proves one click re-targets the map to another unit, and the Off row + Close button clear the shading.",
   "steps": [
-    { "act": "wait_seconds", "seconds": 1.0 },
-    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
-    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
-
-    { "act": "dispatch_action", "action": {
-      "type": "DEPLOY_UNIT",
-      "unit_id": "U_BLADE_CHAMPION_A",
-      "model_positions": [{ "x": 880, "y": 240 }],
-      "model_rotations": [0]
-    }},
-    { "act": "expect_action_result", "path": "success", "equals": true },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
-
-    { "act": "dispatch_action", "action": {
-      "type": "DEPLOY_UNIT",
-      "unit_id": "U_WARBOSS_B",
-      "model_positions": [{ "x": 880, "y": 2160 }],
-      "model_rotations": [0]
-    }},
-    { "act": "expect_action_result", "path": "success", "equals": true },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "screenshot", "label": "01_two_units_deployed" },
-
-    { "act": "click_node", "node": "/root/Main/HUD_Bottom/HBoxContainer/VisionMapButton" },
-    { "act": "expect_node_visible", "node": "/root/Main/VisionMapPanel", "timeout_s": 2.0 },
-    { "act": "screenshot", "label": "02_panel_open" },
-
-    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").item_count", "equals": 3 },
-    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").get_item_text(2)", "equals": "P2 · Warboss" },
-
-    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 2 },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().source_unit_id", "equals": "U_WARBOSS_B" },
-
-    { "act": "wait_seconds", "seconds": 3.0 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_compute_done()", "equals": true },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().visible_cell_count()", "expect_min": 100 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().hidden_cell_count()", "expect_min": 100 },
-    { "act": "execute_script", "script": "var o = tree.root.get_node(\"Main\").get_vision_map_overlay()\nvar r = o.run_self_check(120)\nreturn \"checked=%d mismatches=%d\" % [int(r.checked), int(r.mismatches)]", "multiline": true, "equals": "checked=120 mismatches=0" },
-    { "act": "screenshot", "label": "03_vision_map_enemy_warboss" },
-
-    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 1 },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().source_unit_id", "equals": "U_BLADE_CHAMPION_A" },
-    { "act": "wait_seconds", "seconds": 3.0 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_compute_done()", "equals": true },
-    { "act": "screenshot", "label": "04_switched_to_blade_champion" },
-
-    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 0 },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_active()", "equals": false },
-    { "act": "screenshot", "label": "05_off_row_clears_shading" },
-
-    { "act": "click_node", "node": "/root/Main/VisionMapPanel/VBox/Header/CloseButton", "emit_pressed": true },
-    { "act": "wait_frames", "frames": 3 },
-    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel\").visible", "equals": false },
-    { "act": "execute_script", "script": "Main.get_node(\"HUD_Bottom/HBoxContainer/VisionMapButton\").button_pressed", "equals": false },
-    { "act": "screenshot", "label": "06_panel_closed" }
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 1
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.active_player",
+      "equals": 1
+    },
+    {
+      "act": "dispatch_action",
+      "action": {
+        "type": "DEPLOY_UNIT",
+        "unit_id": "U_BLADE_CHAMPION_A",
+        "model_positions": [
+          {
+            "x": 880,
+            "y": 240
+          }
+        ],
+        "model_rotations": [
+          0
+        ]
+      }
+    },
+    {
+      "act": "expect_action_result",
+      "path": "success",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.active_player",
+      "equals": 2
+    },
+    {
+      "act": "dispatch_action",
+      "action": {
+        "type": "DEPLOY_UNIT",
+        "unit_id": "U_WARBOSS_B",
+        "model_positions": [
+          {
+            "x": 880,
+            "y": 2160
+          }
+        ],
+        "model_rotations": [
+          0
+        ]
+      }
+    },
+    {
+      "act": "expect_action_result",
+      "path": "success",
+      "equals": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "screenshot",
+      "label": "01_two_units_deployed"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/Main/HUD_Bottom/HBoxContainer/VisionMapButton"
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/VisionMapPanel",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "screenshot",
+      "label": "02_panel_open"
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").item_count",
+      "equals": 3
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").get_item_text(2)",
+      "equals": "P2 · Warboss"
+    },
+    {
+      "act": "click_item_list",
+      "node": "/root/Main/VisionMapPanel/VBox/UnitList",
+      "index": 2
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().source_unit_id",
+      "equals": "U_WARBOSS_B"
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().compute_now()"
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().is_compute_done()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().seen_ratio()",
+      "expect_min": 0.03
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().seen_ratio()",
+      "expect_max": 0.97
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var o = tree.root.get_node(\"Main\").get_vision_map_overlay()\nvar r = o.run_self_check(150)\nreturn \"m=%d rm=%d rc_ok=%s\" % [int(r.mismatches), int(r.render_mismatches), str(int(r.render_checked) > 80)]",
+      "equals": "m=0 rm=0 rc_ok=true"
+    },
+    {
+      "act": "screenshot",
+      "label": "03_vision_map_enemy_warboss"
+    },
+    {
+      "act": "click_item_list",
+      "node": "/root/Main/VisionMapPanel/VBox/UnitList",
+      "index": 1
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().source_unit_id",
+      "equals": "U_BLADE_CHAMPION_A"
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().compute_now()"
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().is_compute_done()",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "04_switched_to_blade_champion"
+    },
+    {
+      "act": "click_item_list",
+      "node": "/root/Main/VisionMapPanel/VBox/UnitList",
+      "index": 0
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_vision_map_overlay().is_active()",
+      "equals": false
+    },
+    {
+      "act": "screenshot",
+      "label": "05_off_row_clears_shading"
+    },
+    {
+      "act": "click_node",
+      "node": "/root/Main/VisionMapPanel/VBox/Header/CloseButton",
+      "emit_pressed": true
+    },
+    {
+      "act": "wait_frames",
+      "frames": 3
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_node(\"VisionMapPanel\").visible",
+      "equals": false
+    },
+    {
+      "act": "execute_script",
+      "script": "Main.get_node(\"HUD_Bottom/HBoxContainer/VisionMapButton\").button_pressed",
+      "equals": false
+    },
+    {
+      "act": "screenshot",
+      "label": "06_panel_closed"
+    }
   ]
 }

--- a/40k/tests/scenarios/sp/los_vision_map_deployment.json
+++ b/40k/tests/scenarios/sp/los_vision_map_deployment.json
@@ -1,0 +1,73 @@
+{
+  "id": "los_vision_map_deployment",
+  "covers": [
+    "debug.vision_map.unit_visibility_shading",
+    "debug.vision_map.deployment_unit_picker"
+  ],
+  "fixture": "New Game",
+  "transition_to_phase": 1,
+  "edition": 11,
+  "disable_ai": true,
+  "description": "Vision Map (whole-board visibility shading, per selected unit) drives end-to-end during DEPLOYMENT — the phase it was requested for: deploy one unit per side, open the panel with the real bottom-bar 👁 button, pick the ENEMY Warboss from the unit list with a real click, and the board shades everything that Warboss can see (warm = seen, cool = hidden), ignoring weapon range. Asserts the overlay computes a full grid with BOTH visible and hidden cells on the 44-piece default layout, that run_self_check re-judges sampled cells through the CANONICAL EnhancedLineOfSight._check_single_line_of_sight_11e with zero disagreements (the L-overlay lesson: a debug view with private LoS logic will drift from the rules engine), that a single click re-targets the map to another unit, and that the Off row + Close button clear the shading.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 1 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 1 },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DEPLOY_UNIT",
+      "unit_id": "U_BLADE_CHAMPION_A",
+      "model_positions": [{ "x": 880, "y": 240 }],
+      "model_rotations": [0]
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "expect_state", "path": "meta.active_player", "equals": 2 },
+
+    { "act": "dispatch_action", "action": {
+      "type": "DEPLOY_UNIT",
+      "unit_id": "U_WARBOSS_B",
+      "model_positions": [{ "x": 880, "y": 2160 }],
+      "model_rotations": [0]
+    }},
+    { "act": "expect_action_result", "path": "success", "equals": true },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "screenshot", "label": "01_two_units_deployed" },
+
+    { "act": "click_node", "node": "/root/Main/HUD_Bottom/HBoxContainer/VisionMapButton" },
+    { "act": "expect_node_visible", "node": "/root/Main/VisionMapPanel", "timeout_s": 2.0 },
+    { "act": "screenshot", "label": "02_panel_open" },
+
+    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").item_count", "equals": 3 },
+    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel/VBox/UnitList\").get_item_text(2)", "equals": "P2 · Warboss" },
+
+    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 2 },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().source_unit_id", "equals": "U_WARBOSS_B" },
+
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_compute_done()", "equals": true },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().visible_cell_count()", "expect_min": 100 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().hidden_cell_count()", "expect_min": 100 },
+    { "act": "execute_script", "script": "var o = tree.root.get_node(\"Main\").get_vision_map_overlay()\nvar r = o.run_self_check(120)\nreturn \"checked=%d mismatches=%d\" % [int(r.checked), int(r.mismatches)]", "multiline": true, "equals": "checked=120 mismatches=0" },
+    { "act": "screenshot", "label": "03_vision_map_enemy_warboss" },
+
+    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 1 },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().source_unit_id", "equals": "U_BLADE_CHAMPION_A" },
+    { "act": "wait_seconds", "seconds": 3.0 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_compute_done()", "equals": true },
+    { "act": "screenshot", "label": "04_switched_to_blade_champion" },
+
+    { "act": "click_item_list", "node": "/root/Main/VisionMapPanel/VBox/UnitList", "index": 0 },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main.get_vision_map_overlay().is_active()", "equals": false },
+    { "act": "screenshot", "label": "05_off_row_clears_shading" },
+
+    { "act": "click_node", "node": "/root/Main/VisionMapPanel/VBox/Header/CloseButton", "emit_pressed": true },
+    { "act": "wait_frames", "frames": 3 },
+    { "act": "execute_script", "script": "Main.get_node(\"VisionMapPanel\").visible", "equals": false },
+    { "act": "execute_script", "script": "Main.get_node(\"HUD_Bottom/HBoxContainer/VisionMapButton\").button_pressed", "equals": false },
+    { "act": "screenshot", "label": "06_panel_closed" }
+  ]
+}

--- a/40k/tests/test_vision_map_agreement.gd
+++ b/40k/tests/test_vision_map_agreement.gd
@@ -1,0 +1,247 @@
+extends SceneTree
+
+# VISION-MAP-AGREEMENT — headless half of the Vision Map feature (the
+# whole-board "what can this unit see" shading used for deployment planning).
+#
+# The L-overlay bug taught us that a debug view carrying its own private LoS
+# logic eventually contradicts the rules engine (2026-08 report). The vision
+# map therefore mirrors EnhancedLineOfSight._check_single_line_of_sight_11e
+# per line, with precomputed piece data for speed — and this test holds the
+# mirror to the canon:
+#
+#   1. run_self_check(): on the real default terrain layout, sampled cells
+#      re-judged straight through the canonical per-line function must agree
+#      with the stored grid — zero mismatches.
+#   2. Directed probes on the default layout (behind the centre ruins, open
+#      ground) must agree with a canonical re-judgement of the same cell.
+#   3. Synthetic-terrain semantic pins that isolate each 11e branch: obscuring
+#      areas + the "within" exclusion (13.10), Solid dense features + the
+#      occupies exception (13.11), light features not blocking, elevated
+#      observers ignoring Solid but not Obscuring, wall segments.
+#   4. Lifecycle: a unit with no models on the board reports a status reason
+#      instead of shading garbage; clear_map() empties everything.
+#
+# The windowed half lives in tests/scenarios/sp/los_vision_map_deployment.json.
+#
+# NOTE: `-s` main-loop scripts compile before autoloads register, so autoloads
+# are fetched via root.get_node_or_null (same pattern as
+# test_los_overlay_targeting_agreement.gd). class_name globals resolve fine.
+#
+# Usage: godot --headless --path . -s tests/test_vision_map_agreement.gd
+
+var passed := 0
+var failed := 0
+
+# Autoload handles (resolved at run time)
+var gs = null      # GameState
+var tm = null      # TerrainManager
+var elos = null    # EnhancedLineOfSight
+
+func _check(label: String, cond: bool, detail: String = "") -> void:
+	if cond:
+		passed += 1
+		print("  PASS: %s" % label)
+	else:
+		failed += 1
+		print("  FAIL: %s%s" % [label, ("  --  " + detail) if detail != "" else ""])
+
+func _init():
+	create_timer(0.25).timeout.connect(_run_tests)
+
+func _model(id: String, x: float, y: float, base_mm: int = 32, elevation: float = 0.0) -> Dictionary:
+	var m := {"id": id, "alive": true, "base_mm": base_mm, "base_type": "circular",
+		"position": {"x": x, "y": y}}
+	if elevation > 0.0:
+		m["elevation_inches"] = elevation
+	return m
+
+func _inject_unit(uid: String, models: Array) -> void:
+	gs.state["units"][uid] = {
+		"owner": 1,
+		"status": 2,  # UnitStatus.DEPLOYED (enum ref avoided: -s scripts compile before autoloads)
+		"flags": {},
+		"models": models,
+		"meta": {"name": uid, "keywords": ["INFANTRY"]},
+	}
+
+func _compute_all(overlay) -> void:
+	# Deterministic: pump the chunked compute directly instead of racing frames.
+	var guard := 0
+	while not overlay.is_compute_done() and guard < 10000:
+		overlay._compute_chunk()
+		guard += 1
+
+# Canonical unit-level verdict for one probed point: same observer ray set the
+# overlay uses, every line judged by the CANONICAL 11e function.
+func _canonical_visible(overlay, target: Vector2) -> bool:
+	var cell_groups := {}
+	var cell_feats := {}
+	for piece in overlay._pieces:
+		if Geometry2D.is_point_in_polygon(target, piece.polygon):
+			cell_groups[piece.group_key] = true
+			cell_feats[piece.id] = true
+	for op in overlay._obs_points:
+		var obs: Dictionary = overlay._observers[op[1]]
+		var e11 := {
+			"group_map": overlay._group_map,
+			"exclude_groups": overlay._merged(obs.groups, cell_groups),
+			"exclude_feature_ids": overlay._merged(obs.feats, cell_feats),
+			"ground_level": obs.ground,
+		}
+		var res: Dictionary = elos._check_single_line_of_sight_11e(op[0], target, overlay._raw_features, e11)
+		if res.has_los:
+			return true
+	return false
+
+# Snap a board pos to its cell centre so directed probes judge the exact point
+# the grid judged.
+func _cell_centre(overlay, pos: Vector2) -> Vector2:
+	var cx := int(pos.x / overlay._cell_px)
+	var cy := int(pos.y / overlay._cell_px)
+	return Vector2((float(cx) + 0.5) * overlay._cell_px, (float(cy) + 0.5) * overlay._cell_px)
+
+func _probe_agrees(overlay, label: String, pos: Vector2) -> void:
+	var centre := _cell_centre(overlay, pos)
+	var stored: int = overlay.cell_state_at(pos)
+	var canon := _canonical_visible(overlay, centre)
+	_check(label + " agrees with canonical", (stored == overlay.CELL_VISIBLE) == canon,
+		"stored=%d canonical_visible=%s at %s" % [stored, canon, str(centre)])
+
+func _rect_piece(id: String, cx: float, cy: float, w: float, h: float, cat: String, pclass: String, height: float = 6.0) -> Dictionary:
+	return {
+		"id": id,
+		"type": "ruins",
+		"polygon": PackedVector2Array([
+			Vector2(cx - w / 2, cy - h / 2), Vector2(cx + w / 2, cy - h / 2),
+			Vector2(cx + w / 2, cy + h / 2), Vector2(cx - w / 2, cy + h / 2)]),
+		"category": cat,
+		"piece_class": pclass,
+		"height_inches": height,
+		"height_category": "tall",
+	}
+
+func _run_tests() -> void:
+	print("\n===== VISION MAP ↔ RULES-ENGINE AGREEMENT =====\n")
+	gs = root.get_node_or_null("GameState")
+	tm = root.get_node_or_null("TerrainManager")
+	elos = root.get_node_or_null("EnhancedLineOfSight")
+	if gs == null or tm == null or elos == null:
+		print("FAIL: autoloads missing (GameState=%s TerrainManager=%s EnhancedLineOfSight=%s)" % [gs, tm, elos])
+		quit(1)
+		return
+	# The automated harness pins GameConstants.edition to the legacy 10e
+	# baseline (SettingsService._is_automated_harness); this feature ships on
+	# 11e rules, so opt in explicitly like the other *_11e tests do.
+	GameConstants.edition = 11
+
+	print("-- Part 1: real default layout (%s, %d pieces) --" % [
+		tm.current_layout, tm.terrain_features.size()])
+	_check("default terrain layout loaded", tm.terrain_features.size() > 0)
+
+	# Two-model unit near the south edge (a P2-ish deployment spot, mid-board x)
+	_inject_unit("U_VISION_TEST", [
+		_model("m1", 880.0, 2160.0),          # 22", 54"
+		_model("m2", 960.0, 2200.0, 40),      # 24", 55"
+	])
+	var overlay = load("res://scripts/VisionMapOverlay.gd").new()
+	root.add_child(overlay)
+	overlay.show_for_unit("U_VISION_TEST")
+	_compute_all(overlay)
+
+	_check("compute completes", overlay.is_compute_done())
+	_check("grid fully classified", overlay.visible_cell_count() + overlay.hidden_cell_count() == overlay._cells.size(),
+		"visible=%d hidden=%d cells=%d" % [overlay.visible_cell_count(), overlay.hidden_cell_count(), overlay._cells.size()])
+	_check("some cells visible", overlay.visible_cell_count() > 0)
+	_check("some cells hidden (44-piece layout must cast shadows)", overlay.hidden_cell_count() > 0)
+
+	var self_check: Dictionary = overlay.run_self_check(400)
+	_check("self-check ran on real cells", int(self_check.checked) > 300, "checked=%d" % int(self_check.checked))
+	_check("zero mismatches vs canonical per-line judge", int(self_check.mismatches) == 0,
+		"mismatches=%d examples=%s" % [int(self_check.mismatches), str(self_check.examples)])
+
+	# Directed probes: dead behind the centre trapezoid ruins / open own corner.
+	_probe_agrees(overlay, "probe behind centre ruins (22\",20\")", Vector2(880, 800))
+	_probe_agrees(overlay, "probe open ground (40\",55\")", Vector2(1600, 2200))
+	_probe_agrees(overlay, "probe far corner (2\",2\")", Vector2(80, 80))
+	_probe_agrees(overlay, "probe inside a dense area (37\",42\")", Vector2(1480, 1680))
+
+	# Own cells: a unit always sees where it stands.
+	_check("observer's own cell visible", overlay.cell_state_at(Vector2(880, 2160)) == overlay.CELL_VISIBLE)
+
+	print("\n-- Part 2: synthetic terrain semantic pins --")
+	var saved_features = tm.terrain_features
+	var saved_layout: String = tm.current_layout
+
+	# One legacy dense piece (no piece_class → both its own area AND solid)
+	# spanning x 18..26", y 28..32", observer at (22", 44").
+	tm.terrain_features = [_rect_piece("blk", 880.0, 1200.0, 320.0, 160.0, "dense", "")]
+	_inject_unit("U_VISION_ONE", [_model("m1", 880.0, 1760.0)])  # 22", 44"
+	overlay.show_for_unit("U_VISION_ONE")
+	_compute_all(overlay)
+	_check("legacy dense blocks the far side", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
+	_check("near side stays visible", overlay.cell_state_at(Vector2(880, 1600)) == overlay.CELL_VISIBLE)
+	_check("point INSIDE the dense piece is visible (within-exclusion, 13.10/13.11)",
+		overlay.cell_state_at(Vector2(880, 1200)) == overlay.CELL_VISIBLE)
+	_probe_agrees(overlay, "synthetic blocked probe", Vector2(880, 400))
+	_probe_agrees(overlay, "synthetic inside probe", Vector2(880, 1200))
+
+	# Observer INSIDE the dense piece sees out (its own area/piece excluded).
+	_inject_unit("U_VISION_INSIDE", [_model("m1", 880.0, 1200.0)])
+	overlay.show_for_unit("U_VISION_INSIDE")
+	_compute_all(overlay)
+	_check("observer inside dense piece sees out", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+
+	# Light FEATURE (barricade): features never obscure, light never Solid → no block.
+	tm.terrain_features = [_rect_piece("bar", 880.0, 1200.0, 320.0, 160.0, "light", "feature", 2.0)]
+	overlay.show_for_unit("U_VISION_ONE")
+	_compute_all(overlay)
+	_check("light feature (barricade) does not block", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+
+	# Light AREA: obscures (13.10) → blocked; unless the probed point is within it.
+	tm.terrain_features = [_rect_piece("larea", 880.0, 1200.0, 320.0, 160.0, "light", "area", 2.0)]
+	overlay.show_for_unit("U_VISION_ONE")
+	_compute_all(overlay)
+	_check("light AREA obscures the far side", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
+	_check("point within the light area is visible", overlay.cell_state_at(Vector2(880, 1200)) == overlay.CELL_VISIBLE)
+
+	# Solid vs elevation: dense FEATURE blocks ground observers, not elevated ones
+	# (13.11 is ground-level only); a dense AREA would still obscure regardless.
+	tm.terrain_features = [_rect_piece("wall", 880.0, 1200.0, 320.0, 160.0, "dense", "feature")]
+	overlay.show_for_unit("U_VISION_ONE")
+	_compute_all(overlay)
+	_check("dense feature blocks ground observer", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
+	_inject_unit("U_VISION_UP", [_model("m1", 880.0, 1760.0, 32, 4.0)])  # 4" up a ruin
+	overlay.show_for_unit("U_VISION_UP")
+	_compute_all(overlay)
+	_check("elevated observer sees over the dense feature", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+	_probe_agrees(overlay, "elevated probe", Vector2(880, 400))
+
+	# Explicit wall segment (legacy walls[] array) blocks on its own.
+	tm.terrain_features = [{
+		"id": "wallpiece", "type": "ruins", "polygon": PackedVector2Array(),
+		"category": "exposed", "walls": [{"start": Vector2(720, 1200), "end": Vector2(1040, 1200), "blocks_los": true}],
+	}]
+	overlay.show_for_unit("U_VISION_ONE")
+	_compute_all(overlay)
+	_check("explicit wall segment blocks", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
+	_check("off the wall's line stays visible", overlay.cell_state_at(Vector2(200, 400)) == overlay.CELL_VISIBLE)
+
+	print("\n-- Part 3: lifecycle --")
+	tm.terrain_features = saved_features
+	tm.current_layout = saved_layout
+	_inject_unit("U_VISION_EMPTY", [])
+	overlay.show_for_unit("U_VISION_EMPTY")
+	_check("unit with no models reports a reason", overlay.status_reason() != "")
+	_check("no-model map counts nothing", overlay.visible_cell_count() == 0 and overlay.hidden_cell_count() == 0)
+	overlay.show_for_unit("U_MISSING_UNIT")
+	_check("missing unit reports a reason", overlay.status_reason() != "")
+	overlay.clear_map()
+	_check("clear_map deactivates", not overlay.is_active())
+	_check("clear_map resets cells", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_UNKNOWN)
+
+	# Cleanup injected units
+	for uid in ["U_VISION_TEST", "U_VISION_ONE", "U_VISION_INSIDE", "U_VISION_UP", "U_VISION_EMPTY"]:
+		gs.state["units"].erase(uid)
+
+	print("\n===== RESULT: %d passed, %d failed =====" % [passed, failed])
+	quit(1 if failed > 0 else 0)

--- a/40k/tests/test_vision_map_agreement.gd
+++ b/40k/tests/test_vision_map_agreement.gd
@@ -2,37 +2,31 @@ extends SceneTree
 
 # VISION-MAP-AGREEMENT — headless half of the Vision Map feature (the
 # whole-board "what can this unit see" shading used for deployment planning).
+# v2: the map is rendered as ray-cast fan GEOMETRY (angular sweep with a ray
+# at every terrain vertex), not a cell grid — so this test now audits THREE
+# layers against each other:
 #
-# The L-overlay bug taught us that a debug view carrying its own private LoS
-# logic eventually contradicts the rules engine (2026-08 report). The vision
-# map therefore mirrors EnhancedLineOfSight._check_single_line_of_sight_11e
-# per line, with precomputed piece data for speed — and this test holds the
-# mirror to the canon:
-#
-#   1. run_self_check(): on the real default terrain layout, sampled cells
-#      re-judged straight through the canonical per-line function must agree
-#      with the stored grid — zero mismatches.
-#   2. Directed probes on the default layout (behind the centre ruins, open
-#      ground) must agree with a canonical re-judgement of the same cell.
-#   3. Synthetic-terrain semantic pins that isolate each 11e branch: obscuring
-#      areas + the "within" exclusion (13.10), Solid dense features + the
-#      occupies exception (13.11), light features not blocking, elevated
-#      observers ignoring Solid but not Obscuring, wall segments.
-#   4. Lifecycle: a unit with no models on the board reports a status reason
-#      instead of shading garbage; clear_map() empties everything.
+#   1. the per-POINT judge (the overlay's fast segment judge) vs the CANONICAL
+#      EnhancedLineOfSight._check_single_line_of_sight_11e — zero mismatches
+#      (the L-overlay lesson: debug views with private LoS logic drift);
+#   2. the RENDERED fan geometry vs that judge (run_self_check part B) — what
+#      the player sees must be what the rules say, away from ±ε stitch seams;
+#   3. directed probes + synthetic-terrain semantic pins that isolate each
+#      11e branch: obscuring areas + the "within" exclusion (13.10), Solid
+#      dense features + the occupies exception (13.11), light features not
+#      blocking, elevated observers ignoring Solid, wall segments.
+#   4. Lifecycle: no-models-on-board reporting, clear_map.
 #
 # The windowed half lives in tests/scenarios/sp/los_vision_map_deployment.json.
 #
 # NOTE: `-s` main-loop scripts compile before autoloads register, so autoloads
-# are fetched via root.get_node_or_null (same pattern as
-# test_los_overlay_targeting_agreement.gd). class_name globals resolve fine.
+# are fetched via root.get_node_or_null and the overlay is load()ed untyped.
 #
 # Usage: godot --headless --path . -s tests/test_vision_map_agreement.gd
 
 var passed := 0
 var failed := 0
 
-# Autoload handles (resolved at run time)
 var gs = null      # GameState
 var tm = null      # TerrainManager
 var elos = null    # EnhancedLineOfSight
@@ -64,14 +58,7 @@ func _inject_unit(uid: String, models: Array) -> void:
 		"meta": {"name": uid, "keywords": ["INFANTRY"]},
 	}
 
-func _compute_all(overlay) -> void:
-	# Deterministic: pump the chunked compute directly instead of racing frames.
-	var guard := 0
-	while not overlay.is_compute_done() and guard < 10000:
-		overlay._compute_chunk()
-		guard += 1
-
-# Canonical unit-level verdict for one probed point: same observer ray set the
+# Canonical unit-level verdict for one probed point: same observer set the
 # overlay uses, every line judged by the CANONICAL 11e function.
 func _canonical_visible(overlay, target: Vector2) -> bool:
 	var cell_groups := {}
@@ -80,32 +67,27 @@ func _canonical_visible(overlay, target: Vector2) -> bool:
 		if Geometry2D.is_point_in_polygon(target, piece.polygon):
 			cell_groups[piece.group_key] = true
 			cell_feats[piece.id] = true
-	for op in overlay._obs_points:
-		var obs: Dictionary = overlay._observers[op[1]]
+	for obs in overlay._observers:
 		var e11 := {
 			"group_map": overlay._group_map,
 			"exclude_groups": overlay._merged(obs.groups, cell_groups),
 			"exclude_feature_ids": overlay._merged(obs.feats, cell_feats),
 			"ground_level": obs.ground,
 		}
-		var res: Dictionary = elos._check_single_line_of_sight_11e(op[0], target, overlay._raw_features, e11)
+		var res: Dictionary = elos._check_single_line_of_sight_11e(obs.pos, target, overlay._raw_features, e11)
 		if res.has_los:
 			return true
 	return false
 
-# Snap a board pos to its cell centre so directed probes judge the exact point
-# the grid judged.
-func _cell_centre(overlay, pos: Vector2) -> Vector2:
-	var cx := int(pos.x / overlay._cell_px)
-	var cy := int(pos.y / overlay._cell_px)
-	return Vector2((float(cx) + 0.5) * overlay._cell_px, (float(cy) + 0.5) * overlay._cell_px)
-
+# One directed probe = three-way agreement: judge == canonical, and the
+# rendered fans == judge (all probe points sit far from shadow seams).
 func _probe_agrees(overlay, label: String, pos: Vector2) -> void:
-	var centre := _cell_centre(overlay, pos)
-	var stored: int = overlay.cell_state_at(pos)
-	var canon := _canonical_visible(overlay, centre)
-	_check(label + " agrees with canonical", (stored == overlay.CELL_VISIBLE) == canon,
-		"stored=%d canonical_visible=%s at %s" % [stored, canon, str(centre)])
+	var stored: int = overlay.point_state_at(pos)
+	var canon := _canonical_visible(overlay, pos)
+	_check(label + " agrees with canonical", (stored == overlay.STATE_VISIBLE) == canon,
+		"stored=%d canonical_visible=%s at %s" % [stored, canon, str(pos)])
+	_check(label + " rendered fans agree", overlay.sweep_point_visible(pos) == (stored == overlay.STATE_VISIBLE),
+		"render=%s judge=%d at %s" % [overlay.sweep_point_visible(pos), stored, str(pos)])
 
 func _rect_piece(id: String, cx: float, cy: float, w: float, h: float, cat: String, pclass: String, height: float = 6.0) -> Dictionary:
 	return {
@@ -121,7 +103,7 @@ func _rect_piece(id: String, cx: float, cy: float, w: float, h: float, cat: Stri
 	}
 
 func _run_tests() -> void:
-	print("\n===== VISION MAP ↔ RULES-ENGINE AGREEMENT =====\n")
+	print("\n===== VISION MAP (RAY-CAST SWEEP) ↔ RULES-ENGINE AGREEMENT =====\n")
 	gs = root.get_node_or_null("GameState")
 	tm = root.get_node_or_null("TerrainManager")
 	elos = root.get_node_or_null("EnhancedLineOfSight")
@@ -145,19 +127,25 @@ func _run_tests() -> void:
 	])
 	var overlay = load("res://scripts/VisionMapOverlay.gd").new()
 	root.add_child(overlay)
+	var t0 := Time.get_ticks_usec()
 	overlay.show_for_unit("U_VISION_TEST")
-	_compute_all(overlay)
+	overlay.compute_now()
+	print("  [bench] 2-model sweep on the real layout: %.0f ms, %d rays" % [
+		(Time.get_ticks_usec() - t0) / 1000.0, overlay._total_rays])
 
 	_check("compute completes", overlay.is_compute_done())
-	_check("grid fully classified", overlay.visible_cell_count() + overlay.hidden_cell_count() == overlay._cells.size(),
-		"visible=%d hidden=%d cells=%d" % [overlay.visible_cell_count(), overlay.hidden_cell_count(), overlay._cells.size()])
-	_check("some cells visible", overlay.visible_cell_count() > 0)
-	_check("some cells hidden (44-piece layout must cast shadows)", overlay.hidden_cell_count() > 0)
+	var ratio: float = overlay.seen_ratio()
+	_check("seen ratio is a real mix (0 < %.2f < 1)" % ratio, ratio > 0.02 and ratio < 0.98)
+	_check("fan geometry was emitted", overlay._sweeps.size() > 0 and overlay._sweeps[0].tris.size() > 0)
 
 	var self_check: Dictionary = overlay.run_self_check(400)
-	_check("self-check ran on real cells", int(self_check.checked) > 300, "checked=%d" % int(self_check.checked))
-	_check("zero mismatches vs canonical per-line judge", int(self_check.mismatches) == 0,
+	_check("self-check ran on real points", int(self_check.checked) >= 400, "checked=%d" % int(self_check.checked))
+	_check("zero judge-vs-canonical mismatches", int(self_check.mismatches) == 0,
 		"mismatches=%d examples=%s" % [int(self_check.mismatches), str(self_check.examples)])
+	_check("render check covered most points", int(self_check.render_checked) > 300,
+		"render_checked=%d" % int(self_check.render_checked))
+	_check("zero render-vs-judge mismatches", int(self_check.render_mismatches) == 0,
+		"render_mismatches=%d examples=%s" % [int(self_check.render_mismatches), str(self_check.examples)])
 
 	# Directed probes: dead behind the centre trapezoid ruins / open own corner.
 	_probe_agrees(overlay, "probe behind centre ruins (22\",20\")", Vector2(880, 800))
@@ -165,8 +153,8 @@ func _run_tests() -> void:
 	_probe_agrees(overlay, "probe far corner (2\",2\")", Vector2(80, 80))
 	_probe_agrees(overlay, "probe inside a dense area (37\",42\")", Vector2(1480, 1680))
 
-	# Own cells: a unit always sees where it stands.
-	_check("observer's own cell visible", overlay.cell_state_at(Vector2(880, 2160)) == overlay.CELL_VISIBLE)
+	# A unit always sees the ground at its own feet.
+	_check("observer's own spot visible", overlay.point_state_at(Vector2(880, 2140)) == overlay.STATE_VISIBLE)
 
 	print("\n-- Part 2: synthetic terrain semantic pins --")
 	var saved_features = tm.terrain_features
@@ -177,43 +165,46 @@ func _run_tests() -> void:
 	tm.terrain_features = [_rect_piece("blk", 880.0, 1200.0, 320.0, 160.0, "dense", "")]
 	_inject_unit("U_VISION_ONE", [_model("m1", 880.0, 1760.0)])  # 22", 44"
 	overlay.show_for_unit("U_VISION_ONE")
-	_compute_all(overlay)
-	_check("legacy dense blocks the far side", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
-	_check("near side stays visible", overlay.cell_state_at(Vector2(880, 1600)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("legacy dense blocks the far side", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_HIDDEN)
+	_check("near side stays visible", overlay.point_state_at(Vector2(880, 1600)) == overlay.STATE_VISIBLE)
 	_check("point INSIDE the dense piece is visible (within-exclusion, 13.10/13.11)",
-		overlay.cell_state_at(Vector2(880, 1200)) == overlay.CELL_VISIBLE)
+		overlay.point_state_at(Vector2(880, 1200)) == overlay.STATE_VISIBLE)
 	_probe_agrees(overlay, "synthetic blocked probe", Vector2(880, 400))
 	_probe_agrees(overlay, "synthetic inside probe", Vector2(880, 1200))
 
 	# Observer INSIDE the dense piece sees out (its own area/piece excluded).
 	_inject_unit("U_VISION_INSIDE", [_model("m1", 880.0, 1200.0)])
 	overlay.show_for_unit("U_VISION_INSIDE")
-	_compute_all(overlay)
-	_check("observer inside dense piece sees out", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("observer inside dense piece sees out", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_VISIBLE)
 
 	# Light FEATURE (barricade): features never obscure, light never Solid → no block.
 	tm.terrain_features = [_rect_piece("bar", 880.0, 1200.0, 320.0, 160.0, "light", "feature", 2.0)]
 	overlay.show_for_unit("U_VISION_ONE")
-	_compute_all(overlay)
-	_check("light feature (barricade) does not block", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("light feature (barricade) does not block", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_VISIBLE)
+	_check("…and the fans agree", overlay.sweep_point_visible(Vector2(880, 400)))
 
 	# Light AREA: obscures (13.10) → blocked; unless the probed point is within it.
 	tm.terrain_features = [_rect_piece("larea", 880.0, 1200.0, 320.0, 160.0, "light", "area", 2.0)]
 	overlay.show_for_unit("U_VISION_ONE")
-	_compute_all(overlay)
-	_check("light AREA obscures the far side", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
-	_check("point within the light area is visible", overlay.cell_state_at(Vector2(880, 1200)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("light AREA obscures the far side", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_HIDDEN)
+	_check("point within the light area is visible", overlay.point_state_at(Vector2(880, 1200)) == overlay.STATE_VISIBLE)
+	_check("…window inside the shadow is rendered", overlay.sweep_point_visible(Vector2(880, 1200)),
+		"the excused footprint must punch a visible island through its own shadow")
 
 	# Solid vs elevation: dense FEATURE blocks ground observers, not elevated ones
 	# (13.11 is ground-level only); a dense AREA would still obscure regardless.
 	tm.terrain_features = [_rect_piece("wall", 880.0, 1200.0, 320.0, 160.0, "dense", "feature")]
 	overlay.show_for_unit("U_VISION_ONE")
-	_compute_all(overlay)
-	_check("dense feature blocks ground observer", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
+	overlay.compute_now()
+	_check("dense feature blocks ground observer", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_HIDDEN)
 	_inject_unit("U_VISION_UP", [_model("m1", 880.0, 1760.0, 32, 4.0)])  # 4" up a ruin
 	overlay.show_for_unit("U_VISION_UP")
-	_compute_all(overlay)
-	_check("elevated observer sees over the dense feature", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("elevated observer sees over the dense feature", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_VISIBLE)
 	_probe_agrees(overlay, "elevated probe", Vector2(880, 400))
 
 	# Explicit wall segment (legacy walls[] array) blocks on its own.
@@ -222,9 +213,10 @@ func _run_tests() -> void:
 		"category": "exposed", "walls": [{"start": Vector2(720, 1200), "end": Vector2(1040, 1200), "blocks_los": true}],
 	}]
 	overlay.show_for_unit("U_VISION_ONE")
-	_compute_all(overlay)
-	_check("explicit wall segment blocks", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_HIDDEN)
-	_check("off the wall's line stays visible", overlay.cell_state_at(Vector2(200, 400)) == overlay.CELL_VISIBLE)
+	overlay.compute_now()
+	_check("explicit wall segment blocks", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_HIDDEN)
+	_check("off the wall's line stays visible", overlay.point_state_at(Vector2(200, 400)) == overlay.STATE_VISIBLE)
+	_check("wall shadow is rendered too", not overlay.sweep_point_visible(Vector2(880, 400)))
 
 	print("\n-- Part 3: lifecycle --")
 	tm.terrain_features = saved_features
@@ -232,14 +224,13 @@ func _run_tests() -> void:
 	_inject_unit("U_VISION_EMPTY", [])
 	overlay.show_for_unit("U_VISION_EMPTY")
 	_check("unit with no models reports a reason", overlay.status_reason() != "")
-	_check("no-model map counts nothing", overlay.visible_cell_count() == 0 and overlay.hidden_cell_count() == 0)
+	_check("no-model map claims no sight", overlay.seen_ratio() == 0.0)
 	overlay.show_for_unit("U_MISSING_UNIT")
 	_check("missing unit reports a reason", overlay.status_reason() != "")
 	overlay.clear_map()
 	_check("clear_map deactivates", not overlay.is_active())
-	_check("clear_map resets cells", overlay.cell_state_at(Vector2(880, 400)) == overlay.CELL_UNKNOWN)
+	_check("clear_map resets queries", overlay.point_state_at(Vector2(880, 400)) == overlay.STATE_UNKNOWN)
 
-	# Cleanup injected units
 	for uid in ["U_VISION_TEST", "U_VISION_ONE", "U_VISION_INSIDE", "U_VISION_UP", "U_VISION_EMPTY"]:
 		gs.state["units"].erase(uid)
 


### PR DESCRIPTION
## What

A new deployment-planning tool (requested): pick any unit on the board and the whole board shades into what that unit can see — warm = seen, cool blue = hidden — with weapon range deliberately ignored. The existing LoS debug draws sight lines between two placed units, which can't answer the question a player has *while deploying*: "if I put a model HERE, can that enemy see it?" One unit at a time by design; the panel lists both players' on-board units (during your deployment the unit you care about is usually theirs, and no phase UI can select it).

- **Access:** 👁 Vision button on the phase bar (player-facing, not dev-gated) or rebindable **Shift+L** — the toggle sibling of held-L sight lines. Works in every phase; clears on game load; auto-recomputes as models are placed, moved or slain.
- **Rendering (v2, after feedback that the first grid cut was blocky):** a true angular visibility sweep per observer point — one ray at every terrain vertex (±ε twin rays) plus a sparse uniform fill, exact blocked/visible interval algebra per ray, adjacent rays stitched into triangle fans. Shadow boundaries land exactly on terrain silhouettes: no cells, no stair-steps. Fans render as opaque geometry flattened through one CanvasGroup so overlapping fans never double-darken.
- **Rules fidelity:** per sight line this implements the same 11e judgement as `EnhancedLineOfSight._check_single_line_of_sight_11e` — 13.10 obscuring areas with the within-group exclusion (stand in a ruin and you're visible through its boundary), 13.11 Solid features with the occupies exception and elevation gate, wall segments. `run_self_check()` continuously re-judges sampled points through the canonical rules-engine function **and** cross-checks the rendered fan geometry against that judge — the L-overlay lesson (debug views with private LoS logic drift) applied to a renderer too.
- **Perf:** angular-span prefilter + bbox slab rejects ≈ 40 ms per observer on the real 44-piece layout; frame-sliced in game with live progress. Mobs cast from base centers; small elite units get base-rim rays.

## Testing

- `tests/test_vision_map_agreement.gd` — 42 headless checks: zero mismatches judge↔canonical and fans↔judge over the real layout, plus synthetic-terrain pins for every 13.10/13.11 branch (within-exclusion, solid-vs-elevation, light features, walls) and lifecycle.
- `tests/scenarios/sp/los_vision_map_deployment.json` — 40-step windowed scenario in the DEPLOYMENT phase driving the real player path: real button click, real unit-row clicks, both agreement gates asserted at zero, screenshots.
- Live MCP validation: `verify_delivery` PASS (zero log errors) for both the enemy-unit and own-unit flows; existing LoS suite still 28/28.

## Notes

- Known approximations stated on the panel: point-target at ground level (a base edge can peek from just inside a shadow), 13.09 Hidden intentionally excluded, upper floors approximated.
- Requires the 11e ruleset (players always run 11e; the legacy 10e test-harness baseline gets a status message instead of a wrong map).
- Changelog: 1.28.0 (feature) + 1.28.1 (ray-cast renderer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S47MhyvNX8Szk9rZuwkc8N

---
_Generated by [Claude Code](https://claude.ai/code/session_01S47MhyvNX8Szk9rZuwkc8N)_