### PR TITLE
AI plan: add the BattlePlan layer, plus the autonomous runner prompt

### DIFF
--- a/.llm/ai-overhaul-runner-prompt.md
+++ b/.llm/ai-overhaul-runner-prompt.md
@@ -1,0 +1,90 @@
+# Runner prompt — autonomous execution of the AI overhaul task list
+
+*Paste everything below the rule into a fresh Claude Code session on this repo to work
+through `.llm/ai-overhaul-todo.md` unattended. The prompt is resumable: state lives in the
+todo file's checkboxes/evidence blocks, `.llm/ai-overhaul-progress.md`, and pushed commits,
+so re-running the same prompt in a new session continues instead of restarting.*
+
+---
+
+Work through .llm/ai-overhaul-todo.md and complete every task in it, autonomously, end to end.
+I am away from my computer: never ask me anything, never wait for confirmation, never end your
+turn while workable tasks remain. A task is never "too large" — it can only be decomposed
+further and then done. Run until every task is either completed-and-validated or carries a
+documented, reproduced blocker.
+
+RESUME RULE (also applies to a fresh start): first read .llm/ai-overhaul-progress.md (if it
+exists) and the checkboxes in the todo file, then continue from the first incomplete task.
+Never redo completed work; never trust a checkbox that has no evidence block under it —
+re-verify those.
+
+SETUP
+- Read in full before any work: .llm/ai-overhaul-todo.md (the guardrails preamble is binding),
+  tools/ai_lab/README.md, and docs/AI_CURRENT_AND_FUTURE.html Part III.
+- Environment: export PATH="$HOME/bin:$PATH"; run `godot --headless --import` once. Benchmarks
+  run headless. Windowed scenarios and screenshots DO work in this container via the xvfb godot
+  shim and the MCP bridge on 127.0.0.1:9080 — see CLAUDE.md "You CAN run the game AND
+  screenshot the UI". Do not claim a tool limitation without a reproduced failing command and
+  its exact output.
+- Git: create your working branch from latest origin/main. Push after every task. Do not open
+  or merge PRs — I will review the branch when I return.
+
+ORDER
+Follow the phase table at the bottom of the todo file (Phase 1 → 5), tasks in listed order
+within a phase, respecting each task's Depends line. You are a single session, so Lock tags
+never conflict. Long self-play campaigns (B3, E1, anything over ~30 minutes of games) must run
+in the background (they are resumable — run_lanes skips finished seeds, cem_driver checkpoints
+each generation); while they run, work the next task that does not depend on their results.
+Never idle waiting on games while independent work exists.
+
+PER-TASK LOOP — strictly, for every task
+1. Re-read the task. Verify every premise against the code; line numbers drift, function names
+   are the anchor. If a premise is stale, fix the task text in the same commit and adapt.
+2. Implement completely. No stubs, no placeholders, no "simplified version for now". If an
+   approach stalls, change approach, not scope.
+3. Validate for real: execute every Tier A bullet as an actual command and capture actual
+   output. If a Tier A bullet cannot be executed, the work is not done — make the state
+   observable and rerun. Never fabricate, predict, or paraphrase results you did not run.
+4. Tier B is a human check: perform it yourself honestly and record the assessment as a dated
+   note "Tier B self-assessed — pending human spot-check". Then mark the checkbox [x].
+5. Append a dated evidence block under the task: commands run, key numbers (for evaluator work,
+   E ± SE and games count), files touched.
+6. Commit (message references the task id) and push before starting the next task — the
+   container is ephemeral and unpushed work can vanish.
+7. Update .llm/ai-overhaul-progress.md (create on first task): one line per task — status,
+   key result, timestamp.
+
+GATES YOU MAY NEVER SKIP
+- "Behavior-preserving" requires tools/ai_lab/determinism_check.py byte-identical action
+  streams before vs after, both mirror fixtures, at least 2 seeds each. No exceptions.
+- Behavior changes go through tools/ai_lab/run_paired.py with the stopping rule recorded
+  before the first game, judged by the acceptance thresholds for their change class in the
+  todo preamble (+4 VP at 2 SE for tuned candidates; exam-flip plus >= -1 VP at 1 SE
+  non-regression for structural changes).
+- Every new fixture passes tools/ai_lab/fixture_check.py before its first game.
+- Statistical work defaults to the Custodes mirror (~10x cheaper); use the Ork mirror only
+  where melee coverage is the point (B3, D4).
+- Player-facing tasks (E5, F1, F2, F3): windowed scenario + in-game screenshot + a
+  40k/data/version_history.json entry, per CLAUDE.md.
+
+OUTCOMES THAT COUNT AS COMPLETION — handle and continue, do not stop
+- A kill criterion fires -> execute its documented off-ramp (write-up, default-off parameter,
+  park), record the measured numbers, mark the task done with that outcome.
+- The evaluator returns null or negative -> the honest write-up IS the deliverable (E1 says so
+  explicitly: "ship or null — either outcome is the deliverable").
+- A task assumes a resource you lack (e.g. an external API key for E2/E3's proposer) -> build
+  the pluggable interface as specced, act as the proposer yourself for the validation cycle,
+  and record the substitution in the task notes.
+
+BLOCKED != STOPPED
+If a task is genuinely blocked, record the exact failing command and output under it, mark it
+"BLOCKED — <reason>", move to the next workable task, and retry every blocked task once at the
+end of the run. Never halt the run for one task. Never ask me anything. Do not stop because
+the session is long — context compaction is handled by the harness; the journal, the todo
+file, and pushed commits carry all state.
+
+FINISH LINE
+When every task is done or documented-blocked: write a final summary at the top of the
+progress journal — tasks completed, measured deltas (E ± SE per shipped change), exam-suite
+pass count before vs after, blocked tasks with reasons, and the three highest-value next
+actions — commit, push, and only then end.

--- a/.llm/ai-overhaul-todo.md
+++ b/.llm/ai-overhaul-todo.md
@@ -1,10 +1,12 @@
 # AI Overhaul — task list
 
 Goal: make the AI **stronger** and **improvable** — every decision visible,
-every decision reachable by tuning, phases connected by one plan and one value
-function, bounded lookahead where it pays, and an automated
-propose → play → measure → gate → ship loop (a "Karpathy loop") that turns
-games played into strength gained.
+every decision reachable by tuning, phases connected by a plan for the game
+and a plan for the turn over one shared value function, bounded lookahead
+where it pays, and an automated propose → play → measure → gate → ship loop
+(a "Karpathy loop") that turns games played into strength gained.
+
+36 tasks in six workstreams. See the phase table at the bottom for order.
 
 Companion document: `docs/AI_CURRENT_AND_FUTURE.html` explains the current AI,
 the target architecture, and the reasoning behind this plan. Read it first if
@@ -406,9 +408,11 @@ coordination ledgers, mission awareness) — and the multi-phase plan only
 builds at Hard+ difficulty, so on Normal most cross-phase coordination is
 silently off. A score can pass through five uncalibrated stacked modifiers
 (faction aggression ÷, archetype ×, round strategy ×, tempo ×, difficulty
-noise +). Give the AI one explicit value function and one turn-level plan
-that every phase serves. This is the structural answer to "phase models
-without a connecting layer".*
+noise +). Give the AI one explicit value function and two plan horizons every
+phase serves — a battle plan for the game, a turn plan for the turn. This is
+the structural answer to "phase models without a connecting layer". Note the
+horizons are separate on purpose: deployment and reserves are decided once
+and pay off three rounds later, which no per-turn object can own.*
 
 - [ ] **C0 — One source of truth for combat math**
   - **Lock:** AIDM  • **Depends:** D1 (the property test exists first, as the guard)  • **Cost:** code-only
