### PR TITLE
Add the missing .uid for test_vision_map_agreement.gd

### DIFF
--- a/40k/tests/test_vision_map_agreement.gd.uid
+++ b/40k/tests/test_vision_map_agreement.gd.uid
@@ -1,0 +1,1 @@
+uid://cfa4gvcqkdnl


### PR DESCRIPTION
## Why

`40k/tests/test_vision_map_agreement.gd` landed without its Godot `.uid` companion. Every editor session or `godot --headless --import` regenerates the file, leaving the working tree dirty for whoever runs it next — which is how it surfaced here.

Committed `.uid` siblings are the convention in this repo: 423 of them against 420 scripts under `40k/tests/`, and nothing in `.gitignore` excludes them.

## What

One generated file, produced by `godot --headless --import` rather than written by hand:

```
40k/tests/test_vision_map_agreement.gd.uid   ->   uid://cfa4gvcqkdnl
```

No code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GBEGnUwJrafwZZ7H1aNgm

---
_Generated by [Claude Code](https://claude.ai/code/session_013GBEGnUwJrafwZZ7H1aNgm)_