### PR TITLE
Fight: name the models sitting out of Engagement Range in the attack dialog

### DIFF
--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,6 +2,16 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.27.5",
+      "date": "2026-08-06",
+      "summary": "The attack dialog now names the models that are sitting the fight out, and how far away they are — so a leader with no section is explained instead of looking like a lost model.",
+      "changes": [
+        "Fixed (reported): a Custodian Guard led by a Blade Champion opened Assign Attacks reading \"Models in engagement range: 5/6\" with no Blade Champion section anywhere — no weapon, no target, no way to swing with him. He was simply outside Engagement Range, which is a legal outcome, but nothing on screen said so, and a leader missing from his own squad's attack list is indistinguishable from the game having split him off from it.",
+        "The dialog now adds a line under the count: \"Not fighting — outside Engagement Range (2\\\"): Blade Champion ×1 (nearest enemy 3.4\\\")\". It names each part of the unit that cannot fight, how many of its models are out, and the measured distance from the closest one to the nearest enemy model — so \"out of range\" is one glance away from \"bug\".",
+        "Applies to any unit, not just attached leaders: a mob whose back rank cannot reach gets the same one-line explanation instead of a bare fraction."
+      ]
+    },
+    {
       "version": "1.27.4",
       "date": "2026-08-05",
       "summary": "New setting: let the line-of-sight overlay skip enemies none of your guns could reach, for a quieter and faster board.",

--- a/40k/dialogs/AttackAssignmentDialog.gd
+++ b/40k/dialogs/AttackAssignmentDialog.gd
@@ -192,11 +192,40 @@ func _build_ui() -> void:
 				alive_count += 1
 
 	var instruction = Label.new()
+	instruction.name = "EligibleCountLabel"
 	if _eligible_models.size() < alive_count:
 		instruction.text = "Models in engagement range: %d/%d" % [_eligible_models.size(), alive_count]
 	else:
 		instruction.text = "All %d models in engagement range" % alive_count
 	container.add_child(instruction)
+
+	# ...and WHO the missing ones are. Reported bug: a Custodian Guard led by a
+	# Blade Champion opened this dialog with "Models in engagement range: 5/6"
+	# and no Champion section anywhere — no weapon, no target, no way to swing
+	# with him. The Champion was simply outside Engagement Range, which is a
+	# legal outcome (11e 04.02: "each target must be engaged with the model that
+	# has that weapon"), but the dialog never said so, and a leader vanishing
+	# from his own squad's attack list reads exactly like the game having split
+	# him off from it. Name every alive model that is sitting out, and give the
+	# distance that decided it, so "out of range" is distinguishable from "bug"
+	# without leaving the dialog.
+	var sitting_out := _build_sitting_out_rows()
+	if not sitting_out.is_empty():
+		var sitting_note = Label.new()
+		sitting_note.name = "SittingOutNote"
+		var parts: Array = []
+		for row in sitting_out:
+			if row.nearest < INF:
+				parts.append("%s ×%d (nearest enemy %.1f\")" % [row.name, int(row.count), float(row.nearest)])
+			else:
+				parts.append("%s ×%d" % [row.name, int(row.count)])
+		sitting_note.text = "Not fighting — outside Engagement Range (%s\"): %s" % [
+			_format_inches(GameConstants.engagement_range_inches()), ", ".join(parts)]
+		sitting_note.tooltip_text = "Only models engaged with an enemy can be selected to fight (11e). These models are too far away to swing this activation — pile in closer next time, or accept that this part of the unit sits the fight out."
+		sitting_note.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		sitting_note.add_theme_font_size_override("font_size", 14)
+		sitting_note.modulate = Color(1, 0.85, 0.5)
+		container.add_child(sitting_note)
 
 	# T3-3: Separate melee weapons into regular and Extra Attacks. Both lists
 	# span the Attached unit's components; a weapon named by two of them is ONE
@@ -913,6 +942,84 @@ func _selected_target_id() -> String:
 	if not eligible_targets.is_empty():
 		return str(eligible_targets.keys()[0])
 	return ""
+
+
+# ── who is sitting this activation out ──────────────────────────────────────
+
+# "2" for 2.0, "1.5" for 1.5 — Engagement Range is edition-dependent (1" at
+# 10e, 2" at 11e) and reading it off GameConstants keeps the note honest if the
+# switch ever moves.
+func _format_inches(value: float) -> String:
+	if is_equal_approx(value, roundf(value)):
+		return str(int(roundf(value)))
+	return "%.1f" % value
+
+# One row per COMPONENT that has alive models which cannot fight: the
+# component's name, how many of its models are sitting out, and how far the
+# closest of them is from the nearest enemy model. `nearest` is INF when there
+# is no enemy on the board to measure against (nothing to say, so the caller
+# prints the count alone).
+#
+# Grouped per component rather than per model because that is the unit the
+# player thinks in — "my Blade Champion isn't fighting", not "model 0 of
+# U_BLADE_CHAMPION_A isn't fighting" — and because a bodyguard's back rank
+# sitting out wants ONE line, not eight.
+func _build_sitting_out_rows() -> Array:
+	var rows: Array = []
+	for member_id in _group_unit_ids:
+		var member: Dictionary = phase_reference.get_unit(member_id)
+		var models: Array = member.get("models", [])
+		var eligible_idx := {}
+		for key in _eligible_models:
+			if _model_key_unit.get(key, "") == str(member_id):
+				eligible_idx[int(_mk_index(str(key)))] = true
+
+		var count := 0
+		var nearest := INF
+		for i in range(models.size()):
+			if not models[i].get("alive", true):
+				continue
+			if eligible_idx.has(i):
+				continue
+			count += 1
+			var d := _nearest_enemy_distance_inches(member, models[i])
+			if d < nearest:
+				nearest = d
+		if count == 0:
+			continue
+
+		var member_meta: Dictionary = member.get("meta", {})
+		rows.append({
+			"unit_id": str(member_id),
+			"name": str(member_meta.get("display_name", member_meta.get("name", member_id))),
+			"count": count,
+			"nearest": nearest,
+		})
+		print("[AttackAssignmentDialog] %s: %d model(s) cannot fight — nearest enemy %s" % [
+			member_id, count, ("%.2f\"" % nearest) if nearest < INF else "n/a"])
+	return rows
+
+# Edge-to-edge distance from `model` to the closest alive enemy model anywhere
+# on the board. Deliberately measured against EVERY enemy, not just this
+# activation's eligible targets: the question the note answers is "how far is
+# this model from being in the fight at all".
+func _nearest_enemy_distance_inches(owner_unit: Dictionary, model: Dictionary) -> float:
+	var best := INF
+	if phase_reference == null:
+		return best
+	var owner_side := str(owner_unit.get("owner", 0))
+	var all_units: Dictionary = phase_reference.game_state_snapshot.get("units", {})
+	for other_id in all_units:
+		var other: Dictionary = all_units[other_id]
+		if str(other.get("owner", 0)) == owner_side:
+			continue
+		for enemy_model in other.get("models", []):
+			if not enemy_model.get("alive", true):
+				continue
+			var d: float = Measurement.model_to_model_distance_inches(model, enemy_model)
+			if d < best:
+				best = d
+	return best
 
 
 # ── per-component reach (11e "Select Targets") ──────────────────────────────

--- a/40k/tests/scenarios/sp/fight_leader_out_of_er_explained_11e.json
+++ b/40k/tests/scenarios/sp/fight_leader_out_of_er_explained_11e.json
@@ -1,0 +1,141 @@
+{
+  "id": "fight_leader_out_of_er_explained_11e",
+  "covers": [
+    "dialogs.AttackAssignmentDialog.sitting_out_note",
+    "dialogs.AttackAssignmentDialog.eligible_models",
+    "rules.RulesEngine.get_eligible_melee_model_indices",
+    "rules.11e.fight.engaged"
+  ],
+  "fixture": "audit_370_bgnt_shoot",
+  "edition": 11,
+  "rng_seed": 4242,
+  "transition_to_phase": 10,
+  "disable_ai": true,
+  "description": "Reported bug: a Custodian Guard led by a Blade Champion opened the attack dialog and the Champion was simply NOT THERE — no section, no weapon, no way to swing with him — while the header read 'Models in engagement range: 5/6'. The player could not tell whether the Champion was out of Engagement Range or whether the game had wrongly split him off from his squad. This scenario builds exactly that board: the Guard line locked with a Boyz mob and the Champion in base contact BEHIND them, 3.4\" from the nearest Boy (11e Engagement Range is 2\"). The Champion is correctly ineligible - 11e 04.02 requires each target to be engaged with the model carrying the weapon - so the dialog must SAY SO by name and by distance instead of silently dropping his section.",
+  "steps": [
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "expect_state", "path": "meta.phase", "equals": 10 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "clear the board so only the reported geometry is in play",
+      "script": "var GS = GameState.state\nvar keep = [\"U_CUSTODIAN_GUARD_B\", \"U_BLADE_CHAMPION_A\", \"U_BOYZ_E\"]\nfor uid in GS[\"units\"].keys():\n\tif uid in keep:\n\t\tcontinue\n\tvar i = 0\n\tfor m in GS[\"units\"][uid][\"models\"]:\n\t\tm[\"position\"] = {\"x\": 25000.0 + float(i) * 60.0, \"y\": 25000.0}\n\t\ti += 1\nGS[\"meta\"][\"active_player\"] = 1\nreturn \"parked\""
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "19.03: Blade Champion + Custodian Guard are ONE Attached unit, ONE activation",
+      "script": "CharacterAttachmentManager.attach_character(\"U_BLADE_CHAMPION_A\", \"U_CUSTODIAN_GUARD_B\")\nreturn str(GameState.state[\"units\"][\"U_BLADE_CHAMPION_A\"].get(\"attached_to\", \"\"))",
+      "equals": "U_CUSTODIAN_GUARD_B"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the reported geometry — 40px = 1\". A Boyz line at y=600; the Guard line 1.8\" in front of it (engaged, 11e ER is 2\"); the Champion in base contact BEHIND the Guard line, which puts him 3.375\" from the nearest Boy.",
+      "script": "var GS = GameState.state\nvar guard = GS[\"units\"][\"U_CUSTODIAN_GUARD_B\"][\"models\"]\nvar gx = 1200.0\nfor i in range(guard.size()):\n\tguard[i][\"alive\"] = true\n\tguard[i][\"position\"] = {\"x\": gx + float(i) * 66.0, \"y\": 728.7}\nGS[\"units\"][\"U_BLADE_CHAMPION_A\"][\"models\"][0][\"alive\"] = true\nGS[\"units\"][\"U_BLADE_CHAMPION_A\"][\"models\"][0][\"position\"] = {\"x\": gx + 66.0, \"y\": 791.7}\n# One live Boy facing each Guard model; every other Boy stays parked. The\n# fixture already has casualties in this mob, so index 0 is not necessarily\n# alive — and a dead model is skipped by every range check.\nvar ms = GS[\"units\"][\"U_BOYZ_E\"][\"models\"]\nfor i in range(ms.size()):\n\tms[i][\"position\"] = {\"x\": 25000.0 + float(i) * 60.0, \"y\": 25000.0}\nvar placed = []\nfor i in range(ms.size()):\n\tif placed.size() >= guard.size():\n\t\tbreak\n\tif ms[i].get(\"alive\", true):\n\t\tms[i][\"position\"] = {\"x\": gx + float(placed.size()) * 66.0, \"y\": 600.0}\n\t\tplaced.append(\"U_BOYZ_E#%d\" % i)\nreturn \" \".join(placed)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the measured truth: every Guard model is engaged, the Champion is 3.375\" away — well outside the 2\" Engagement Range",
+      "script": "var GS = GameState.state\nvar boyz = []\nfor m in GS[\"units\"][\"U_BOYZ_E\"][\"models\"]:\n\tif m.get(\"alive\", true) and float(m[\"position\"][\"y\"]) < 10000.0:\n\t\tboyz.append(m)\nvar worst_guard = 0.0\nfor g in GS[\"units\"][\"U_CUSTODIAN_GUARD_B\"][\"models\"]:\n\tvar best = 9999.0\n\tfor b in boyz:\n\t\tbest = min(best, Measurement.model_to_model_distance_inches(g, b))\n\tworst_guard = max(worst_guard, best)\nvar champ = GS[\"units\"][\"U_BLADE_CHAMPION_A\"][\"models\"][0]\nvar champ_d = 9999.0\nfor b in boyz:\n\tchamp_d = min(champ_d, Measurement.model_to_model_distance_inches(champ, b))\nreturn \"boyz=%d guard=%.2f champ=%.2f er=%.1f\" % [boyz.size(), worst_guard, champ_d, GameConstants.engagement_range_inches()]",
+      "equals": "boyz=3 guard=1.80 champ=3.38 er=2.0"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "RulesEngine agrees per component: every Guard model may fight, the Champion may not",
+      "script": "var GS = GameState.state\nvar g = RulesEngine.get_eligible_melee_model_indices(GS[\"units\"][\"U_CUSTODIAN_GUARD_B\"], GS)\nvar c = RulesEngine.get_eligible_melee_model_indices(GS[\"units\"][\"U_BLADE_CHAMPION_A\"], GS)\nreturn \"guard=%d champ=%d\" % [g.size(), c.size()]",
+      "equals": "guard=3 champ=0"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "re-enter the Fight phase so it stamps eligibility against the new geometry",
+      "script": "PhaseManager.transition_to_phase(10)\nreturn \"re-entered\""
+    },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 2 } },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "END_PILE_IN", "player": 2 } },
+    {
+      "act": "execute_script",
+      "comment": "PileInStep11e.DONE — units may now be selected to fight",
+      "script": "PhaseManager.get_current_phase_instance().pile_in_step_11e",
+      "equals": 2
+    },
+    { "act": "wait_seconds", "seconds": 0.5 },
+    { "act": "dispatch_action", "action": { "type": "SELECT_FIGHTER", "unit_id": "U_CUSTODIAN_GUARD_B", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_EPIC_CHALLENGE", "unit_id": "U_CUSTODIAN_GUARD_B", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "SELECT_KATAH_STANCE", "unit_id": "U_CUSTODIAN_GUARD_B", "stance": "dacatarai", "player": 1 } },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the reported symptom: the Champion has no section in the dialog at all",
+      "script": "var d = Engine.get_main_loop().root.get_node_or_null(\"AttackAssignmentDialog\")\nvar out = []\nfor g in d._groups:\n\tout.append(\"%s x%d\" % [str(g.get(\"owner\", \"\")), int(g.get(\"models\", []).size())])\nout.sort()\nreturn \" | \".join(out)",
+      "equals": "U_CUSTODIAN_GUARD_B x3"
+    },
+    {
+      "act": "expect_node_visible",
+      "comment": "THE FIX — the dialog now names who is sitting out and how far away he is, so the player can tell 'out of range' from 'the game lost my Champion'",
+      "node": "/root/AttackAssignmentDialog/Content/SittingOutNote"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the note names the Blade Champion, his model count and his measured distance to the nearest enemy",
+      "script": "var d = Engine.get_main_loop().root.get_node_or_null(\"AttackAssignmentDialog\")\nvar n = d.get_node_or_null(\"Content/SittingOutNote\")\nvar t = str(n.text)\nreturn \"%s|%s|%s\" % [str(\"Blade Champion\" in t), str(\"3.4\" in t), str(\"2\\\"\" in t)]",
+      "equals": "true|true|true"
+    },
+    { "act": "screenshot", "label": "01_dialog_names_the_leader_sitting_out_of_engagement_range" },
+
+    {
+      "act": "click_node",
+      "comment": "un-pick the unit so the same activation can be re-opened against new geometry",
+      "node": "/root/AttackAssignmentDialog/Content/ButtonContainer/BackToSelectionButton",
+      "emit_pressed": true
+    },
+    { "act": "wait_seconds", "seconds": 1.0 },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the CONTROL: a Boy gets round the back and engages the Champion (0.29\"). Nothing else on the board moves — only the Champion's own reach changes.",
+      "script": "var GS = GameState.state\nvar ms = GS[\"units\"][\"U_BOYZ_E\"][\"models\"]\nfor i in range(ms.size()):\n\tif ms[i].get(\"alive\", true) and float(ms[i][\"position\"][\"y\"]) > 10000.0:\n\t\tms[i][\"position\"] = {\"x\": 1266.0, \"y\": 860.0}\n\t\treturn \"U_BOYZ_E#%d moved behind the Champion\" % i\nreturn \"no spare Boy\""
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "the Champion is now engaged — and RulesEngine says so for HIS component, with no change to the Guard's",
+      "script": "var GS = GameState.state\nvar g = RulesEngine.get_eligible_melee_model_indices(GS[\"units\"][\"U_CUSTODIAN_GUARD_B\"], GS)\nvar c = RulesEngine.get_eligible_melee_model_indices(GS[\"units\"][\"U_BLADE_CHAMPION_A\"], GS)\nreturn \"guard=%d champ=%d\" % [g.size(), c.size()]",
+      "equals": "guard=3 champ=1"
+    },
+    { "act": "dispatch_action", "action": { "type": "SELECT_FIGHTER", "unit_id": "U_CUSTODIAN_GUARD_B", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "DECLINE_EPIC_CHALLENGE", "unit_id": "U_CUSTODIAN_GUARD_B", "player": 1 } },
+    { "act": "dispatch_action", "action": { "type": "SELECT_KATAH_STANCE", "unit_id": "U_CUSTODIAN_GUARD_B", "stance": "dacatarai", "player": 1 } },
+    { "act": "wait_seconds", "seconds": 1.5 },
+    { "act": "expect_node_visible", "node": "/root/AttackAssignmentDialog" },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "comment": "REGRESSION GUARD: the leader is NOT structurally split off from his squad — engage him and he gets his own section in the very same dialog, alongside the bodyguard's",
+      "script": "var d = Engine.get_main_loop().root.get_node_or_null(\"AttackAssignmentDialog\")\nvar out = []\nfor g in d._groups:\n\tout.append(\"%s x%d\" % [str(g.get(\"owner\", \"\")), int(g.get(\"models\", []).size())])\nout.sort()\nreturn \" | \".join(out)",
+      "equals": "U_BLADE_CHAMPION_A x1 | U_CUSTODIAN_GUARD_B x3"
+    },
+    {
+      "act": "execute_script",
+      "comment": "and with nobody sitting out, the note is gone rather than reading '×0'",
+      "script": "str(Engine.get_main_loop().root.get_node_or_null(\"AttackAssignmentDialog\").get_node_or_null(\"Content/SittingOutNote\"))",
+      "equals": "<Object#null>"
+    },
+    {
+      "act": "execute_script",
+      "comment": "every model of the Attached unit is now in the fight",
+      "script": "str(Engine.get_main_loop().root.get_node_or_null(\"AttackAssignmentDialog\").get_node_or_null(\"Content/EligibleCountLabel\").text)",
+      "equals": "All 4 models in engagement range"
+    },
+    { "act": "screenshot", "label": "02_engaged_leader_gets_his_own_section" }
+  ]
+}