@@ -492,6 +496,63 @@ without a connecting layer".*
     movement + shooting + charge intents (the "whole turn's intent at once"
     the July review asked for).
 
+- [ ] **C2b — BattlePlan: how we intend to win this game**
+  - **Lock:** AIDM  • **Depends:** C1 (V terms), C2 (TurnPlan is its execution vehicle)  • **Cost:** code + gate (~200 games)
+  - **Context:** Above TurnPlan there is nothing. No object states how the AI
+    intends to win the *game* — which objectives it contests all game versus
+    concedes, whether it is the alpha strike or the counter-punch, when
+    reserves land and what job they do, how CP and once-per-battle abilities
+    spread across five rounds. Deployment and reserves are decided before
+    round 1 and only pay off in rounds 2-3, so no per-turn object can own
+    them: today reserves scoring is an orphan (18 hardcoded coefficients,
+    promoted in A4) and deployment invents its own strategy per unit. The
+    measured evidence says this layer carries the project's largest effects —
+    the reserves cap alone moved a benchmark matchup from 12 to 39 primary VP
+    (`docs/AI_REVIEW_2026-07-11.md` §2.4, §5), while every purely tactical
+    change measured so far sat inside the noise.
+  - **Spec:** `BattlePlan` — a per-player object built once after both armies
+    are known and before deployment, and **reviewed** at each command phase,
+    never rebuilt from scratch. Contents:
+    - **win route** — projected primary/secondary VP for both sides from the
+      mission cards and both army compositions; a chosen route (out-hold /
+      out-kill / trade-and-hold) naming the C1 value terms it maximizes;
+    - **objective stance** — per objective, for the game: contest-always /
+      take-late / concede, with the round it matters;
+    - **tempo** — commit round (alpha strike vs counter-punch), derived from
+      relative threat ranges and durability;
+    - **force allocation** — a durable per-unit job for the game (anchor
+      home, hammer, screen, harass, reserve delivery) that TurnPlan tasks
+      serve or explicitly override with a reason;
+    - **resource arcs** — reserve manifest (which units, target arrival
+      round, target job), CP arc per round (feeding C3), once-per-battle
+      ability timing.
+    Review semantics mirror the movement plan's replan-for-cause: the plan is
+    re-scored each command phase against V and revised only when evidence
+    contradicts it (a conceded objective becomes cheap, the commit round
+    passed with no viable strike, the win route's projection inverts). Every
+    revision is narrated. Downstream: TurnPlan (C2) derives unit tasks from
+    the force allocation; C5's deployment posture derives from win route +
+    tempo + objective stance instead of being independently invented;
+    reserves declarations read the reserve manifest instead of their own
+    scoring.
+  - **Acceptance — Tier A:** (1) Built-but-not-consulted (flag off) is
+    byte-identical vs pre-C2b on `determinism_check.py`. (2) Two new exams
+    pass: "against a faster, tougher enemy the plan concedes the far
+    objective and holds two near ones all game", and "reserves arrive in the
+    round the manifest named, not on generic arrival scoring". (3) Pooled
+    E ≥ −1 VP at 1 SE across both mirrors and the B2 asymmetric fixture, and
+    a plan-vs-no-plan arm reported with its measured E whichever way it
+    falls. (4) Plan revisions are recorded decisions with candidates; ≥1
+    revision occurs and is narrated across a 5-round game.
+  - **Tier B:** A replayed game reads as one story — deployment, reserve
+    arrival and the round-4 push all serve the plan the log announced before
+    round 1.
+  - **Kill criterion:** if the plan arm measures worse than no plan at 1 SE
+    on both mirrors after one revision pass of the review triggers, ship it
+    default-off behind a parameter and write up which commitments hurt. A
+    wrong plan committed to is worse than no plan; this criterion exists to
+    catch exactly that.
+
 - [ ] **C3 — CP budget as a decision, not nine private floors**
   - **Lock:** AIDM  • **Depends:** C2  • **Cost:** code + evaluator gate (~100 games)
   - **Context:** AUDIT Tier-3: no CP economy exists — nine stratagem
@@ -523,17 +584,22 @@ without a connecting layer".*
   - **Tier B:** WAAAGH! timing narration still reads correctly.
 
 - [ ] **C5 — Deployment master plan (posture before placement)**
-  - **Lock:** AIDM  • **Depends:** A5 (deployment params exist)  • **Cost:** code + gate (~150 games)
+  - **Lock:** AIDM  • **Depends:** A5 (deployment params exist), C2b (the posture comes from the battle plan)  • **Cost:** code + gate (~150 games)
   - **Context:** Deployment is reactive per unit; no whole-army posture
     ("castle center", "refuse left flank", "spread for scout screens")
     exists, and misclassification is known (Stormboyz deploy as "durable
     ranged", `docs/AI_REVIEW_2026-07-11.md` §6). Deployment largely decides
-    round 1-2.
-  - **Spec:** Score 3-4 explicit postures against opponent deployment,
-    mission, and army archetype; chosen posture parameterizes the existing
-    per-unit placement (column geometry, depth, role targets). Fix role
-    classification to weigh melee reach vs token pistols. Posture is a
-    recorded decision and a persona bias point (F1).
+    round 1-2. It is independent in *timing* — it happens once, before
+    everything — but maximally coupled in *consequence*, which is why the
+    posture must be derived rather than invented: cover is only valuable if
+    the plan intends to shoot from there.
+  - **Spec:** Derive the posture from C2b's win route, tempo and objective
+    stance (score 3-4 candidate postures for how well each *serves the plan*,
+    rather than scoring them against the board in isolation); the chosen
+    posture then parameterizes the existing per-unit placement (column
+    geometry, depth, role targets). Fix role classification to weigh melee
+    reach vs token pistols. Posture is a recorded decision, and its bias
+    point for personas lives in the battle plan (F1).
   - **Acceptance — Tier A:** (1) two deployment exams pass (melee horde
     deploys forward-weighted vs shooting army; fragile shooters castle
     against melee). (2) pooled E ≥ −1 VP at 1 SE; deployment scenarios
@@ -832,17 +898,20 @@ strategist biases), not code forks — so the improvement loop can tune each
 persona the same way it tunes the default.*
 
 - [ ] **F1 — Persona schema: strategist biases in shipped profiles**
-  - **Lock:** Profiles + AIDM  • **Depends:** C2 (TurnPlan reads biases), E5 (shipping channel)  • **Cost:** code + gate (~100 games)
+  - **Lock:** Profiles + AIDM  • **Depends:** C2b (BattlePlan reads biases), C2, E5 (shipping channel)  • **Cost:** code + gate (~100 games)
   - **Context:** Profiles already carry `playstyle`/`faction_affinity`
     metadata that nothing reads. Faction behavior today is five hardcoded
-    aggression constants plus archetype detection. The persona surface
-    should be: parameter pack (exists) + rules (exists) + **strategist
-    biases** (new: posture preference, risk posture, reserve appetite,
-    objective-vs-kill lean, target priorities) consumed by TurnPlan/C5.
+    aggression constants plus archetype detection. A persona is not "charges
+    more" — it is *how this army wins*, which makes the battle plan its
+    natural home. The persona surface should be: parameter pack (exists) +
+    rules (exists) + **strategist biases** (new) consumed by **C2b first**
+    (win-route preference, tempo bias, reserve appetite, objective stance
+    lean) and TurnPlan/C5 second (risk posture, target priorities).
   - **Spec:** Extend `wh40k_ai_profile` v2 with a `strategist` block (all
-    fields optional, defaults = current behavior); TurnPlan and deployment
-    posture read them; `validate_profile.py` and `ai-creator` learn the new
-    fields. Document in `AI_TUNING.md`.
+    fields optional, defaults = current behavior); BattlePlan reads the
+    game-level biases, TurnPlan and deployment posture the turn-level ones;
+    `validate_profile.py` and `ai-creator` learn the new fields. Document in
+    `AI_TUNING.md`.
   - **Acceptance — Tier A:** (1) v1 profiles still load (round-trip test).
     (2) A test profile with `risk_posture: reckless` measurably shifts the
     fingerprint (charge rate up, reserve % down) on 10 games vs default —
