### PR TITLE
Death Trap: make Booby Trap's "terrain areas" mean what the rules mean

### DIFF
--- a/40k/autoloads/MissionManager.gd
+++ b/40k/autoloads/MissionManager.gd
@@ -1551,21 +1551,24 @@ func _run_primary_auto_actions_11e(player: int, battle_round: int) -> void:
 					st["operation_markers"] = int(st.get("operation_markers", 0)) + 1
 					print("MissionManager: 11e Vital Link operation marker %d placed (P%s)" % [st["operation_markers"], pk])
 			"death_trap":
-				# Booby Trap: once per turn, an untrapped terrain area containing
-				# one of your models (eligibility simplified)
-				var tm = get_node_or_null("/root/TerrainManager")
-				if tm != null:
-					for feature in tm.terrain_features:
-						var fid = feature.get("id", "")
-						if fid == "" or fid in st["trapped"]:
-							continue
-						if _player_model_in_terrain_11e(player, feature):
-							st["trapped"].append(fid)
-							if not st.has("trapped_this_turn"):
-								st["trapped_this_turn"] = []
-							st["trapped_this_turn"].append(fid)
-							print("MissionManager: 11e Booby Trapped %s (P%s)" % [fid, pk])
-							break
+				# Booby Trap: unlimited uses per turn, one untrapped TERRAIN AREA
+				# per acting unit (see the 13.01 note above the terrain helpers).
+				# This is the AI/headless backstop, so it takes every area it can
+				# staff with a distinct unit — objective areas first.
+				var dt_wanted = []
+				for entry in get_booby_trap_candidates_11e(player):
+					dt_wanted.append(str(entry["id"]))
+				var dt_assign = _assign_booby_trap_units_11e(player, dt_wanted)
+				if not st.has("trapped_this_turn"):
+					st["trapped_this_turn"] = []
+				for fid in dt_assign["granted"]:
+					st["trapped"].append(fid)
+					st["trapped_this_turn"].append(fid)
+					print("MissionManager: 11e Booby Trapped %s (P%s, unit %s)" % [
+						fid, pk, dt_assign["units"].find_key(fid)])
+				if not dt_assign["refused"].is_empty():
+					print("MissionManager: 11e Booby Trap skipped %d area(s) — no spare unit (P%s)" % [
+						dt_assign["refused"].size(), pk])
 			"gather_intel":
 				if battle_round >= 2:
 					for obj in GameState.state.board.get("objectives", []):
@@ -1946,18 +1949,20 @@ func get_pending_card_action_11e(player: int, battle_round: int = -1) -> Diction
 				targets.append(_objective_target_entry_11e(obj_id))
 		"death_trap":
 			pending["action_name"] = "Booby Trap"
-			pending["description"] = "Once per turn: trap an untrapped terrain area containing one of your models (2 VP this turn, +3 more if it holds an objective; kills in trapped terrain pay separately)."
-			var tm = get_node_or_null("/root/TerrainManager")
-			if tm != null:
-				for feature in tm.terrain_features:
-					var fid = feature.get("id", "")
-					if fid == "" or fid in st.get("trapped", []):
-						continue
-					if _player_model_in_terrain_11e(player, feature):
-						var label = str(fid)
-						if _terrain_contains_objective_11e(tm, fid):
-							label += " (holds an objective)"
-						targets.append({"id": fid, "label": label})
+			pending["description"] = "A TERRAIN AREA is one of the marked footprints your scenery stands on \u2014 the whole outlined zone, not each individual wall or crate inside it. Tick every area you want to trap; each one needs a different unit of yours standing inside it, and stays Trapped for the rest of the game."
+			pending["help"] = "End of this turn: 2 VP per area you trapped, or 5 VP if the area holds an objective. Separately, 3 VP if you destroyed an enemy unit that began the turn in terrain you had already trapped."
+			pending["mode"] = "multi"
+			pending["highlight_kind"] = "terrain_area"
+			var dt_candidates = get_booby_trap_candidates_11e(player)
+			var dt_all = []
+			for entry in dt_candidates:
+				targets.append({"id": entry["id"], "label": entry["label"]})
+				dt_all.append(str(entry["id"]))
+			# One trap per acting unit — pre-tick (and cap at) the best set the
+			# player's units can actually staff, objective areas first.
+			var dt_best = _assign_booby_trap_units_11e(player, dt_all)["granted"]
+			pending["default_selected"] = dt_best
+			pending["max_picks"] = dt_best.size()
 		"gather_intel":
 			if battle_round < 2:
 				return {}
@@ -2047,12 +2052,18 @@ func resolve_card_action_11e(player: int, target_ids: Array) -> Dictionary:
 					st["decoyed_ever"].append(tid)
 				print("MissionManager: 11e Decoyed %s (P%s, player choice)" % [tid, pk])
 		"death_trap":
+			# One trap per acting unit: a unit can only perform one action, so two
+			# areas sharing their only occupant cannot both be trapped this turn.
+			var dt_assign = _assign_booby_trap_units_11e(player, picks)
+			if not dt_assign["refused"].is_empty():
+				return {"success": false, "error": "No spare unit to trap %s \u2014 each Booby Trap needs its own unit inside that terrain area" % ", ".join(PackedStringArray(dt_assign["refused"]))}
 			if not st.has("trapped_this_turn"):
 				st["trapped_this_turn"] = []
-			for tid in picks:
+			for tid in dt_assign["granted"]:
 				st["trapped"].append(tid)
 				st["trapped_this_turn"].append(tid)
-				print("MissionManager: 11e Booby Trapped %s (P%s, player choice)" % [tid, pk])
+				print("MissionManager: 11e Booby Trapped %s (P%s, player choice, unit %s)" % [
+					tid, pk, dt_assign["units"].find_key(tid)])
 		"gather_intel":
 			for tid in picks:
 				st["intel_tokens"].append(tid)
@@ -2596,6 +2607,197 @@ func _player_model_in_terrain_11e(player: int, feature: Dictionary) -> bool:
 				return true
 	return false
 