### PR DESCRIPTION
## The report

A Custodian Guard led by a Blade Champion opened **Assign Attacks** reading `Models in engagement range: 5/6` with **no Blade Champion section anywhere** — no weapon, no target, no way to swing with him. The question raised was: *is he out of engagement range, or does the game think he is separate from the rest of the squad?*

## Diagnosis: out of range, not split off

He was out of range, and the dialog was correct to omit him — but it never said so.

Eligibility is decided per model in `RulesEngine.get_eligible_melee_model_indices`: a model can fight only if it is within Engagement Range (2" horizontally / 5" vertically at 11e, edge-to-edge) of a live enemy model. The Champion measured outside that, contributed 0 eligible models, and so `_build_groups` built no section for him and the header dropped to `5/6`. That matches 11e 04.02 — *"Each target must be engaged with the model that has that weapon."*

He is **not** structurally split from his squad: the activation, the dialog title (`Custodian Guard Beta + Blade Champion Beta`) and the target list all span both components of the Attached unit. The only trace of the exclusion was a fraction with an unexplained numerator, which reads exactly like a lost model.

## The change

`AttackAssignmentDialog` now prints, under the model count, every component of the Attached unit that has alive models which cannot fight — its name, how many of its models are out, and the edge-to-edge distance from the closest one to the nearest enemy model:

```
Models in engagement range: 3/4
Not fighting — outside Engagement Range (2"): Blade Champion ×1 (nearest enemy 3.4")
```

- The Engagement Range in the note is read from `GameConstants` so it stays honest across the edition switch.
- Not attached-leader-specific: a mob whose back rank cannot reach gets the same one-line explanation instead of a bare fraction.
- The count label gained a node name (`EligibleCountLabel`) so scenarios can assert on it.

No rules semantics were changed — this is presentation only. Eligibility, targeting and resolution behave exactly as before.

## Validation

New windowed scenario `fight_leader_out_of_er_explained_11e` drives **both halves** of the reported question against the real UI:

1. Champion in base contact behind his Guard line, 3.375" from the nearest Boy → no section, and the new note names him with his measured distance.
2. A Boy then gets round behind him (0.29") and the **same dialog** grows a `Blade Champion ×1` section with his Vaultswords profiles, `All 4 models in engagement range`, note gone — proving the leader is not structurally split off from the squad.

37/37 steps pass. 12 existing fight/dialog scenarios re-run green, including `fight_split_engagement_attached_11e`, `fight_loadout_groups_split_11e`, `counter_offensive_attached_char_11e` and `tut_t6_krumpin`. All three attached-unit fight scenarios re-run green again after merging `main` (Vision Map, #885) into the branch.

## CI note

`Headless audit suite` is red on this PR, and was already red on `main` before it — `main` reports the identical `Audit suite: 2412 passed, 1 failed across 111 tests`. The single failure is `test_iss020_public_api` → *"no private RulesEngine access outside RulesEngine"*, flagging `40k/scripts/ShootingController.gd:6170` calling `RulesEngine._filter_eligible_model_ids`. That line arrived in commit `3f1f59e` (#882) and is untouched by this branch, whose diff is 3 files. `Run GUT Test Suite` and `Coverage matrix validation` pass; `Code Quality Checks` passed on the push run and failed at *"Set up job"* (runner provisioning) on the PR run.

## Known limitation

The reproduction is of the **mechanism**, not of the reporter's exact board — that save was not available. If their Champion was in fact within 2" of an enemy, that would be a separate defect needing the save to measure.

Separately flagged but deliberately **not** changed: the legacy 10e base-to-base-chain path in `get_eligible_melee_model_indices` is evaluated against a single component's model list, so an attached leader can never chain off a bodyguard model. At 11e this is near-moot (base contact with a 40mm-based friend already puts a model ≤1.58" from whatever that friend touches, inside the 2" range) and 11e replaced the chain clause with the wider Engagement Range — so loosening eligibility here was left out of scope rather than done quietly.

## Version

Landed as `1.28.2` in `40k/data/version_history.json`. (It was written as `1.27.5`; #885 merged first and took 1.28.0/1.28.1, so the conflict resolution renumbered this entry to stay newest-first.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQHAV91cyi88fJtgPubjE7