@@ -900,7 +969,7 @@ persona the same way it tunes the default.*
 |---|---|---|---|
 | 1 | A1 A2 A3 A4 A5 D1 · B0 B1 B2 B4 | See clearly, measure cheaply | records honest; unreachable ≤50%; games ≤30 s/300 s; exams live; baseline frozen |
 | 2 | A6 A7 B3 B5 C0 C1 · B6 spike | Instrument everything, dedupe the math, validate V, nightly pulse | census ≥9 types; one combat-math module; V correlation ≥0.5; nightly report running |
-| 3 | C2 C3 C4 E1 · E4 E5 | One plan; first full-budget search; ship channel | TurnPlan live in all phases; E1 shipped-or-null; profiles shippable |
+| 3 | C2 C2b C3 C4 E1 · E4 E5 | Two plan horizons; first full-budget search; ship channel | TurnPlan live in all phases; BattlePlan built, reviewed and measured; E1 shipped-or-null; profiles shippable |
 | 4 | D2 D3 D4 C5 C6 C7 | Lookahead + remaining plan features | D3 pays ≥+1 VP or is parked with numbers |
 | 5 | E2 E3 E6 F1 F2 F3 | The loop runs itself; personas; difficulty | one analyst cycle + one patch cycle complete; two personas shipped |
 