+# ============================================================
+# 11e DEATH TRAP — terrain AREA helpers
+# ============================================================
+# "Terrain area" is a defined term in the 11e core rules (13.01, Placing
+# Terrain). After listing the three ways to place terrain, the rule says:
+# "In each case, the area of the battlefield occupied by that boundary or
+# terrain feature is known as a terrain area."
+#
+# GW's matched-play layouts — the ones this game ships in 40k/terrain_layouts/
+# — all use the FIRST of those methods: a flat boundary marker (7"x11.5"
+# rectangles, 8"x11.5" triangles, ...) with one or more terrain features
+# standing wholly within it. So a layout's trappable terrain areas are its
+# piece_class "area" footprints; the crates, barricades, gantries and corner
+# ruins inside them are terrain FEATURES and are NOT separately trappable.
+#
+# Legacy / pre-11e layouts author no "area" pieces at all — every piece was
+# dropped straight onto the battlefield, which is 13.01's SECOND method, and
+# there each piece genuinely IS its own terrain area. So the filter below only
+# engages for layouts that actually define area footprints.
+
+## True when this layout uses boundary-marker terrain areas (11e GW layouts).
+func _layout_defines_terrain_areas_11e(tm) -> bool:
+	if tm == null:
+		return false
+	for feature in tm.terrain_features:
+		if str(feature.get("piece_class", "")) == "area":
+			return true
+	return false
+
+## Unit IDs with at least one living model inside this terrain area's
+## footprint. Booby Trap is a UNIT action, so each trap consumes one unit.
+func _units_with_model_in_terrain_11e(player: int, feature: Dictionary) -> Array:
+	var polygon = feature.get("polygon", PackedVector2Array())
+	var out = []
+	if polygon.is_empty():
+		return out
+	for unit_id in GameState.state.get("units", {}):
+		var unit = GameState.state.units[unit_id]
+		if int(unit.get("owner", 0)) != player:
+			continue
+		if not _unit_on_battlefield_11e(unit_id):
+			continue
+		for model in unit.get("models", []):
+			if not model.get("alive", true) or model.get("position") == null:
+				continue
+			var pos = model.get("position")
+			if pos is Dictionary:
+				pos = Vector2(pos.x, pos.y)
+			if Geometry2D.is_point_in_polygon(pos, polygon):
+				out.append(str(unit_id))
+				break
+	return out
+
+## Objective IDs belonging to this terrain area. GW's 11e layouts name the
+## terrain areas that ARE each objective (14.01, carried on the objective as
+## source_pieces) — more reliable than a point-in-polygon test, since a linked
+## centre pair lists both halves and a marker can sit right on a boundary.
+## Legacy layouts carry no source_pieces, so those fall back to geometry.
+func _terrain_objective_ids_11e(tm, feature_id: String) -> Array:
+	var out = []
+	for obj in GameState.state.board.get("objectives", []):
+		if feature_id in obj.get("source_pieces", []):
+			out.append(str(obj.get("id", "")))
+	if not out.is_empty():
+		return out
+	for feature in tm.terrain_features:
+		if str(feature.get("id", "")) != feature_id:
+			continue
+		var polygon = feature.get("polygon", PackedVector2Array())
+		if polygon.is_empty():
+			continue
+		for obj in GameState.state.board.get("objectives", []):
+			var pos = obj.get("position")
+			if pos is Dictionary:
+				pos = Vector2(pos.x, pos.y)
+			if pos != null and Geometry2D.is_point_in_polygon(pos, polygon):
+				out.append(str(obj.get("id", "")))
+	return out
+
+## Rough size word for a terrain area, from the GW template its id came from
+## ("area-large-9" -> "Large"). Legacy layouts fall back to the piece type.
+func _terrain_area_size_word_11e(feature: Dictionary) -> String:
+	var fid = str(feature.get("id", ""))
+	if fid.begins_with("area-large"):
+		return "Large"
+	if fid.begins_with("area-medium"):
+		return "Medium"
+	if fid.begins_with("area-trapezoid"):
+		return "Angled"
+	if fid.begins_with("area-long-line"):
+		return "Long"
+	if fid.begins_with("area-short-line"):
+		return "Small"
+	return str(feature.get("type", "terrain")).capitalize()
+
+## Human-readable name for a terrain area. Players pick these off a list and
+## then have to find them on the table, so lead with WHERE it is and close
+## with what it pays. Raw ids like "area-trapezoid-3" told them neither.
+func _terrain_area_label_11e(tm, feature: Dictionary, player: int) -> String:
+	var pos = feature.get("position", Vector2.ZERO)
+	if pos is Dictionary:
+		pos = Vector2(pos.get("x", 0), pos.get("y", 0))
+
+	# Territory, not board-thirds: deployment zones can be quarters (Search
+	# and Destroy) or diagonals, and "enemy territory" is what the card cares
+	# about anyway.
+	var territory = "No Man's Land"
+	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")
+	if secondary_mgr != null:
+		var mine = secondary_mgr._get_deployment_zone_polygon(player)
+		var theirs = secondary_mgr._get_deployment_zone_polygon(3 - player)
+		if not mine.is_empty() and Geometry2D.is_point_in_polygon(pos, mine):
+			territory = "your territory"
+		elif not theirs.is_empty() and Geometry2D.is_point_in_polygon(pos, theirs):
+			territory = "enemy territory"
+
+	var board = GameState.state.get("board", {}).get("size", {})
+	var board_w = Measurement.inches_to_px(float(board.get("width", 44)))
+	var flank = "centre"
+	if board_w > 0:
+		if pos.x < board_w / 3.0:
+			flank = "left"
+		elif pos.x > board_w * 2.0 / 3.0:
+			flank = "right"
+
+	var label = "%s area — %s, %s" % [_terrain_area_size_word_11e(feature), flank, territory]
+	var obj_ids = _terrain_objective_ids_11e(tm, str(feature.get("id", "")))
+	if obj_ids.is_empty():
+		return "%s (2 VP)" % label
+	var designation = str(_get_objective_by_id(obj_ids[0]).get("designation", ""))
+	if designation != "":
+		return "%s — holds the %s objective (5 VP)" % [label, designation.capitalize()]
+	return "%s — holds an objective (5 VP)" % label
+
+## The terrain areas `player` could Booby Trap right now: untrapped, and
+## holding at least one of their models. Booby Trap is a unit action, so each
+## entry also carries the units that could perform it — one trap each.
+## Shape: [{id, label, holds_objective, units: [unit_id]}], objectives first.
+func get_booby_trap_candidates_11e(player: int) -> Array:
+	var tm = get_node_or_null("/root/TerrainManager")
+	if tm == null:
+		return []
+	var already = _primary_state_11e.get(str(player), {}).get("trapped", [])
+	var layout_has_areas = _layout_defines_terrain_areas_11e(tm)
+	var out = []
+	for feature in tm.terrain_features:
+		var fid = str(feature.get("id", ""))
+		if fid == "" or fid in already:
+			continue
+		if layout_has_areas and str(feature.get("piece_class", "")) != "area":
+			continue
+		var units = _units_with_model_in_terrain_11e(player, feature)
+		if units.is_empty():
+			continue
+		out.append({
+			"id": fid,
+			"label": _terrain_area_label_11e(tm, feature, player),
+			"holds_objective": not _terrain_objective_ids_11e(tm, fid).is_empty(),
+			"units": units,
+		})
+	# An objective area pays 5 VP against 2 — surface those first.
+	out.sort_custom(func(a, b):
+		if a["holds_objective"] != b["holds_objective"]:
+			return a["holds_objective"]
+		return str(a["id"]) < str(b["id"]))
+	return out
+
+## Booby Trap is performed BY a unit and a unit can only act once, so N traps
+## in a turn need N distinct units. Greedily backs each requested area with
+## its own unit and reports the ones that could not be staffed.
+func _assign_booby_trap_units_11e(player: int, area_ids: Array) -> Dictionary:
+	var candidates = {}
+	for entry in get_booby_trap_candidates_11e(player):
+		candidates[str(entry["id"])] = entry["units"]
+	var used = {}
+	var granted = []
+	var refused = []
+	for aid in area_ids:
+		var aid_s = str(aid)
+		var assigned = ""
+		for unit_id in candidates.get(aid_s, []):
+			if not used.has(unit_id):
+				assigned = str(unit_id)
+				break
+		if assigned == "":
+			refused.append(aid_s)
+			continue
+		used[assigned] = aid_s
+		granted.append(aid_s)
+	return {"granted": granted, "refused": refused, "units": used}
+
 ## Enemy units destroyed this turn (on the battlefield at the active
 ## player's turn start, fully dead now). Dead models keep their positions,
 ## which the location-conditioned kill checks below rely on.
