### PR TITLE
Hermetic scenario settings — and fix the audit-gate red that was masking the windowed suite

### DIFF
--- a/40k/autoloads/RulesEngine.gd
+++ b/40k/autoloads/RulesEngine.gd
@@ -16192,6 +16192,13 @@ static func apply_damage_to_unit_pool(target_unit_id: String, total_damage: int,
 static func get_model_by_id(unit: Dictionary, model_id: String) -> Dictionary:
 	return _get_model_by_id(unit, model_id)
 
+## SPLIT-FIRE / PER-MODEL LOS+RANGE: the subset of `model_ids` still eligible
+## to fire weapon_id at target_unit_id ({kept, dropped, reasons}) — the same
+## resolve-time filter the engine applies, so UI previews (the blocked-bearers
+## panel) agree with which models will actually shoot.
+static func filter_eligible_model_ids(model_ids: Array, actor_unit_id: String, weapon_id: String, target_unit_id: String, board: Dictionary) -> Dictionary:
+	return _filter_eligible_model_ids(model_ids, actor_unit_id, weapon_id, target_unit_id, board)
+
 ## Legacy center-to-center LoS check (debug/visualization only).
 static func check_legacy_line_of_sight(from_pos: Vector2, to_pos: Vector2, board: Dictionary) -> bool:
 	return _check_legacy_line_of_sight(from_pos, to_pos, board)

--- a/40k/autoloads/ScenarioRunner.gd
+++ b/40k/autoloads/ScenarioRunner.gd
@@ -27,8 +27,95 @@ var _step_results: Array = []
 var _last_action_result = null
 var _start_cp: Dictionary = {}  # player_id -> cp at scenario start (for delta_from_start)
 var _started: bool = false
+var _hermetic_active: bool = false
 
 const RESULTS_SUBDIR := "test_results/scenarios"
+
+# ============================================================================
+# HERMETIC SETTINGS (2026-08-06)
+#
+# A scenario's result must not depend on the machine it runs on. SettingsService
+# persists user preferences to user://settings.cfg, and several of them change
+# game LOGIC, not just presentation — auto_allocate_wounds decides whether an
+# attack pauses for the defender's save overlay at all. Worse, scenarios that
+# call SettingsService setters mid-run persist the change, poisoning the
+# machine's settings.cfg for every later scenario AND for later suite runs
+# (found 2026-08-06: aao_lions_melee_provenance and friends set
+# auto_allocate_wounds=true and never set it back, which is exactly the
+# settings.cfg state that made ai_shooting_stall_defender_lock fail 7/35).
+#
+# Two guarantees, enforced for every automated harness run (--scenario-file,
+# gut_cmdln, and godot -s test scripts — autoloads are live in all of them):
+#   1. IN:  every setting in HERMETIC_SETTINGS starts at its fresh-install
+#      default (the declared var default in SettingsService.gd), machine
+#      overrides are logged loudly so a failure report is self-diagnosing.
+#   2. OUT: user://settings.cfg is byte-restored to its pre-run state on exit,
+#      so nothing a run persists can leak into the next run or clobber the
+#      developer's real preferences. A stale backup left by a crashed run is
+#      healed at the next startup.
+#
+# A scenario that NEEDS a non-default value must set it itself in a step
+# (e.g. "SettingsService.set_auto_allocate_wounds(true)") — see _schema.md.
+# ============================================================================
+
+const SETTINGS_FILE := "user://settings.cfg"
+const SETTINGS_BACKUP := "user://settings.cfg.scenario_backup"
+const SETTINGS_ABSENT_MARKER := "<<no settings.cfg existed before this run>>"
+
+# Every persisted SettingsService value that can change what a scenario or a
+# headless test observes: rules flow, UI flow, input geometry, save side
+# effects, and board/token visuals that scenarios assert on.
+#
+# Deliberately NOT pinned:
+#   - input_mode_policy: InputDeviceManager pins the harness to "dynamic"
+#     itself; re-applying the player default ("auto") would resolve and LOCK
+#     kbm and break every pad_* scenario.
+#   - window_mode / window_resolution / vsync_enabled: SettingsService's
+#     _apply_display_settings() already no-ops under the harness.
+#   - controller_text_boost: _pad_text_boost_active() is already false under
+#     --scenario-file.
+#   - master/music/sfx volume, audio_muted: inaudible to assertions; CI runs
+#     the Dummy audio driver.
+const HERMETIC_SETTINGS: Array[String] = [
+	# Gameplay / rules flow
+	"auto_allocate_wounds",
+	"shooting_pause_policy",
+	"shooting_show_all_units",
+	"hotseat_handoff_enabled",
+	# Input-driven placement behaviour (where dragged/placed models land)
+	"drag_clamp_to_max_range",
+	"placement_clamp_to_exclusion",
+	# Timing / canvas geometry
+	"animation_speed",
+	"ui_scale",
+	# Save/load side effects
+	"save_files_pretty_print",
+	"save_files_compression",
+	"save_measurements",
+	"autosave_on_round_end",
+	"autosave_on_phase_transition",
+	"autosave_on_phase_start",
+	# Board/token visuals that scenarios assert on
+	"unit_visual_style",
+	"unit_color_display_mode",
+	"retro_mode",
+	"show_unit_labels",
+	"terrain_debug_labels",
+	"show_terrain_scatter",
+	"show_terrain_cover_labels",
+	"los_debug_check_out_of_range",
+	"board_style",
+	"ruins_style",
+	"colorblind_mode",
+	# Controls that alter scenario input math
+	"menu_scroll_speed",
+	"pad_invert_camera_y",
+	"pad_swap_sticks",
+	"pad_camera_sensitivity",
+	"pad_cursor_sensitivity",
+	"pad_cursor_magnetism",
+	"pad_hover_stats_card",
+]
 
 
 func _ready() -> void:
@@ -39,13 +126,131 @@ func _ready() -> void:
 			_scenario_path = a.split("=", true, 1)[1]
 			break
 
+	# Crash healing: a previous harness run that died mid-scenario may have left
+	# its settings.cfg backup behind (with mid-run values still on disk). Put
+	# the machine file back before anything else reads or writes it. No-op when
+	# no backup exists, so normal player launches are unaffected.
+	_heal_stale_settings_backup()
+
 	if _scenario_path == "":
-		return  # not in scenario mode — no-op autoload
+		# Not in scenario mode. The headless test harnesses (gut_cmdln /
+		# godot -s tests/…) run with live autoloads too, and are exposed to the
+		# same ambient-settings hazard — give them the same hermetic guarantee.
+		if _is_cmdline_test_harness():
+			_hermetic_settings_setup()
+		return  # otherwise: normal play — no-op autoload
 
 	print("[ScenarioRunner] Activating, scenario_file=%s" % _scenario_path)
+	_hermetic_settings_setup()
 	# Defer to next idle frame so other autoloads (GameState, SaveLoadManager,
 	# PhaseManager, etc.) finish their _ready before we touch them.
 	call_deferred("_kick_off")
+
+
+func _exit_tree() -> void:
+	# Runs on get_tree().quit() for every exit path (all-pass, step failures,
+	# _fail_and_quit) — the single choke point that guarantees the machine's
+	# settings.cfg leaves a harness run exactly as it entered it.
+	if _hermetic_active:
+		_restore_settings_file()
+
+
+func _is_cmdline_test_harness() -> bool:
+	# Mirrors SettingsService._is_automated_harness() for the NON-scenario
+	# harnesses: the GUT suite (gut_cmdln) and direct script runs
+	# (godot -s tests/test_*.gd). Scenario mode is detected separately via
+	# --scenario-file in _ready. A normal player launch never passes these.
+	for a in OS.get_cmdline_args() + OS.get_cmdline_user_args():
+		if typeof(a) != TYPE_STRING:
+			continue
+		if a.find("gut_cmdln") != -1 or a == "-s" or a == "--script":
+			return true
+	return false
+
+
+func _hermetic_settings_setup() -> void:
+	# See the HERMETIC SETTINGS block at the top of this file.
+	var ss = get_node_or_null("/root/SettingsService")
+	if ss == null:
+		return
+	_backup_settings_file()
+	_hermetic_active = true
+	# Fresh-install defaults come from a throwaway instance of the script
+	# itself (its _ready never runs), so this can never drift from the declared
+	# var defaults in SettingsService.gd.
+	var fresh = (ss.get_script() as GDScript).new()
+	var overrides := 0
+	for prop in HERMETIC_SETTINGS:
+		if not (prop in fresh):
+			push_warning("[ScenarioRunner] HERMETIC_SETTINGS names unknown property '%s' — skipped" % prop)
+			continue
+		var machine_val = ss.get(prop)
+		var default_val = fresh.get(prop)
+		if machine_val != default_val:
+			overrides += 1
+			print("[ScenarioRunner] HERMETIC: %s machine value %s -> fresh-install default %s" % [prop, machine_val, default_val])
+		ss.set(prop, default_val)
+	fresh.free()
+	# Re-push the few consumers that cached machine values during their own
+	# _ready (everything else reads SettingsService at decision time).
+	ss._apply_ui_scale()
+	if StateSerializer:
+		StateSerializer.set_pretty_print(ss.save_files_pretty_print)
+		StateSerializer.set_compression_enabled(ss.save_files_compression)
+	if MeasuringTapeManager:
+		MeasuringTapeManager.set_save_persistence(ss.save_measurements)
+	if SaveLoadManager:
+		SaveLoadManager.set_autosave_on_round_end(ss.autosave_on_round_end)
+		SaveLoadManager.set_autosave_on_phase_transition(ss.autosave_on_phase_transition)
+		SaveLoadManager.set_autosave_on_phase_start(ss.autosave_on_phase_start)
+	if ScrollSpeedController:
+		ScrollSpeedController.menu_scroll_speed = ss.menu_scroll_speed
+	print("[ScenarioRunner] settings hermetic: %d value(s) pinned to fresh-install defaults (%d machine override(s) neutralised); settings.cfg backed up, byte-restored on exit" % [HERMETIC_SETTINGS.size(), overrides])
+
+
+func _heal_stale_settings_backup() -> void:
+	if not FileAccess.file_exists(SETTINGS_BACKUP):
+		return
+	print("[ScenarioRunner] stale settings backup from a crashed harness run found — restoring the machine's settings.cfg")
+	_restore_settings_file()
+
+
+func _backup_settings_file() -> void:
+	var backup := FileAccess.open(SETTINGS_BACKUP, FileAccess.WRITE)
+	if backup == null:
+		print("[ScenarioRunner] WARNING: could not create settings backup at %s — machine settings.cfg will NOT be restored after this run" % SETTINGS_BACKUP)
+		return
+	if FileAccess.file_exists(SETTINGS_FILE):
+		var src := FileAccess.open(SETTINGS_FILE, FileAccess.READ)
+		if src != null:
+			backup.store_buffer(src.get_buffer(src.get_length()))
+			src.close()
+	else:
+		backup.store_string(SETTINGS_ABSENT_MARKER)
+	backup.close()
+
+
+func _restore_settings_file() -> void:
+	# Put user://settings.cfg back exactly as the run found it (byte-for-byte),
+	# then drop the backup. Idempotent — a second call is a no-op.
+	if not FileAccess.file_exists(SETTINGS_BACKUP):
+		return
+	var backup := FileAccess.open(SETTINGS_BACKUP, FileAccess.READ)
+	if backup == null:
+		return
+	var bytes := backup.get_buffer(backup.get_length())
+	backup.close()
+	if bytes.get_string_from_utf8() == SETTINGS_ABSENT_MARKER:
+		if FileAccess.file_exists(SETTINGS_FILE):
+			DirAccess.remove_absolute(ProjectSettings.globalize_path(SETTINGS_FILE))
+		print("[ScenarioRunner] settings.cfg removed on exit (none existed before this run)")
+	else:
+		var dst := FileAccess.open(SETTINGS_FILE, FileAccess.WRITE)
+		if dst != null:
+			dst.store_buffer(bytes)
+			dst.close()
+		print("[ScenarioRunner] settings.cfg byte-restored to its pre-run machine state")
+	DirAccess.remove_absolute(ProjectSettings.globalize_path(SETTINGS_BACKUP))
 
 
 func _kick_off() -> void:
@@ -252,6 +457,11 @@ func _run_scenario() -> void:
 	if selector_dry_run:
 		_write_selectors_report(scenario_id, passed, failed)
 	_write_results(scenario_id, passed, failed)
+	# Hermetic OUT-guarantee: hand the machine its settings.cfg back before the
+	# summary line, so the log shows the restore happened. (_exit_tree would
+	# also catch this; the call is idempotent.)
+	if _hermetic_active:
+		_restore_settings_file()
 	print("[ScenarioRunner] === %s: %d passed, %d failed ===" % [scenario_id, passed, failed])
 	emit_signal("scenario_finished", scenario_id, passed, failed)
 	get_tree().quit(0 if failed == 0 else 1)
@@ -2365,4 +2575,6 @@ func _write_results(scenario_id: String, passed: int, failed: int) -> void:
 
 func _fail_and_quit(reason: String) -> void:
 	print("[ScenarioRunner] FATAL: %s" % reason)
+	if _hermetic_active:
+		_restore_settings_file()
 	get_tree().quit(2)

--- a/40k/phases/FightPhase.gd
+++ b/40k/phases/FightPhase.gd
@@ -1491,6 +1491,8 @@ func _should_stage_fight(action: Dictionary, interactive_saves: bool = true) -> 
 ## to call from `fighting_begun` (confirmed_attacks is already populated).
 func fight_activation_will_stage() -> bool:
 	var ss = get_node_or_null("/root/SettingsService")
+	# (null service == stripped headless harness -> auto-allocate, same as
+	# _process_roll_dice above and ShootingPhase._should_pause_for_human_saves.)
 	var auto_alloc: bool = ss == null or ss.get_auto_allocate_wounds()
 	if NetworkManager.is_networked():
 		auto_alloc = false

--- a/40k/phases/ShootingPhase.gd
+++ b/40k/phases/ShootingPhase.gd
@@ -3031,8 +3031,14 @@ func _should_pause_for_human_saves(save_data_list: Array) -> bool:
 		return false
 	if not _is_player_human(_defending_player_for_save_data(save_data_list)):
 		return false
+	# (null SettingsService only happens in stripped headless harnesses — treat
+	# it as auto-allocate so engine-level tests keep one-shot resolution and
+	# nothing waits for an APPLY_SAVES that no overlay will ever send. Same
+	# fallback, for the same reason, as FightPhase._process_roll_dice and
+	# FightPhase.fight_activation_will_stage; in a real game the autoload
+	# always exists and the player's setting decides.)
 	var ss = get_node_or_null("/root/SettingsService")
-	var auto_alloc: bool = ss != null and ss.get_auto_allocate_wounds()
+	var auto_alloc: bool = ss == null or ss.get_auto_allocate_wounds()
 	return not auto_alloc
 
 # Store the AI shoot context and hand the first save batch to the defender.

--- a/40k/scripts/ShootingController.gd
+++ b/40k/scripts/ShootingController.gd
@@ -6167,7 +6167,7 @@ func _eligible_bearer_slice(weapon_id: String, target_id: String, model_ids: Arr
 	if model_ids.is_empty():
 		return []
 	var board: Dictionary = current_phase.game_state_snapshot if current_phase else GameState.create_snapshot(false)
-	var filtered = RulesEngine._filter_eligible_model_ids(model_ids, active_shooter_id, weapon_id, target_id, board)
+	var filtered = RulesEngine.filter_eligible_model_ids(model_ids, active_shooter_id, weapon_id, target_id, board)
 	var kept: Array = filtered.get("kept", model_ids)
 	var dropped: Array = filtered.get("dropped", [])
 	if not dropped.is_empty():

--- a/40k/tests/scenarios/_schema.md
+++ b/40k/tests/scenarios/_schema.md
@@ -373,6 +373,36 @@ CI runs the multi-peer suite as a separate job
 need Xvfb because the multi-peer subprocesses run `--headless` and the
 network sync is the unit under test, not the UI rendering.
 
+## Hermetic settings (2026-08-06)
+
+A scenario's result must not depend on the machine it runs on. `SettingsService`
+persists user preferences to `user://settings.cfg`, and several change game
+LOGIC, not presentation — `auto_allocate_wounds` decides whether an attack
+pauses for the defender's save overlay at all. The runner therefore guarantees,
+for every harness run (`--scenario-file`, `gut_cmdln`, `godot -s`):
+
+1. **IN**: every setting in `ScenarioRunner.HERMETIC_SETTINGS` starts at its
+   fresh-install default (the declared var default in `SettingsService.gd`).
+   Machine overrides are logged (`[ScenarioRunner] HERMETIC: ...`) so a failure
+   report is self-diagnosing.
+2. **OUT**: `user://settings.cfg` is byte-restored to its pre-run state on
+   every exit path, so a scenario that calls a `SettingsService` setter cannot
+   poison the next scenario or the developer's real preferences. (Before this,
+   `aao_lions_melee_provenance` and friends persisted `auto_allocate_wounds=true`
+   into the machine config and broke `ai_shooting_stall_defender_lock` 7/35.)
+
+A scenario that NEEDS a non-default value must set it itself in a step and,
+ideally, assert it — e.g.
+
+```json
+{ "act": "execute_script", "multiline": true,
+  "script": "SettingsService.set_auto_allocate_wounds(true)\nreturn SettingsService.get_auto_allocate_wounds()",
+  "equals": true }
+```
+
+Do not rely on a value another scenario set, and do not bother restoring at the
+end of the scenario — the runner's exit restore already isolates you.
+
 ## Anti-patterns
 
 - **`dispatch_action` for the player-facing trigger.** If a player would have
@@ -380,6 +410,8 @@ network sync is the unit under test, not the UI rendering.
   (or equivalent) not `dispatch_action`. Past sessions have closed features
   as "verified" using `dispatch_action` only and the player could not
   actually reach the button. See `CLAUDE.md` feature-validation rule.
+- **Inheriting ambient settings.** If your assertions depend on a
+  `SettingsService` value, set it in a step (see "Hermetic settings" above).
 - **Skipping screenshots on UI flows.** A screenshot every 2-3 steps catches
   silent visual regressions and gives a human auditor something to check
   when results look ambiguous.

--- a/40k/tests/scenarios/sp/ai_shooting_stall_defender_lock.json
+++ b/40k/tests/scenarios/sp/ai_shooting_stall_defender_lock.json
@@ -11,7 +11,7 @@
   "rng_seed": 42,
   "transition_to_phase": 8,
   "disable_ai": true,
-  "description": "AI SHOOTING STALL (reported 2026-08-03): the AI's shooting phase froze mid-activation after the human defender took a while to roll saves \u2014 the 'AI is thinking' banner flashed on every watchdog tick and the phase never ended. While an attack is paused on the defender's save allocation the phase used to keep offering RESOLVE_SHOOTING / SELECT_SHOOTER / SKIP_UNIT / END_SHOOTING (active_shooter_id and confirmed_assignments are still populated), so a stray click or AI evaluation re-entered the paused activation: RESOLVE_SHOOTING re-rolled the WHOLE attack behind the defender's back while their overlay still showed the discarded dice, and the second saves_required was deduped away \u2014 after which no save window ever opened again and pending_save_data never drained. This scenario drives the atomic SHOOT that pauses on the defender, asserts the DEFENDER CONTROL LOCK (only APPLY_SAVES on offer, every re-entry action rejected, END_SHOOTING left unlocked as the player's manual escape hatch), then walks the real allocation overlay to Done and asserts the batch drained and the attacker's controls came back.",
+  "description": "AI SHOOTING STALL (reported 2026-08-03): the AI's shooting phase froze mid-activation after the human defender took a while to roll saves \u2014 the 'AI is thinking' banner flashed on every watchdog tick and the phase never ended. While an attack is paused on the defender's save allocation the phase used to keep offering RESOLVE_SHOOTING / SELECT_SHOOTER / SKIP_UNIT / END_SHOOTING (active_shooter_id and confirmed_assignments are still populated), so a stray click or AI evaluation re-entered the paused activation: RESOLVE_SHOOTING re-rolled the WHOLE attack behind the defender's back while their overlay still showed the discarded dice, and the second saves_required was deduped away \u2014 after which no save window ever opened again and pending_save_data never drained. This scenario drives the atomic SHOOT that pauses on the defender, asserts the DEFENDER CONTROL LOCK (only APPLY_SAVES on offer, every re-entry action rejected, END_SHOOTING left unlocked as the player's manual escape hatch), then walks the real allocation overlay to Done and asserts the batch drained and the attacker's controls came back. HERMETIC: the pause under test only exists while auto_allocate_wounds is OFF, so the scenario sets it explicitly instead of inheriting the machine's settings.cfg (2026-08-06: an ambient auto_allocate_wounds=true, left behind by earlier suite runs, auto-rolled the saves and failed 7 of 35 asserts here; ScenarioRunner now also pins fresh-install defaults for every harness run).",
   "steps": [
     {
       "act": "wait_seconds",
@@ -26,6 +26,12 @@
       "act": "execute_script",
       "script": "GameState.set_edition(11)",
       "equals": 11
+    },
+    {
+      "act": "execute_script",
+      "multiline": true,
+      "script": "SettingsService.set_auto_allocate_wounds(false)\nreturn SettingsService.get_auto_allocate_wounds()",
+      "equals": false
     },
     {
       "act": "execute_script",


### PR DESCRIPTION
## Finding 1 — `ai_shooting_stall_defender_lock` failed 7/35 on machines with ambient settings

`ShootingPhase._should_pause_for_human_saves()` honours the player's `auto_allocate_wounds` setting (correctly). With `auto_allocate_wounds=true` in the machine's `user://settings.cfg` the AI auto-rolls the defender's saves, the pause under test never happens, and 7 asserts cascade. Reproduced both ways locally (fresh cfg → 35/35; poisoned cfg → 28/35 with exactly the reported failure set).

That cfg value is planted by the suite itself: `aao_lions_melee_provenance`, `global_consolidation_step_11e`, `pile_in_drag_clamps_to_max_range` and `fight_ff_opponent_remaining_visible_11e` set it `true` mid-run and never restore, and any later `SettingsService` setter persists the whole in-memory state to disk. 16 more scenarios walk the defender-save overlay without pinning the setting — the whole class was one suite run away from breaking, locally and inside a CI job (`user://` is fresh per job, not per scenario process; `aao_…` sorts before `ai_…`).

**Fix (both directions, harness-level + scenario-level):**
- `ScenarioRunner` pins 32 scenario-observable persisted settings to fresh-install defaults for every harness run (`--scenario-file`, `gut_cmdln`, `godot -s`), reading defaults off a throwaway `SettingsService` instance so the table can't drift, and logging every machine override so failure reports self-diagnose.
- `user://settings.cfg` is byte-backed-up at harness start and restored on every exit path (`_exit_tree`, with stale-backup healing after crashes) — a run can no longer leak persisted settings into the next run or clobber the developer's real preferences.
- The scenario now sets `auto_allocate_wounds=false` itself and asserts it (36 asserts, up from 35), and `_schema.md` documents the hermetic contract.
- `ShootingPhase`'s null-`SettingsService` fallback is aligned to FightPhase's documented convention (null == stripped headless harness → auto-resolve, so engine tests can never deadlock waiting for an `APPLY_SAVES` no overlay will send); rationale now documented at all three phase-side sites. Unreachable in real play — the autoload always exists.

**Validated:** scenario passes 36/36 under poisoned-true / explicit-false / absent cfg, with md5-identical cfg restore (and correct deletion in the absent case); 18-scenario regression batch (all 14 settings-manipulating scenarios + 3 exposure-class overlay scenarios) under the poisoned cfg: 18/18, cfg byte-identical after the whole batch; full 111-test audit suite: **2429 passed, 0 failed**, cfg untouched.

## Finding 2 — the Windowed Scenario Suite red on main is NOT a windowed scenario

Every executed run since 2026-08-05 fails in the **headless-audit gate job** (`2428 passed, 1 failed across 111 tests` on the current merge-base), so the windowed job is *skipped* — no windowed scenario has run on main since Aug 5. The one failing check is `test_iss020_public_api`: `ShootingController._eligible_bearer_slice` called private `RulesEngine._filter_eligible_model_ids` (introduced 2026-08-03 in 249261c, the blocked-bearers panel). Fixed with the documented public-wrapper pattern the test enforces (`RulesEngine.filter_eligible_model_ids`); behaviour unchanged, `test_iss020` 5/5 locally, gate suite 2429/0 at this branch tip.

(Separate, non-code: Actions had a runner outage Aug 6 ~15:53 → overnight — jobs cancelled with `runner_id: 0` / runs stuck queued across both workflows. It drained overnight. `test-suite.yml`'s own vision-map failure from PR #885 is unrelated and already has fixes merged.)

**CI note:** pushes from this integration don't trigger `on: push` workflows and `workflow_dispatch` is not permitted for it, so no run exists for this branch — the merge commit may need an owner-initiated run (or the next owner push) to show the suite green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AJbFCuXjco5duDimfXenQo

---
_Generated by [Claude Code](https://claude.ai/code/session_01AJbFCuXjco5duDimfXenQo)_