--- a/docs/AI_CURRENT_AND_FUTURE.html
+++ b/docs/AI_CURRENT_AND_FUTURE.html
@@ -163,7 +163,7 @@
     <li>A serious <b>self-play measurement lab already exists</b> in the repo (deterministic
     AI-vs-AI games, a paired evaluator, an optimizer, acceptance gates). It has honestly measured
     two plausible improvement ideas as useless and one as harmful. It is starved, not broken.</li>
-    <li>The target: a <b>three-layer AI</b> (turn-level strategist → per-phase tacticians →
+    <li>The target: a <b>three-layer AI</b> (game- and turn-level strategist → per-phase tacticians →
     bounded lookahead) over <b>one board-value function</b>, with personas as data — wrapped in an
     <b>automated improvement loop</b> (propose → play → measure → gate → ship): a Karpathy loop
     for the AI itself.</li>
@@ -361,7 +361,7 @@ per-phase knowledge that already works.</p>
       </marker>
     </defs>
     <g fill="none" stroke="var(--accent)" stroke-width="2">
-      <rect x="150" y="18" width="380" height="64" rx="4" stroke-dasharray="6 4"/>
+      <rect x="150" y="8" width="380" height="82" rx="4" stroke-dasharray="6 4"/>
     </g>
     <g fill="none" stroke="currentColor" stroke-width="1.3">
       <rect x="70"  y="140" width="110" height="54" rx="4"/>
@@ -375,8 +375,9 @@ per-phase knowledge that already works.</p>
       <rect x="620" y="18" width="215" height="64" rx="4" stroke-dasharray="6 4"/>
     </g>
     <g font-family="ui-sans-serif,system-ui,sans-serif" font-size="12.5" fill="currentColor">
-      <text x="340" y="44" text-anchor="middle" font-weight="700" fill="var(--accent)">Strategist — TurnPlan (new)</text>
-      <text x="340" y="62" text-anchor="middle" font-size="11.5">unit → task · postures · CP budget · at every difficulty</text>
+      <text x="340" y="30" text-anchor="middle" font-weight="700" fill="var(--accent)">Strategist (new)</text>
+      <text x="340" y="52" text-anchor="middle" font-size="11.5">BattlePlan — win route · objective stance · reserve &amp; CP arcs · once per game</text>
+      <text x="340" y="72" text-anchor="middle" font-size="11.5">TurnPlan — unit → task · postures · CP budget · once per turn</text>
       <text x="125" y="163" text-anchor="middle" font-weight="700">Move</text>
       <text x="255" y="163" text-anchor="middle" font-weight="700">Shoot</text>
       <text x="385" y="163" text-anchor="middle" font-weight="700">Charge</text>
@@ -399,22 +400,22 @@ per-phase knowledge that already works.</p>
       <text x="727" y="61" text-anchor="middle" font-size="11.5">profile + strategist biases</text>
     </g>
     <g stroke="currentColor" stroke-width="1.3" fill="none">
-      <line x1="255" y1="82" x2="255" y2="138" marker-end="url(#arr2)"/>
-      <line x1="425" y1="82" x2="425" y2="138" marker-end="url(#arr2)"/>
+      <line x1="255" y1="90" x2="255" y2="138" marker-end="url(#arr2)"/>
+      <line x1="425" y1="90" x2="425" y2="138" marker-end="url(#arr2)"/>
       <line x1="255" y1="194" x2="255" y2="250" marker-end="url(#arr2)"/>
       <line x1="425" y1="194" x2="425" y2="250" marker-end="url(#arr2)"/>
       <line x1="340" y1="312" x2="340" y2="366" marker-end="url(#arr2)"/>
-      <line x1="618" y1="50" x2="532" y2="50" marker-end="url(#arr2)"/>
+      <line x1="618" y1="49" x2="532" y2="49" marker-end="url(#arr2)"/>
       <line x1="618" y1="157" x2="572" y2="157" marker-end="url(#arr2)" stroke="var(--accent)" stroke-width="1.6"/>
       <line x1="618" y1="260" x2="590" y2="260" stroke-width="1.3"/>
       <path d="M 590 260 L 555 260 L 555 200" marker-end="url(#arr2)"/>
       <path d="M 727 194 L 727 214" marker-end="url(#arr2)" stroke="var(--accent)" stroke-width="1.6"/>
     </g>
     <g font-family="ui-sans-serif,system-ui,sans-serif" font-size="11" fill="currentColor" opacity=".75">
-      <text x="243" y="106" text-anchor="end">tasks</text>
+      <text x="243" y="112" text-anchor="end">tasks</text>
       <text x="243" y="222" text-anchor="end">candidates</text>
       <text x="352" y="344" text-anchor="start">best action</text>
-      <text x="575" y="42"  text-anchor="middle">biases</text>
+      <text x="575" y="41"  text-anchor="middle">biases</text>
       <text x="596" y="149" text-anchor="middle">scores</text>
       <text x="737" y="209" text-anchor="start">leaf eval</text>
     </g>
@@ -427,17 +428,28 @@ per-phase knowledge that already works.</p>
   </svg>
   </div>
   <figcaption>Fig. 2 — Target architecture. The four phase tacticians are today's solvers, kept.
-  What is new: one plan above them, one value function and one combat-math module beside them,
-  bounded lookahead below them, and personas as data.</figcaption>
+  What is new: two plan horizons above them — one for the game, one for the turn — one value
+  function and one combat-math module beside them, bounded lookahead below them, and personas as
+  data.</figcaption>
 </figure>
 
 <ul>
-  <li><b>Strategist.</b> Once per turn, at every difficulty, build a <code>TurnPlan</code>: which
-  objectives matter this round (from the mission math that already exists), a task per unit
-  (hold, take, screen, hunt, deliver, hold-lane), a deployment posture, and a CP budget that can
-  hold a command point back for overwatch. The eight ad-hoc caches become views of this one
-  object. The plan persists, is consumed as units act, replans only for cause, and is narrated —
-  the July coordination work already proved this pattern in the movement phase.</li>
+  <li><b>Strategist, at two horizons.</b> A <code>BattlePlan</code> is built once, before
+  deployment, from both army lists and the mission cards: how we intend to win (out-hold,
+  out-kill, trade-and-hold), which objectives we contest all game and which we concede, whether
+  we are the alpha strike or the counter-punch, a job per unit for the game, and the resource
+  arcs — reserve manifest, CP per round, once-per-battle timing. Below it, a <code>TurnPlan</code>
+  is built each turn, at every difficulty: a task per unit serving the battle plan's job list,
+  focus-fire and charge intentions, and this turn's CP budget. The eight ad-hoc caches become
+  views of the turn plan. Both plans persist, are consumed as units act, and are revised only
+  for cause — the July coordination work already proved that pattern in the movement phase.</li>
+  <li><b>Why two horizons and not one.</b> Deployment and reserves are decided once, before
+  round one, and only pay off in rounds two and three; no per-turn object can own them. That is
+  also why deployment is not split off as its own independent AI: it is independent in
+  <em>timing</em> but maximally coupled in <em>consequence</em>. Cover is only worth deploying
+  into if the plan intends to shoot from there. The largest measured behavior swing in this
+  project's history was a deployment-phase decision — a reserves cap that moved a benchmark
+  matchup from 12 to 39 primary victory points.</li>
   <li><b>Tacticians.</b> The per-phase solvers stay — they hold real domain knowledge. They
   change in two ways: candidates are generated <em>against the TurnPlan's tasks</em>, and scored
   with named, reachable, recorded terms instead of inline literals.</li>
@@ -452,8 +464,9 @@ per-phase knowledge that already works.</p>
   validated against actual outcomes (does round-3 V predict the final margin?), and only then
   allowed to steer decisions. The scoring-horizon failure taught this order.</li>
   <li><b>Personas.</b> A persona is a data file: parameter pack + conditional rules (both exist
-  today) + strategist biases (new: risk posture, reserve appetite, posture preference, target
-  priorities). Ork "Green Tide" and Custodes "Shield Host" ship first. Difficulty stops meaning
+  today) + strategist biases (new). The biases attach to the battle plan first, because a persona
+  is not "charges more" — it is <em>how this army wins</em>: win route, tempo, reserve appetite,
+  which objectives it refuses to concede. Ork "Green Tide" and Custodes "Shield Host" ship first. Difficulty stops meaning
   "how much random noise" and starts meaning "how deep the plan and the search go".</li>
 </ul>
 