@@ -2692,17 +2894,7 @@ func _final_relic_marker_held_11e(player: int) -> bool:
 	return false
 
 func _terrain_contains_objective_11e(tm, feature_id: String) -> bool:
-	for feature in tm.terrain_features:
-		if feature.get("id", "") != feature_id:
-			continue
-		var polygon = feature.get("polygon", PackedVector2Array())
-		for obj in GameState.state.board.get("objectives", []):
-			var pos = obj.get("position")
-			if pos is Dictionary:
-				pos = Vector2(pos.x, pos.y)
-			if not polygon.is_empty() and Geometry2D.is_point_in_polygon(pos, polygon):
-				return true
-	return false
+	return not _terrain_objective_ids_11e(tm, feature_id).is_empty()
 
 func _enemy_wholly_in_my_dz_11e(player: int) -> bool:
 	var secondary_mgr = get_node_or_null("/root/SecondaryMissionManager")

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -2,13 +2,27 @@
   "_comment": "Single source of truth for the game version shown on the main menu. Newest release first. When you make a player-facing change, PREPEND a new entry (bump the version, set today's date, write a short summary + change bullets). See CLAUDE.md 'Version / changelog' for the convention.",
   "releases": [
     {
+      "version": "1.28.0",
+      "date": "2026-08-06",
+      "summary": "Death Trap's Booby Trap now names the terrain areas it means, highlights them on the board, and lets every eligible unit spring one.",
+      "changes": [
+        "The Booby Trap list no longer shows raw ids like \"area-trapezoid-3\". Each row now reads e.g. \"Large area — left, enemy territory — holds the Expansion objective (5 VP)\", naming where the area sits, whether it holds an objective and what it pays.",
+        "Picking a target now lights the candidate areas up on the board in orange, and the one you are hovering or have keyboard focus on is drawn brighter — so you can see exactly which footprint each row refers to.",
+        "The dialog now explains what a \"terrain area\" actually is (the marked footprint your scenery stands on — the whole outlined zone, not each wall or crate inside it) and lists how the mission scores.",
+        "Fixed: individual scenery pieces (barricades, gantries, generators) were offered as trap targets. Only the terrain-area footprints are trappable now, matching the core rules — on the standard layouts that is 16 areas, not the 44 loose pieces.",
+        "Fixed: Booby Trap was limited to one area per turn. The card allows unlimited uses, so you can now trap several areas in a turn — one per unit standing in them. The dialog tells you how many units you have and stops you over-picking.",
+        "Fixed: an objective sitting on the boundary of its terrain area could be missed, so a 5 VP area scored 2. Objective-to-area links now come from the layout data itself.",
+        "Fixed: Booby Trap and relic markers on the board could lose their names when the overlay redrew, which made them impossible to look up."
+      ]
+    },
+    {
       "version": "1.27.4",
       "date": "2026-08-05",
       "summary": "New setting: let the line-of-sight overlay skip enemies none of your guns could reach, for a quieter and faster board.",
       "changes": [
-        "New (requested): Settings > Visual > \"LoS Debug: include units out of weapon range\". On by default \u2014 enemies no weapon in the selected unit could reach are still checked and drawn dashed amber, labelled \"is out of range\", which is what explains a squad you can plainly see but cannot select.",
+        "New (requested): Settings > Visual > \"LoS Debug: include units out of weapon range\". On by default — enemies no weapon in the selected unit could reach are still checked and drawn dashed amber, labelled \"is out of range\", which is what explains a squad you can plainly see but cannot select.",
         "Turn it off and those enemies are dropped before any line-of-sight work happens at all: the overlay then shows only the enemies your guns can actually reach. On a deployed 2000pt board that took a whole-board sweep from 64 lines and ~0.9s down to 16 lines and ~0.3s.",
-        "A unit carrying no ranged weapons has no range to be outside of, so its sight lines are never filtered \u2014 assault units still get the full overlay either way."
+        "A unit carrying no ranged weapons has no range to be outside of, so its sight lines are never filtered — assault units still get the full overlay either way."
       ]
     },
     {
@@ -16,8 +30,8 @@
       "date": "2026-08-05",
       "summary": "The line-of-sight overlay (hold L) now tells you what you can actually SHOOT, not just what you can see: green means it is a legal target, amber means visible-but-off-limits and says why.",
       "changes": [
-        "Fixed (reported): the L overlay drew a solid green line to a squad that was not offered as a target at all \u2014 'there is at least one green line between the two squads but the target is not an option'. Green meant nothing more than 'terrain is not in the way', so any squad that was out of range, Hidden, engaged with one of your own units, a Lone Operative or inside a transport still got a green line and no explanation.",
-        "Sight lines now come in three states: solid green \u2014 this unit IS in your target list, click it and it works; dashed amber \u2014 your models can see it but the shot is illegal, with the reason (for example 'Kommandos is out of range') written on the line itself; dashed red \u2014 no line of sight, still split at the terrain that blocks it.",
+        "Fixed (reported): the L overlay drew a solid green line to a squad that was not offered as a target at all — 'there is at least one green line between the two squads but the target is not an option'. Green meant nothing more than 'terrain is not in the way', so any squad that was out of range, Hidden, engaged with one of your own units, a Lone Operative or inside a transport still got a green line and no explanation.",
+        "Sight lines now come in three states: solid green — this unit IS in your target list, click it and it works; dashed amber — your models can see it but the shot is illegal, with the reason (for example 'Kommandos is out of range') written on the line itself; dashed red — no line of sight, still split at the terrain that blocks it.",
         "Fixed the same disagreement in the other direction: a squad you COULD legally shoot was sometimes drawn red, because the overlay only tested the one or two closest pairs of models and applied a stricter visibility test than the game's own targeting does. Both now use the same rules-engine check.",
         "With a shooter selected, holding L also draws one line per enemy you cannot target, each labelled with the reason. Previously it drew lines only to targets you could already shoot, so the squad you were actually asking about got nothing.",
         "Fixed: clicking an enemy that is inside a transport, or a Lone Operative whose datasheet range is not 12\", showed the generic 'Target cannot be shot' instead of the real reason."

--- a/40k/data/version_history.json
+++ b/40k/data/version_history.json
@@ -7,7 +7,7 @@
       "summary": "Death Trap's Booby Trap now names the terrain areas it means, highlights them on the board, and lets every eligible unit spring one.",
       "changes": [
         "The Booby Trap list no longer shows raw ids like \"area-trapezoid-3\". Each row now reads e.g. \"Large area — left, enemy territory — holds the Expansion objective (5 VP)\", naming where the area sits, whether it holds an objective and what it pays.",
-        "Picking a target now lights the candidate areas up on the board in orange, and the one you are hovering or have keyboard focus on is drawn brighter — so you can see exactly which footprint each row refers to.",
+        "Picking a target now lights the candidate areas up on the board in orange, and the one you are hovering or have keyboard focus on is drawn brighter — so you can see exactly which footprint each row refers to. The dialog says so in as many words, in the same orange, so the outlines are not left to guesswork.",
         "The dialog now explains what a \"terrain area\" actually is (the marked footprint your scenery stands on — the whole outlined zone, not each wall or crate inside it) and lists how the mission scores.",
         "Fixed: individual scenery pieces (barricades, gantries, generators) were offered as trap targets. Only the terrain-area footprints are trappable now, matching the core rules — on the standard layouts that is 16 areas, not the 44 loose pieces.",
         "Fixed: Booby Trap was limited to one area per turn. The card allows unlimited uses, so you can now trap several areas in a turn — one per unit standing in them. The dialog tells you how many units you have and stops you over-picking.",

--- a/40k/scripts/CardActionOverlay.gd
+++ b/40k/scripts/CardActionOverlay.gd
@@ -10,6 +10,22 @@ class_name CardActionOverlay
 const BADGE_TRAP_COLOR = Color(1.0, 0.45, 0.25, 1.0)
 const BADGE_RELIC_COLOR = Color(0.55, 0.9, 1.0, 1.0)
 
+# Candidate-area highlight (Booby Trap target picking). A terrain AREA is the
+# marked footprint the scenery stands in — players could not tell which one a
+# raw id like "area-trapezoid-3" meant, so the dialog lights them up on the
+# board while it is open.
+const HIGHLIGHT_COLOR = Color(1.0, 0.55, 0.2, 1.0)
+# The board renders at ~0.3 scale, so these are deliberately heavy: at the
+# original 3px/0.16 they survived the zoom-out as barely a pixel of tint and
+# the candidate areas read as ordinary terrain.
+const HIGHLIGHT_FILL_ALPHA = 0.22
+const HIGHLIGHT_FILL_ALPHA_FOCUS = 0.40
+const HIGHLIGHT_WIDTH = 5.0
+const HIGHLIGHT_WIDTH_FOCUS = 10.0
+
+var _highlight_ids: Array = []
+var _focus_id: String = ""
+
 func _ready() -> void:
 	name = "CardActionOverlay"
 	z_index = 40
@@ -19,8 +35,29 @@ func _ready() -> void:
 		mm.card_action_state_changed.connect(refresh)
 	refresh()
 
+## Outline these terrain areas on the board. `focus_id` (optional) is drawn
+## brighter — the dialog passes the row the player is hovering.
+func highlight_terrain_areas(ids: Array, focus_id: String = "") -> void:
+	_highlight_ids = []
+	for i in ids:
+		_highlight_ids.append(str(i))
+	_focus_id = str(focus_id)
+	refresh()
+
+func clear_terrain_area_highlights() -> void:
+	if _highlight_ids.is_empty() and _focus_id == "":
+		return
+	_highlight_ids = []
+	_focus_id = ""
+	refresh()
+
 func refresh() -> void:
+	# remove_child BEFORE queue_free: a queued-but-still-parented child keeps
+	# its name reserved for the rest of the frame, so re-adding "Badge_<id>"
+	# in the same refresh would silently land as "@Label@1234" and every
+	# lookup by name (scenarios, callers) would miss it.
 	for child in get_children():
+		remove_child(child)
 		child.queue_free()
 	if GameConstants.edition < 11:
 		return
@@ -28,6 +65,33 @@ func refresh() -> void:
 	var tm = get_node_or_null("/root/TerrainManager")
 	if mm == null or tm == null:
 		return
+
+	# Candidate outlines first so the badge labels below stay legible on top.
+	for feature in tm.terrain_features:
+		var hid = str(feature.get("id", ""))
+		if hid == "" or not hid in _highlight_ids:
+			continue
+		var polygon = feature.get("polygon", PackedVector2Array())
+		if polygon.size() < 3:
+			continue
+		var focused: bool = hid == _focus_id
+
+		var fill = Polygon2D.new()
+		fill.name = "Highlight_%s" % hid
+		fill.polygon = polygon
+		fill.color = Color(HIGHLIGHT_COLOR.r, HIGHLIGHT_COLOR.g, HIGHLIGHT_COLOR.b,
+			HIGHLIGHT_FILL_ALPHA_FOCUS if focused else HIGHLIGHT_FILL_ALPHA)
+		add_child(fill)
+
+		var outline = Line2D.new()
+		outline.name = "HighlightEdge_%s" % hid
+		var closed = PackedVector2Array(polygon)
+		closed.append(polygon[0])
+		outline.points = closed
+		outline.width = HIGHLIGHT_WIDTH_FOCUS if focused else HIGHLIGHT_WIDTH
+		outline.default_color = HIGHLIGHT_COLOR
+		add_child(outline)
+
 	for feature in tm.terrain_features:
 		var fid = str(feature.get("id", ""))
 		if fid == "":

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -955,15 +955,40 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 	content.add_child(HSeparator.new())
 
 	var desc = Label.new()
+	desc.name = "Description"
 	desc.text = str(pending.get("description", ""))
 	desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	content.add_child(desc)
+
+	# Optional scoring crib — the mission cards are terse and players cannot
+	# see the card while this dialog is up.
+	if str(pending.get("help", "")) != "":
+		var help = Label.new()
+		help.name = "HelpText"
+		help.text = str(pending.get("help", ""))
+		help.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		help.add_theme_font_size_override("font_size", 13)
+		help.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
+		content.add_child(help)
 	content.add_child(HSeparator.new())
 
 	# Double-fire guard shared by target buttons / confirm / skip / cancel
 	var resolved = [false]
 	var multi_mode: bool = str(pending.get("mode", "single")) == "multi"
 	var checkboxes: Array = []
+	# Terrain-area actions (Booby Trap) light their candidates up on the board:
+	# a list of ids alone never told the player which footprint was which.
+	var highlights_terrain: bool = str(pending.get("highlight_kind", "")) == "terrain_area"
+	var all_target_ids: Array = []
+	for t in pending.get("targets", []):
+		all_target_ids.append(str(t.get("id", "")))
+	if highlights_terrain:
+		_set_terrain_area_highlight(all_target_ids)
+
+	# max_picks caps a multi action whose uses are limited (Booby Trap needs a
+	# distinct unit per area). Absent/0 means "no cap" — Decoy et al.
+	var max_picks: int = int(pending.get("max_picks", 0))
+	var default_selected = pending.get("default_selected", null)
 
 	for target in pending.get("targets", []):
 		var tid: String = str(target.get("id", ""))
@@ -973,9 +998,14 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 			check.name = "Check_%s" % tid
 			check.text = tlabel
 			# Default all-selected mirrors the auto-resolve (Decoy/Extract
-			# Intelligence place on every eligible objective).
-			check.button_pressed = true
+			# Intelligence place on every eligible objective). Cards that cap
+			# their own uses send an explicit default_selected instead.
+			check.button_pressed = tid in default_selected if default_selected is Array else true
 			check.set_meta("target_id", tid)
+			if highlights_terrain:
+				check.mouse_entered.connect(func(): _set_terrain_area_highlight(all_target_ids, tid))
+				check.focus_entered.connect(func(): _set_terrain_area_highlight(all_target_ids, tid))
+				check.mouse_exited.connect(func(): _set_terrain_area_highlight(all_target_ids))
 			content.add_child(check)
 			checkboxes.append(check)
 		else:
@@ -986,6 +1016,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 				if resolved[0]:
 					return
 				resolved[0] = true
+				_set_terrain_area_highlight([])
 				emit_signal("scoring_action_requested", {
 					"type": "RESOLVE_CARD_ACTION",
 					"targets": [tid],
@@ -996,6 +1027,18 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 			content.add_child(btn)
 
 	content.add_child(HSeparator.new())
+
+	# Over-selection notice for capped multi actions (Booby Trap): every trap
+	# needs its own unit, so ticking a fourth area with three units available
+	# has to be refused BEFORE the resolve rejects the whole action.
+	var cap_notice = Label.new()
+	cap_notice.name = "CapNotice"
+	cap_notice.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	cap_notice.add_theme_font_size_override("font_size", 13)
+	cap_notice.add_theme_color_override("font_color", Color(1.0, 0.45, 0.35))
+	cap_notice.visible = false
+	content.add_child(cap_notice)
+
 	var button_row = HBoxContainer.new()
 	button_row.name = "Actions"
 	button_row.alignment = BoxContainer.ALIGNMENT_CENTER
@@ -1006,6 +1049,22 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 		confirm_btn.name = "ConfirmCardAction"
 		confirm_btn.text = "Confirm Selection"
 		confirm_btn.custom_minimum_size = Vector2(170, 36)
+		var sync_cap = func():
+			if max_picks <= 0:
+				return
+			var ticked = 0
+			for check in checkboxes:
+				if is_instance_valid(check) and check.button_pressed:
+					ticked += 1
+			var over = ticked > max_picks
+			cap_notice.visible = over
+			if over:
+				cap_notice.text = "You have %d unit(s) able to do this — untick %d area(s)." % [
+					max_picks, ticked - max_picks]
+			confirm_btn.disabled = over
+		for check in checkboxes:
+			check.toggled.connect(func(_pressed): sync_cap.call())
+		sync_cap.call()
 		confirm_btn.pressed.connect(func():
 			if resolved[0]:
 				return
@@ -1014,6 +1073,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 			for check in checkboxes:
 				if is_instance_valid(check) and check.button_pressed:
 					picks.append(str(check.get_meta("target_id")))
+			_set_terrain_area_highlight([])
 			emit_signal("scoring_action_requested", {
 				"type": "RESOLVE_CARD_ACTION",
 				"targets": picks,
@@ -1031,6 +1091,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 		if resolved[0]:
 			return
 		resolved[0] = true
+		_set_terrain_area_highlight([])
 		emit_signal("scoring_action_requested", {
 			"type": "SKIP_CARD_ACTION",
 			"player": player,
@@ -1045,6 +1106,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 		if resolved[0]:
 			return
 		resolved[0] = true
+		_set_terrain_area_highlight([])
 		emit_signal("scoring_action_requested", {
 			"type": "SKIP_CARD_ACTION",
 			"player": player,
@@ -1055,6 +1117,17 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 	dialog.add_child(content)
 	get_tree().root.add_child(dialog)
 	DialogUtils.popup_at_bottom(dialog, DialogConstants.MEDIUM)
+
+## Light the candidate terrain areas up on the board while a terrain-targeting
+## card action (Booby Trap) is being picked. An empty list clears them.
+func _set_terrain_area_highlight(ids: Array, focus_id: String = "") -> void:
+	var overlay = get_tree().root.get_node_or_null("Main/BoardRoot/CardActionOverlay")
+	if overlay == null or not overlay.has_method("highlight_terrain_areas"):
+		return
+	if ids.is_empty():
+		overlay.clear_terrain_area_highlights()
+	else:
+		overlay.highlight_terrain_areas(ids, focus_id)
 
 func _recheck_card_action() -> void:
 	# After resolve/skip the gate should be down — finish the turn the player

--- a/40k/scripts/ScoringController.gd
+++ b/40k/scripts/ScoringController.gd
@@ -970,12 +970,7 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 		help.add_theme_font_size_override("font_size", 13)
 		help.add_theme_color_override("font_color", WhiteDwarfTheme.WH_GOLD)
 		content.add_child(help)
-	content.add_child(HSeparator.new())
 
-	# Double-fire guard shared by target buttons / confirm / skip / cancel
-	var resolved = [false]
-	var multi_mode: bool = str(pending.get("mode", "single")) == "multi"
-	var checkboxes: Array = []
 	# Terrain-area actions (Booby Trap) light their candidates up on the board:
 	# a list of ids alone never told the player which footprint was which.
 	var highlights_terrain: bool = str(pending.get("highlight_kind", "")) == "terrain_area"
@@ -984,6 +979,21 @@ func _show_card_action_dialog(pending: Dictionary, player: int) -> void:
 		all_target_ids.append(str(t.get("id", "")))
 	if highlights_terrain:
 		_set_terrain_area_highlight(all_target_ids)
+		# Say out loud what the orange on the board means — the outlines are
+		# useless as a cue if the player does not connect them to these rows.
+		var hint = Label.new()
+		hint.name = "HighlightHint"
+		hint.text = "Every area you can trap is outlined in orange on the board. Point at a row below (or tab to it) and that area lights up brighter, so you can see exactly which footprint it is."
+		hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		hint.add_theme_font_size_override("font_size", 13)
+		hint.add_theme_color_override("font_color", CardActionOverlay.HIGHLIGHT_COLOR)
+		content.add_child(hint)
+	content.add_child(HSeparator.new())
+
+	# Double-fire guard shared by target buttons / confirm / skip / cancel
+	var resolved = [false]
+	var multi_mode: bool = str(pending.get("mode", "single")) == "multi"
+	var checkboxes: Array = []
 
 	# max_picks caps a multi action whose uses are limited (Booby Trap needs a
 	# distinct unit per area). Absent/0 means "no cap" — Decoy et al.

--- a/40k/tests/scenarios/sp/iss064j_booby_trap_areas_11e.json
+++ b/40k/tests/scenarios/sp/iss064j_booby_trap_areas_11e.json
@@ -1,0 +1,243 @@
+{
+  "id": "iss064j_booby_trap_areas_11e",
+  "covers": [
+    "missions.primary_11e.booby_trap_areas",
+    "missions.primary_11e.card_action_prompt"
+  ],
+  "fixture": "audit_374_kunnin",
+  "edition": 11,
+  "rng_seed": 42,
+  "transition_to_phase": 11,
+  "disable_ai": true,
+  "description": "Death Trap / Booby Trap targets are TERRAIN AREAS (11e core rules 13.01) — the marked footprints scenery stands in, not each wall or crate inside them. Drives the real End Turn button into the CardActionDialog and proves: only piece_class 'area' footprints are offered (the 28 feature pieces are not), every row is a human-readable label naming board position and VP value, the candidates are outlined on the board and brighten on hover, and several units can each trap an area in the same turn.",
+  "steps": [
+    {
+      "act": "wait_seconds",
+      "seconds": 0.5
+    },
+    {
+      "act": "expect_state",
+      "path": "meta.phase",
+      "equals": 11
+    },
+    {
+      "act": "execute_script",
+      "script": "GameState.state[\"meta\"].merge({\"game_config\": {\"deployment\": \"sweeping_engagement\", \"player1_disposition\": \"take_and_hold\", \"player2_disposition\": \"disruption\"}}, true)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "TerrainManager.load_terrain_layout(\"take_and_hold_vs_disruption_1\")\nMissionManager.check_all_objectives()\nvar areas = 0\nvar feats = 0\nfor p in TerrainManager.terrain_features:\n\tif str(p.get(\"piece_class\", \"\")) == \"area\":\n\t\tareas += 1\n\telse:\n\t\tfeats += 1\nreturn \"%d areas / %d features\" % [areas, feats]",
+      "equals": "16 areas / 28 features"
+    },
+    {
+      "act": "execute_script",
+      "script": "MissionManager.initialize_mission(\"take_and_hold\")"
+    },
+    {
+      "act": "execute_script",
+      "script": "MissionManager.get_primary_mission_for_player(2)[\"id\"]",
+      "equals": "death_trap"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var want = [\"area-large-9\", \"area-medium-15\"]\nvar centres = {}\nfor p in TerrainManager.terrain_features:\n\tvar pid = str(p.get(\"id\", \"\"))\n\tif pid in want:\n\t\tvar poly = p.get(\"polygon\", PackedVector2Array())\n\t\tvar acc = Vector2.ZERO\n\t\tfor v in poly:\n\t\t\tacc += v\n\t\tcentres[pid] = acc / max(1, poly.size())\nvar picked = []\nfor uid in GameState.state.units:\n\tvar u = GameState.state.units[uid]\n\tif int(u.get(\"owner\", 0)) != 2:\n\t\tcontinue\n\tif u.get(\"embarked_in\", null) != null and str(u.get(\"embarked_in\", \"\")) != \"\":\n\t\tcontinue\n\tvar live = false\n\tfor m in u.get(\"models\", []):\n\t\tif m.get(\"alive\", true) and m.get(\"position\") != null:\n\t\t\tlive = true\n\tif live:\n\t\tpicked.append(str(uid))\n\tif picked.size() >= 2:\n\t\tbreak\nvar moved = 0\nfor i in range(min(picked.size(), want.size())):\n\tvar c = centres.get(want[i], null)\n\tif c == null:\n\t\tcontinue\n\tfor m in GameState.state.units[picked[i]][\"models\"]:\n\t\tif m.get(\"alive\", true):\n\t\t\tm[\"position\"] = {\"x\": c.x, \"y\": c.y}\n\tmoved += 1\nreturn moved",
+      "equals": 2
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var ids = []\nfor e in MissionManager.get_booby_trap_candidates_11e(2):\n\tids.append(str(e[\"id\"]))\nreturn ids",
+      "equals": [
+        "area-large-10",
+        "area-large-9",
+        "area-medium-15",
+        "area-medium-16"
+      ]
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "for e in MissionManager.get_booby_trap_candidates_11e(2):\n\tvar pc = \"\"\n\tfor p in TerrainManager.terrain_features:\n\t\tif str(p.get(\"id\", \"\")) == str(e[\"id\"]):\n\t\t\tpc = str(p.get(\"piece_class\", \"\"))\n\tif pc != \"area\":\n\t\treturn false\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "MissionManager.on_turn_start_11e(2)"
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "GameState.state[\"meta\"][\"active_player\"] = 2\nreturn int(GameState.state[\"meta\"][\"active_player\"])",
+      "equals": 2
+    },
+    {
+      "act": "click_node",
+      "node": "/root/Main/PhaseActionButton",
+      "emit_pressed": true
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var d = tree.current_scene._phase_end_confirm\nif d != null and d.visible:\n\td.get_ok_button().pressed.emit()\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.8
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/CardActionDialog",
+      "timeout_s": 3.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/CardActionDialog/Content/Check_area-large-9",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/CardActionDialog/Content/Check_area-medium-15",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var names = []\nfor c in tree.root.get_node(\"CardActionDialog/Content\").get_children():\n\tif str(c.name).begins_with(\"Check_\"):\n\t\tnames.append(str(c.name).replace(\"Check_\", \"\"))\nreturn names.size()",
+      "equals": 4
+    },
+    {
+      "act": "execute_script",
+      "script": "\"5 VP\" in main.get_tree().root.get_node(\"CardActionDialog/Content/Check_area-large-9\").text",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"CardActionDialog/Content/Check_area-large-9\").text"
+    },
+    {
+      "act": "execute_script",
+      "script": "\"2 VP\" in main.get_tree().root.get_node(\"CardActionDialog/Content/Check_area-medium-15\").text",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_tree().root.get_node(\"CardActionDialog/Content/Check_area-large-9\").text != \"area-large-9\"",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "\"terrain area\" in main.get_tree().root.get_node(\"CardActionDialog/Content/Description\").text.to_lower()",
+      "equals": true
+    },
+    {
+      "act": "execute_script",
+      "script": "\"5 VP\" in main.get_tree().root.get_node(\"CardActionDialog/Content/HelpText\").text",
+      "equals": true
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/BoardRoot/CardActionOverlay/Highlight_area-large-9",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/Main/BoardRoot/CardActionOverlay/Highlight_area-medium-15",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var n = 0\nfor c in tree.current_scene.get_node(\"BoardRoot/CardActionOverlay\").get_children():\n\tif str(c.name).begins_with(\"Highlight_\"):\n\t\tn += 1\nreturn n",
+      "equals": 4
+    },
+    {
+      "act": "screenshot",
+      "label": "01_booby_trap_dialog_areas_highlighted"
+    },
+    {
+      "act": "screenshot",
+      "label": "01b_board_closeup_highlighted",
+      "region": [
+        695,
+        175,
+        535,
+        360
+      ]
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "tree.root.get_node(\"CardActionDialog/Content/Check_area-large-9\").grab_focus()\nreturn true",
+      "equals": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 0.4
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/CardActionOverlay/HighlightEdge_area-large-9\").width",
+      "equals": 10.0
+    },
+    {
+      "act": "execute_script",
+      "script": "main.get_node(\"BoardRoot/CardActionOverlay/HighlightEdge_area-medium-15\").width",
+      "equals": 5.0
+    },
+    {
+      "act": "screenshot",
+      "label": "02_hovered_area_brightened"
+    },
+    {
+      "act": "screenshot",
+      "label": "02b_board_closeup_hovered",
+      "region": [
+        695,
+        175,
+        535,
+        360
+      ]
+    },
+    {
+      "act": "click_node",
+      "node": "/root/CardActionDialog/Content/Actions/ConfirmCardAction",
+      "emit_pressed": true
+    },
+    {
+      "act": "wait_seconds",
+      "seconds": 1.0
+    },
+    {
+      "act": "execute_script",
+      "script": "MissionManager._primary_state_11e[\"2\"][\"trapped\"].size()",
+      "equals": 4
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "var n = 0\nfor c in tree.current_scene.get_node(\"BoardRoot/CardActionOverlay\").get_children():\n\tif str(c.name).begins_with(\"Highlight_\"):\n\t\tn += 1\nreturn n",
+      "equals": 0
+    },
+    {
+      "act": "execute_script",
+      "script": "var b = tree.current_scene.get_node_or_null(\"BoardRoot/CardActionOverlay/Badge_area-large-9\")\nif b == null:\n\treturn \"MISSING\"\nreturn str(b.text)",
+      "multiline": true
+    },
+    {
+      "act": "screenshot",
+      "label": "03_trapped_areas_badged_on_board"
+    },
+    {
+      "act": "execute_script",
+      "script": "\"BOOBY TRAP (P2)\" in main.get_node(\"BoardRoot/CardActionOverlay/Badge_area-large-9\").text",
+      "equals": true
+    },
+    {
+      "act": "screenshot",
+      "label": "03_trapped_areas_badged_on_board"
+    }
+  ]
+}

--- a/40k/tests/scenarios/sp/iss064j_booby_trap_areas_11e.json
+++ b/40k/tests/scenarios/sp/iss064j_booby_trap_areas_11e.json
@@ -9,7 +9,7 @@
   "rng_seed": 42,
   "transition_to_phase": 11,
   "disable_ai": true,
-  "description": "Death Trap / Booby Trap targets are TERRAIN AREAS (11e core rules 13.01) — the marked footprints scenery stands in, not each wall or crate inside them. Drives the real End Turn button into the CardActionDialog and proves: only piece_class 'area' footprints are offered (the 28 feature pieces are not), every row is a human-readable label naming board position and VP value, the candidates are outlined on the board and brighten on hover, and several units can each trap an area in the same turn.",
+  "description": "Death Trap / Booby Trap targets are TERRAIN AREAS (11e core rules 13.01) — the marked footprints scenery stands in, not each wall or crate inside them. Drives the real End Turn button into the CardActionDialog and proves: only piece_class 'area' footprints are offered (the 28 feature pieces are not), every row is a human-readable label naming board position and VP value, the candidates are outlined on the board and brighten on hover, with an in-dialog line telling the player that is what the orange means, and several units can each trap an area in the same turn.",
   "steps": [
     {
       "act": "wait_seconds",
@@ -135,6 +135,16 @@
     {
       "act": "execute_script",
       "script": "\"5 VP\" in main.get_tree().root.get_node(\"CardActionDialog/Content/HelpText\").text",
+      "equals": true
+    },
+    {
+      "act": "expect_node_visible",
+      "node": "/root/CardActionDialog/Content/HighlightHint",
+      "timeout_s": 2.0
+    },
+    {
+      "act": "execute_script",
+      "script": "\"outlined in orange\" in main.get_tree().root.get_node(\"CardActionDialog/Content/HighlightHint\").text",
       "equals": true
     },
     {

--- a/40k/tests/test_card_action_prompts_11e.gd
+++ b/40k/tests/test_card_action_prompts_11e.gd
@@ -321,6 +321,90 @@ func _run_tests():
 		mgr._relic_setup_prompt_pending == true)
 	tm.terrain_features = saved_features
 
+	print("\n-- Death Trap: Booby Trap targets are terrain AREAS, one per unit --")
+	# 11e core rules 13.01: a terrain AREA is the boundary/footprint the scenery
+	# stands in. GW layouts put several terrain FEATURES inside one area marker,
+	# so only the area footprints are trappable.
+	var dt_saved = tm.terrain_features
+	var dt_pos = _obj_position(nml)
+	var ox = float(dt_pos.x)
+	var oy = float(dt_pos.y)
+	var dt_area_a = PackedVector2Array([Vector2(ox - 100, oy - 100), Vector2(ox + 100, oy - 100),
+		Vector2(ox + 100, oy + 100), Vector2(ox - 100, oy + 100)])
+	var dt_area_b = PackedVector2Array([Vector2(ox + 500, oy - 100), Vector2(ox + 700, oy - 100),
+		Vector2(ox + 700, oy + 100), Vector2(ox + 500, oy + 100)])
+	tm.terrain_features = [
+		{"id": "area-large-1", "piece_class": "area", "type": "ruins",
+			"position": Vector2(ox, oy), "polygon": dt_area_a},
+		{"id": "area-medium-2", "piece_class": "area", "type": "ruins",
+			"position": Vector2(ox + 600, oy), "polygon": dt_area_b},
+		# Scenery standing INSIDE area-medium-2 — a terrain feature, not an area.
+		{"id": "barricade-3", "piece_class": "feature", "type": "barricade",
+			"position": Vector2(ox + 600, oy),
+			"polygon": PackedVector2Array([Vector2(ox + 580, oy - 20), Vector2(ox + 620, oy - 20),
+				Vector2(ox + 620, oy + 20), Vector2(ox + 580, oy + 20)])},
+	]
+	mgr.initialize_dispositions_11e("take_and_hold", "disruption")
+	_check("P2 plays Death Trap", mgr.get_primary_mission_for_player(2).get("id", "") == "death_trap")
+	_spawn_unit("U_DT1", 2, {"x": ox, "y": oy})
+	_spawn_unit("U_DT2", 2, {"x": ox + 600, "y": oy})
+	var dt_pending = mgr.get_pending_card_action_11e(2)
+	var dt_ids = _target_ids(dt_pending)
+	_check("Booby Trap is multi-pick (unlimited uses per turn)",
+		dt_pending.get("mode", "") == "multi", str(dt_pending.get("mode")))
+	_check("both terrain AREAS offered",
+		"area-large-1" in dt_ids and "area-medium-2" in dt_ids, str(dt_ids))
+	_check("scenery inside an area is NOT separately trappable",
+		not "barricade-3" in dt_ids, str(dt_ids))
+	_check("objective area sorts first", dt_ids.size() > 0 and dt_ids[0] == "area-large-1", str(dt_ids))
+	var dt_label = str(dt_pending.get("targets", [{}])[0].get("label", ""))
+	_check("label is human-readable, not a raw id",
+		dt_label != "area-large-1" and "VP" in dt_label, dt_label)
+	_check("objective area advertises 5 VP", "5 VP" in dt_label, dt_label)
+	_check("max_picks matches the units available",
+		int(dt_pending.get("max_picks", 0)) == 2, str(dt_pending.get("max_picks")))
+	_check("dialog is told to highlight terrain areas",
+		str(dt_pending.get("highlight_kind", "")) == "terrain_area", str(dt_pending.get("highlight_kind")))
+	var dt_res = mgr.resolve_card_action_11e(2, ["area-large-1", "area-medium-2"])
+	_check("two units can trap two areas in the same turn", dt_res.get("success", false), str(dt_res))
+	_check("both areas recorded as trapped this turn",
+		mgr._primary_state_11e["2"].get("trapped_this_turn", []).size() == 2,
+		str(mgr._primary_state_11e["2"].get("trapped_this_turn", [])))
+
+	# A unit only gets one action, so it cannot spring two traps: overlapping
+	# areas with a single occupant must be refused.
+	tm.terrain_features = [
+		{"id": "area-large-1", "piece_class": "area", "type": "ruins",
+			"position": Vector2(ox, oy), "polygon": dt_area_a},
+		{"id": "area-medium-2", "piece_class": "area", "type": "ruins",
+			"position": Vector2(ox, oy), "polygon": dt_area_a},
+	]
+	mgr.initialize_dispositions_11e("take_and_hold", "disruption")
+	gs.state.units.erase("U_DT2")
+	var ov_pending = mgr.get_pending_card_action_11e(2)
+	_check("both overlapping areas are offered", _target_ids(ov_pending).size() == 2,
+		str(_target_ids(ov_pending)))
+	_check("but only one of them can be staffed",
+		int(ov_pending.get("max_picks", 0)) == 1, str(ov_pending.get("max_picks")))
+	var ov_res = mgr.resolve_card_action_11e(2, ["area-large-1", "area-medium-2"])
+	_check("trapping two areas with one unit is refused",
+		not ov_res.get("success", true), str(ov_res))
+	var ov_ok = mgr.resolve_card_action_11e(2, ["area-large-1"])
+	_check("trapping one area with one unit is accepted", ov_ok.get("success", false), str(ov_ok))
+
+	# Legacy/pre-11e layouts author no "area" pieces at all. There every piece
+	# was placed directly on the battlefield (13.01's second method) and so IS
+	# its own terrain area — the area filter must not empty the list.
+	tm.terrain_features = [
+		{"id": "ruins_legacy", "type": "ruins", "position": Vector2(ox, oy), "polygon": dt_area_a},
+	]
+	mgr.initialize_dispositions_11e("take_and_hold", "disruption")
+	var legacy_pending = mgr.get_pending_card_action_11e(2)
+	_check("legacy layout (no area pieces) still offers its terrain",
+		"ruins_legacy" in _target_ids(legacy_pending), str(_target_ids(legacy_pending)))
+	gs.state.units.erase("U_DT1")
+	tm.terrain_features = dt_saved
+
 	print("\n-- Per-unit mission actions: Sabotage / Vanguard / Extract Intel --")
 	var pm = root.get_node_or_null("PhaseManager")
 	_check("PhaseManager present", pm != null)


### PR DESCRIPTION
## Why

The Booby Trap prompt listed raw layout ids (`area-trapezoid-3 (holds an objective)`) and gave players no way to tell which footprint on the table each row referred to. Chasing that down surfaced three rules bugs sitting behind it.

**"Terrain area" is a defined term** in the 11e core rules (13.01, *Placing Terrain*): after listing the three ways to place terrain, the rule says *"In each case, the area of the battlefield occupied by that boundary or terrain feature is known as a terrain area."* GW's matched-play layouts — the ones shipped in `40k/terrain_layouts/` — all use the first of those methods: a flat boundary marker (7"×11.5" rectangles, 8"×11.5" triangles) with several terrain features standing wholly within it. So a layout's trappable terrain areas are its `piece_class: "area"` footprints; the crates, barricades and gantries inside them are terrain *features* and are not separately trappable.

## Rules fixes

- **Loose scenery was trappable.** Target enumeration walked every `TerrainManager` piece. It now filters to area footprints — on the standard layout that is 16 areas rather than 44 pieces — with a fallback for legacy layouts that define no area pieces, since there each piece genuinely *is* its own terrain area (13.01's second method).
- **Booby Trap was capped at one area per turn.** The card allows unlimited uses, one area per acting unit. The prompt is now multi-select, the resolve enforces a distinct unit per trap, and the auto-resolve backstop takes every area it can staff.
- **Objective-to-area matching used point-in-polygon**, which missed markers sitting on a boundary and scored a 5 VP area as 2. It now reads the layout's own `source_pieces` links first (14.01), falling back to geometry for legacy layouts.

## Clarity

- Rows read `Large area — left, enemy territory — holds the Expansion objective (5 VP)` instead of a bare id.
- Candidate areas are outlined in orange on the board while picking, brighter for the hovered/keyboard-focused row — and the dialog says so in as many words, in the same orange, so the outlines aren't left to guesswork.
- The dialog defines what a terrain area is and lists how the mission scores.
- Over-picking is caught inline with a count of available units, before the resolve rejects it.

## Also fixed

A latent `CardActionOverlay` bug: `refresh()` called `queue_free()` on children that stayed parented for the rest of the frame, so re-added `Badge_<id>` nodes silently landed as `@Label@1234` and could not be found by name.

## Testing

- `test_card_action_prompts_11e` — 87 pass (+16 new, covering the area filter, multi-pick, labels, the one-unit-per-trap constraint and the legacy-layout fallback).
- New windowed scenario `iss064j_booby_trap_areas_11e` — 45 pass. Drives the real End Turn button into the dialog and asserts the filtering, labels, help and hint text, board highlights, focus brightening, and the multi-trap resolve.
- No regressions: `test_primary_missions_11e` 56, `test_terrain_area_visibility_11e` 20, `test_secondary_deck_11e` 102.

## Notes for the reviewer

- **Balance shift.** The mission now scores considerably more — the validation run paid P2 **14 VP** in one turn (two objective areas at 5, two plain at 2). That is what the card says, but it is a real change from the old one-trap-per-turn behaviour.
- `iss064h_card_action_visibility_11e` fails 3 of 35 steps (`Badge_ruins_1`/`ruins_2` missing). Verified via `git stash` that it fails identically on `main` — a stale scenario expecting pre-11e terrain ids, left alone as out of scope.
- Mission-specific VP values came from secondary commentary; the core-rules definition of "terrain area" is from Wahapedia's 11e core rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GBEGnUwJrafwZZ7H1aNgm

---
_Generated by [Claude Code](https://claude.ai/code/session_013GBEGnUwJrafwZZ7H1aNgm)_