@@ -621,8 +634,8 @@ precisely the right shape here, and the repo is already more than half way to it
 <!-- ============================ PART III ============================ -->
 <div class="partband"><span class="n">PART III</span><h2>The path</h2></div>
 
-<h3><span class="sn">§13</span>Six workstreams, thirty tasks</h3>
-<p>The full plan is <code>.llm/ai-overhaul-todo.md</code>: 30 tasks, each self-contained — context
+<h3><span class="sn">§13</span>Six workstreams, thirty-six tasks</h3>
+<p>The full plan is <code>.llm/ai-overhaul-todo.md</code>: 36 tasks, each self-contained — context
 with evidence, an exact spec, machine-checkable acceptance (Tier A), a human check (Tier B),
 cost, dependencies, and kill criteria for the speculative ones. Any task can be handed alone to
 an engineer or an LLM session. In brief:</p>
@@ -631,7 +644,7 @@ an engineer or an LLM session. In brief:</p>
   <tbody>
     <tr><td><b>A — Truth &amp; Reach</b> (7)</td><td>Honest decision records everywhere; promote ~90 hardcoded literals to named parameters; a CI ratchet so neither regresses.</td><td>Tears down walls 1–2. The repo's own evidence says this is worth more than any search over the current surface.</td></tr>
     <tr><td><b>B — Measurement Engine</b> (7)</td><td>Freeze a baseline opponent; make games ~2× faster; asymmetric fixtures; a 12-exam tactical suite; nightly self-play with drift alarms; a counterfactual-replay spike.</td><td>Tears down wall 5. Every later workstream pays its bills in games.</td></tr>
-    <tr><td><b>C — One Plan, One Value</b> (8)</td><td>One combat-math module; V(state) validated dark; TurnPlan across all phases and difficulties; CP budgeting; scored command phase; deployment postures; dependency-ordered movement; escort pairing.</td><td>Tears down wall 4 — the connecting layer.</td></tr>
+    <tr><td><b>C — One Plan, One Value</b> (9)</td><td>One combat-math module; V(state) validated dark; TurnPlan across all phases and difficulties; BattlePlan for the whole game; CP budgeting; scored command phase; deployment postures derived from the battle plan; dependency-ordered movement; escort pairing.</td><td>Tears down wall 4 — the connecting layer, at both horizons.</td></tr>
     <tr><td><b>D — Looking Ahead</b> (4)</td><td>Reconcile AI math with the RulesEngine; an EV forward model with a measured budget; 1-ply opponent replies on high-stakes moves; beam search over charge/fight order.</td><td>Tears down wall 3. Each search feature must pay ≥ +1 VP or it ships off by default.</td></tr>
     <tr><td><b>E — The Loop</b> (6)</td><td>Full-budget parameter search; LLM rule proposer; LLM patch proposer; fingerprint gate; a shipping channel for profiles; a runbook an LLM can execute.</td><td>Option B made real. Every proposer goes through the same gate.</td></tr>
     <tr><td><b>F — Personas &amp; Difficulty</b> (3)</td><td>Persona schema read by the strategist; two shipped personas, provably distinct and non-regressing; difficulty from capability instead of noise.</td><td>The product face of all of the above.</td></tr>
@@ -644,7 +657,7 @@ an engineer or an LLM session. In brief:</p>
   <tbody>
     <tr><td>1 — See clearly, measure cheaply</td><td>A1–A5, D1 · B0–B2, B4</td><td>Records honest; unreachable arithmetic ≤ 50%; games ≤ 30 s / 300 s; exams live; baseline frozen.</td></tr>
     <tr><td>2 — Instrument, dedupe, validate V</td><td>A6–A7, B3, B5, C0–C1 · B6</td><td>≥ 9 decision types recorded; one combat-math module; V predicts outcomes (ρ ≥ 0.5); nightly report running. <b>← decision checkpoint (§11)</b></td></tr>
-    <tr><td>3 — One plan; first real search; ship channel</td><td>C2–C4, E1 · E4–E5</td><td>TurnPlan live in all phases; full-budget tuning campaign shipped-or-null; profiles shippable.</td></tr>
+    <tr><td>3 — Both plan horizons; first real search; ship channel</td><td>C2, C2b, C3–C4, E1 · E4–E5</td><td>TurnPlan live in all phases; BattlePlan built, reviewed and measured; full-budget tuning campaign shipped-or-null; profiles shippable.</td></tr>
     <tr><td>4 — Lookahead and the rest of the plan</td><td>D2–D4, C5–C7</td><td>1-ply replies pay ≥ +1 VP or are parked with numbers.</td></tr>
     <tr><td>5 — The loop runs; personas ship</td><td>E2–E3, E6, F1–F3</td><td>One analyst cycle and one patch cycle complete end-to-end; two personas shipped; difficulty ladder measured.</td></tr>
   </tbody>


### PR DESCRIPTION
## Summary

Follow-up to #893. Documentation only — no game code changes.

**The gap this closes.** The plan topped out at one turn: `TurnPlan` covered a turn, but nothing stated how the AI intends to win the *game*. That left deployment and reserves — decided once, before round 1, paying off in rounds 2–3 — without an owner. Deployment is independent in *timing* but maximally coupled in *consequence*, so splitting it into its own AI would reproduce today's failure mode (it optimizes cover and spacing with no idea what the army intends to do). The evidence is in-repo: the largest measured behavior swing in this project's history was a deployment-phase decision — a reserves cap that moved a benchmark matchup from 12 to 39 primary VP — while every purely tactical change measured so far has sat inside the noise.

**Changes**

- **New task C2b — BattlePlan.** A per-player object built once after both armies are known and before deployment, and *reviewed* (never rebuilt) each command phase: win route (out-hold / out-kill / trade-and-hold) naming the value terms it maximizes; per-objective stance for the game (contest-always / take-late / concede); tempo (alpha strike vs counter-punch); a durable job per unit; and the resource arcs — reserve manifest, CP per round, once-per-battle timing. Replan-for-cause semantics mirror the movement plan that already proved the pattern. Acceptance requires the plan-vs-no-plan arm to be reported whichever way it falls, and carries a kill criterion: a wrong plan committed to is worse than no plan, so if it measures worse it ships default-off with a write-up.
- **C5 (deployment posture)** now *derives* from the battle plan's win route, tempo and objective stance instead of being scored against the board in isolation, and depends on C2b.
- **F1 (personas)** attaches strategist biases to the battle plan first — a persona is not "charges more", it is how that army wins — with turn-level biases second.
- **WS-C framing and the Phase 3 table** updated for the two plan horizons.
- **`docs/AI_CURRENT_AND_FUTURE.html`**: §8 gains the two-horizon strategist and the why-not-separate-deployment reasoning; Fig. 2 shows both plans; §13/§14 updated.
- **Correction:** the task count was stated as 30; the actual total is 36 (35 before C2b). Fixed in §13 and the plan header.
- **`.llm/ai-overhaul-runner-prompt.md`** (from the earlier commit on this branch): a resumable prompt for running the task list unattended — per-task implement/validate/commit loop, the non-skippable determinism and paired-evaluator gates, background handling for long self-play campaigns, and blocked-not-stopped semantics.

## Validation

- Docs-only: no engine, scene, or script files touched; not player-facing, so no version_history entry.
- Verified mechanically: 36 tasks total, WS-C at 9; HTML tags balanced (div/table/tr/svg/figure/ul/ol all matched); no stale task-count references remain; C2b cross-referenced from C5, F1, the phase table and the HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0129AWoTrcrN1oYqC2eBGYVH

---
_Generated by [Claude Code](https://claude.ai/code/session_0129AWoTrcrN1oYqC2eBGYVH)_